### PR TITLE
fix: remove CI Lambda env var overrides to prevent Terraform drift

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -126,11 +126,8 @@ jobs:
           aws lambda wait function-updated \
             --function-name ${{ secrets.LAMBDA_FUNCTION_NAME }}
 
-          # Update environment variables for calendar Lambda
-          echo '{"Variables":{"NODE_ENV":"production","ENVIRONMENT":"prod","DYNAMODB_REGION":"${{ secrets.AWS_REGION }}","EVENTS_TABLE_NAME":"${{ secrets.EVENTS_TABLE_NAME }}","DATA_SOURCES_TABLE_NAME":"${{ secrets.DATA_SOURCES_TABLE_NAME }}","FEEDBACK_TABLE_NAME":"${{ secrets.FEEDBACK_TABLE_NAME }}","RECAPTCHA_SECRET_KEY":"${{ secrets.RECAPTCHA_SECRET_KEY }}","USE_NEW_API":"true","CACHE_S3_BUCKET":"${{ secrets.CACHE_S3_BUCKET }}","CACHE_MEMORY_TTL_MINUTES":"60","CACHE_S3_TTL_MINUTES":"60","CACHE_S3_KEY_PREFIX":"calendar-cache"}}' > env.json
-          aws lambda update-function-configuration \
-            --function-name ${{ secrets.LAMBDA_FUNCTION_NAME }} \
-            --environment file://env.json
+          # Environment variables are managed by Terraform — do not set them here
+          # to avoid drift between CI and infrastructure-as-code.
 
           # Clean up
           rm -rf package_temp lambda-calendar.zip
@@ -187,14 +184,11 @@ jobs:
           aws lambda wait function-updated \
             --function-name ${{ secrets.ADMIN_LAMBDA_FUNCTION_NAME }}
 
-          # Update environment variables for admin Lambda
-          echo '{"Variables":{"NODE_ENV":"production","ENVIRONMENT":"prod","FEEDBACK_TABLE_NAME":"${{ secrets.FEEDBACK_TABLE_NAME }}","NEXTAUTH_SECRET":"${{ secrets.NEXTAUTH_SECRET }}","JWT_SECRET":"${{ secrets.NEXTAUTH_SECRET }}","GOOGLE_CLIENT_ID":"${{ secrets.GOOGLE_CLIENT_ID }}","GOOGLE_CLIENT_SECRET":"${{ secrets.GOOGLE_CLIENT_SECRET }}","ADMIN_EMAIL_WHITELIST":"${{ secrets.ADMIN_EMAIL_WHITELIST }}","ADMIN_API_URL":"https://admin-api.chqcal.org"}}' > admin-env.json
-          aws lambda update-function-configuration \
-            --function-name ${{ secrets.ADMIN_LAMBDA_FUNCTION_NAME }} \
-            --environment file://admin-env.json
+          # Environment variables are managed by Terraform — do not set them here
+          # to avoid drift between CI and infrastructure-as-code.
 
           # Clean up
-          rm -rf package_temp lambda-admin.zip admin-env.json
+          rm -rf package_temp lambda-admin.zip
 
       - name: Deploy sync Lambda functions
         working-directory: ./backend


### PR DESCRIPTION
## Summary

- Remove `update-function-configuration` calls from CI deploy workflow for calendar and admin Lambdas
- Terraform is the single source of truth for Lambda environment variables; CI now only deploys code
- Eliminates drift that caused `terraform apply` to show unexpected changes after every CI deploy

## Details

The CI workflow was calling `aws lambda update-function-configuration` to set env vars, which **replaces ALL env vars** on the Lambda. This conflicted with Terraform in two ways:

**Extra vars set by CI (not in Terraform):**
- `NODE_ENV` — redundant, `ENVIRONMENT=prod` covers the same check
- `NEXTAUTH_SECRET` — dead variable, only `JWT_SECRET` is used
- `DYNAMODB_REGION` — only used in local dev scripts, not Lambda handlers

**Vars removed by CI (managed by Terraform):**
- `SYNC_STATUS_TABLE_NAME` — needed by calendar Lambda
- `CACHE_S3_BUCKET` — CI secret may differ from Terraform-managed bucket name

After this change, CI only runs `update-function-code` (deploys the zip), and Terraform exclusively manages env vars via `aws_lambda_function.environment`.

**Important:** After merging, run `terraform apply` from `infrastructure/` to restore the correct env vars on both Lambdas.

## Test plan

- [ ] Verify CI deploy completes successfully (code-only deploy)
- [ ] Run `terraform apply` — should show no drift after a clean apply
- [ ] Verify feedback POST works with correct RECAPTCHA env vars
- [ ] Verify admin OAuth login works with correct JWT_SECRET

🤖 Generated with [Claude Code](https://claude.com/claude-code)