### PR TITLE
fix(ci): pass raw JSON to aws lambda invoke (post-deploy sync)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -318,9 +318,12 @@ jobs:
         continue-on-error: true
         run: |
           echo "Triggering calendar data sync to refresh cache..."
+          # AWS CLI v2 expects base64 payloads by default; --cli-binary-format
+          # raw-in-base64-out lets us keep passing the JSON literal.
           aws lambda invoke \
             --function-name chq-calendar-data-sync \
             --invocation-type Event \
+            --cli-binary-format raw-in-base64-out \
             --payload '{"source":"chq-calendar.deployment","detail-type":"Weekly Full Sync"}' \
             /tmp/sync-response.json
 


### PR DESCRIPTION
## Summary

The post-deploy "Trigger calendar data sync" step in `deploy-production.yml` has been silently failing on every deploy with `Invalid base64: {"source":...}`. AWS CLI v2 base64-decodes `--payload` by default; passing `--cli-binary-format raw-in-base64-out` restores the v1 behavior of accepting raw JSON.

The step has `continue-on-error: true` so deploys still report success, and the EventBridge-scheduled hourly sync still runs — so this is a freshness-lag fix, not an outage fix. Symptom: cache wasn't getting an immediate refresh after deploys, only on the next hourly tick.

## Test plan

- [ ] After merge, watch the next deploy and confirm the "Trigger calendar data sync" step succeeds
- [ ] Confirm `last-modified` on `https://www.chqcal.org/cache/calendar-cache/all-events-2026.json` updates within a couple minutes of deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)