### PR TITLE
fix(publisher): resolve venueId to location in sidecar

### DIFF
--- a/backend/src/__tests__/publisherSidecarPublisher.test.ts
+++ b/backend/src/__tests__/publisherSidecarPublisher.test.ts
@@ -113,4 +113,73 @@ describe('PublisherSidecarPublisher', () => {
     const deletes = mockSend.mock.calls.filter(c => c[0] instanceof DeleteObjectCommand);
     expect(deletes).toHaveLength(3);
   });
+
+  describe('venue resolution', () => {
+    const venueEvent = (overrides: Record<string, unknown> = {}): StoredPublisherEvent => ({
+      ...ev('venue-evt', 2026, 'published'),
+      payload: {
+        id: 'venue-evt',
+        title: 'Venue Evt',
+        startDate: '2026-07-04T18:00:00-04:00',
+        endDate: '2026-07-04T19:00:00-04:00',
+        category: 'Lecture',
+        lastModified: 't',
+        sourcePublisherId: 'p',
+        sourcePublisherName: 'P',
+        venueId: 'hall-of-philosophy',
+        ...overrides,
+      } as any,
+    });
+
+    function getPayload(): any {
+      const putCall = mockSend.mock.calls.find(c => c[0] instanceof PutObjectCommand);
+      const body = JSON.parse((putCall![0] as any).input.Body as string);
+      return body.data[0];
+    }
+
+    it('resolves venueId to location and venue when a lookup is provided', async () => {
+      mockListReturns();
+      const venuesById = new Map([
+        ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy', address: '34 South Ave' }],
+      ]);
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', venuesById);
+      await pub.publish([venueEvent()]);
+      const p = getPayload();
+      expect(p.location).toBe('Hall of Philosophy');
+      expect(p.venue).toEqual({ name: 'Hall of Philosophy', address: '34 South Ave' });
+    });
+
+    it('leaves payload unchanged when venueId is unknown', async () => {
+      mockListReturns();
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', new Map());
+      await pub.publish([venueEvent({ venueId: 'unknown-venue' })]);
+      const p = getPayload();
+      expect(p.location).toBeUndefined();
+      expect(p.venue).toBeUndefined();
+    });
+
+    it('does not overwrite an explicit publisher-supplied location', async () => {
+      mockListReturns();
+      const venuesById = new Map([
+        ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy' }],
+      ]);
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', venuesById);
+      await pub.publish([venueEvent({ location: 'Custom Location Override' })]);
+      const p = getPayload();
+      expect(p.location).toBe('Custom Location Override');
+      // venue object still gets attached
+      expect(p.venue).toEqual({ name: 'Hall of Philosophy' });
+    });
+
+    it('omits venue.address when the lookup has no address', async () => {
+      mockListReturns();
+      const venuesById = new Map([
+        ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy' }],
+      ]);
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', venuesById);
+      await pub.publish([venueEvent()]);
+      const p = getPayload();
+      expect(p.venue).toEqual({ name: 'Hall of Philosophy' });
+    });
+  });
 });

--- a/backend/src/__tests__/publisherSidecarPublisher.test.ts
+++ b/backend/src/__tests__/publisherSidecarPublisher.test.ts
@@ -236,7 +236,7 @@ describe('PublisherSidecarPublisher', () => {
       expect(p.categories).toBeUndefined();
     });
 
-    it('passes through events with no venueId unchanged', async () => {
+    it('omits location and venue when venueId is absent', async () => {
       mockListReturns();
       const venuesById = new Map([
         ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy' }],

--- a/backend/src/__tests__/publisherSidecarPublisher.test.ts
+++ b/backend/src/__tests__/publisherSidecarPublisher.test.ts
@@ -181,5 +181,37 @@ describe('PublisherSidecarPublisher', () => {
       const p = getPayload();
       expect(p.venue).toEqual({ name: 'Hall of Philosophy' });
     });
+
+    it('preserves publisher-supplied venue fields (e.g. url) when merging the lookup', async () => {
+      mockListReturns();
+      const venuesById = new Map([
+        ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy', address: '34 South Ave' }],
+      ]);
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', venuesById);
+      await pub.publish([
+        venueEvent({
+          venue: { name: 'Custom Hall', url: 'https://example.com/hall' },
+        }),
+      ]);
+      const p = getPayload();
+      // Publisher's venue.name + url survive; address is supplied by the lookup.
+      expect(p.venue).toEqual({
+        name: 'Custom Hall',
+        url: 'https://example.com/hall',
+        address: '34 South Ave',
+      });
+    });
+
+    it('passes through events with no venueId unchanged', async () => {
+      mockListReturns();
+      const venuesById = new Map([
+        ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy' }],
+      ]);
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', venuesById);
+      await pub.publish([venueEvent({ venueId: undefined })]);
+      const p = getPayload();
+      expect(p.location).toBeUndefined();
+      expect(p.venue).toBeUndefined();
+    });
   });
 });

--- a/backend/src/__tests__/publisherSidecarPublisher.test.ts
+++ b/backend/src/__tests__/publisherSidecarPublisher.test.ts
@@ -202,6 +202,40 @@ describe('PublisherSidecarPublisher', () => {
       });
     });
 
+    it('promotes singular category string to categories array for the frontend', async () => {
+      mockListReturns();
+      const venuesById = new Map([
+        ['hall-of-philosophy', { id: 'hall-of-philosophy', name: 'Hall of Philosophy' }],
+      ]);
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', venuesById);
+      await pub.publish([venueEvent({ category: 'Special Lectures' })]);
+      const p = getPayload();
+      expect(p.categories).toEqual([{ name: 'Special Lectures' }]);
+      // Original singular category is preserved too.
+      expect(p.category).toBe('Special Lectures');
+    });
+
+    it('does not overwrite an explicit publisher-supplied categories array', async () => {
+      mockListReturns();
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', new Map());
+      await pub.publish([
+        venueEvent({
+          category: 'Lecture',
+          categories: [{ name: 'Custom A' }, { name: 'Custom B' }],
+        } as any),
+      ]);
+      const p = getPayload();
+      expect(p.categories).toEqual([{ name: 'Custom A' }, { name: 'Custom B' }]);
+    });
+
+    it('skips categories promotion when category is empty', async () => {
+      mockListReturns();
+      const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache', new Map());
+      await pub.publish([venueEvent({ category: '' })]);
+      const p = getPayload();
+      expect(p.categories).toBeUndefined();
+    });
+
     it('passes through events with no venueId unchanged', async () => {
       mockListReturns();
       const venuesById = new Map([

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -1,9 +1,10 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { S3Client } from '@aws-sdk/client-s3';
+import { loadReferences } from '@chq-calendar/publisher-format';
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherEventStore } from '../services/publisherEventStore';
-import { PublisherSidecarPublisher } from '../services/publisherSidecarPublisher';
+import { PublisherSidecarPublisher, type VenueLookup } from '../services/publisherSidecarPublisher';
 import { fetchAndParseFeed } from '../services/publisherFeedFetcher';
 import { reconcile } from '../services/publisherReconciler';
 
@@ -68,6 +69,8 @@ export async function runIngest(deps: IngestDeps): Promise<void> {
 
 export async function scheduledHandler(): Promise<void> {
   const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+  const refs = loadReferences();
+  const venuesById = new Map<string, VenueLookup>(refs.venues.map(v => [v.id, v]));
   await runIngest({
     registry: new PublisherRegistryService(ddb, process.env.PUBLISHERS_TABLE_NAME!),
     store: new PublisherEventStore(ddb, process.env.PUBLISHER_EVENTS_TABLE_NAME!),
@@ -75,6 +78,7 @@ export async function scheduledHandler(): Promise<void> {
       new S3Client({}),
       process.env.CACHE_S3_BUCKET!,
       process.env.CACHE_S3_KEY_PREFIX!,
+      venuesById,
     ),
     fetcher: fetchAndParseFeed,
     now: new Date(),

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -1,10 +1,10 @@
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { S3Client } from '@aws-sdk/client-s3';
-import { loadReferences } from '@chq-calendar/publisher-format';
+import { loadReferences, type VenueReference } from '@chq-calendar/publisher-format';
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherEventStore } from '../services/publisherEventStore';
-import { PublisherSidecarPublisher, type VenueLookup } from '../services/publisherSidecarPublisher';
+import { PublisherSidecarPublisher } from '../services/publisherSidecarPublisher';
 import { fetchAndParseFeed } from '../services/publisherFeedFetcher';
 import { reconcile } from '../services/publisherReconciler';
 
@@ -69,8 +69,16 @@ export async function runIngest(deps: IngestDeps): Promise<void> {
 
 export async function scheduledHandler(): Promise<void> {
   const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
-  const refs = loadReferences();
-  const venuesById = new Map<string, VenueLookup>(refs.venues.map(v => [v.id, v]));
+  // Don't let a missing/malformed refs bundle take down the whole Lambda —
+  // unknown venueIds already gracefully pass through unchanged in the
+  // sidecar publisher. Worst case: events render with venueId but no name.
+  let venuesById = new Map<string, VenueReference>();
+  try {
+    const refs = loadReferences();
+    venuesById = new Map(refs.venues.map(v => [v.id, v]));
+  } catch (err) {
+    console.warn('[publisher-ingest] failed to load venue refs, venue enrichment disabled:', err);
+  }
   await runIngest({
     registry: new PublisherRegistryService(ddb, process.env.PUBLISHERS_TABLE_NAME!),
     store: new PublisherEventStore(ddb, process.env.PUBLISHER_EVENTS_TABLE_NAME!),

--- a/backend/src/services/publisherSidecarPublisher.ts
+++ b/backend/src/services/publisherSidecarPublisher.ts
@@ -92,11 +92,10 @@ export class PublisherSidecarPublisher {
     // in EventCard, and search-tag set all read `event.categories`.
     // Without this, publisher events were absent from category filters
     // and rendered without category badges in the expanded card.
-    const existingCategories = (enriched as { categories?: unknown }).categories;
     if (
       typeof payload.category === 'string' &&
       payload.category.length > 0 &&
-      (!Array.isArray(existingCategories) || existingCategories.length === 0)
+      (!Array.isArray(enriched.categories) || enriched.categories.length === 0)
     ) {
       enriched.categories = [{ name: payload.category }];
     }

--- a/backend/src/services/publisherSidecarPublisher.ts
+++ b/backend/src/services/publisherSidecarPublisher.ts
@@ -4,15 +4,10 @@ import {
   PutObjectCommand,
   type S3Client,
 } from '@aws-sdk/client-s3';
+import type { VenueReference } from '@chq-calendar/publisher-format';
 import type { StoredPublisherEvent } from '../types/publisher';
 
 const SIDECAR_KEY_PATTERN = /\/publisher-events-(\d{4})\.json$/;
-
-export interface VenueLookup {
-  id: string;
-  name: string;
-  address?: string;
-}
 
 export class PublisherSidecarPublisher {
   constructor(
@@ -23,9 +18,10 @@ export class PublisherSidecarPublisher {
      * Optional venue lookup. When provided, payloads with a `venueId` get a
      * resolved `location` (and `venue.name`/`venue.address`) added so the
      * frontend's location filter and EventCard rendering work without
-     * publisher-aware code paths.
+     * publisher-aware code paths. Publisher-supplied `location` and `venue`
+     * fields are merged with the lookup, never overwritten.
      */
-    private readonly venuesById: Map<string, VenueLookup> = new Map(),
+    private readonly venuesById: Map<string, VenueReference> = new Map(),
   ) {}
 
   async publish(events: StoredPublisherEvent[]): Promise<void> {
@@ -65,20 +61,22 @@ export class PublisherSidecarPublisher {
     return `${this.keyPrefix}/publisher-events-${year}.json`;
   }
 
-  private enrichPayload(payload: StoredPublisherEvent['payload']): Record<string, unknown> {
-    const p = payload as unknown as Record<string, unknown>;
-    const venueId = typeof p.venueId === 'string' ? p.venueId : undefined;
-    if (!venueId) return p;
+  private enrichPayload(payload: StoredPublisherEvent['payload']): StoredPublisherEvent['payload'] {
+    const venueId = payload.venueId;
+    if (!venueId) return payload;
     const venue = this.venuesById.get(venueId);
-    if (!venue) return p;
-    const enriched: Record<string, unknown> = { ...p };
+    if (!venue) return payload;
+    const enriched: StoredPublisherEvent['payload'] & { location?: string } = { ...payload };
     // Don't overwrite a location the publisher explicitly supplied.
     if (typeof enriched.location !== 'string' || enriched.location.length === 0) {
       enriched.location = venue.name;
     }
+    // Merge venue rather than replace — preserves publisher-supplied url
+    // and any future fields on VenueRef.
     enriched.venue = {
-      name: venue.name,
-      ...(venue.address ? { address: venue.address } : {}),
+      ...(enriched.venue ?? {}),
+      name: enriched.venue?.name ?? venue.name,
+      ...(venue.address && !enriched.venue?.address ? { address: venue.address } : {}),
     };
     return enriched;
   }

--- a/backend/src/services/publisherSidecarPublisher.ts
+++ b/backend/src/services/publisherSidecarPublisher.ts
@@ -8,11 +8,24 @@ import type { StoredPublisherEvent } from '../types/publisher';
 
 const SIDECAR_KEY_PATTERN = /\/publisher-events-(\d{4})\.json$/;
 
+export interface VenueLookup {
+  id: string;
+  name: string;
+  address?: string;
+}
+
 export class PublisherSidecarPublisher {
   constructor(
     private readonly s3: S3Client,
     private readonly bucket: string,
     private readonly keyPrefix: string,
+    /**
+     * Optional venue lookup. When provided, payloads with a `venueId` get a
+     * resolved `location` (and `venue.name`/`venue.address`) added so the
+     * frontend's location filter and EventCard rendering work without
+     * publisher-aware code paths.
+     */
+    private readonly venuesById: Map<string, VenueLookup> = new Map(),
   ) {}
 
   async publish(events: StoredPublisherEvent[]): Promise<void> {
@@ -28,7 +41,7 @@ export class PublisherSidecarPublisher {
     const existingYears = await this.listExistingSidecarYears();
 
     for (const [year, group] of byYear) {
-      const body = JSON.stringify({ data: group.map(g => g.payload) });
+      const body = JSON.stringify({ data: group.map(g => this.enrichPayload(g.payload)) });
       await this.s3.send(new PutObjectCommand({
         Bucket: this.bucket,
         Key: this.keyForYear(year),
@@ -50,6 +63,24 @@ export class PublisherSidecarPublisher {
 
   private keyForYear(year: number): string {
     return `${this.keyPrefix}/publisher-events-${year}.json`;
+  }
+
+  private enrichPayload(payload: StoredPublisherEvent['payload']): Record<string, unknown> {
+    const p = payload as unknown as Record<string, unknown>;
+    const venueId = typeof p.venueId === 'string' ? p.venueId : undefined;
+    if (!venueId) return p;
+    const venue = this.venuesById.get(venueId);
+    if (!venue) return p;
+    const enriched: Record<string, unknown> = { ...p };
+    // Don't overwrite a location the publisher explicitly supplied.
+    if (typeof enriched.location !== 'string' || enriched.location.length === 0) {
+      enriched.location = venue.name;
+    }
+    enriched.venue = {
+      name: venue.name,
+      ...(venue.address ? { address: venue.address } : {}),
+    };
+    return enriched;
   }
 
   private async listExistingSidecarYears(): Promise<Set<number>> {

--- a/backend/src/services/publisherSidecarPublisher.ts
+++ b/backend/src/services/publisherSidecarPublisher.ts
@@ -61,23 +61,46 @@ export class PublisherSidecarPublisher {
     return `${this.keyPrefix}/publisher-events-${year}.json`;
   }
 
-  private enrichPayload(payload: StoredPublisherEvent['payload']): StoredPublisherEvent['payload'] {
+  private enrichPayload(
+    payload: StoredPublisherEvent['payload'],
+  ): StoredPublisherEvent['payload'] & { location?: string; categories?: Array<{ name: string }> } {
+    const enriched: StoredPublisherEvent['payload'] & {
+      location?: string;
+      categories?: Array<{ name: string }>;
+    } = { ...payload };
+
+    // Resolve venueId → location + venue when a lookup entry exists.
     const venueId = payload.venueId;
-    if (!venueId) return payload;
-    const venue = this.venuesById.get(venueId);
-    if (!venue) return payload;
-    const enriched: StoredPublisherEvent['payload'] & { location?: string } = { ...payload };
-    // Don't overwrite a location the publisher explicitly supplied.
-    if (typeof enriched.location !== 'string' || enriched.location.length === 0) {
-      enriched.location = venue.name;
+    if (venueId) {
+      const venue = this.venuesById.get(venueId);
+      if (venue) {
+        if (typeof enriched.location !== 'string' || enriched.location.length === 0) {
+          enriched.location = venue.name;
+        }
+        // Merge venue rather than replace — preserves publisher-supplied url
+        // and any future fields on VenueRef.
+        enriched.venue = {
+          ...(enriched.venue ?? {}),
+          name: enriched.venue?.name ?? venue.name,
+          ...(venue.address && !enriched.venue?.address ? { address: venue.address } : {}),
+        };
+      }
     }
-    // Merge venue rather than replace — preserves publisher-supplied url
-    // and any future fields on VenueRef.
-    enriched.venue = {
-      ...(enriched.venue ?? {}),
-      name: enriched.venue?.name ?? venue.name,
-      ...(venue.address && !enriched.venue?.address ? { address: venue.address } : {}),
-    };
+
+    // Promote singular `category` (string) to a `categories` array. The
+    // frontend's tag-filter pre-computation, clickable category badges
+    // in EventCard, and search-tag set all read `event.categories`.
+    // Without this, publisher events were absent from category filters
+    // and rendered without category badges in the expanded card.
+    const existingCategories = (enriched as { categories?: unknown }).categories;
+    if (
+      typeof payload.category === 'string' &&
+      payload.category.length > 0 &&
+      (!Array.isArray(existingCategories) || existingCategories.length === 0)
+    ) {
+      enriched.categories = [{ name: payload.category }];
+    }
+
     return enriched;
   }
 


### PR DESCRIPTION
## Summary

Publisher events use \`venueId\` (slug, e.g. \`hall-of-philosophy\`) but the frontend filter and \`EventCard\` both read \`event.location\` (display string). Result: publisher events vanished from the location filter and rendered without a venue.

\`PublisherSidecarPublisher\` now accepts a \`venuesById\` map and enriches each emitted payload with:
- \`event.location\` ← venue display name (only if not already set by the publisher)
- \`event.venue\` ← \`{ name, address? }\`

Unknown \`venueId\`s pass through unchanged (graceful degradation). The scheduled handler loads venues from \`@chq-calendar/publisher-format\`'s \`loadReferences()\` (already bundled into the Lambda by PR #72's build:publisher-refs step).

## Test plan

- [x] 4 new unit tests in \`publisherSidecarPublisher.test.ts\` — resolves, no-op for unknown id, doesn't overwrite explicit location, omits empty address
- [x] All 223 backend + 130 frontend tests pass
- [x] \`npm run build:prod --workspace=backend\` clean
- [ ] After merge: redeploy \`chq-publisher-ingest\` Lambda and manually invoke once to regenerate the sidecar with \`location\` populated
- [ ] Hard-refresh \`https://www.chqcal.org/\`, filter by Hall of Philosophy, confirm publisher events appear with the venue rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)