### PR TITLE
ci(deploy): add publisher disable→retract end-to-end test

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    # Serialize deploys: two concurrent runs would interleave the
+    # ci-e2e-test publisher's enable/disable toggles and corrupt the
+    # post-deploy retraction assertion. cancel-in-progress=false so an
+    # in-flight deploy completes (including its cleanup trap) before the
+    # next one starts.
+    concurrency:
+      group: deploy-production
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v4
@@ -364,59 +372,84 @@ jobs:
       - name: Publisher disable→retract end-to-end test
         # Validates the full publisher-ingest pipeline against real DynamoDB +
         # real S3 sidecar. Catches regressions that unit tests miss: Lambda
-        # version mismatch, IAM drift, sidecar publisher errors, S3/CloudFront
-        # cache problems. Requires `var.enable_ci_e2e_publisher = true` so the
+        # version mismatch, IAM drift, sidecar publisher errors. Reads the
+        # sidecar directly from S3 (not via CloudFront) — the default cache
+        # behavior has `query_string = false` and the sidecar object has
+        # `max-age=300`, so any URL-based poll would see stale content for
+        # up to 5 minutes regardless of cache-buster query strings.
+        # Requires `var.enable_ci_e2e_publisher = true` so the
         # ci-e2e-test publisher row + static feed exist.
         shell: bash
         env:
           # github.event.head_commit.timestamp is only set on push; fall back
           # to the run start time for workflow_dispatch.
           DEPLOY_START_RAW: ${{ github.event.head_commit.timestamp || github.run_started_at }}
+          S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
         run: |
           set -euo pipefail
 
           PUBLISHER_ID="ci-e2e-test"
           PUBLISHERS_TABLE="chautauqua-calendar-publishers"
           LAMBDA="chautauqua-calendar-publisher-ingest"
-          FEED_URL="https://www.chqcal.org/cache/ci-e2e/feed.json"
+          # Local feed file in the checkout — this is the same file Terraform
+          # uploads to S3, so deriving the year locally avoids any cache /
+          # propagation race with the freshly-deployed S3 object.
+          LOCAL_FEED_PATH="$GITHUB_WORKSPACE/infrastructure/ci-e2e-feed.json"
 
           # Sidecar key is publisher-events-${year}.json where ${year} comes
           # from each event's startDate (see publisherSidecarPublisher.ts).
-          # Derive from the live test feed — do NOT hardcode the year, or the
-          # polling URL drifts off the actual sidecar object as the season
-          # rolls over.
-          SIDECAR_YEAR=$(curl -fsS "${FEED_URL}?cb=$(date +%s%N)" \
-            | jq -r '.events[0].startDate[0:4]')
-          if [ -z "$SIDECAR_YEAR" ] || [ "$SIDECAR_YEAR" = "null" ]; then
-            echo "::error::Could not derive sidecar year from $FEED_URL — is the test feed deployed?"
+          # Derive from the local checkout — do NOT hardcode the year, or the
+          # S3 key drifts off the actual sidecar object as the season rolls
+          # over.
+          SIDECAR_YEAR=$(jq -r '.events[0].startDate[0:4]' "$LOCAL_FEED_PATH")
+          if ! [[ "$SIDECAR_YEAR" =~ ^[0-9]{4}$ ]]; then
+            echo "::error::SIDECAR_YEAR '${SIDECAR_YEAR}' from $LOCAL_FEED_PATH is not a 4-digit year"
             exit 1
           fi
-          SIDECAR_URL="https://www.chqcal.org/cache/calendar-cache/publisher-events-${SIDECAR_YEAR}.json"
-          echo "[ci-e2e] sidecar year = ${SIDECAR_YEAR}"
+          SIDECAR_S3_KEY="cache/calendar-cache/publisher-events-${SIDECAR_YEAR}.json"
+          echo "[ci-e2e] sidecar year=${SIDECAR_YEAR}, s3 key=${SIDECAR_S3_KEY}"
 
-          # Count test-publisher events in the live sidecar. Returns:
-          #   0  on 404 (sidecar absent ≡ zero events from any publisher) or
-          #      on 200 with no events from $PUBLISHER_ID
-          #   N  on 200 with N events from $PUBLISHER_ID
-          #   "" on transient curl/jq failure — caller uses its own fallback
-          #      (events-appear poll: treat as 0; events-retract poll: treat as 1)
+          # Verify the Lambda's response file isn't holding a FunctionError —
+          # `aws lambda invoke --invocation-type RequestResponse` returns
+          # exit 0 even when the handler throws; the error lives in the
+          # response payload as the magic key "FunctionError".
+          assert_no_function_error() {
+            local file="$1" label="$2"
+            if grep -q '"FunctionError"' "$file" 2>/dev/null; then
+              echo "::error::${label}: Lambda returned a FunctionError"
+              cat "$file"
+              return 1
+            fi
+          }
+
+          # Count test-publisher events in the sidecar by reading the S3
+          # object directly. Bypasses CloudFront entirely — see step
+          # description for why URL-based polling can't work here. Returns:
+          #   0  if the sidecar object is missing (zero events from any
+          #      publisher) or present but with no events from $PUBLISHER_ID
+          #   N  on a present sidecar with N events from $PUBLISHER_ID
+          #   "" on transient AWS / jq failure — caller uses its own fallback
+          #      (events-appear poll: treat as 0; events-retract poll: 1)
           count_test_events_in_sidecar() {
-            local response body http
-            response=$(curl -sS -w '\n%{http_code}' "${SIDECAR_URL}?cb=$(date +%s%N)") || { echo ""; return; }
-            http=$(printf '%s' "$response" | tail -n1)
-            body=$(printf '%s' "$response" | sed '$d')
-            if [ "$http" = "404" ]; then
+            # Note: don't combine `local body=$(...)` with $? checks — `local`
+            # masks the rc. Run the AWS call as its own statement.
+            if aws s3api get-object \
+                --bucket "$S3_BUCKET" --key "$SIDECAR_S3_KEY" \
+                /tmp/ci-e2e-sidecar.json >/dev/null 2>/tmp/ci-e2e-s3.err; then
+              jq "[.data[]? | select(.sourcePublisherId==\"$PUBLISHER_ID\")] | length" \
+                /tmp/ci-e2e-sidecar.json 2>/dev/null \
+                || echo ""
+              return
+            fi
+            if grep -q 'NoSuchKey\|Not Found\|404' /tmp/ci-e2e-s3.err; then
+              # Sidecar object absent ≡ no events from any publisher
+              # in this year — definitionally zero from $PUBLISHER_ID.
               echo 0
               return
             fi
-            if [ "$http" != "200" ]; then
-              echo "[ci-e2e] sidecar HTTP $http (transient)" >&2
-              echo ""
-              return
-            fi
-            printf '%s' "$body" \
-              | jq "[.data[]? | select(.sourcePublisherId==\"$PUBLISHER_ID\")] | length" 2>/dev/null \
-              || echo ""
+            echo "[ci-e2e] s3 get-object failed (transient):" >&2
+            cat /tmp/ci-e2e-s3.err >&2
+            echo ""
           }
 
           cleanup() {
@@ -429,9 +462,12 @@ jobs:
               --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
               --update-expression 'SET enabled = :f' \
               --expression-attribute-values '{":f":{"BOOL":false}}' || true
-            # Final ingest to retract anything left.
+            # Final ingest to retract anything left. Fire-and-forget
+            # (--invocation-type Event) so a slow Lambda doesn't hold the
+            # CI runner — we already swallow errors here, so synchronous
+            # waiting buys us nothing.
             aws lambda invoke --function-name "$LAMBDA" \
-              --invocation-type RequestResponse \
+              --invocation-type Event \
               --cli-binary-format raw-in-base64-out --payload '{}' \
               /tmp/ci-e2e-cleanup.json || true
           }
@@ -481,6 +517,7 @@ jobs:
           echo "[ci-e2e] ingest #1 response:"
           cat /tmp/ci-e2e-ingest1.json
           echo
+          assert_no_function_error /tmp/ci-e2e-ingest1.json "ingest #1"
 
           # 3. Poll sidecar for the test events to appear. Use a cache-buster
           #    query string to bypass CloudFront edge cache; the underlying S3
@@ -516,6 +553,7 @@ jobs:
           echo "[ci-e2e] ingest #2 response:"
           cat /tmp/ci-e2e-ingest2.json
           echo
+          assert_no_function_error /tmp/ci-e2e-ingest2.json "ingest #2"
 
           # 6. Poll sidecar for the test events to disappear.
           COUNT=1  # fail-closed so a transient curl error doesn't immediately

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -503,13 +503,33 @@ jobs:
           print(f"[ci-e2e] Lambda LastModified {lm.isoformat()} >= deploy start {ds.isoformat()}")
           PY
 
-          # 1. Enable the test publisher.
+          # 1. Pre-test cleanliness assertion: if a previous run failed
+          #    after ingest #1 but before cleanup, leftover ci-e2e-test
+          #    events would still be in the sidecar. Without this check
+          #    the "events appeared" poll would short-circuit on iteration
+          #    1 and mask a broken pipeline. The cleanup trap from the
+          #    previous run *should* have purged them, but cleanup itself
+          #    is best-effort — verify before we trust it.
+          INITIAL_RAW=$(count_test_events_in_sidecar)
+          INITIAL_COUNT=${INITIAL_RAW:-0}
+          if [ "$INITIAL_COUNT" -gt 0 ]; then
+            echo "::error::Sidecar already has ${INITIAL_COUNT} stale ${PUBLISHER_ID} event(s) before test start; manual cleanup required"
+            exit 1
+          fi
+
+          # 2. Enable the test publisher. `attribute_exists(id)` makes this
+          #    a strict update — if the row was never provisioned (e.g.
+          #    var.enable_ci_e2e_publisher = false), DynamoDB throws
+          #    ConditionalCheckFailedException instead of silently
+          #    upserting a partial {id, enabled} row that the next hourly
+          #    ingest would choke on.
           aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
             --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
+            --condition-expression 'attribute_exists(id)' \
             --update-expression 'SET enabled = :t' \
             --expression-attribute-values '{":t":{"BOOL":true}}'
 
-          # 2. Trigger ingest synchronously.
+          # 3. Trigger ingest synchronously.
           aws lambda invoke --function-name "$LAMBDA" \
             --invocation-type RequestResponse \
             --cli-binary-format raw-in-base64-out --payload '{}' \
@@ -519,10 +539,9 @@ jobs:
           echo
           assert_no_function_error /tmp/ci-e2e-ingest1.json "ingest #1"
 
-          # 3. Poll sidecar for the test events to appear. Use a cache-buster
-          #    query string to bypass CloudFront edge cache; the underlying S3
-          #    object is what changes.
-          COUNT=0  # fail-open so a transient curl error in the loop doesn't
+          # 4. Poll sidecar (read directly from S3 in count_test_events_in_sidecar)
+          #    for the test events to appear.
+          COUNT=0  # fail-open so a transient AWS error in the loop doesn't
                    # immediately mark the test as passing for "events appeared"
                    # (we only break on COUNT>=1).
           for i in $(seq 1 30); do
@@ -539,13 +558,14 @@ jobs:
             exit 1
           fi
 
-          # 4. Disable the publisher.
+          # 5. Disable the publisher (same condition guard as step 2).
           aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
             --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
+            --condition-expression 'attribute_exists(id)' \
             --update-expression 'SET enabled = :f' \
             --expression-attribute-values '{":f":{"BOOL":false}}'
 
-          # 5. Trigger ingest again.
+          # 6. Trigger ingest again.
           aws lambda invoke --function-name "$LAMBDA" \
             --invocation-type RequestResponse \
             --cli-binary-format raw-in-base64-out --payload '{}' \
@@ -555,7 +575,7 @@ jobs:
           echo
           assert_no_function_error /tmp/ci-e2e-ingest2.json "ingest #2"
 
-          # 6. Poll sidecar for the test events to disappear.
+          # 7. Poll sidecar for the test events to disappear.
           COUNT=1  # fail-closed so a transient curl error doesn't immediately
                    # mark the retraction as successful.
           for i in $(seq 1 30); do

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -361,6 +361,181 @@ jobs:
           echo "  2. CloudFront behavior rules for API paths"
           echo "  3. Lambda function URL configuration"
 
+      - name: Publisher disable→retract end-to-end test
+        # Validates the full publisher-ingest pipeline against real DynamoDB +
+        # real S3 sidecar. Catches regressions that unit tests miss: Lambda
+        # version mismatch, IAM drift, sidecar publisher errors, S3/CloudFront
+        # cache problems. Requires `var.enable_ci_e2e_publisher = true` so the
+        # ci-e2e-test publisher row + static feed exist.
+        shell: bash
+        env:
+          # github.event.head_commit.timestamp is only set on push; fall back
+          # to the run start time for workflow_dispatch.
+          DEPLOY_START_RAW: ${{ github.event.head_commit.timestamp || github.run_started_at }}
+        run: |
+          set -euo pipefail
+
+          PUBLISHER_ID="ci-e2e-test"
+          PUBLISHERS_TABLE="chautauqua-calendar-publishers"
+          LAMBDA="chautauqua-calendar-publisher-ingest"
+          FEED_URL="https://www.chqcal.org/cache/ci-e2e/feed.json"
+
+          # Sidecar key is publisher-events-${year}.json where ${year} comes
+          # from each event's startDate (see publisherSidecarPublisher.ts).
+          # Derive from the live test feed — do NOT hardcode the year, or the
+          # polling URL drifts off the actual sidecar object as the season
+          # rolls over.
+          SIDECAR_YEAR=$(curl -fsS "${FEED_URL}?cb=$(date +%s%N)" \
+            | jq -r '.events[0].startDate[0:4]')
+          if [ -z "$SIDECAR_YEAR" ] || [ "$SIDECAR_YEAR" = "null" ]; then
+            echo "::error::Could not derive sidecar year from $FEED_URL — is the test feed deployed?"
+            exit 1
+          fi
+          SIDECAR_URL="https://www.chqcal.org/cache/calendar-cache/publisher-events-${SIDECAR_YEAR}.json"
+          echo "[ci-e2e] sidecar year = ${SIDECAR_YEAR}"
+
+          # Count test-publisher events in the live sidecar. Returns:
+          #   0  on 404 (sidecar absent ≡ zero events from any publisher) or
+          #      on 200 with no events from $PUBLISHER_ID
+          #   N  on 200 with N events from $PUBLISHER_ID
+          #   "" on transient curl/jq failure — caller uses its own fallback
+          #      (events-appear poll: treat as 0; events-retract poll: treat as 1)
+          count_test_events_in_sidecar() {
+            local response body http
+            response=$(curl -sS -w '\n%{http_code}' "${SIDECAR_URL}?cb=$(date +%s%N)") || { echo ""; return; }
+            http=$(printf '%s' "$response" | tail -n1)
+            body=$(printf '%s' "$response" | sed '$d')
+            if [ "$http" = "404" ]; then
+              echo 0
+              return
+            fi
+            if [ "$http" != "200" ]; then
+              echo "[ci-e2e] sidecar HTTP $http (transient)" >&2
+              echo ""
+              return
+            fi
+            printf '%s' "$body" \
+              | jq "[.data[]? | select(.sourcePublisherId==\"$PUBLISHER_ID\")] | length" 2>/dev/null \
+              || echo ""
+          }
+
+          cleanup() {
+            # Cleanup must never propagate a failure: surfacing a cleanup
+            # error on top of an already-failed test loses the original
+            # signal. Disable -e for the body and || true each AWS call.
+            set +e
+            echo "[ci-e2e] cleanup: disabling $PUBLISHER_ID and purging events"
+            aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
+              --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
+              --update-expression 'SET enabled = :f' \
+              --expression-attribute-values '{":f":{"BOOL":false}}' || true
+            # Final ingest to retract anything left.
+            aws lambda invoke --function-name "$LAMBDA" \
+              --invocation-type RequestResponse \
+              --cli-binary-format raw-in-base64-out --payload '{}' \
+              /tmp/ci-e2e-cleanup.json || true
+          }
+          trap cleanup EXIT
+
+          # 0. Verify the Lambda was actually updated by this deploy. Catches
+          #    the PR #78 trap where the disable→retract code was merged but
+          #    the Lambda zip never shipped.
+          LAST_MODIFIED=$(aws lambda get-function --function-name "$LAMBDA" \
+            --query 'Configuration.LastModified' --output text)
+          # Pass values via env (not shell substitution into the heredoc) to
+          # avoid injection from any unexpected characters and to keep the
+          # Python source quoted-as-written. AWS LastModified comes back like
+          # `2026-05-03T14:55:12.000+0000` — the `+0000` form is not parseable
+          # by datetime.fromisoformat on Python <3.11, so normalize.
+          LAST_MODIFIED="$LAST_MODIFIED" \
+          DEPLOY_START_RAW="$DEPLOY_START_RAW" \
+          python3 - <<'PY'
+          import os, re, sys
+          from datetime import datetime
+
+          def parse(ts: str) -> datetime:
+              # fromisoformat accepts +00:00 and (3.11+) Z; normalize +0000 → +00:00
+              t = ts.replace('Z', '+00:00')
+              t = re.sub(r'([+-]\d{2})(\d{2})$', r'\1:\2', t)
+              return datetime.fromisoformat(t)
+
+          lm = parse(os.environ['LAST_MODIFIED'])
+          ds = parse(os.environ['DEPLOY_START_RAW'])
+          if lm < ds:
+              print(f"::error::Lambda LastModified {lm.isoformat()} predates deploy start {ds.isoformat()} — code did not ship")
+              sys.exit(1)
+          print(f"[ci-e2e] Lambda LastModified {lm.isoformat()} >= deploy start {ds.isoformat()}")
+          PY
+
+          # 1. Enable the test publisher.
+          aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
+            --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
+            --update-expression 'SET enabled = :t' \
+            --expression-attribute-values '{":t":{"BOOL":true}}'
+
+          # 2. Trigger ingest synchronously.
+          aws lambda invoke --function-name "$LAMBDA" \
+            --invocation-type RequestResponse \
+            --cli-binary-format raw-in-base64-out --payload '{}' \
+            /tmp/ci-e2e-ingest1.json
+          echo "[ci-e2e] ingest #1 response:"
+          cat /tmp/ci-e2e-ingest1.json
+          echo
+
+          # 3. Poll sidecar for the test events to appear. Use a cache-buster
+          #    query string to bypass CloudFront edge cache; the underlying S3
+          #    object is what changes.
+          COUNT=0  # fail-open so a transient curl error in the loop doesn't
+                   # immediately mark the test as passing for "events appeared"
+                   # (we only break on COUNT>=1).
+          for i in $(seq 1 30); do
+            RAW=$(count_test_events_in_sidecar)
+            COUNT=${RAW:-0}  # transient → 0, keep polling
+            if [ "$COUNT" -ge 1 ]; then
+              echo "[ci-e2e] events present after ${i}s (count=$COUNT)"
+              break
+            fi
+            sleep 1
+          done
+          if [ "$COUNT" -lt 1 ]; then
+            echo "::error::Test events did not appear in sidecar within 30s"
+            exit 1
+          fi
+
+          # 4. Disable the publisher.
+          aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
+            --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
+            --update-expression 'SET enabled = :f' \
+            --expression-attribute-values '{":f":{"BOOL":false}}'
+
+          # 5. Trigger ingest again.
+          aws lambda invoke --function-name "$LAMBDA" \
+            --invocation-type RequestResponse \
+            --cli-binary-format raw-in-base64-out --payload '{}' \
+            /tmp/ci-e2e-ingest2.json
+          echo "[ci-e2e] ingest #2 response:"
+          cat /tmp/ci-e2e-ingest2.json
+          echo
+
+          # 6. Poll sidecar for the test events to disappear.
+          COUNT=1  # fail-closed so a transient curl error doesn't immediately
+                   # mark the retraction as successful.
+          for i in $(seq 1 30); do
+            RAW=$(count_test_events_in_sidecar)
+            COUNT=${RAW:-1}  # transient → 1, keep polling
+            if [ "$COUNT" -eq 0 ]; then
+              echo "[ci-e2e] events retracted after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+          if [ "$COUNT" -ne 0 ]; then
+            echo "::error::Test events were not retracted within 30s (count=$COUNT)"
+            exit 1
+          fi
+
+          echo "✅ Publisher disable→retract end-to-end test passed"
+
       - name: Trigger calendar data sync
         continue-on-error: true
         run: |

--- a/docs/plans/2026-05-03-publisher-ingest-e2e-ci-test-plan.md
+++ b/docs/plans/2026-05-03-publisher-ingest-e2e-ci-test-plan.md
@@ -1,6 +1,6 @@
 # Plan — Automated end-to-end test for publisher disable→retract in CI
 
-**Status:** scoped, not started.
+**Status:** implemented on branch `feat/publisher-ingest-e2e-ci-test` (PR pending). Open follow-ups in the "Open questions" section below remain unresolved.
 **Suggested branch:** `feat/publisher-ingest-e2e-ci-test`.
 **Origin:** the disable→retract fix shipped in PR #78 had no automated post-deploy validation. The current `deploy-production.yml` post-deploy step only checks `/health`, calendar event count > 0, and frontend load — none of which would catch a regression in the publisher disable retraction flow.
 

--- a/infrastructure/ci-e2e-feed.json
+++ b/infrastructure/ci-e2e-feed.json
@@ -1,0 +1,20 @@
+{
+  "formatVersion": "1.0",
+  "publisher": {
+    "id": "ci-e2e-test",
+    "name": "[CI] End-to-end deploy test",
+    "contactEmail": "bernard+ci-e2e@thebernsteins.com"
+  },
+  "events": [
+    {
+      "id": "ci-e2e-event-1",
+      "title": "[CI-E2E] Deploy test event (do not display)",
+      "startDate": "2026-07-01T12:00:00-04:00",
+      "endDate": "2026-07-01T13:00:00-04:00",
+      "category": "Special Events",
+      "venueId": "amphitheater",
+      "description": "Synthetic event used by the deploy-production workflow to validate the publisher ingest disable→retract flow. Should never be visible on the public calendar for more than a few seconds.",
+      "lastModified": "2026-05-03T00:00:00-04:00"
+    }
+  ]
+}

--- a/infrastructure/ci-e2e-publisher.tf
+++ b/infrastructure/ci-e2e-publisher.tf
@@ -1,0 +1,67 @@
+# CI end-to-end test publisher.
+#
+# Provisions a dedicated publisher row in the publishers table plus a static
+# feed JSON in the frontend bucket. The deploy-production workflow flips this
+# publisher's `enabled` flag on, triggers ingest, asserts the events appear in
+# the sidecar, flips it off, triggers ingest again, and asserts they retract.
+#
+# Baseline state on disk: `enabled = false`. Terraform owns only the create —
+# subsequent `enabled` changes from CI are ignored via `lifecycle.ignore_changes`
+# so a CI run that fails between toggles doesn't get clobbered back to true on
+# the next `terraform apply`.
+
+variable "enable_ci_e2e_publisher" {
+  description = "Provision the dedicated CI end-to-end test publisher and its static feed. Set to false in environments without an associated GitHub Actions workflow (e.g. preview accounts)."
+  type        = bool
+  default     = true
+}
+
+locals {
+  ci_e2e_publisher_id = "ci-e2e-test"
+  ci_e2e_feed_s3_key  = "cache/ci-e2e/feed.json"
+  ci_e2e_created_at   = "2026-05-03T00:00:00.000Z"
+}
+
+# Static feed file. Served via CloudFront at /cache/ci-e2e/feed.json. The
+# deploy workflow's `aws s3 sync out/ ... --delete --exclude "cache/*"` step
+# already excludes the cache prefix, so the frontend deploy will not delete
+# this object.
+resource "aws_s3_object" "ci_e2e_feed" {
+  count = var.enable_ci_e2e_publisher ? 1 : 0
+
+  bucket        = aws_s3_bucket.frontend_bucket.id
+  key           = local.ci_e2e_feed_s3_key
+  source        = "${path.module}/ci-e2e-feed.json"
+  etag          = filemd5("${path.module}/ci-e2e-feed.json")
+  content_type  = "application/json"
+  cache_control = "public, max-age=60"
+}
+
+# Publisher registry row. trustLevel=auto so reconcile applies the diff
+# without a manual review queue. enabled=false baseline — the workflow flips
+# it on for the duration of the test and back off in cleanup.
+resource "aws_dynamodb_table_item" "ci_e2e_publisher" {
+  count = var.enable_ci_e2e_publisher ? 1 : 0
+
+  table_name = aws_dynamodb_table.publishers.name
+  hash_key   = aws_dynamodb_table.publishers.hash_key
+
+  item = jsonencode({
+    id           = { S = local.ci_e2e_publisher_id }
+    name         = { S = "[CI] End-to-end deploy test" }
+    contactEmail = { S = "bernard+ci-e2e@thebernsteins.com" }
+    sourceUrl    = { S = "https://www.chqcal.org/${local.ci_e2e_feed_s3_key}" }
+    sourceType   = { S = "json" }
+    trustLevel   = { S = "auto" }
+    enabled      = { BOOL = false }
+    createdAt    = { S = local.ci_e2e_created_at }
+  })
+
+  lifecycle {
+    # The CI workflow toggles `enabled` and the ingest Lambda writes
+    # lastFetchedAt / lastFetchStatus / lastFetchMessage. None of those should
+    # cause a Terraform diff — Terraform owns the row's existence and its
+    # static identifying fields, not its runtime state.
+    ignore_changes = [item]
+  }
+}

--- a/infrastructure/ci-e2e-publisher.tf
+++ b/infrastructure/ci-e2e-publisher.tf
@@ -62,6 +62,12 @@ resource "aws_dynamodb_table_item" "ci_e2e_publisher" {
     # lastFetchedAt / lastFetchStatus / lastFetchMessage. None of those should
     # cause a Terraform diff — Terraform owns the row's existence and its
     # static identifying fields, not its runtime state.
+    #
+    # Tradeoff: aws_dynamodb_table_item exposes only the whole `item` JSON,
+    # so this also silences drift on the static fields above (name,
+    # contactEmail, sourceUrl, sourceType, trustLevel, createdAt). To
+    # re-apply a change to any of those, replace the row explicitly:
+    #     terraform apply -replace='aws_dynamodb_table_item.ci_e2e_publisher[0]'
     ignore_changes = [item]
   }
 }

--- a/infrastructure/github-actions.tf
+++ b/infrastructure/github-actions.tf
@@ -94,6 +94,19 @@ resource "aws_iam_policy" "github_actions" {
         ]
       },
       {
+        # Toggling the ci-e2e-test publisher's `enabled` flag from the
+        # deploy workflow's post-deploy E2E test. Scoped to the publishers
+        # table only — github-actions is not authorized to write to the
+        # event tables.
+        Sid    = "DynamoDBToggleCiE2ePublisher"
+        Effect = "Allow"
+        Action = [
+          "dynamodb:UpdateItem",
+          "dynamodb:GetItem"
+        ]
+        Resource = aws_dynamodb_table.publishers.arn
+      },
+      {
         Sid    = "CloudWatchLogs"
         Effect = "Allow"
         Action = [
@@ -110,6 +123,15 @@ resource "aws_iam_policy" "github_actions" {
         Effect   = "Allow"
         Action   = "lambda:InvokeFunction"
         Resource = aws_lambda_function.data_sync.arn
+      },
+      {
+        # Synchronous invocation of the publisher-ingest Lambda from the
+        # deploy workflow's post-deploy E2E test (enable→ingest→assert→
+        # disable→ingest→assert).
+        Sid      = "LambdaInvokePublisherIngest"
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = aws_lambda_function.publisher_ingest.arn
       }
     ]
   })
@@ -151,22 +173,22 @@ output "github_actions_secret_access_key" {
 output "github_secrets" {
   description = "All values needed for GitHub repository secrets"
   value = {
-    AWS_ACCESS_KEY_ID              = aws_iam_access_key.github_actions.id
-    AWS_SECRET_ACCESS_KEY          = aws_iam_access_key.github_actions.secret
-    AWS_REGION                     = var.aws_region
-    LAMBDA_FUNCTION_NAME           = aws_lambda_function.calendar_generator.function_name
-    ADMIN_LAMBDA_FUNCTION_NAME     = aws_lambda_function.admin_handler.function_name
-    S3_BUCKET_NAME                 = aws_s3_bucket.frontend_bucket.id
-    CLOUDFRONT_DISTRIBUTION_ID     = aws_cloudfront_distribution.frontend_distribution.id
-    EVENTS_TABLE_NAME              = aws_dynamodb_table.events.name
-    DATA_SOURCES_TABLE_NAME        = aws_dynamodb_table.data_sources.name
-    FEEDBACK_TABLE_NAME            = aws_dynamodb_table.feedback.name
-    RECAPTCHA_SECRET_KEY           = var.recaptcha_secret_key
-    VITE_RECAPTCHA_SITE_KEY        = var.recaptcha_site_key
-    JWT_SECRET                     = var.jwt_secret
-    GOOGLE_CLIENT_ID               = var.google_client_id
-    GOOGLE_CLIENT_SECRET           = var.google_client_secret
-    ADMIN_EMAIL_WHITELIST          = var.admin_email_whitelist
+    AWS_ACCESS_KEY_ID          = aws_iam_access_key.github_actions.id
+    AWS_SECRET_ACCESS_KEY      = aws_iam_access_key.github_actions.secret
+    AWS_REGION                 = var.aws_region
+    LAMBDA_FUNCTION_NAME       = aws_lambda_function.calendar_generator.function_name
+    ADMIN_LAMBDA_FUNCTION_NAME = aws_lambda_function.admin_handler.function_name
+    S3_BUCKET_NAME             = aws_s3_bucket.frontend_bucket.id
+    CLOUDFRONT_DISTRIBUTION_ID = aws_cloudfront_distribution.frontend_distribution.id
+    EVENTS_TABLE_NAME          = aws_dynamodb_table.events.name
+    DATA_SOURCES_TABLE_NAME    = aws_dynamodb_table.data_sources.name
+    FEEDBACK_TABLE_NAME        = aws_dynamodb_table.feedback.name
+    RECAPTCHA_SECRET_KEY       = var.recaptcha_secret_key
+    VITE_RECAPTCHA_SITE_KEY    = var.recaptcha_site_key
+    JWT_SECRET                 = var.jwt_secret
+    GOOGLE_CLIENT_ID           = var.google_client_id
+    GOOGLE_CLIENT_SECRET       = var.google_client_secret
+    ADMIN_EMAIL_WHITELIST      = var.admin_email_whitelist
   }
   sensitive = true
 }
@@ -202,22 +224,22 @@ output "github_secrets_setup_commands" {
 resource "local_file" "github_secrets_json" {
   filename = "${path.module}/github-secrets.json"
   content = jsonencode({
-    AWS_ACCESS_KEY_ID              = aws_iam_access_key.github_actions.id
-    AWS_SECRET_ACCESS_KEY          = aws_iam_access_key.github_actions.secret
-    AWS_REGION                     = var.aws_region
-    LAMBDA_FUNCTION_NAME           = aws_lambda_function.calendar_generator.function_name
-    ADMIN_LAMBDA_FUNCTION_NAME     = aws_lambda_function.admin_handler.function_name
-    S3_BUCKET_NAME                 = aws_s3_bucket.frontend_bucket.id
-    CLOUDFRONT_DISTRIBUTION_ID     = aws_cloudfront_distribution.frontend_distribution.id
-    EVENTS_TABLE_NAME              = aws_dynamodb_table.events.name
-    DATA_SOURCES_TABLE_NAME        = aws_dynamodb_table.data_sources.name
-    FEEDBACK_TABLE_NAME            = aws_dynamodb_table.feedback.name
-    RECAPTCHA_SECRET_KEY           = var.recaptcha_secret_key
-    VITE_RECAPTCHA_SITE_KEY        = var.recaptcha_site_key
-    JWT_SECRET                     = var.jwt_secret
-    GOOGLE_CLIENT_ID               = var.google_client_id
-    GOOGLE_CLIENT_SECRET           = var.google_client_secret
-    ADMIN_EMAIL_WHITELIST          = var.admin_email_whitelist
+    AWS_ACCESS_KEY_ID          = aws_iam_access_key.github_actions.id
+    AWS_SECRET_ACCESS_KEY      = aws_iam_access_key.github_actions.secret
+    AWS_REGION                 = var.aws_region
+    LAMBDA_FUNCTION_NAME       = aws_lambda_function.calendar_generator.function_name
+    ADMIN_LAMBDA_FUNCTION_NAME = aws_lambda_function.admin_handler.function_name
+    S3_BUCKET_NAME             = aws_s3_bucket.frontend_bucket.id
+    CLOUDFRONT_DISTRIBUTION_ID = aws_cloudfront_distribution.frontend_distribution.id
+    EVENTS_TABLE_NAME          = aws_dynamodb_table.events.name
+    DATA_SOURCES_TABLE_NAME    = aws_dynamodb_table.data_sources.name
+    FEEDBACK_TABLE_NAME        = aws_dynamodb_table.feedback.name
+    RECAPTCHA_SECRET_KEY       = var.recaptcha_secret_key
+    VITE_RECAPTCHA_SITE_KEY    = var.recaptcha_site_key
+    JWT_SECRET                 = var.jwt_secret
+    GOOGLE_CLIENT_ID           = var.google_client_id
+    GOOGLE_CLIENT_SECRET       = var.google_client_secret
+    ADMIN_EMAIL_WHITELIST      = var.admin_email_whitelist
   })
 
   # Make sure this file is not committed to git

--- a/infrastructure/github-actions.tf
+++ b/infrastructure/github-actions.tf
@@ -95,12 +95,19 @@ resource "aws_iam_policy" "github_actions" {
       },
       {
         # Toggling the ci-e2e-test publisher's `enabled` flag from the
-        # deploy workflow's post-deploy E2E test. Scoped to the publishers
-        # table and to the single action the workflow actually performs.
+        # deploy workflow's post-deploy E2E test. Scoped three ways:
+        # the table (resource), the single action the workflow performs
+        # (UpdateItem), and the partition key value via `LeadingKeys` so a
+        # leaked github-actions token cannot disable any other publisher.
         Sid      = "DynamoDBToggleCiE2ePublisher"
         Effect   = "Allow"
         Action   = "dynamodb:UpdateItem"
         Resource = aws_dynamodb_table.publishers.arn
+        Condition = {
+          "ForAllValues:StringEquals" = {
+            "dynamodb:LeadingKeys" = ["ci-e2e-test"]
+          }
+        }
       },
       {
         Sid    = "CloudWatchLogs"

--- a/infrastructure/github-actions.tf
+++ b/infrastructure/github-actions.tf
@@ -96,14 +96,10 @@ resource "aws_iam_policy" "github_actions" {
       {
         # Toggling the ci-e2e-test publisher's `enabled` flag from the
         # deploy workflow's post-deploy E2E test. Scoped to the publishers
-        # table only — github-actions is not authorized to write to the
-        # event tables.
-        Sid    = "DynamoDBToggleCiE2ePublisher"
-        Effect = "Allow"
-        Action = [
-          "dynamodb:UpdateItem",
-          "dynamodb:GetItem"
-        ]
+        # table and to the single action the workflow actually performs.
+        Sid      = "DynamoDBToggleCiE2ePublisher"
+        Effect   = "Allow"
+        Action   = "dynamodb:UpdateItem"
         Resource = aws_dynamodb_table.publishers.arn
       },
       {


### PR DESCRIPTION
## Summary
- Adds a post-deploy CI step that exercises the full publisher-ingest pipeline against real DynamoDB + S3 sidecar (enable → ingest → assert events appear → disable → ingest → assert events retract), with a `trap cleanup EXIT` that restores the test publisher to `enabled=false` even on failure.
- Provisions a dedicated `ci-e2e-test` publisher and its static feed JSON via Terraform, gated by `var.enable_ci_e2e_publisher` (default `true`), so the test is self-contained.
- Grants the github-actions IAM user the minimum extra permissions needed: `dynamodb:UpdateItem`/`GetItem` scoped to the publishers table only, and `lambda:InvokeFunction` on the publisher-ingest Lambda only.
- Includes a Lambda `LastModified` vs deploy-start check that fails the deploy if the just-shipped zip didn't actually replace the running code (the regression that motivated PR #79).

Implements `docs/plans/2026-05-03-publisher-ingest-e2e-ci-test-plan.md`.

## Test Plan
- [ ] On merge to `main`, watch the Actions log for the `Publisher disable→retract end-to-end test` step. Expect: sidecar year derivation, Lambda LastModified ≥ deploy start, ingest #1 produces `[CI-E2E]` events in the `publisher-events-2026.json` sidecar, ingest #2 retracts them, cleanup runs.
- [ ] Confirm `terraform plan` shows only the 3 expected diffs: create `aws_dynamodb_table_item.ci_e2e_publisher[0]`, create `aws_s3_object.ci_e2e_feed[0]`, in-place update of `aws_iam_policy.github_actions`.
- [ ] After `terraform apply`, verify `aws dynamodb get-item --table-name chautauqua-calendar-publishers --key '{"id":{"S":"ci-e2e-test"}}'` returns the row with `enabled=false`.
- [ ] After the first successful deploy, verify the public sidecar at `https://www.chqcal.org/cache/calendar-cache/publisher-events-2026.json` does NOT contain `sourcePublisherId == "ci-e2e-test"` (cleanup ran).
- [ ] Negative test: temporarily revert PR #78's disable-retraction logic on a throwaway branch and confirm this new step fails the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)