### PR TITLE
Add automatic calendar sync trigger to deployment workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -268,11 +268,7 @@ jobs:
           --payload '{"detail-type":"Deployment Sync","source":"github.deployment"}' \
           /tmp/sync-response.json
         
-        echo "Calendar sync triggered successfully"
-        
-        # Optional: Wait a moment and check if sync completed
-        sleep 10
-        echo "Sync should be running in background to refresh cache data"
+        echo "Calendar sync triggered successfully - running in background to refresh cache data"
     
     - name: Notify deployment success
       if: success()

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -258,6 +258,22 @@ jobs:
         echo "  2. CloudFront behavior rules for API paths"
         echo "  3. Lambda function URL configuration"
     
+    - name: Trigger calendar data sync
+      continue-on-error: true
+      run: |
+        echo "Triggering calendar data sync to refresh cache..."
+        aws lambda invoke \
+          --function-name chq-calendar-data-sync \
+          --invocation-type Event \
+          --payload '{"detail-type":"Deployment Sync","source":"github.deployment"}' \
+          /tmp/sync-response.json
+        
+        echo "Calendar sync triggered successfully"
+        
+        # Optional: Wait a moment and check if sync completed
+        sleep 10
+        echo "Sync should be running in background to refresh cache data"
+    
     - name: Notify deployment success
       if: success()
       run: |


### PR DESCRIPTION
## Summary
Adds automatic triggering of the `chq-calendar-data-sync` Lambda function after successful production deployments to ensure fresh calendar cache data is immediately available.

## Changes
- Added "Trigger calendar data sync" step to `.github/workflows/deploy-production.yml`
- Triggers the production Lambda function `chq-calendar-data-sync` asynchronously after deployment
- Uses `continue-on-error: true` to prevent deployment failures if sync has temporary issues
- Sends custom payload to identify deployment-triggered syncs in logs

## Benefits
- **Fresh Data**: Calendar cache is automatically refreshed after each deployment
- **No Manual Steps**: Eliminates need to manually trigger sync after deployments
- **Production Ready**: Uses the same Lambda function that runs on schedule
- **Non-Blocking**: Deployment won't fail if sync encounters temporary issues

## Implementation Details
- Uses `aws lambda invoke` with `--invocation-type Event` for async execution
- Payload includes `"source":"github.deployment"` for log identification
- Runs after successful deployment tests but before final notifications

## Test Plan
- [x] Verify workflow syntax is valid
- [ ] Test on next production deployment
- [ ] Confirm Lambda function is triggered correctly
- [ ] Verify fresh cache data is available post-deployment

🤖 Generated with [Claude Code](https://claude.ai/code)