### PR TITLE
Sync 'This Week' button with current week selection and highlighting

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -255,15 +255,30 @@ function HomeContent() {
     return eventDate >= oneHourAgo && eventDate <= nextWeek;
   };
 
+  // Get current Chautauqua week number (1-9) or null if not in season
+  const getCurrentChautauquaWeek = () => {
+    const now = new Date();
+    
+    for (let i = 0; i < seasonWeeks.length; i++) {
+      const week = seasonWeeks[i];
+      if (now >= week.start && now <= week.end) {
+        return week.number;
+      }
+    }
+    return null; // Not in season
+  };
+
+  const currentWeekNumber = useMemo(() => getCurrentChautauquaWeek(), [seasonWeeks]);
+
   const isThisWeek = (dateString: string) => {
-    const today = new Date();
     const eventDate = new Date(dateString);
-    const dayOfWeek = today.getDay();
-    const sunday = new Date(today);
-    sunday.setDate(today.getDate() - dayOfWeek - 1);
-    const saturday = new Date(today);
-    saturday.setDate(today.getDate() - dayOfWeek + 6);
-    return eventDate >= sunday && eventDate <= saturday;
+    
+    if (currentWeekNumber === null) {
+      return false; // Not in season
+    }
+    
+    const currentWeek = seasonWeeks[currentWeekNumber - 1];
+    return eventDate >= currentWeek.start && eventDate <= currentWeek.end;
   };
 
   const isInChautauquaWeek = (dateString: string, weekNumber: number) => {
@@ -299,11 +314,19 @@ function HomeContent() {
       console.log('handleWeekMouseDown called for week', weekNum);
     }
 
+    // If clicking the current week, activate "This Week" filter instead
+    if (weekNum === currentWeekNumber) {
+      setDateFilter('this-week');
+      setSelectedWeeks([]);
+      return;
+    }
+
     // Batch state updates to reduce re-renders
     setIsDragging(true);
     setDragStart(weekNum);
     setHasMouseMoved(false);
     setSelectedWeeks([weekNum]);
+    setDateFilter('all'); // Clear date filter when selecting weeks
 
     // Prevent text selection during potential drag
     document.body.style.userSelect = 'none';
@@ -328,13 +351,21 @@ function HomeContent() {
   const handleWeekMouseUp = (weekNum: number) => {
     if (isDragging && dragStart !== null) {
       if (!hasMouseMoved) {
-        // This was a click, not a drag - select only this week
-        setSelectedWeeks([weekNum]);
+        // This was a click, not a drag
+        if (weekNum === currentWeekNumber) {
+          // If clicking the current week, activate "This Week" filter instead
+          setDateFilter('this-week');
+          setSelectedWeeks([]);
+        } else {
+          // Select only this week
+          setSelectedWeeks([weekNum]);
+          setDateFilter('all');
+        }
+      } else {
+        // If hasMouseMoved is true, the selection was already set in handleWeekMouseEnter
+        // Clear date filter when selecting weeks via drag
+        setDateFilter('all');
       }
-      // If hasMouseMoved is true, the selection was already set in handleWeekMouseEnter
-
-      // Clear date filter when selecting weeks
-      setDateFilter('all');
     }
 
     setIsDragging(false);
@@ -346,6 +377,13 @@ function HomeContent() {
 
   // Mobile-friendly tap-to-toggle handler
   const handleWeekTap = (weekNum: number) => {
+    // If clicking the current week, activate "This Week" filter instead
+    if (weekNum === currentWeekNumber) {
+      setDateFilter('this-week');
+      setSelectedWeeks([]);
+      return;
+    }
+
     setSelectedWeeks(prev => {
       const newSelection = prev.includes(weekNum)
         ? prev.filter(w => w !== weekNum) // Remove if already selected
@@ -805,16 +843,18 @@ function HomeContent() {
                   {seasonWeeks.map((week) => {
                     const isPast = isWeekInPast(week.number);
                     const isSelected = selectedWeeks.includes(week.number);
+                    const isCurrent = currentWeekNumber === week.number;
+                    const isCurrentWeekFilterActive = dateFilter === 'this-week' && isCurrent;
                     
                     return (
                       <div
                         key={week.number}
                         className={`w-6 h-6 flex items-center justify-center cursor-pointer border-r border-gray-300 dark:border-gray-600 last:border-r-0 transition-all text-xs flex-shrink-0 ${
                           isPast
-                            ? isSelected
+                            ? isSelected || isCurrentWeekFilterActive
                               ? 'bg-gray-400 dark:bg-gray-500 text-white' // Past and selected
                               : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600' // Past but not selected
-                            : isSelected
+                            : isSelected || isCurrentWeekFilterActive
                             ? 'bg-blue-600 text-white' // Current/future and selected
                             : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700' // Current/future and not selected
                         }`}
@@ -880,7 +920,7 @@ function HomeContent() {
                   }}
                   title="Show events for this week"
                   className={`px-2 py-1 sm:px-4 sm:py-2 rounded-md border transition-all text-xs sm:text-sm whitespace-nowrap ${
-                    dateFilter === 'this-week'
+                    dateFilter === 'this-week' || (currentWeekNumber !== null && selectedWeeks.length === 1 && selectedWeeks[0] === currentWeekNumber)
                       ? 'bg-blue-600 text-white border-blue-600'
                       : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-gray-600'
                   }`}
@@ -899,16 +939,18 @@ function HomeContent() {
                     {seasonWeeks.map((week) => {
                       const isPast = isWeekInPast(week.number);
                       const isSelected = selectedWeeks.includes(week.number);
+                      const isCurrent = currentWeekNumber === week.number;
+                      const isCurrentWeekFilterActive = dateFilter === 'this-week' && isCurrent;
                       
                       return (
                         <div
                           key={week.number}
                           className={`w-8 h-8 flex items-center justify-center cursor-pointer border-r border-gray-300 dark:border-gray-600 last:border-r-0 transition-all text-xs flex-shrink-0 ${
                             isPast
-                              ? isSelected
+                              ? isSelected || isCurrentWeekFilterActive
                                 ? 'bg-gray-400 dark:bg-gray-500 text-white' // Past and selected
                                 : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600' // Past but not selected
-                              : isSelected
+                              : isSelected || isCurrentWeekFilterActive
                               ? 'bg-blue-600 text-white' // Current/future and selected
                               : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700' // Current/future and not selected
                           }`}
@@ -951,16 +993,15 @@ function HomeContent() {
                       });
                       return `Next events after ${timeString}`;
                     } else if (dateFilter === 'this-week') {
-                      const today = new Date();
-                      const dayOfWeek = today.getDay();
-                      const sunday = new Date(today);
-                      sunday.setDate(today.getDate() - dayOfWeek);
-                      const saturday = new Date(today);
-                      saturday.setDate(today.getDate() - dayOfWeek + 6);
-
-                      const sundayStr = sunday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-                      const saturdayStr = saturday.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-                      return `This Week (${sundayStr} - ${saturdayStr})`;
+                      if (currentWeekNumber === null) {
+                        return 'This Week (Not in season)';
+                      }
+                      
+                      const currentWeek = seasonWeeks[currentWeekNumber - 1];
+                      const startStr = currentWeek.start.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                      const endStr = currentWeek.end.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+                      
+                      return `This Week (${startStr} 12pm - ${endStr} 12pm)`;
                     } else if (selectedWeeks.length === 1) {
                       const weekNum = selectedWeeks[0];
                       const week = seasonWeeks[weekNum - 1];

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -100,7 +100,6 @@ function HomeContent() {
   const [availableTags, setAvailableTags] = useState<string[]>([]);
   const [isDragging, setIsDragging] = useState(false);
   const [dragStart, setDragStart] = useState<number | null>(null);
-  const [hasMouseMoved, setHasMouseMoved] = useState(false);
 
   const apiUrl = useMemo(() =>
     process.env.NODE_ENV === 'development'
@@ -256,7 +255,7 @@ function HomeContent() {
   };
 
   // Get current Chautauqua week number (1-9) or null if not in season
-  const getCurrentChautauquaWeek = () => {
+  const currentWeekNumber = useMemo(() => {
     const now = new Date();
     
     for (let i = 0; i < seasonWeeks.length; i++) {
@@ -266,9 +265,7 @@ function HomeContent() {
       }
     }
     return null; // Not in season
-  };
-
-  const currentWeekNumber = useMemo(() => getCurrentChautauquaWeek(), []);
+  }, [seasonWeeks]);
 
   const isThisWeek = (dateString: string) => {
     const eventDate = new Date(dateString);
@@ -309,24 +306,83 @@ function HomeContent() {
   };
 
   // Week selection handlers
-  const handleWeekMouseDown = (weekNum: number) => {
+  const handleWeekMouseDown = (weekNum: number, event: React.MouseEvent) => {
     if (process.env.NODE_ENV === 'development') {
-      console.log('handleWeekMouseDown called for week', weekNum);
+      console.log('handleWeekMouseDown called for week', weekNum, { shift: event.shiftKey, cmd: event.metaKey || event.ctrlKey });
     }
 
-    // If clicking the current week, activate "This Week" filter instead
-    if (weekNum === currentWeekNumber) {
+    // Prevent default to avoid text selection
+    event.preventDefault();
+    
+    // Clear "This Week" filter when selecting weeks (except for current week without modifiers)
+    if (!(weekNum === currentWeekNumber && !event.shiftKey && !event.metaKey && !event.ctrlKey)) {
+      setDateFilter('all');
+    }
+
+    // Handle different click types - modifier keys take precedence over current week logic
+    if (event.metaKey || event.ctrlKey) {
+      // CMD/CTRL-Click: Toggle individual week (including current week)
+      setSelectedWeeks(prev => {
+        return prev.includes(weekNum)
+          ? prev.filter(w => w !== weekNum)
+          : [...prev, weekNum].sort((a, b) => a - b);
+      });
+      setDateFilter('all'); // Always clear "This Week" filter for cmd-click
+      return;
+    }
+
+    if (event.shiftKey && selectedWeeks.length > 0) {
+      // Shift-Click: Extend selection to nearest existing week (including current week)
+      const existingWeeks = [...selectedWeeks].sort((a, b) => a - b);
+      const minExisting = existingWeeks[0];
+      const maxExisting = existingWeeks[existingWeeks.length - 1];
+      
+      const newRange: number[] = [];
+      
+      if (weekNum < minExisting) {
+        // Extend from clicked week to minimum existing week
+        for (let i = weekNum; i <= maxExisting; i++) {
+          newRange.push(i);
+        }
+      } else if (weekNum > maxExisting) {
+        // Extend from minimum existing week to clicked week
+        for (let i = minExisting; i <= weekNum; i++) {
+          newRange.push(i);
+        }
+      } else {
+        // Click is within existing range, extend to nearest boundary
+        const distanceToMin = Math.abs(weekNum - minExisting);
+        const distanceToMax = Math.abs(weekNum - maxExisting);
+        
+        if (distanceToMin <= distanceToMax) {
+          // Extend from clicked week to max
+          for (let i = weekNum; i <= maxExisting; i++) {
+            newRange.push(i);
+          }
+        } else {
+          // Extend from min to clicked week
+          for (let i = minExisting; i <= weekNum; i++) {
+            newRange.push(i);
+          }
+        }
+      }
+      
+      setSelectedWeeks(newRange);
+      setDateFilter('all'); // Always clear "This Week" filter for shift-click
+      return;
+    }
+
+    // If clicking the current week without modifiers, activate "This Week" filter instead
+    if (weekNum === currentWeekNumber && !event.shiftKey && !event.metaKey && !event.ctrlKey) {
       setDateFilter('this-week');
       setSelectedWeeks([]);
       return;
     }
 
-    // Batch state updates to reduce re-renders
+    // Regular click or drag start
     setIsDragging(true);
     setDragStart(weekNum);
-    setHasMouseMoved(false);
     setSelectedWeeks([weekNum]);
-    setDateFilter('all'); // Clear date filter when selecting weeks
 
     // Prevent text selection during potential drag
     document.body.style.userSelect = 'none';
@@ -334,7 +390,6 @@ function HomeContent() {
 
   const handleWeekMouseEnter = (weekNum: number) => {
     if (isDragging && dragStart !== null) {
-      setHasMouseMoved(true);
       const start = Math.min(dragStart, weekNum);
       const end = Math.max(dragStart, weekNum);
       const range = [];
@@ -348,48 +403,34 @@ function HomeContent() {
     }
   };
 
-  const handleWeekMouseUp = (weekNum: number) => {
+  const handleWeekMouseUp = () => {
     if (isDragging && dragStart !== null) {
-      if (!hasMouseMoved) {
-        // This was a click, not a drag
-        if (weekNum === currentWeekNumber) {
-          // If clicking the current week, activate "This Week" filter instead
-          setDateFilter('this-week');
-          setSelectedWeeks([]);
-        } else {
-          // Select only this week
-          setSelectedWeeks([weekNum]);
-          setDateFilter('all');
-        }
-      } else {
-        // If hasMouseMoved is true, the selection was already set in handleWeekMouseEnter
-        // Clear date filter when selecting weeks via drag
-        setDateFilter('all');
-      }
+      // Selection is handled in handleWeekMouseDown and handleWeekMouseEnter
+      // No additional logic needed here for the new interaction modes
     }
 
     setIsDragging(false);
     setDragStart(null);
-    setHasMouseMoved(false);
     // Restore text selection
     document.body.style.userSelect = '';
   };
 
   // Mobile-friendly tap-to-toggle handler
   const handleWeekTap = (weekNum: number) => {
-    // If clicking the current week, activate "This Week" filter instead
-    if (weekNum === currentWeekNumber) {
+    // If tapping the current week and no other weeks selected, activate "This Week" filter
+    if (weekNum === currentWeekNumber && selectedWeeks.length === 0) {
       setDateFilter('this-week');
       setSelectedWeeks([]);
       return;
     }
 
+    // Otherwise, toggle the week in the selection (including current week if already selected)
     setSelectedWeeks(prev => {
       const newSelection = prev.includes(weekNum)
         ? prev.filter(w => w !== weekNum) // Remove if already selected
         : [...prev, weekNum].sort((a, b) => a - b); // Add if not selected
 
-      // Clear date filter when selecting weeks
+      // Clear "This Week" date filter when selecting weeks
       if (newSelection.length > 0) {
         setDateFilter('all');
       }
@@ -772,7 +813,6 @@ function HomeContent() {
       if (isDragging) {
         setIsDragging(false);
         setDragStart(null);
-        setHasMouseMoved(false);
         // Restore text selection
         document.body.style.userSelect = '';
       }
@@ -858,9 +898,9 @@ function HomeContent() {
                             ? 'bg-blue-600 text-white' // Current/future and selected
                             : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700' // Current/future and not selected
                         }`}
-                        onMouseDown={() => handleWeekMouseDown(week.number)}
+                        onMouseDown={(e) => handleWeekMouseDown(week.number, e)}
                         onMouseEnter={() => handleWeekMouseEnter(week.number)}
-                        onMouseUp={() => handleWeekMouseUp(week.number)}
+                        onMouseUp={handleWeekMouseUp}
                         onTouchStart={(e) => {
                           e.preventDefault(); // Prevent mouse events from also firing
                           handleWeekTap(week.number);
@@ -954,9 +994,9 @@ function HomeContent() {
                               ? 'bg-blue-600 text-white' // Current/future and selected
                               : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700' // Current/future and not selected
                           }`}
-                          onMouseDown={() => handleWeekMouseDown(week.number)}
+                          onMouseDown={(e) => handleWeekMouseDown(week.number, e)}
                           onMouseEnter={() => handleWeekMouseEnter(week.number)}
-                          onMouseUp={() => handleWeekMouseUp(week.number)}
+                          onMouseUp={handleWeekMouseUp}
                           onTouchStart={(e) => {
                             e.preventDefault(); // Prevent mouse events from also firing
                             handleWeekTap(week.number);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -268,7 +268,7 @@ function HomeContent() {
     return null; // Not in season
   };
 
-  const currentWeekNumber = useMemo(() => getCurrentChautauquaWeek(), [seasonWeeks]);
+  const currentWeekNumber = useMemo(() => getCurrentChautauquaWeek(), []);
 
   const isThisWeek = (dateString: string) => {
     const eventDate = new Date(dateString);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -267,6 +267,17 @@ function HomeContent() {
     return null; // Not in season
   }, [seasonWeeks]);
 
+  // Helper functions for UI state
+  const isThisWeekButtonActive = () => {
+    return dateFilter === 'this-week' || (currentWeekNumber !== null && selectedWeeks.length === 1 && selectedWeeks[0] === currentWeekNumber);
+  };
+
+  const isWeekHighlighted = (weekNumber: number, isSelected: boolean) => {
+    const isCurrent = currentWeekNumber === weekNumber;
+    const isCurrentWeekFilterActive = dateFilter === 'this-week' && isCurrent;
+    return isSelected || isCurrentWeekFilterActive;
+  };
+
   const isThisWeek = (dateString: string) => {
     const eventDate = new Date(dateString);
     
@@ -883,18 +894,17 @@ function HomeContent() {
                   {seasonWeeks.map((week) => {
                     const isPast = isWeekInPast(week.number);
                     const isSelected = selectedWeeks.includes(week.number);
-                    const isCurrent = currentWeekNumber === week.number;
-                    const isCurrentWeekFilterActive = dateFilter === 'this-week' && isCurrent;
+                    const isHighlighted = isWeekHighlighted(week.number, isSelected);
                     
                     return (
                       <div
                         key={week.number}
                         className={`w-6 h-6 flex items-center justify-center cursor-pointer border-r border-gray-300 dark:border-gray-600 last:border-r-0 transition-all text-xs flex-shrink-0 ${
                           isPast
-                            ? isSelected || isCurrentWeekFilterActive
+                            ? isHighlighted
                               ? 'bg-gray-400 dark:bg-gray-500 text-white' // Past and selected
                               : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600' // Past but not selected
-                            : isSelected || isCurrentWeekFilterActive
+                            : isHighlighted
                             ? 'bg-blue-600 text-white' // Current/future and selected
                             : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700' // Current/future and not selected
                         }`}
@@ -960,7 +970,7 @@ function HomeContent() {
                   }}
                   title="Show events for this week"
                   className={`px-2 py-1 sm:px-4 sm:py-2 rounded-md border transition-all text-xs sm:text-sm whitespace-nowrap ${
-                    dateFilter === 'this-week' || (currentWeekNumber !== null && selectedWeeks.length === 1 && selectedWeeks[0] === currentWeekNumber)
+                    isThisWeekButtonActive()
                       ? 'bg-blue-600 text-white border-blue-600'
                       : 'bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-gray-600'
                   }`}
@@ -979,18 +989,17 @@ function HomeContent() {
                     {seasonWeeks.map((week) => {
                       const isPast = isWeekInPast(week.number);
                       const isSelected = selectedWeeks.includes(week.number);
-                      const isCurrent = currentWeekNumber === week.number;
-                      const isCurrentWeekFilterActive = dateFilter === 'this-week' && isCurrent;
+                      const isHighlighted = isWeekHighlighted(week.number, isSelected);
                       
                       return (
                         <div
                           key={week.number}
                           className={`w-8 h-8 flex items-center justify-center cursor-pointer border-r border-gray-300 dark:border-gray-600 last:border-r-0 transition-all text-xs flex-shrink-0 ${
                             isPast
-                              ? isSelected || isCurrentWeekFilterActive
+                              ? isHighlighted
                                 ? 'bg-gray-400 dark:bg-gray-500 text-white' // Past and selected
                                 : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600' // Past but not selected
-                              : isSelected || isCurrentWeekFilterActive
+                              : isHighlighted
                               ? 'bg-blue-600 text-white' // Current/future and selected
                               : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700' // Current/future and not selected
                           }`}


### PR DESCRIPTION
## Summary
• Update 'This Week' filter to use Saturday noon to Saturday noon week boundaries (matching Chautauqua week definitions)
• Add mutual highlighting between 'This Week' button and current week number button
• Improve user experience with intuitive week selection behavior

## Changes Made
• Modified `isThisWeek()` function to use Chautauqua season weeks instead of Sunday-Saturday calendar weeks
• Added `getCurrentChautauquaWeek()` function to detect current week number (1-9) or null if not in season
• Updated 'This Week' button highlighting to activate when current week is selected via week number
• Updated current week number button highlighting to activate when 'This Week' filter is active
• Modified week selection handlers: clicking current week number now activates 'This Week' filter
• Updated display text to show consistent Saturday noon boundaries

## Behavior
- **When 'This Week' is clicked**: Shows events for current Chautauqua week (Saturday noon to Saturday noon), both buttons highlight
- **When current week number is clicked**: Activates 'This Week' filter instead of week selection, both buttons highlight  
- **When other week numbers are clicked**: Normal week selection behavior, 'This Week' not highlighted
- **When multiple weeks selected**: 'This Week' not highlighted (filter doesn't exactly match current week)

## Test Plan
- [ ] Verify 'This Week' uses Saturday noon boundaries matching week number definitions
- [ ] Test mutual highlighting between 'This Week' and current week number buttons
- [ ] Confirm clicking current week number activates 'This Week' filter 
- [ ] Test that 'This Week' only highlights when selection exactly matches current week
- [ ] Verify behavior outside Chautauqua season (should show "Not in season")

🤖 Generated with [Claude Code](https://claude.ai/code)