### PR TITLE
Add auto-deploy trigger on main branch merges

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,6 +1,8 @@
 name: Deploy to Production
 
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       force_deploy:


### PR DESCRIPTION
## Summary
• Configure production deployment workflow to automatically trigger on main branch merges
• Maintains existing manual workflow_dispatch trigger option
• Enables continuous deployment for faster iteration

## Test plan
- [ ] Verify workflow triggers correctly when merged to main
- [ ] Confirm manual dispatch still works as expected
- [ ] Monitor first auto-deployment for any issues

🤖 Generated with [Claude Code](https://claude.ai/code)