### PR TITLE
Fix deployment scripts to preserve cache directory and add proper cache headers

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -199,16 +199,18 @@ jobs:
       - name: Deploy frontend to S3 and CloudFront
         working-directory: ./frontend
         run: |
-          # Sync to S3 bucket
+          # Sync to S3 bucket (exclude cache directory to preserve backend-generated cache files)
           aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
             --delete \
+            --exclude "cache/*" \
             --exclude "*.map" \
             --cache-control "public, max-age=31536000, immutable" \
             --metadata-directive REPLACE
 
-          # Update HTML files with shorter cache
+          # Update HTML files with shorter cache (also exclude cache directory)
           aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
             --exclude "*" \
+            --exclude "cache/*" \
             --include "*.html" \
             --cache-control "public, max-age=3600" \
             --metadata-directive REPLACE

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -152,9 +152,27 @@ else
     # Build
     npm run build
 
-    # Upload to S3
+    # Upload to S3 with proper cache headers and cache directory exclusion
     if [ -d "out" ]; then
-        aws s3 sync out/ s3://$S3_BUCKET --delete
+        print_status "Syncing frontend to S3 with optimized cache headers..."
+        
+        # Sync all files except source maps and HTML with long cache
+        aws s3 sync out/ s3://$S3_BUCKET/ \
+            --delete \
+            --exclude "cache/*" \
+            --exclude "*.map" \
+            --cache-control "public, max-age=31536000, immutable" \
+            --metadata-directive REPLACE
+
+        # Update HTML files with shorter cache
+        aws s3 sync out/ s3://$S3_BUCKET/ \
+            --exclude "*" \
+            --exclude "cache/*" \
+            --include "*.html" \
+            --cache-control "public, max-age=3600" \
+            --metadata-directive REPLACE
+            
+        print_success "Frontend synced to S3 (cache directory preserved)"
     else
         print_error "Frontend build output not found"
         exit 1


### PR DESCRIPTION
## Summary
• Prevent frontend deployments from overwriting backend cache files
• Add proper cache headers for optimal performance
• Ensure consistency between manual and automated deployments

## Problem
The deployment scripts were inconsistent:
- `deploy.sh` used basic S3 sync without cache headers or exclusions
- GitHub Actions had proper cache headers but no cache directory protection
- Risk of overwriting backend-generated cache files in `s3://<bucket>/cache/`

## Solution

### Updated `deploy.sh`:
```bash
# Added proper cache headers and cache exclusion
aws s3 sync out/ s3://$S3_BUCKET/ \
    --delete \
    --exclude "cache/*" \
    --exclude "*.map" \
    --cache-control "public, max-age=31536000, immutable" \
    --metadata-directive REPLACE
```

### Updated `deploy-production.yml`:
```bash
# Added cache directory exclusion
aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
    --delete \
    --exclude "cache/*" \
    --exclude "*.map" \
    ...
```

## Benefits
- ✅ Cache directory (`cache/*`) is preserved during deployments
- ✅ Frontend assets get 1-year cache headers (immutable)
- ✅ HTML files get 1-hour cache for faster updates
- ✅ Consistent behavior between manual and CI/CD deployments
- ✅ No risk of deleting backend-generated cache files

## Testing
- [ ] Manual deployment with `deploy.sh` preserves cache directory
- [ ] GitHub Actions deployment preserves cache directory
- [ ] Cache headers are properly set on deployed files
- [ ] Backend cache files remain intact after deployment

🤖 Generated with [Claude Code](https://claude.ai/code)