### PR TITLE
fix: set VITE_API_URL to empty string in CI deploy workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Build frontend
         run: npm run build --workspace=frontend
         env:
-          VITE_API_URL: https://www.chqcal.org/api
+          VITE_API_URL: ""
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
 
       - name: Deploy calendar Lambda function


### PR DESCRIPTION
## Summary

- Fix feedback POST returning 403 by eliminating double `/api` prefix (`/api/api/feedback`)
- Fix admin Google OAuth login returning 403 by routing `/auth/google` to the correct CloudFront behavior
- Root cause: `VITE_API_URL` was set to `https://www.chqcal.org/api` in CI, a leftover from the Next.js → Vite migration that was never updated

## Details

CloudFront uses path-based behaviors to route requests:
- `/api/*` → Main API Gateway (strips `/api` prefix)
- `/auth/*` → Admin API Gateway
- `/admin/api/*` → Admin API Gateway (strips `/admin/api` prefix)

With `VITE_API_URL=https://www.chqcal.org/api`, the frontend constructed:
- Feedback: `https://www.chqcal.org/api` + `/api/feedback` = `/api/api/feedback` → 403
- Auth: `https://www.chqcal.org/api` + `/auth/google` = `/api/auth/google` → matched `/api/*` instead of `/auth/*` → wrong API Gateway → 403

Setting `VITE_API_URL=""` (matching `scripts/deploy.sh`) lets CloudFront handle routing correctly.

## Test plan

- [ ] Deploy and verify POST to `/api/feedback` returns 200 (not 403)
- [ ] Deploy and verify GET to `/auth/google` redirects to Google OAuth (not 403)
- [ ] Verify admin feedback dashboard loads after login
- [ ] Verify calendar data and ICS endpoints still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)