### PR TITLE
fix(iam): allow github-actions user to deploy publisher-ingest Lambda

### DIFF
--- a/infrastructure/github-actions.tf
+++ b/infrastructure/github-actions.tf
@@ -40,7 +40,8 @@ resource "aws_iam_policy" "github_actions" {
           aws_lambda_function.manual_sync.arn,
           aws_lambda_function.sync_health.arn,
           aws_lambda_function.sync_status.arn,
-          aws_lambda_function.sync_list.arn
+          aws_lambda_function.sync_list.arn,
+          aws_lambda_function.publisher_ingest.arn
         ]
       },
       {

--- a/infrastructure/github-actions.tf
+++ b/infrastructure/github-actions.tf
@@ -33,6 +33,10 @@ resource "aws_iam_policy" "github_actions" {
           "lambda:GetFunction",
           "lambda:GetFunctionConfiguration"
         ]
+        # Every new aws_lambda_function resource that the deploy workflow
+        # ships MUST be added below, or `lambda:UpdateFunctionCode` will
+        # fail with AccessDeniedException at deploy time. (We learned this
+        # the hard way when publisher_ingest was missing — see PR #80.)
         Resource = [
           aws_lambda_function.calendar_generator.arn,
           aws_lambda_function.admin_handler.arn,


### PR DESCRIPTION
## Summary

PR #79 added a deploy step for the publisher-ingest Lambda but it failed at the AWS API call:

\`\`\`
AccessDeniedException: User chautauqua-calendar-github-actions is not
authorized to perform: lambda:UpdateFunctionCode on resource
function:chautauqua-calendar-publisher-ingest because no identity-based
policy allows the lambda:UpdateFunctionCode action
\`\`\`

The CI user's IAM policy (\`infrastructure/github-actions.tf\`) lists 7 Lambdas under \`LambdaDeployment\` — calendar, admin, and 5 sync handlers — but never included \`publisher_ingest\`. This PR adds it.

## Changes

- One line in \`infrastructure/github-actions.tf\`: append \`aws_lambda_function.publisher_ingest.arn\` to the \`LambdaDeployment\` Resource list. The existing actions (\`UpdateFunctionCode\`, \`UpdateFunctionConfiguration\`, \`GetFunction\`, \`GetFunctionConfiguration\`) are exactly what the deploy step needs.

## Required after merge

\`terraform apply\` against the prod workspace to push the IAM update to AWS. Auto-deploy alone won't do this — the deploy workflow doesn't run \`terraform apply\`. The next code merge after the apply should auto-deploy the publisher-ingest Lambda successfully.

## Test plan

- [ ] After merge: run \`terraform apply\` from \`infrastructure/\`.
- [ ] Trigger a new deploy run (e.g. by re-running the failed deploy or pushing a no-op commit).
- [ ] Verify the \"Deploy publisher-ingest Lambda\" step succeeds.
- [ ] \`aws lambda get-function --function-name chautauqua-calendar-publisher-ingest --query 'Configuration.LastModified'\` returns a timestamp > merge time.
- [ ] Run the manual disable→retract verification for PR #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)