### PR TITLE
Sort filter lists by display names for better UX

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1025,8 +1025,18 @@ function HomeContent() {
           }
         }
 
-        const sortedCategories = categories.sort();
-        const sortedLocations = locations.sort();
+        // Sort categories and locations by their display names (shortcuts), not original names
+        const sortedCategories = categories.sort((a, b) => {
+          const displayA = getCategoryDisplayName(a);
+          const displayB = getCategoryDisplayName(b);
+          return displayA.localeCompare(displayB);
+        });
+        
+        const sortedLocations = locations.sort((a, b) => {
+          const displayA = getLocationDisplayName(a);
+          const displayB = getLocationDisplayName(b);
+          return displayA.localeCompare(displayB);
+        });
         const sortedTags = uniqueTags.sort();
         const weeks = seasonWeeks.map(w => w.number);
 
@@ -1050,7 +1060,7 @@ function HomeContent() {
           localStorage.setItem('chq-calendar-events', JSON.stringify({
             events: fetchedEvents,
             categories: sortedCategories,
-            locations: locations.sort(),
+            locations: sortedLocations,
             tags: sortedTags,
             weeks: weeks,
             timestamp: Date.now(),


### PR DESCRIPTION
## Summary
Updates the sorting logic for location and category filter lists to sort by their display names (shortcuts) instead of the original full names. This improves user experience by making the alphabetical ordering match what users actually see in the interface.

## Changes Made
- Modified the sorting logic in `frontend/src/app/page.tsx`
- Categories now sort by their shortcuts (e.g., "CSO" instead of "Chautauqua Symphony Orchestra")
- Locations now sort by their shortcuts (e.g., "Lenna Hall" instead of "Elizabeth S. Lenna Hall")
- Used existing `getCategoryDisplayName()` and `getLocationDisplayName()` helper functions

## Examples

### Before (sorted by full names):
**Locations:**
- AAHH African American Heritage House
- Amphitheater
- Elizabeth S. Lenna Hall
- Fletcher Music Hall

**Categories:**
- Chautauqua Institution Program
- Chautauqua Literary and Scientific Circle (CLSC)
- Chautauqua Symphony Orchestra/Classical Concerts

### After (sorted by display names):
**Locations:**
- AAHH (from "AAHH African American Heritage House")
- Amphitheater
- Fletcher Hall (from "Fletcher Music Hall")
- Lenna Hall (from "Elizabeth S. Lenna Hall")

**Categories:**
- CHQ Program (from "Chautauqua Institution Program")
- CLSC (from "Chautauqua Literary and Scientific Circle")
- CSO (from "Chautauqua Symphony Orchestra/Classical Concerts")

## Test Plan
- [x] Verify location filter list is sorted alphabetically by display names
- [x] Verify category filter list is sorted alphabetically by display names
- [x] Confirm items without shortcuts still sort correctly
- [x] Test that filtering functionality still works as expected
- [x] Check that the actual filtering logic is unaffected (only display order changed)

## User Impact
✅ **Improved UX**: Filter lists are now intuitively alphabetized by what users see
✅ **No Breaking Changes**: All existing functionality remains intact
✅ **Better Discoverability**: Easier to find items in alphabetized lists

🤖 Generated with [Claude Code](https://claude.ai/code)