### PR TITLE
Fix case-insensitive tag filtering

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -42,6 +42,25 @@ function useGlobalEventData() {
   return context;
 }
 
+// Custom hook for tag selection management
+function useTagSelection(selectedTags: string[], setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>) {
+  const toggleTag = useCallback((tag: string) => {
+    setSelectedTags(prev => {
+      const tagLower = tag.toLowerCase();
+      const existingTag = prev.find(t => t.toLowerCase() === tagLower);
+      return existingTag
+        ? prev.filter(t => t.toLowerCase() !== tagLower)
+        : [...prev, tag];
+    });
+  }, [setSelectedTags]);
+
+  const isTagSelected = useCallback((tag: string) => {
+    return selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase());
+  }, [selectedTags]);
+
+  return { toggleTag, isTagSelected };
+}
+
 function GlobalEventDataProvider({ children }: { children: React.ReactNode }) {
   const [globalEventData, setGlobalEventData] = useState<GlobalEventData>({
     events: null,
@@ -131,20 +150,8 @@ function HomeContent() {
     };
   }, []);
 
-  // Helper functions for case-insensitive tag operations
-  const toggleTagSelection = useCallback((tag: string, setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>) => {
-    setSelectedTags(prev => {
-      const tagLower = tag.toLowerCase();
-      const existingTag = prev.find(t => t.toLowerCase() === tagLower);
-      return existingTag
-        ? prev.filter(t => t.toLowerCase() !== tagLower)
-        : [...prev, tag];
-    });
-  }, []);
-
-  const isTagSelected = useCallback((tag: string, selectedTags: string[]) => {
-    return selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase());
-  }, []);
+  // Use the tag selection hook
+  const { toggleTag, isTagSelected } = useTagSelection(selectedTags, setSelectedTags);
 
   // Calculate Chautauqua season weeks (9 weeks starting from 4th Sunday of June)
   const getChautauquaSeasonWeeks = (year: number = 2025) => {
@@ -838,9 +845,9 @@ function HomeContent() {
                       .map(tag => (
                       <button
                         key={tag}
-                        onClick={() => toggleTagSelection(tag, setSelectedTags)}
+                        onClick={() => toggleTag(tag)}
                         className={`px-1 py-0.5 rounded-full text-xs font-medium transition-colors ${
-                          isTagSelected(tag, selectedTags)
+                          isTagSelected(tag)
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
@@ -864,9 +871,9 @@ function HomeContent() {
                       .map(tag => (
                       <button
                         key={tag}
-                        onClick={() => toggleTagSelection(tag, setSelectedTags)}
+                        onClick={() => toggleTag(tag)}
                         className={`px-2 py-1 rounded-full text-xs font-medium transition-colors ${
-                          isTagSelected(tag, selectedTags)
+                          isTagSelected(tag)
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
@@ -996,9 +1003,9 @@ function HomeContent() {
                                           return uniqueTags.map((tag, index) => (
                                             <button
                                               key={`${tag}-${index}`}
-                                              onClick={() => toggleTagSelection(tag, setSelectedTags)}
+                                              onClick={() => toggleTag(tag)}
                                               className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
-                                                isTagSelected(tag, selectedTags)
+                                                isTagSelected(tag)
                                                   ? 'bg-blue-600 text-white'
                                                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                                               }`}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -21,7 +21,8 @@ interface Event {
     isImage: boolean;
   }>;
   url?: string;
-  // Pre-computed lowercase tag set for efficient filtering
+  // Pre-computed set containing lowercase versions of tags and categories
+  // combined, used for efficient filtering
   _tagsLowerSet?: Set<string>;
 }
 
@@ -118,10 +119,10 @@ function HomeContent() {
 
   const decodeHtmlEntities = (encodedString: string | undefined) => {
     if (!encodedString) return undefined;
-    
+
     // If no HTML entities found, return original string
     if (!encodedString.includes('&')) return encodedString;
-    
+
     try {
       const parser = new DOMParser();
       const doc = parser.parseFromString(encodedString, 'text/html');
@@ -137,13 +138,13 @@ function HomeContent() {
   const decodeEventHtmlEntities = useCallback((event: Event): Event => {
     const decodedTags = event.tags?.map(tag => decodeHtmlEntities(tag) || tag);
     const decodedCategories = event.originalCategories?.map(cat => decodeHtmlEntities(cat) || cat);
-    
+
     // Pre-compute lowercase tag set for efficient filtering
     const allTags: string[] = [];
     if (decodedTags) allTags.push(...decodedTags);
     if (decodedCategories) allTags.push(...decodedCategories);
     const _tagsLowerSet = new Set(allTags.map(tag => tag.toLowerCase()));
-    
+
     return {
       ...event,
       title: decodeHtmlEntities(event.title) || event.title,
@@ -166,7 +167,7 @@ function HomeContent() {
   const { toggleTag, isTagSelected } = useTagSelection(selectedTags, setSelectedTags);
 
   // Memoize lowercase selected tags as a Set for O(1) lookup performance
-  const selectedTagsLowerSet = useMemo(() => 
+  const selectedTagsLowerSet = useMemo(() =>
     new Set(selectedTags.map(tag => tag.toLowerCase())),
     [selectedTags]
   );
@@ -332,7 +333,7 @@ function HomeContent() {
       const presenter = (event.presenter || '').toLowerCase();
       const location = (event.location || '').toLowerCase();
       const category = (event.category || '').toLowerCase();
-      
+
 
       // Combine all tags and categories for searching
       const allTags = [
@@ -431,7 +432,7 @@ function HomeContent() {
           }
           return false;
         }
-        
+
         // Fallback for events without pre-computed sets (shouldn't happen normally)
         if (event.tags) {
           for (const eventTag of event.tags) {
@@ -594,12 +595,12 @@ function HomeContent() {
           if (event.tags) allTagsAndCategories.push(...event.tags);
           if (event.originalCategories) allTagsAndCategories.push(...event.originalCategories);
         });
-        
+
         // Deduplicate tags using the same logic as event display
         const normalizeTag = (tag: string) => tag.toLowerCase().replace(/[-\s]+/g, ' ').trim();
         const seenNormalized = new Set<string>();
         const uniqueTags: string[] = [];
-        
+
         // Sort by preference: prefer tags with spaces and proper capitalization
         const sortedByPreference = allTagsAndCategories.sort((a, b) => {
           // Prefer tags with spaces over dashes
@@ -607,16 +608,16 @@ function HomeContent() {
           const bHasSpaces = b.includes(' ');
           if (aHasSpaces && !bHasSpaces) return -1;
           if (!aHasSpaces && bHasSpaces) return 1;
-          
+
           // Prefer tags with capital letters
           const aHasCapitals = /[A-Z]/.test(a);
           const bHasCapitals = /[A-Z]/.test(b);
           if (aHasCapitals && !bHasCapitals) return -1;
           if (!aHasCapitals && bHasCapitals) return 1;
-          
+
           return 0;
         });
-        
+
         for (const tag of sortedByPreference) {
           if (!tag.startsWith('Week ')) {
             const normalized = normalizeTag(tag);
@@ -825,18 +826,18 @@ function HomeContent() {
                     if (dateFilter === 'today') {
                       const today = new Date();
                       const dayName = today.toLocaleDateString('en-US', { weekday: 'long' });
-                      const fullDate = today.toLocaleDateString('en-US', { 
-                        year: 'numeric', 
-                        month: 'long', 
-                        day: 'numeric' 
+                      const fullDate = today.toLocaleDateString('en-US', {
+                        year: 'numeric',
+                        month: 'long',
+                        day: 'numeric'
                       });
                       return `Today, ${dayName}, ${fullDate}`;
                     } else if (dateFilter === 'next') {
                       const now = new Date();
-                      const timeString = now.toLocaleTimeString('en-US', { 
-                        hour: 'numeric', 
+                      const timeString = now.toLocaleTimeString('en-US', {
+                        hour: 'numeric',
                         minute: '2-digit',
-                        hour12: true 
+                        hour12: true
                       });
                       return `Next events after ${timeString}`;
                     } else if (dateFilter === 'this-week') {
@@ -846,7 +847,7 @@ function HomeContent() {
                       sunday.setDate(today.getDate() - dayOfWeek);
                       const saturday = new Date(today);
                       saturday.setDate(today.getDate() - dayOfWeek + 6);
-                      
+
                       const sundayStr = sunday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
                       const saturdayStr = saturday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
                       return `This Week (${sundayStr} - ${saturdayStr})`;
@@ -897,7 +898,7 @@ function HomeContent() {
                   </div>
                 </div>
               </details>
-              
+
               {/* Desktop tags */}
               <div className="hidden sm:block">
                 <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -978,16 +979,16 @@ function HomeContent() {
                             <div className="flex-1 min-w-0">
                               {/* Time and location above title */}
                               <div className="text-xs sm:text-sm text-gray-500 mb-1">
-                                🕐 {new Date(event.startDate).toLocaleTimeString([], { 
-                                  hour: 'numeric', 
+                                🕐 {new Date(event.startDate).toLocaleTimeString([], {
+                                  hour: 'numeric',
                                   minute: '2-digit',
-                                  hour12: true 
+                                  hour12: true
                                 })}
                                 {event.location && (
                                   <span className="ml-2">📍 {event.location}</span>
                                 )}
                               </div>
-                              
+
                               {/* Event title */}
                               <h4 className="text-sm sm:text-lg font-semibold text-gray-900 mb-1 leading-tight">
                                 {event.url ? (
@@ -1013,7 +1014,7 @@ function HomeContent() {
                                       {event.description && (
                                         <p className="text-gray-600 text-sm mb-2">{event.description}</p>
                                       )}
-                                      
+
                                       {/* Show all tags and categories when expanded */}
                                       <div className="mb-2 flex flex-wrap gap-1">
                                         {(() => {
@@ -1023,12 +1024,12 @@ function HomeContent() {
                                             ...(event.originalCategories || []),
                                             ...(event.tags || [])
                                           ];
-                                          
+
                                           // Filter out Week tags and deduplicate
                                           const normalizeTag = (tag: string) => tag.toLowerCase().replace(/[-\s]+/g, ' ').trim();
                                           const seenNormalized = new Set();
                                           const uniqueTags = [];
-                                          
+
                                           for (const tag of allTagsAndCategories) {
                                             if (!tag.startsWith('Week ')) {
                                               const normalized = normalizeTag(tag);
@@ -1038,7 +1039,7 @@ function HomeContent() {
                                               }
                                             }
                                           }
-                                          
+
                                           return uniqueTags.map((tag, index) => (
                                             <button
                                               key={`${tag}-${index}`}
@@ -1054,7 +1055,7 @@ function HomeContent() {
                                           ));
                                         })()}
                                       </div>
-                                      
+
                                       <button
                                         onClick={() => toggleDescription(event.id)}
                                         className="text-blue-600 hover:text-blue-800 text-xs font-medium flex items-center gap-1"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -382,9 +382,9 @@ function HomeContent() {
 
     // Tag filter - case insensitive
     if (selectedTags.length > 0) {
+      const selectedTagsLower = selectedTags.map(tag => tag.toLowerCase());
       filtered = filtered.filter(event =>
-        selectedTags.some(selectedTag => {
-          const selectedTagLower = selectedTag.toLowerCase();
+        selectedTagsLower.some(selectedTagLower => {
           return event.tags?.some(eventTag => eventTag.toLowerCase() === selectedTagLower) ||
                  event.originalCategories?.some(eventCat => eventCat.toLowerCase() === selectedTagLower);
         })

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -380,13 +380,14 @@ function HomeContent() {
       );
     }
 
-    // Tag filter
+    // Tag filter - case insensitive
     if (selectedTags.length > 0) {
       filtered = filtered.filter(event =>
-        selectedTags.some(tag =>
-          event.tags?.includes(tag) ||
-          event.originalCategories?.includes(tag)
-        )
+        selectedTags.some(selectedTag => {
+          const selectedTagLower = selectedTag.toLowerCase();
+          return event.tags?.some(eventTag => eventTag.toLowerCase() === selectedTagLower) ||
+                 event.originalCategories?.some(eventCat => eventCat.toLowerCase() === selectedTagLower);
+        })
       );
     }
 
@@ -824,14 +825,16 @@ function HomeContent() {
                       <button
                         key={tag}
                         onClick={() => {
-                          setSelectedTags(prev =>
-                            prev.includes(tag)
-                              ? prev.filter(t => t !== tag)
-                              : [...prev, tag]
-                          );
+                          setSelectedTags(prev => {
+                            const tagLower = tag.toLowerCase();
+                            const existingTag = prev.find(t => t.toLowerCase() === tagLower);
+                            return existingTag
+                              ? prev.filter(t => t.toLowerCase() !== tagLower)
+                              : [...prev, tag];
+                          });
                         }}
                         className={`px-1 py-0.5 rounded-full text-xs font-medium transition-colors ${
-                          selectedTags.includes(tag)
+                          selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase())
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
@@ -856,14 +859,16 @@ function HomeContent() {
                       <button
                         key={tag}
                         onClick={() => {
-                          setSelectedTags(prev =>
-                            prev.includes(tag)
-                              ? prev.filter(t => t !== tag)
-                              : [...prev, tag]
-                          );
+                          setSelectedTags(prev => {
+                            const tagLower = tag.toLowerCase();
+                            const existingTag = prev.find(t => t.toLowerCase() === tagLower);
+                            return existingTag
+                              ? prev.filter(t => t.toLowerCase() !== tagLower)
+                              : [...prev, tag];
+                          });
                         }}
                         className={`px-2 py-1 rounded-full text-xs font-medium transition-colors ${
-                          selectedTags.includes(tag)
+                          selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase())
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
@@ -994,15 +999,17 @@ function HomeContent() {
                                             <button
                                               key={`${tag}-${index}`}
                                               onClick={() => {
-                                                // Toggle the tag in the main filter
-                                                setSelectedTags(prev => 
-                                                  prev.includes(tag)
-                                                    ? prev.filter(t => t !== tag) // Remove if already selected
+                                                // Toggle the tag in the main filter (case insensitive)
+                                                setSelectedTags(prev => {
+                                                  const tagLower = tag.toLowerCase();
+                                                  const existingTag = prev.find(t => t.toLowerCase() === tagLower);
+                                                  return existingTag
+                                                    ? prev.filter(t => t.toLowerCase() !== tagLower) // Remove if already selected
                                                     : [...prev, tag] // Add if not selected
-                                                );
+                                                });
                                               }}
                                               className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
-                                                selectedTags.includes(tag)
+                                                selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase())
                                                   ? 'bg-blue-600 text-white'
                                                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                                               }`}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -131,6 +131,20 @@ function HomeContent() {
     };
   }, []);
 
+  // Helper functions for case-insensitive tag operations
+  const toggleTagSelection = useCallback((tag: string, setSelectedTags: React.Dispatch<React.SetStateAction<string[]>>) => {
+    setSelectedTags(prev => {
+      const tagLower = tag.toLowerCase();
+      const existingTag = prev.find(t => t.toLowerCase() === tagLower);
+      return existingTag
+        ? prev.filter(t => t.toLowerCase() !== tagLower)
+        : [...prev, tag];
+    });
+  }, []);
+
+  const isTagSelected = useCallback((tag: string, selectedTags: string[]) => {
+    return selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase());
+  }, []);
 
   // Calculate Chautauqua season weeks (9 weeks starting from 4th Sunday of June)
   const getChautauquaSeasonWeeks = (year: number = 2025) => {
@@ -824,17 +838,9 @@ function HomeContent() {
                       .map(tag => (
                       <button
                         key={tag}
-                        onClick={() => {
-                          setSelectedTags(prev => {
-                            const tagLower = tag.toLowerCase();
-                            const existingTag = prev.find(t => t.toLowerCase() === tagLower);
-                            return existingTag
-                              ? prev.filter(t => t.toLowerCase() !== tagLower)
-                              : [...prev, tag];
-                          });
-                        }}
+                        onClick={() => toggleTagSelection(tag, setSelectedTags)}
                         className={`px-1 py-0.5 rounded-full text-xs font-medium transition-colors ${
-                          selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase())
+                          isTagSelected(tag, selectedTags)
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
@@ -858,17 +864,9 @@ function HomeContent() {
                       .map(tag => (
                       <button
                         key={tag}
-                        onClick={() => {
-                          setSelectedTags(prev => {
-                            const tagLower = tag.toLowerCase();
-                            const existingTag = prev.find(t => t.toLowerCase() === tagLower);
-                            return existingTag
-                              ? prev.filter(t => t.toLowerCase() !== tagLower)
-                              : [...prev, tag];
-                          });
-                        }}
+                        onClick={() => toggleTagSelection(tag, setSelectedTags)}
                         className={`px-2 py-1 rounded-full text-xs font-medium transition-colors ${
-                          selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase())
+                          isTagSelected(tag, selectedTags)
                             ? 'bg-blue-600 text-white'
                             : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                         }`}
@@ -998,18 +996,9 @@ function HomeContent() {
                                           return uniqueTags.map((tag, index) => (
                                             <button
                                               key={`${tag}-${index}`}
-                                              onClick={() => {
-                                                // Toggle the tag in the main filter (case insensitive)
-                                                setSelectedTags(prev => {
-                                                  const tagLower = tag.toLowerCase();
-                                                  const existingTag = prev.find(t => t.toLowerCase() === tagLower);
-                                                  return existingTag
-                                                    ? prev.filter(t => t.toLowerCase() !== tagLower) // Remove if already selected
-                                                    : [...prev, tag] // Add if not selected
-                                                });
-                                              }}
+                                              onClick={() => toggleTagSelection(tag, setSelectedTags)}
                                               className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
-                                                selectedTags.some(selectedTag => selectedTag.toLowerCase() === tag.toLowerCase())
+                                                isTagSelected(tag, selectedTags)
                                                   ? 'bg-blue-600 text-white'
                                                   : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
                                               }`}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -153,6 +153,12 @@ function HomeContent() {
   // Use the tag selection hook
   const { toggleTag, isTagSelected } = useTagSelection(selectedTags, setSelectedTags);
 
+  // Memoize lowercase selected tags to avoid repeated conversions during filtering
+  const selectedTagsLower = useMemo(() => 
+    selectedTags.map(tag => tag.toLowerCase()),
+    [selectedTags]
+  );
+
   // Calculate Chautauqua season weeks (9 weeks starting from 4th Sunday of June)
   const getChautauquaSeasonWeeks = (year: number = 2025) => {
     // Start from June 1st and find the 4th Sunday
@@ -401,9 +407,8 @@ function HomeContent() {
       );
     }
 
-    // Tag filter - case insensitive
-    if (selectedTags.length > 0) {
-      const selectedTagsLower = selectedTags.map(tag => tag.toLowerCase());
+    // Tag filter - case insensitive (using memoized lowercase tags)
+    if (selectedTagsLower.length > 0) {
       filtered = filtered.filter(event =>
         selectedTagsLower.some(selectedTagLower => {
           return event.tags?.some(eventTag => eventTag.toLowerCase() === selectedTagLower) ||


### PR DESCRIPTION
## Summary
- Fix case-insensitive tag filtering throughout the application
- Resolve issue where clicking "Movie" tag wouldn't show events tagged with "movie" (lowercase)
- Update all tag interaction logic to work regardless of case differences

## Changes Made
- **Main filter logic**: Updated tag filtering to use case-insensitive comparison
- **Filter buttons**: Both mobile and desktop tag buttons now use case-insensitive logic for selection and highlighting
- **Event detail tags**: Clickable tags in expanded event details now use case-insensitive filtering
- **Visual consistency**: All tag highlighting and selection states work case-insensitively

## Problem Solved
Previously, if a user clicked on a "Movie" tag to filter events, it would not show events that were tagged with "movie" (lowercase) due to case-sensitive string comparison. This fix ensures all tag interactions work regardless of case differences between tag names.

## Testing
- All TypeScript and ESLint checks pass
- Tag filtering now works consistently across different case variations
- No breaking changes to existing functionality

🤖 Generated with [Claude Code](https://claude.ai/code)