### PR TITLE
feat: publisher portal Phase C — admin review + publisher status

### DIFF
--- a/backend/src/__tests__/adminHandler.applications.test.ts
+++ b/backend/src/__tests__/adminHandler.applications.test.ts
@@ -1,0 +1,236 @@
+// Handler-level tests for the Phase C admin pending-application routes.
+// We bypass auth via DEV_AUTH_BYPASS so the test focuses on routing +
+// service-error → HTTP-status translation. The PublisherAdminService is
+// stubbed via _setPublisherAdminForTests so we don't hit DynamoDB/SES.
+
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { handler, _setPublisherAdminForTests } from '../handlers/adminHandler';
+import { ApplicationStateError } from '../services/publisherAdminService';
+
+const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
+  body: null,
+  headers: {},
+  multiValueHeaders: {},
+  httpMethod: 'GET',
+  isBase64Encoded: false,
+  path: '/',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  stageVariables: null,
+  requestContext: { identity: { sourceIp: '203.0.113.1' } } as any,
+  resource: '/',
+  ...overrides,
+});
+
+const ctx = {} as Context;
+
+const mkAdmin = () => ({
+  listPendingApplications: jest.fn(),
+  approveApplication: jest.fn(),
+  rejectApplication: jest.fn(),
+  // The route handler also calls into other methods; provide harmless stubs
+  // so unrelated routing through the file (which builds the response) works.
+  listPublishers: jest.fn(),
+  createPublisher: jest.fn(),
+  updatePublisher: jest.fn(),
+  listPendingEvents: jest.fn(),
+  approveEvent: jest.fn(),
+  rejectEvent: jest.fn(),
+  listThresholdHalts: jest.fn(),
+  approveThresholdHalt: jest.fn(),
+  cancelThresholdHalt: jest.fn(),
+});
+
+const PRIOR_DEV_BYPASS = process.env.DEV_AUTH_BYPASS;
+const PRIOR_NODE_ENV = process.env.NODE_ENV;
+
+beforeAll(() => {
+  // Bypass admin JWT auth — production guards prevent this in real envs.
+  process.env.DEV_AUTH_BYPASS = 'true';
+  delete process.env.NODE_ENV;
+  delete process.env.ENVIRONMENT;
+});
+
+afterAll(() => {
+  if (PRIOR_DEV_BYPASS === undefined) delete process.env.DEV_AUTH_BYPASS;
+  else process.env.DEV_AUTH_BYPASS = PRIOR_DEV_BYPASS;
+  if (PRIOR_NODE_ENV === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = PRIOR_NODE_ENV;
+});
+
+afterEach(() => {
+  _setPublisherAdminForTests(null);
+});
+
+describe('GET /publisher-applications/pending', () => {
+  it('returns 200 with the wrapped list on success', async () => {
+    const stub = mkAdmin();
+    stub.listPendingApplications.mockResolvedValue([
+      { id: 'p1', name: 'Pending One', applicationStatus: 'pending' },
+    ]);
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/pending', httpMethod: 'GET' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.applications).toHaveLength(1);
+    expect(body.applications[0].id).toBe('p1');
+    expect(stub.listPendingApplications).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 500 on service exception', async () => {
+    const stub = mkAdmin();
+    stub.listPendingApplications.mockRejectedValue(new Error('DDB throttled'));
+    _setPublisherAdminForTests(stub as any);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/pending', httpMethod: 'GET' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(500);
+    expect(JSON.parse(r.body).error).toMatch(/Failed to list/);
+    errSpy.mockRestore();
+  });
+});
+
+describe('POST /publisher-applications/:id/approve', () => {
+  it('returns 200 with the updated publisher on success', async () => {
+    const stub = mkAdmin();
+    stub.approveApplication.mockResolvedValue({
+      id: 'p1', applicationStatus: 'approved', enabled: true,
+    });
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/p1/approve', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body).publisher.id).toBe('p1');
+    // Reviewer email comes from the dev-bypass user, never from the body.
+    expect(stub.approveApplication).toHaveBeenCalledWith('p1', 'dev@localhost.local');
+  });
+
+  it('translates ApplicationStateError to HTTP 409', async () => {
+    const stub = mkAdmin();
+    stub.approveApplication.mockRejectedValue(
+      new ApplicationStateError('cannot approve: applicationStatus is approved, expected pending', 'approved'),
+    );
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/p1/approve', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(409);
+    const body = JSON.parse(r.body);
+    expect(body.error).toMatch(/cannot approve/);
+    expect(body.currentStatus).toBe('approved');
+  });
+
+  it('translates "unknown publisher" to HTTP 404', async () => {
+    const stub = mkAdmin();
+    stub.approveApplication.mockRejectedValue(new Error('unknown publisher missing'));
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/missing/approve', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('returns 500 on unexpected service exception', async () => {
+    const stub = mkAdmin();
+    stub.approveApplication.mockRejectedValue(new Error('SES brokenness'));
+    _setPublisherAdminForTests(stub as any);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/p1/approve', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(500);
+    errSpy.mockRestore();
+  });
+
+  it('URL-decodes the publisher id parameter', async () => {
+    const stub = mkAdmin();
+    stub.approveApplication.mockResolvedValue({ id: 'pub-with/slash' });
+    _setPublisherAdminForTests(stub as any);
+
+    // The route regex disallows internal slashes anyway; use percent-encoded
+    // alternative so we can still verify decoding when allowed characters
+    // are encoded.
+    const encoded = encodeURIComponent('pub special');
+    await handler(
+      evt({ path: `/publisher-applications/${encoded}/approve`, httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(stub.approveApplication).toHaveBeenCalledWith('pub special', 'dev@localhost.local');
+  });
+});
+
+describe('POST /publisher-applications/:id/reject', () => {
+  it('passes the optional reason from the body to the service', async () => {
+    const stub = mkAdmin();
+    stub.rejectApplication.mockResolvedValue({
+      id: 'p1', applicationStatus: 'rejected', enabled: false, rejectionReason: 'because',
+    });
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({
+        path: '/publisher-applications/p1/reject',
+        httpMethod: 'POST',
+        body: JSON.stringify({ reason: 'because' }),
+      }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(200);
+    expect(stub.rejectApplication).toHaveBeenCalledWith('p1', 'dev@localhost.local', 'because');
+  });
+
+  it('omits reason from the call when the body has none', async () => {
+    const stub = mkAdmin();
+    stub.rejectApplication.mockResolvedValue({ id: 'p1', applicationStatus: 'rejected' });
+    _setPublisherAdminForTests(stub as any);
+
+    await handler(
+      evt({ path: '/publisher-applications/p1/reject', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(stub.rejectApplication).toHaveBeenCalledWith('p1', 'dev@localhost.local', undefined);
+  });
+
+  it('translates ApplicationStateError to HTTP 409', async () => {
+    const stub = mkAdmin();
+    stub.rejectApplication.mockRejectedValue(
+      new ApplicationStateError('cannot reject: another admin reviewed this application first', undefined),
+    );
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/p1/reject', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(409);
+  });
+
+  it('translates "unknown publisher" to HTTP 404', async () => {
+    const stub = mkAdmin();
+    stub.rejectApplication.mockRejectedValue(new Error('unknown publisher missing'));
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-applications/missing/reject', httpMethod: 'POST' }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(404);
+  });
+});

--- a/backend/src/__tests__/mailService.test.ts
+++ b/backend/src/__tests__/mailService.test.ts
@@ -62,4 +62,102 @@ describe('SesMailService', () => {
     ).rejects.toThrow(/SES_FROM_ADDRESS/);
     expect(mockSend).not.toHaveBeenCalled();
   });
+
+  // ─── Phase C: approval / rejection emails ─────────────────────────────
+
+  it('sendApprovalEmail uses approval subject and embeds login + status URLs', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-app-1' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    const out = await svc.sendApprovalEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme Concerts',
+      statusUrl: 'https://x.test/publish/status/',
+      loginUrl: 'https://x.test/publish/login/',
+    });
+    expect(out.messageId).toBe('mid-app-1');
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Destination.ToAddresses).toEqual(['pub@example.com']);
+    expect(cmd.input.Content.Simple.Subject.Data).toMatch(/approved/i);
+    const text = cmd.input.Content.Simple.Body.Text.Data;
+    expect(text).toContain('Acme Concerts');
+    expect(text).toContain('https://x.test/publish/login/');
+    expect(text).toContain('https://x.test/publish/status/');
+    const html = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).toContain('Acme Concerts');
+    expect(html).toContain('https://x.test/publish/login/');
+  });
+
+  it('sendApprovalEmail HTML-escapes the publisher name', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-app-2' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendApprovalEmail({
+      to: 'p@x.com',
+      publisherName: '<script>alert(1)</script>',
+      statusUrl: 'https://x.test/s',
+      loginUrl: 'https://x.test/l',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    const html: string = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).not.toContain('<script>alert');
+    expect(html).toContain('&lt;script&gt;');
+  });
+
+  it('sendRejectionEmail includes reviewer reason when supplied', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-rej-1' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendRejectionEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme',
+      reason: 'Source URL returned non-public events.',
+      applyAgainUrl: 'https://x.test/publish/apply/',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Content.Simple.Subject.Data).toMatch(/Update on your/i);
+    const text = cmd.input.Content.Simple.Body.Text.Data;
+    expect(text).toContain('Source URL returned non-public events.');
+    expect(text).toContain('https://x.test/publish/apply/');
+    const html = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).toContain('blockquote');
+    expect(html).toContain('Source URL returned non-public events.');
+  });
+
+  it('sendRejectionEmail omits the reason block when reason is missing', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-rej-2' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendRejectionEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme',
+      applyAgainUrl: 'https://x.test/publish/apply/',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    const html = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).not.toContain('blockquote');
+    expect(html).not.toContain('Reviewer note');
+  });
+
+  it('sendRejectionEmail HTML-escapes the reviewer reason', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-rej-3' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendRejectionEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme',
+      reason: '<img src=x onerror=alert(1)>',
+      applyAgainUrl: 'https://x.test/publish/apply/',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    const html: string = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).not.toContain('<img src=x');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('approval/rejection emails throw if SES_FROM_ADDRESS is empty', async () => {
+    const svc = new SesMailService(mockClient, '');
+    await expect(
+      svc.sendApprovalEmail({ to: 'a@b.com', publisherName: 'X', statusUrl: 'https://x', loginUrl: 'https://x' }),
+    ).rejects.toThrow(/SES_FROM_ADDRESS/);
+    await expect(
+      svc.sendRejectionEmail({ to: 'a@b.com', publisherName: 'X', applyAgainUrl: 'https://x' }),
+    ).rejects.toThrow(/SES_FROM_ADDRESS/);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/__tests__/publisherAdminService.test.ts
+++ b/backend/src/__tests__/publisherAdminService.test.ts
@@ -1,4 +1,4 @@
-import { PublisherAdminService } from '../services/publisherAdminService';
+import { ApplicationStateError, PublisherAdminService } from '../services/publisherAdminService';
 import type { PublisherRecord, StoredPublisherEvent } from '../types/publisher';
 
 function makeRecord(overrides: Partial<PublisherRecord> = {}): PublisherRecord {
@@ -61,7 +61,8 @@ describe('PublisherAdminService', () => {
       get: jest.fn(),
       upsert: jest.fn(),
       setThresholdHalt: jest.fn(),
-    };
+      listPending: jest.fn(),
+    } as any;
     store = {
       listPending: jest.fn(),
       approveEvent: jest.fn(),
@@ -265,5 +266,183 @@ describe('PublisherAdminService', () => {
 
     expect(registry.setThresholdHalt).toHaveBeenCalledWith('pub-1', undefined);
     expect(registry.setThresholdHalt).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── Phase C: pending application review ─────────────────────────────────
+
+  describe('listPendingApplications', () => {
+    it('delegates to registry.listPending', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending', enabled: false });
+      (registry as any).listPending.mockResolvedValue([pending]);
+
+      const result = await svc.listPendingApplications();
+
+      expect(result).toEqual([pending]);
+      expect((registry as any).listPending).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('approveApplication', () => {
+    it('flips status to approved + enabled=true and persists reviewer + reviewedAt', async () => {
+      const pending = makeRecord({
+        id: 'pub-pending',
+        applicationStatus: 'pending',
+        enabled: false,
+      });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+
+      const result = await svc.approveApplication('pub-pending', 'admin@chqcal.org');
+
+      expect(result.applicationStatus).toBe('approved');
+      expect(result.enabled).toBe(true);
+      expect(result.reviewerEmail).toBe('admin@chqcal.org');
+      expect(typeof result.reviewedAt).toBe('string');
+      expect(new Date(result.reviewedAt!).toISOString()).toBe(result.reviewedAt);
+      expect(result.rejectionReason).toBeUndefined();
+      expect(registry.upsert).toHaveBeenCalledWith(result);
+    });
+
+    it('clears any prior rejectionReason on re-review', async () => {
+      const pending = makeRecord({
+        id: 'pub-pending',
+        applicationStatus: 'pending',
+        enabled: false,
+        rejectionReason: 'old reason that should be cleared',
+      });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+
+      const result = await svc.approveApplication('pub-pending', 'admin@chqcal.org');
+
+      expect(result.rejectionReason).toBeUndefined();
+    });
+
+    it('throws unknown publisher when row is missing', async () => {
+      registry.get.mockResolvedValue(null);
+      await expect(svc.approveApplication('missing', 'a@chqcal.org')).rejects.toThrow('unknown publisher missing');
+      expect(registry.upsert).not.toHaveBeenCalled();
+    });
+
+    it('throws ApplicationStateError when row is already approved', async () => {
+      const approved = makeRecord({ id: 'pub-1', applicationStatus: 'approved' });
+      registry.get.mockResolvedValue(approved);
+      await expect(svc.approveApplication('pub-1', 'a@chqcal.org')).rejects.toBeInstanceOf(ApplicationStateError);
+      expect(registry.upsert).not.toHaveBeenCalled();
+    });
+
+    it('throws ApplicationStateError when row has no applicationStatus (admin-created)', async () => {
+      const adminCreated = makeRecord({ id: 'pub-1' }); // no applicationStatus
+      registry.get.mockResolvedValue(adminCreated);
+      await expect(svc.approveApplication('pub-1', 'a@chqcal.org')).rejects.toBeInstanceOf(ApplicationStateError);
+    });
+
+    it('still persists state change when approval email throws', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+      const mail = { sendApprovalEmail: jest.fn().mockRejectedValue(new Error('SES down')) } as any;
+      const svcWithMail = new PublisherAdminService(registry as any, store as any, { mail });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const result = await svcWithMail.approveApplication('pub-pending', 'a@chqcal.org');
+
+      expect(result.applicationStatus).toBe('approved');
+      expect(registry.upsert).toHaveBeenCalledTimes(1);
+      expect(mail.sendApprovalEmail).toHaveBeenCalledTimes(1);
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it('passes the correct email payload to mail.sendApprovalEmail', async () => {
+      const pending = makeRecord({
+        id: 'pub-pending',
+        name: 'Acme',
+        contactEmail: 'pub@example.com',
+        applicationStatus: 'pending',
+      });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+      const mail = { sendApprovalEmail: jest.fn().mockResolvedValue({ messageId: 'm' }) } as any;
+      const svcWithMail = new PublisherAdminService(registry as any, store as any, {
+        mail,
+        siteBaseUrl: 'https://x.test/',
+      });
+
+      await svcWithMail.approveApplication('pub-pending', 'admin@chqcal.org');
+
+      expect(mail.sendApprovalEmail).toHaveBeenCalledWith({
+        to: 'pub@example.com',
+        publisherName: 'Acme',
+        statusUrl: 'https://x.test/publish/status/',
+        loginUrl: 'https://x.test/publish/login/',
+      });
+    });
+  });
+
+  describe('rejectApplication', () => {
+    it('flips to rejected + enabled=false and persists reason/reviewer', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending', enabled: false });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+
+      const result = await svc.rejectApplication('pub-pending', 'admin@chqcal.org', 'Spam-looking events.');
+
+      expect(result.applicationStatus).toBe('rejected');
+      expect(result.enabled).toBe(false);
+      expect(result.reviewerEmail).toBe('admin@chqcal.org');
+      expect(result.rejectionReason).toBe('Spam-looking events.');
+      expect(typeof result.reviewedAt).toBe('string');
+    });
+
+    it('truncates reasons longer than 500 chars', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+
+      const longReason = 'x'.repeat(700);
+      const result = await svc.rejectApplication('pub-pending', 'a@chqcal.org', longReason);
+
+      expect(result.rejectionReason!.length).toBe(500);
+    });
+
+    it('allows omitting the reason', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+
+      const result = await svc.rejectApplication('pub-pending', 'a@chqcal.org');
+
+      expect(result.applicationStatus).toBe('rejected');
+      expect(result.rejectionReason).toBeUndefined();
+    });
+
+    it('throws unknown publisher when row is missing', async () => {
+      registry.get.mockResolvedValue(null);
+      await expect(svc.rejectApplication('missing', 'a@chqcal.org')).rejects.toThrow('unknown publisher missing');
+    });
+
+    it('throws ApplicationStateError when row is already rejected', async () => {
+      const rejected = makeRecord({ id: 'pub-1', applicationStatus: 'rejected' });
+      registry.get.mockResolvedValue(rejected);
+      await expect(svc.rejectApplication('pub-1', 'a@chqcal.org')).rejects.toBeInstanceOf(ApplicationStateError);
+      expect(registry.upsert).not.toHaveBeenCalled();
+    });
+
+    it('still persists state change when rejection email throws', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      registry.upsert.mockResolvedValue(undefined);
+      const mail = { sendRejectionEmail: jest.fn().mockRejectedValue(new Error('SES down')) } as any;
+      const svcWithMail = new PublisherAdminService(registry as any, store as any, { mail });
+      const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+      const result = await svcWithMail.rejectApplication('pub-pending', 'a@chqcal.org', 'reason');
+
+      expect(result.applicationStatus).toBe('rejected');
+      expect(registry.upsert).toHaveBeenCalledTimes(1);
+      expect(mail.sendRejectionEmail).toHaveBeenCalledTimes(1);
+      errorSpy.mockRestore();
+    });
   });
 });

--- a/backend/src/__tests__/publisherAdminService.test.ts
+++ b/backend/src/__tests__/publisherAdminService.test.ts
@@ -1,4 +1,5 @@
 import { ApplicationStateError, PublisherAdminService } from '../services/publisherAdminService';
+import { ConcurrentApplicationUpdateError } from '../services/publisherRegistryService';
 import type { PublisherRecord, StoredPublisherEvent } from '../types/publisher';
 
 function makeRecord(overrides: Partial<PublisherRecord> = {}): PublisherRecord {
@@ -62,6 +63,7 @@ describe('PublisherAdminService', () => {
       upsert: jest.fn(),
       setThresholdHalt: jest.fn(),
       listPending: jest.fn(),
+      setApplicationStatus: jest.fn(),
     } as any;
     store = {
       listPending: jest.fn(),
@@ -283,14 +285,14 @@ describe('PublisherAdminService', () => {
   });
 
   describe('approveApplication', () => {
-    it('flips status to approved + enabled=true and persists reviewer + reviewedAt', async () => {
+    it('flips status to approved + enabled=true atomically and returns the merged record', async () => {
       const pending = makeRecord({
         id: 'pub-pending',
         applicationStatus: 'pending',
         enabled: false,
       });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
 
       const result = await svc.approveApplication('pub-pending', 'admin@chqcal.org');
 
@@ -300,7 +302,17 @@ describe('PublisherAdminService', () => {
       expect(typeof result.reviewedAt).toBe('string');
       expect(new Date(result.reviewedAt!).toISOString()).toBe(result.reviewedAt);
       expect(result.rejectionReason).toBeUndefined();
-      expect(registry.upsert).toHaveBeenCalledWith(result);
+      // The atomic write must include the conditional guard.
+      expect((registry as any).setApplicationStatus).toHaveBeenCalledWith(
+        'pub-pending',
+        'approved',
+        expect.objectContaining({
+          reviewerEmail: 'admin@chqcal.org',
+          enabled: true,
+          rejectionReason: undefined,
+          expectedFromStatus: 'pending',
+        }),
+      );
     });
 
     it('clears any prior rejectionReason on re-review', async () => {
@@ -311,7 +323,7 @@ describe('PublisherAdminService', () => {
         rejectionReason: 'old reason that should be cleared',
       });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
 
       const result = await svc.approveApplication('pub-pending', 'admin@chqcal.org');
 
@@ -321,14 +333,14 @@ describe('PublisherAdminService', () => {
     it('throws unknown publisher when row is missing', async () => {
       registry.get.mockResolvedValue(null);
       await expect(svc.approveApplication('missing', 'a@chqcal.org')).rejects.toThrow('unknown publisher missing');
-      expect(registry.upsert).not.toHaveBeenCalled();
+      expect((registry as any).setApplicationStatus).not.toHaveBeenCalled();
     });
 
     it('throws ApplicationStateError when row is already approved', async () => {
       const approved = makeRecord({ id: 'pub-1', applicationStatus: 'approved' });
       registry.get.mockResolvedValue(approved);
       await expect(svc.approveApplication('pub-1', 'a@chqcal.org')).rejects.toBeInstanceOf(ApplicationStateError);
-      expect(registry.upsert).not.toHaveBeenCalled();
+      expect((registry as any).setApplicationStatus).not.toHaveBeenCalled();
     });
 
     it('throws ApplicationStateError when row has no applicationStatus (admin-created)', async () => {
@@ -337,10 +349,20 @@ describe('PublisherAdminService', () => {
       await expect(svc.approveApplication('pub-1', 'a@chqcal.org')).rejects.toBeInstanceOf(ApplicationStateError);
     });
 
+    it('translates ConcurrentApplicationUpdateError from the registry into ApplicationStateError (race-loser)', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      (registry as any).setApplicationStatus.mockRejectedValue(
+        new ConcurrentApplicationUpdateError('pending'),
+      );
+      await expect(svc.approveApplication('pub-pending', 'a@chqcal.org'))
+        .rejects.toBeInstanceOf(ApplicationStateError);
+    });
+
     it('still persists state change when approval email throws', async () => {
       const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
       const mail = { sendApprovalEmail: jest.fn().mockRejectedValue(new Error('SES down')) } as any;
       const svcWithMail = new PublisherAdminService(registry as any, store as any, { mail });
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -348,7 +370,7 @@ describe('PublisherAdminService', () => {
       const result = await svcWithMail.approveApplication('pub-pending', 'a@chqcal.org');
 
       expect(result.applicationStatus).toBe('approved');
-      expect(registry.upsert).toHaveBeenCalledTimes(1);
+      expect((registry as any).setApplicationStatus).toHaveBeenCalledTimes(1);
       expect(mail.sendApprovalEmail).toHaveBeenCalledTimes(1);
       expect(errorSpy).toHaveBeenCalled();
       errorSpy.mockRestore();
@@ -362,7 +384,7 @@ describe('PublisherAdminService', () => {
         applicationStatus: 'pending',
       });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
       const mail = { sendApprovalEmail: jest.fn().mockResolvedValue({ messageId: 'm' }) } as any;
       const svcWithMail = new PublisherAdminService(registry as any, store as any, {
         mail,
@@ -381,10 +403,10 @@ describe('PublisherAdminService', () => {
   });
 
   describe('rejectApplication', () => {
-    it('flips to rejected + enabled=false and persists reason/reviewer', async () => {
+    it('flips to rejected + enabled=false and persists reason/reviewer atomically', async () => {
       const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending', enabled: false });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
 
       const result = await svc.rejectApplication('pub-pending', 'admin@chqcal.org', 'Spam-looking events.');
 
@@ -393,12 +415,22 @@ describe('PublisherAdminService', () => {
       expect(result.reviewerEmail).toBe('admin@chqcal.org');
       expect(result.rejectionReason).toBe('Spam-looking events.');
       expect(typeof result.reviewedAt).toBe('string');
+      expect((registry as any).setApplicationStatus).toHaveBeenCalledWith(
+        'pub-pending',
+        'rejected',
+        expect.objectContaining({
+          reviewerEmail: 'admin@chqcal.org',
+          rejectionReason: 'Spam-looking events.',
+          enabled: false,
+          expectedFromStatus: 'pending',
+        }),
+      );
     });
 
     it('truncates reasons longer than 500 chars', async () => {
       const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
 
       const longReason = 'x'.repeat(700);
       const result = await svc.rejectApplication('pub-pending', 'a@chqcal.org', longReason);
@@ -409,12 +441,29 @@ describe('PublisherAdminService', () => {
     it('allows omitting the reason', async () => {
       const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
 
       const result = await svc.rejectApplication('pub-pending', 'a@chqcal.org');
 
       expect(result.applicationStatus).toBe('rejected');
       expect(result.rejectionReason).toBeUndefined();
+    });
+
+    it('normalizes whitespace-only or empty-string reason to undefined', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
+
+      const r1 = await svc.rejectApplication('pub-pending', 'a@chqcal.org', '');
+      expect(r1.rejectionReason).toBeUndefined();
+
+      // Reset mocks for the second call.
+      jest.clearAllMocks();
+      registry.get.mockResolvedValue(pending);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
+
+      const r2 = await svc.rejectApplication('pub-pending', 'a@chqcal.org', '   \n\t  ');
+      expect(r2.rejectionReason).toBeUndefined();
     });
 
     it('throws unknown publisher when row is missing', async () => {
@@ -426,13 +475,23 @@ describe('PublisherAdminService', () => {
       const rejected = makeRecord({ id: 'pub-1', applicationStatus: 'rejected' });
       registry.get.mockResolvedValue(rejected);
       await expect(svc.rejectApplication('pub-1', 'a@chqcal.org')).rejects.toBeInstanceOf(ApplicationStateError);
-      expect(registry.upsert).not.toHaveBeenCalled();
+      expect((registry as any).setApplicationStatus).not.toHaveBeenCalled();
+    });
+
+    it('translates ConcurrentApplicationUpdateError into ApplicationStateError (race-loser)', async () => {
+      const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
+      registry.get.mockResolvedValue(pending);
+      (registry as any).setApplicationStatus.mockRejectedValue(
+        new ConcurrentApplicationUpdateError('pending'),
+      );
+      await expect(svc.rejectApplication('pub-pending', 'a@chqcal.org', 'r'))
+        .rejects.toBeInstanceOf(ApplicationStateError);
     });
 
     it('still persists state change when rejection email throws', async () => {
       const pending = makeRecord({ id: 'pub-pending', applicationStatus: 'pending' });
       registry.get.mockResolvedValue(pending);
-      registry.upsert.mockResolvedValue(undefined);
+      (registry as any).setApplicationStatus.mockResolvedValue(undefined);
       const mail = { sendRejectionEmail: jest.fn().mockRejectedValue(new Error('SES down')) } as any;
       const svcWithMail = new PublisherAdminService(registry as any, store as any, { mail });
       const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
@@ -440,7 +499,7 @@ describe('PublisherAdminService', () => {
       const result = await svcWithMail.rejectApplication('pub-pending', 'a@chqcal.org', 'reason');
 
       expect(result.applicationStatus).toBe('rejected');
-      expect(registry.upsert).toHaveBeenCalledTimes(1);
+      expect((registry as any).setApplicationStatus).toHaveBeenCalledTimes(1);
       expect(mail.sendRejectionEmail).toHaveBeenCalledTimes(1);
       errorSpy.mockRestore();
     });

--- a/backend/src/__tests__/publisherApplicationService.test.ts
+++ b/backend/src/__tests__/publisherApplicationService.test.ts
@@ -193,7 +193,7 @@ describe('PublisherApplicationService — login flow', () => {
     expect(deps.mail.sendLoginMagicLink).toHaveBeenCalled();
   });
 
-  it('requestLogin returns ok but sends no email when only pending row matches', async () => {
+  it('requestLogin sends a magic link to a pending applicant (Phase C — pending applicants need to view their status)', async () => {
     const deps = mkDeps();
     deps.registry.getByEmail.mockResolvedValue([{
       id: 'pending',
@@ -206,11 +206,66 @@ describe('PublisherApplicationService — login flow', () => {
       createdAt: 't',
       applicationStatus: 'pending',
     }]);
+    deps.tokens.issueToken.mockResolvedValue({ rawToken: 'tok', expiresAt: 9 });
     const svc = new PublisherApplicationService(deps);
     const r = await svc.requestLogin('a@b.com');
     expect(r).toEqual({ ok: true });
-    expect(deps.mail.sendLoginMagicLink).not.toHaveBeenCalled();
-    expect(deps.tokens.issueToken).not.toHaveBeenCalled();
+    expect(deps.mail.sendLoginMagicLink).toHaveBeenCalledTimes(1);
+    expect(deps.tokens.issueToken).toHaveBeenCalledWith(expect.objectContaining({
+      purpose: 'login',
+      publisherId: 'pending',
+    }));
+  });
+
+  it('requestLogin sends a magic link to a rejected applicant so they can see the rejection reason', async () => {
+    const deps = mkDeps();
+    deps.registry.getByEmail.mockResolvedValue([{
+      id: 'rejected',
+      name: 'Rejected',
+      contactEmail: 'a@b.com',
+      sourceUrl: 'u',
+      sourceType: 'json',
+      trustLevel: 'review',
+      enabled: false,
+      createdAt: 't',
+      applicationStatus: 'rejected',
+      rejectionReason: 'spam-looking',
+    }]);
+    deps.tokens.issueToken.mockResolvedValue({ rawToken: 'tok', expiresAt: 9 });
+    const svc = new PublisherApplicationService(deps);
+    await svc.requestLogin('a@b.com');
+    expect(deps.mail.sendLoginMagicLink).toHaveBeenCalledTimes(1);
+  });
+
+  it('requestLogin prefers an approved row when both approved and pending share an email', async () => {
+    // Real-world scenario: a publisher reapplies (new pending row) while
+    // their approved account is still active. Login should route them to
+    // the approved account.
+    const deps = mkDeps();
+    deps.registry.getByEmail.mockResolvedValue([
+      {
+        id: 'pending-new',
+        name: 'New App',
+        contactEmail: 'a@b.com',
+        sourceUrl: 'u', sourceType: 'json', trustLevel: 'review',
+        enabled: false, createdAt: 't',
+        applicationStatus: 'pending',
+      },
+      {
+        id: 'approved-old',
+        name: 'Old Account',
+        contactEmail: 'a@b.com',
+        sourceUrl: 'u', sourceType: 'json', trustLevel: 'auto',
+        enabled: true, createdAt: 't',
+        applicationStatus: 'approved',
+      },
+    ]);
+    deps.tokens.issueToken.mockResolvedValue({ rawToken: 'tok', expiresAt: 9 });
+    const svc = new PublisherApplicationService(deps);
+    await svc.requestLogin('a@b.com');
+    expect(deps.tokens.issueToken).toHaveBeenCalledWith(expect.objectContaining({
+      publisherId: 'approved-old',
+    }));
   });
 
   it('requestLogin returns ok but sends no email for unknown email (anti-enumeration)', async () => {

--- a/backend/src/__tests__/publisherPortalHandler.status.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.status.test.ts
@@ -1,0 +1,164 @@
+// Tests for the GET /api/publisher-status route added in Phase C.
+// The publisher-JWT verifier is mocked at module level so we don't need to
+// stand up Secrets Manager. The registry is replaced via _setStatusRegistryForTests.
+
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import { handlePublisherStatus, _setStatusRegistryForTests } from '../handlers/publisherPortalHandler';
+import type { PublisherRecord } from '../types/publisher';
+
+jest.mock('../services/publisherAuthService', () => ({
+  verifyPublisherJwt: jest.fn(),
+}));
+import { verifyPublisherJwt } from '../services/publisherAuthService';
+
+const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
+  body: '',
+  headers: {},
+  multiValueHeaders: {},
+  httpMethod: 'GET',
+  isBase64Encoded: false,
+  path: '/publisher-status',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  stageVariables: null,
+  resource: '/publisher-status',
+  requestContext: { identity: { sourceIp: '203.0.113.1' } } as any,
+  ...overrides,
+});
+
+const makeRecord = (overrides: Partial<PublisherRecord> = {}): PublisherRecord => ({
+  id: 'pub-1',
+  name: 'Test Publisher',
+  contactEmail: 'test@example.com',
+  sourceUrl: 'https://example.com/feed.json',
+  sourceType: 'json',
+  trustLevel: 'review',
+  enabled: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('handlePublisherStatus', () => {
+  let registry: { get: jest.Mock };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    registry = { get: jest.fn() };
+    _setStatusRegistryForTests(registry as any);
+  });
+  afterEach(() => {
+    _setStatusRegistryForTests(null);
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    const r = await handlePublisherStatus(evt(), {});
+    expect(r.statusCode).toBe(401);
+    expect(JSON.parse(r.body).error).toMatch(/Authentication required/);
+    expect(registry.get).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when Authorization header is malformed (no Bearer)', async () => {
+    const r = await handlePublisherStatus(
+      evt({ headers: { Authorization: 'token-without-bearer' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns 401 when JWT verification fails', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue(null);
+    const r = await handlePublisherStatus(
+      evt({ headers: { Authorization: 'Bearer bad.jwt.value' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(401);
+    expect(registry.get).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when publisher row no longer exists', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-deleted', role: 'publisher', email: 'p@x.com',
+    });
+    registry.get.mockResolvedValue(null);
+    const r = await handlePublisherStatus(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(404);
+    expect(JSON.parse(r.body).error).toMatch(/not found/i);
+  });
+
+  it('returns 200 with the sanitized publisher record on success', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-1', role: 'publisher', email: 'pub@example.com',
+    });
+    const rec = makeRecord({
+      id: 'pub-1',
+      applicationStatus: 'approved',
+      reviewerEmail: 'admin@chqcal.org', // PII — must be stripped
+      reviewedAt: '2026-05-03T00:00:00.000Z',
+      lastFetchedAt: '2026-05-03T01:00:00.000Z',
+      lastFetchStatus: 'ok',
+      pendingThresholdHalt: { // ops-internal — must be stripped
+        detectedAt: '2026-05-02T00:00:00.000Z',
+        incomingFeed: { eventCount: 9999, publisherId: 'pub-1' },
+      },
+    });
+    registry.get.mockResolvedValue(rec);
+
+    const r = await handlePublisherStatus(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.publisher.id).toBe('pub-1');
+    expect(body.publisher.applicationStatus).toBe('approved');
+    expect(body.publisher.lastFetchStatus).toBe('ok');
+    // Sanitized fields must NOT appear:
+    expect(body.publisher.reviewerEmail).toBeUndefined();
+    expect(body.publisher.pendingThresholdHalt).toBeUndefined();
+    // Public fields preserved:
+    expect(body.publisher.contactEmail).toBe('test@example.com');
+    expect(body.publisher.sourceUrl).toBe('https://example.com/feed.json');
+  });
+
+  it('uses authoritative sub from JWT to look up the row (not any header)', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-from-jwt', role: 'publisher', email: 'p@x.com',
+    });
+    registry.get.mockResolvedValue(makeRecord({ id: 'pub-from-jwt' }));
+    await handlePublisherStatus(
+      evt({ headers: { Authorization: 'Bearer good.jwt', 'X-Publisher-Id': 'spoofed' } }),
+      {},
+    );
+    expect(registry.get).toHaveBeenCalledWith('pub-from-jwt');
+  });
+
+  it('accepts lowercase "authorization" header', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-1', role: 'publisher', email: 'p@x.com',
+    });
+    registry.get.mockResolvedValue(makeRecord({ id: 'pub-1' }));
+    const r = await handlePublisherStatus(
+      evt({ headers: { authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(200);
+  });
+
+  it('returns 500 on registry exception', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-1', role: 'publisher', email: 'p@x.com',
+    });
+    registry.get.mockRejectedValue(new Error('DDB throttled'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const r = await handlePublisherStatus(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(500);
+    errSpy.mockRestore();
+  });
+});

--- a/backend/src/__tests__/publisherRegistryService.test.ts
+++ b/backend/src/__tests__/publisherRegistryService.test.ts
@@ -1,6 +1,6 @@
 jest.unmock('@aws-sdk/lib-dynamodb');
 
-import { PublisherRegistryService } from '../services/publisherRegistryService';
+import { ConcurrentApplicationUpdateError, PublisherRegistryService } from '../services/publisherRegistryService';
 
 const mockSend = jest.fn();
 const mockClient: any = { send: mockSend };
@@ -127,5 +127,47 @@ describe('PublisherRegistryService', () => {
     const cmd: any = mockSend.mock.calls[0][0];
     expect(cmd.input.ExpressionAttributeValues[':s']).toBe('rejected');
     expect(cmd.input.ExpressionAttributeValues[':rr']).toBe('feed not parseable');
+  });
+
+  it('setApplicationStatus with expectedFromStatus emits a ConditionExpression', async () => {
+    mockSend.mockResolvedValue({});
+    await svc.setApplicationStatus('p1', 'approved', {
+      reviewerEmail: 'admin@chqcal.org',
+      expectedFromStatus: 'pending',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.ConditionExpression).toBe('applicationStatus = :expected');
+    expect(cmd.input.ExpressionAttributeValues[':expected']).toBe('pending');
+  });
+
+  it('setApplicationStatus with enabled flag includes it in the SET clause', async () => {
+    mockSend.mockResolvedValue({});
+    await svc.setApplicationStatus('p1', 'approved', {
+      reviewerEmail: 'admin@chqcal.org',
+      enabled: true,
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.UpdateExpression).toMatch(/enabled = :enabled/);
+    expect(cmd.input.ExpressionAttributeValues[':enabled']).toBe(true);
+  });
+
+  it('setApplicationStatus translates ConditionalCheckFailedException to ConcurrentApplicationUpdateError when condition was supplied', async () => {
+    const ddbErr = Object.assign(new Error('cond fail'), { name: 'ConditionalCheckFailedException' });
+    mockSend.mockRejectedValue(ddbErr);
+    await expect(svc.setApplicationStatus('p1', 'approved', {
+      reviewerEmail: 'admin@chqcal.org',
+      expectedFromStatus: 'pending',
+    })).rejects.toBeInstanceOf(ConcurrentApplicationUpdateError);
+  });
+
+  it('setApplicationStatus surfaces ConditionalCheckFailedException unchanged when no condition was supplied', async () => {
+    const ddbErr = Object.assign(new Error('cond fail'), { name: 'ConditionalCheckFailedException' });
+    mockSend.mockRejectedValue(ddbErr);
+    // No expectedFromStatus → the error should pass through (this code path
+    // shouldn't normally trigger because there's no condition, but if some
+    // other DDB constraint fails we don't want to mis-translate).
+    await expect(svc.setApplicationStatus('p1', 'approved', {
+      reviewerEmail: 'admin@chqcal.org',
+    })).rejects.not.toBeInstanceOf(ConcurrentApplicationUpdateError);
   });
 });

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -4,15 +4,17 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, ScanCommand, PutCommand, GetCommand, DeleteCommand } from '@aws-sdk/lib-dynamodb';
 import jwt from 'jsonwebtoken';
 import { google } from 'googleapis';
-import { PublisherAdminService } from '../services/publisherAdminService';
+import { ApplicationStateError, PublisherAdminService } from '../services/publisherAdminService';
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherEventStore } from '../services/publisherEventStore';
+import { SesMailService } from '../services/mailService';
 import {
   handlePublisherTest,
   handlePublisherApplyRequest,
   handlePublisherApplyVerify,
   handlePublisherAuthRequest,
   handlePublisherAuthVerify,
+  handlePublisherStatus,
 } from './publisherPortalHandler';
 
 // DynamoDB client
@@ -29,15 +31,26 @@ const dynamoClient = new DynamoDBClient({
 const docClient = DynamoDBDocumentClient.from(dynamoClient);
 
 // Lazy singleton for PublisherAdminService — one instance per Lambda warm container.
+// Phase C: pass MailService + siteBaseUrl so approve/reject can notify publishers.
 let _publisherAdmin: PublisherAdminService | null = null;
 function publisherAdmin(): PublisherAdminService {
   if (!_publisherAdmin) {
     _publisherAdmin = new PublisherAdminService(
       new PublisherRegistryService(docClient, process.env.PUBLISHERS_TABLE_NAME ?? 'chautauqua-calendar-publishers'),
       new PublisherEventStore(docClient, process.env.PUBLISHER_EVENTS_TABLE_NAME ?? 'chautauqua-calendar-publisher-events'),
+      {
+        mail: new SesMailService(),
+        siteBaseUrl: process.env.SITE_BASE_URL ?? 'https://www.chqcal.org',
+      },
     );
   }
   return _publisherAdmin;
+}
+
+// Test-only: reset the cached singleton between test cases that need to inject
+// stubs (mocks aws-sdk-client-mock-style). Production code never calls this.
+export function _resetPublisherAdminForTests(): void {
+  _publisherAdmin = null;
 }
 
 // Environment variables
@@ -361,6 +374,13 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       return await handlePublisherAuthVerify(event, requestBody);
     }
 
+    // Phase C: publisher-facing status endpoint. JWT-protected with the
+    // publisher JWT (NOT the admin JWT) — auth check lives inside the
+    // handler, so it sits BEFORE the admin auth gate below.
+    if (path === '/publisher-status' && httpMethod === 'GET') {
+      return await handlePublisherStatus(event, requestBody);
+    }
+
     // All remaining endpoints require authentication, except in local development
     let user = authenticateRequest(event);
     console.log('Authentication result:', user ? `authenticated as "${user.name}"` : 'unauthenticated');
@@ -400,6 +420,61 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
           return createResponse(409, { error: message });
         }
         return createResponse(500, { error: 'Failed to create publisher' });
+      }
+    }
+
+    // Phase C: pending application review (admin-only).
+    if (path === '/publisher-applications/pending' && httpMethod === 'GET') {
+      try {
+        const applications = await publisherAdmin().listPendingApplications();
+        return createResponse(200, { applications });
+      } catch (error) {
+        console.error('Error listing pending applications:', error);
+        return createResponse(500, { error: 'Failed to list pending applications' });
+      }
+    }
+
+    const matchAppApprove = path.match(/^\/publisher-applications\/([^/]+)\/approve$/);
+    if (matchAppApprove && httpMethod === 'POST') {
+      try {
+        const publisher = await publisherAdmin().approveApplication(
+          decodeURIComponent(matchAppApprove[1]),
+          user.email,
+        );
+        return createResponse(200, { publisher });
+      } catch (error) {
+        if (error instanceof ApplicationStateError) {
+          return createResponse(409, { error: error.message, currentStatus: error.currentStatus });
+        }
+        const message = error instanceof Error ? error.message : '';
+        if (message.startsWith('unknown publisher')) {
+          return createResponse(404, { error: message });
+        }
+        console.error('Error approving application:', error);
+        return createResponse(500, { error: 'Failed to approve application' });
+      }
+    }
+
+    const matchAppReject = path.match(/^\/publisher-applications\/([^/]+)\/reject$/);
+    if (matchAppReject && httpMethod === 'POST') {
+      try {
+        const reason = typeof requestBody?.reason === 'string' ? requestBody.reason : undefined;
+        const publisher = await publisherAdmin().rejectApplication(
+          decodeURIComponent(matchAppReject[1]),
+          user.email,
+          reason,
+        );
+        return createResponse(200, { publisher });
+      } catch (error) {
+        if (error instanceof ApplicationStateError) {
+          return createResponse(409, { error: error.message, currentStatus: error.currentStatus });
+        }
+        const message = error instanceof Error ? error.message : '';
+        if (message.startsWith('unknown publisher')) {
+          return createResponse(404, { error: message });
+        }
+        console.error('Error rejecting application:', error);
+        return createResponse(500, { error: 'Failed to reject application' });
       }
     }
 

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -53,6 +53,12 @@ export function _resetPublisherAdminForTests(): void {
   _publisherAdmin = null;
 }
 
+// Test-only: inject a fake PublisherAdminService so handler tests can drive
+// the route layer without standing up DynamoDB/SES. Pass null to revert.
+export function _setPublisherAdminForTests(svc: PublisherAdminService | null): void {
+  _publisherAdmin = svc;
+}
+
 // Environment variables
 const FEEDBACK_TABLE_NAME = process.env.FEEDBACK_TABLE_NAME || 'chautauqua-calendar-feedback';
 const GOOGLE_CLIENT_ID = process.env.GOOGLE_CLIENT_ID;

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -24,7 +24,8 @@ import { MagicTokenService } from '../services/magicTokenService';
 import { SesMailService } from '../services/mailService';
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherApplicationService } from '../services/publisherApplicationService';
-import type { ApplyFormPayload } from '../types/publisher';
+import { verifyPublisherJwt } from '../services/publisherAuthService';
+import type { ApplyFormPayload, PublisherRecord } from '../types/publisher';
 
 // ─── Rate limiter ────────────────────────────────────────────────────────
 // In-memory per-IP sliding window. Per-instance only — each Lambda warm
@@ -358,6 +359,91 @@ export async function handlePublisherAuthVerify(
     console.error('Error in /publisher-auth/verify:', err);
     return json(500, { error: 'Internal server error' });
   }
+}
+
+// ─── Publisher status singleton (registry only — no email/token deps) ────
+//
+// Reused across cold starts. Distinct from `appService` so the status
+// endpoint avoids paying the SES/Secrets-Manager init cost (the
+// PublisherApplicationService eagerly constructs both).
+
+let _statusRegistry: PublisherRegistryService | null = null;
+
+function statusRegistry(): PublisherRegistryService {
+  if (!_statusRegistry) {
+    const dynamoClient = new DynamoDBClient({
+      region: process.env.AWS_REGION || 'us-east-1',
+      ...(process.env.DYNAMODB_ENDPOINT && {
+        endpoint: process.env.DYNAMODB_ENDPOINT,
+        credentials: {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID || 'dummy',
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || 'dummy',
+        },
+      }),
+    });
+    const docClient = DynamoDBDocumentClient.from(dynamoClient);
+    _statusRegistry = new PublisherRegistryService(
+      docClient,
+      process.env.PUBLISHERS_TABLE_NAME ?? 'chautauqua-calendar-publishers',
+    );
+  }
+  return _statusRegistry;
+}
+
+export function _setStatusRegistryForTests(r: PublisherRegistryService | null): void {
+  _statusRegistry = r;
+}
+
+// ─── /publisher-status (publisher JWT only) ──────────────────────────────
+//
+// Returns the caller's own publisher record, sanitized:
+//   - omits `pendingThresholdHalt` (ops-internal signal)
+//   - omits `reviewerEmail` (admin PII not relevant to the publisher)
+//
+// Auth: `Authorization: Bearer <publisher-jwt>`. Invalid or missing → 401.
+// Publisher row deleted while JWT is still valid → 404 (clears stale local
+// session on the frontend).
+export async function handlePublisherStatus(
+  event: APIGatewayProxyEvent,
+  _requestBody: Record<string, unknown>,
+): Promise<APIGatewayProxyResult> {
+  const auth = readAuthHeader(event);
+  if (!auth) {
+    return json(401, { error: 'Authentication required' });
+  }
+  const claims = await verifyPublisherJwt(auth);
+  if (!claims) {
+    return json(401, { error: 'Authentication required' });
+  }
+  try {
+    const rec = await statusRegistry().get(claims.sub);
+    if (!rec) {
+      return json(404, { error: 'Publisher not found' });
+    }
+    return json(200, { publisher: sanitizePublisher(rec) });
+  } catch (err) {
+    console.error('Error in /publisher-status:', err);
+    return json(500, { error: 'Internal server error' });
+  }
+}
+
+// Header lookup is case-insensitive; APIGatewayProxyEvent normalizes to the
+// caller's casing, so we check both common forms.
+function readAuthHeader(event: APIGatewayProxyEvent): string | null {
+  const headers = event.headers ?? {};
+  const raw = headers.Authorization ?? headers.authorization;
+  if (typeof raw !== 'string') return null;
+  const m = raw.match(/^Bearer\s+(.+)$/i);
+  return m ? m[1].trim() : null;
+}
+
+function sanitizePublisher(rec: PublisherRecord) {
+  const {
+    pendingThresholdHalt: _omitHalt,
+    reviewerEmail: _omitReviewer,
+    ...rest
+  } = rec;
+  return rest;
 }
 
 function explainTokenFailure(

--- a/backend/src/services/mailService.ts
+++ b/backend/src/services/mailService.ts
@@ -19,6 +19,22 @@ import { SESv2Client, SendEmailCommand } from '@aws-sdk/client-sesv2';
 export interface MailService {
   sendApplyMagicLink(toEmail: string, applicantName: string, magicLinkUrl: string): Promise<{ messageId: string }>;
   sendLoginMagicLink(toEmail: string, magicLinkUrl: string): Promise<{ messageId: string }>;
+  sendApprovalEmail(opts: ApprovalEmailOpts): Promise<{ messageId: string }>;
+  sendRejectionEmail(opts: RejectionEmailOpts): Promise<{ messageId: string }>;
+}
+
+export interface ApprovalEmailOpts {
+  to: string;
+  publisherName: string;
+  statusUrl: string;
+  loginUrl: string;
+}
+
+export interface RejectionEmailOpts {
+  to: string;
+  publisherName: string;
+  reason?: string;
+  applyAgainUrl: string;
 }
 
 export class SesMailService implements MailService {
@@ -45,6 +61,26 @@ export class SesMailService implements MailService {
     const text = loginText(magicLinkUrl);
     const html = loginHtml(magicLinkUrl);
     return this._send(toEmail, subject, text, html);
+  }
+
+  async sendApprovalEmail(opts: ApprovalEmailOpts) {
+    if (!this.fromAddress) {
+      throw new Error('SES_FROM_ADDRESS env var not set');
+    }
+    const subject = 'Your Chautauqua Calendar publisher application is approved';
+    const text = approvalText(opts);
+    const html = approvalHtml(opts);
+    return this._send(opts.to, subject, text, html);
+  }
+
+  async sendRejectionEmail(opts: RejectionEmailOpts) {
+    if (!this.fromAddress) {
+      throw new Error('SES_FROM_ADDRESS env var not set');
+    }
+    const subject = 'Update on your Chautauqua Calendar publisher application';
+    const text = rejectionText(opts);
+    const html = rejectionHtml(opts);
+    return this._send(opts.to, subject, text, html);
   }
 
   private async _send(to: string, subject: string, text: string, html: string) {
@@ -128,6 +164,75 @@ function loginHtml(url: string): string {
     '<p>Click the link below within 15 minutes to sign in to your Chautauqua Calendar publisher account:</p>',
     `<p><a href="${safeUrl}">${safeUrl}</a></p>`,
     '<p>If you did not request this, you can safely ignore this email.</p>',
+    '<p>— Chautauqua Calendar</p>',
+    '</body></html>',
+  ].join('');
+}
+
+function approvalText(o: ApprovalEmailOpts): string {
+  return [
+    `Hi ${o.publisherName || 'there'},`,
+    '',
+    'Good news — your Chautauqua Calendar publisher application has been approved.',
+    'Your feed is now in the ingest schedule and your events will start appearing on chqcal.org after the next sync.',
+    '',
+    'Sign in to view your status and recent fetch history:',
+    o.loginUrl,
+    '',
+    'You can check your status anytime here:',
+    o.statusUrl,
+    '',
+    '— Chautauqua Calendar',
+  ].join('\n');
+}
+
+function approvalHtml(o: ApprovalEmailOpts): string {
+  const safeName = escapeHtml(o.publisherName || 'there');
+  const safeLogin = encodeURI(o.loginUrl);
+  const safeStatus = encodeURI(o.statusUrl);
+  return [
+    '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
+    `<p>Hi ${safeName},</p>`,
+    '<p>Good news — your Chautauqua Calendar publisher application has been <strong>approved</strong>.</p>',
+    '<p>Your feed is now in the ingest schedule and your events will start appearing on chqcal.org after the next sync.</p>',
+    `<p>Sign in to view your status and recent fetch history: <a href="${safeLogin}">${safeLogin}</a></p>`,
+    `<p>You can check your status anytime here: <a href="${safeStatus}">${safeStatus}</a></p>`,
+    '<p>— Chautauqua Calendar</p>',
+    '</body></html>',
+  ].join('');
+}
+
+function rejectionText(o: RejectionEmailOpts): string {
+  const lines = [
+    `Hi ${o.publisherName || 'there'},`,
+    '',
+    'Thanks for applying to publish events on chqcal.org. After review, we are not able to approve your application at this time.',
+  ];
+  if (o.reason && o.reason.trim().length > 0) {
+    lines.push('', 'Reviewer note:', o.reason.trim());
+  }
+  lines.push(
+    '',
+    'You are welcome to address any issues and apply again here:',
+    o.applyAgainUrl,
+    '',
+    '— Chautauqua Calendar',
+  );
+  return lines.join('\n');
+}
+
+function rejectionHtml(o: RejectionEmailOpts): string {
+  const safeName = escapeHtml(o.publisherName || 'there');
+  const safeApply = encodeURI(o.applyAgainUrl);
+  const reasonBlock = o.reason && o.reason.trim().length > 0
+    ? `<p><strong>Reviewer note:</strong></p><blockquote style="margin:0 0 0 1em;padding-left:1em;border-left:3px solid #ccc;color:#444">${escapeHtml(o.reason.trim())}</blockquote>`
+    : '';
+  return [
+    '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
+    `<p>Hi ${safeName},</p>`,
+    '<p>Thanks for applying to publish events on chqcal.org. After review, we are not able to approve your application at this time.</p>',
+    reasonBlock,
+    `<p>You are welcome to address any issues and apply again here: <a href="${safeApply}">${safeApply}</a></p>`,
     '<p>— Chautauqua Calendar</p>',
     '</body></html>',
   ].join('');

--- a/backend/src/services/publisherAdminService.ts
+++ b/backend/src/services/publisherAdminService.ts
@@ -1,4 +1,5 @@
 import type { ApplicationStatus, PublisherRecord, StoredPublisherEvent } from '../types/publisher';
+import { ConcurrentApplicationUpdateError } from './publisherRegistryService';
 import type { PublisherRegistryService } from './publisherRegistryService';
 import type { PublisherEventStore } from './publisherEventStore';
 import type { MailService } from './mailService';
@@ -125,7 +126,11 @@ export class PublisherAdminService {
   }
 
   // approveApplication transitions a pending row to approved + enabled.
-  // Refuses if the row is not pending (status mismatch → ApplicationStateError).
+  // Refuses if the row is not pending — throws ApplicationStateError, which
+  // the handler translates to HTTP 409. The status check + write happen
+  // atomically via a DynamoDB ConditionExpression so two admins acting on
+  // the same row at the same time cannot both "succeed".
+  //
   // Sends an approval email best-effort; SES errors are logged and swallowed
   // so the state change persists.
   async approveApplication(id: string, reviewerEmail: string): Promise<PublisherRecord> {
@@ -139,24 +144,47 @@ export class PublisherAdminService {
         existing.applicationStatus,
       );
     }
+    try {
+      await this.registry.setApplicationStatus(id, 'approved', {
+        reviewerEmail,
+        // Explicit undefined clears any prior rejection reason on re-review.
+        rejectionReason: undefined,
+        enabled: true,
+        expectedFromStatus: 'pending',
+      });
+    } catch (err) {
+      if (err instanceof ConcurrentApplicationUpdateError) {
+        // Another admin won the race; surface as the same 409 the up-front
+        // check would have produced. We don't know what they decided, so
+        // the message is intentionally generic.
+        throw new ApplicationStateError(
+          'cannot approve: another admin reviewed this application first',
+          undefined,
+        );
+      }
+      throw err;
+    }
+    // Build the response shape from the known mutation rather than re-reading
+    // (eventual consistency could otherwise return stale fields).
     const updated: PublisherRecord = {
       ...existing,
       applicationStatus: 'approved',
       enabled: true,
       reviewedAt: new Date().toISOString(),
       reviewerEmail,
-      // Clear any prior rejection reason if this is a re-review.
       rejectionReason: undefined,
     };
-    await this.registry.upsert(updated);
     await this.sendApprovalNotification(updated).catch(err => {
       console.error('[publisherAdminService] approval email failed (state change persists):', err);
     });
     return updated;
   }
 
-  // rejectApplication transitions pending → rejected. Defensive: also clears
-  // enabled. Persists optional reviewer reason (truncated to 500 chars).
+  // rejectApplication transitions pending → rejected and clears `enabled`
+  // defensively. Reviewer reason is trimmed and capped to 500 chars; an
+  // empty / whitespace-only reason is normalized to undefined so we don't
+  // persist a meaningless empty string. Atomic via ConditionExpression
+  // (see approveApplication for the rationale).
   async rejectApplication(
     id: string,
     reviewerEmail: string,
@@ -172,18 +200,34 @@ export class PublisherAdminService {
         existing.applicationStatus,
       );
     }
-    const truncated = typeof reason === 'string'
-      ? reason.slice(0, MAX_REJECTION_REASON_LEN)
+    const trimmed = typeof reason === 'string' ? reason.trim() : '';
+    const cleanReason = trimmed.length > 0
+      ? trimmed.slice(0, MAX_REJECTION_REASON_LEN)
       : undefined;
+    try {
+      await this.registry.setApplicationStatus(id, 'rejected', {
+        reviewerEmail,
+        rejectionReason: cleanReason,
+        enabled: false,
+        expectedFromStatus: 'pending',
+      });
+    } catch (err) {
+      if (err instanceof ConcurrentApplicationUpdateError) {
+        throw new ApplicationStateError(
+          'cannot reject: another admin reviewed this application first',
+          undefined,
+        );
+      }
+      throw err;
+    }
     const updated: PublisherRecord = {
       ...existing,
       applicationStatus: 'rejected',
       enabled: false,
       reviewedAt: new Date().toISOString(),
       reviewerEmail,
-      rejectionReason: truncated,
+      rejectionReason: cleanReason,
     };
-    await this.registry.upsert(updated);
     await this.sendRejectionNotification(updated).catch(err => {
       console.error('[publisherAdminService] rejection email failed (state change persists):', err);
     });

--- a/backend/src/services/publisherAdminService.ts
+++ b/backend/src/services/publisherAdminService.ts
@@ -1,6 +1,7 @@
-import type { PublisherRecord, StoredPublisherEvent } from '../types/publisher';
+import type { ApplicationStatus, PublisherRecord, StoredPublisherEvent } from '../types/publisher';
 import type { PublisherRegistryService } from './publisherRegistryService';
 import type { PublisherEventStore } from './publisherEventStore';
+import type { MailService } from './mailService';
 
 export interface CreatePublisherInput {
   id: string;
@@ -11,10 +12,35 @@ export interface CreatePublisherInput {
   trustLevel?: PublisherRecord['trustLevel'];
 }
 
+// Thrown by approveApplication / rejectApplication when the target row is not
+// in 'pending' state (already approved, already rejected, or admin-created
+// without an applicationStatus). Caught by the handler to return HTTP 409.
+export class ApplicationStateError extends Error {
+  constructor(
+    message: string,
+    public readonly currentStatus: ApplicationStatus | undefined,
+  ) {
+    super(message);
+    this.name = 'ApplicationStateError';
+  }
+}
+
+export interface ApplicationReviewDeps {
+  // Optional so existing call sites that don't review applications don't have
+  // to wire the mailer. Approve/reject paths require it.
+  mail?: MailService;
+  // Used to build the magic-link login URL embedded in the approval email.
+  // Falls back to https://www.chqcal.org if not set.
+  siteBaseUrl?: string;
+}
+
+const MAX_REJECTION_REASON_LEN = 500;
+
 export class PublisherAdminService {
   constructor(
     private readonly registry: PublisherRegistryService,
     private readonly store: PublisherEventStore,
+    private readonly reviewDeps: ApplicationReviewDeps = {},
   ) {}
 
   listPublishers(): Promise<PublisherRecord[]> {
@@ -87,5 +113,105 @@ export class PublisherAdminService {
 
   cancelThresholdHalt(publisherId: string): Promise<void> {
     return this.registry.setThresholdHalt(publisherId, undefined);
+  }
+
+  // ─── Phase C: pending application review ───────────────────────────────
+  //
+  // listPendingApplications returns rows whose applicationStatus === 'pending'.
+  // Admin-created publishers (no applicationStatus field) are excluded by
+  // virtue of the registry filter expression.
+  listPendingApplications(): Promise<PublisherRecord[]> {
+    return this.registry.listPending();
+  }
+
+  // approveApplication transitions a pending row to approved + enabled.
+  // Refuses if the row is not pending (status mismatch → ApplicationStateError).
+  // Sends an approval email best-effort; SES errors are logged and swallowed
+  // so the state change persists.
+  async approveApplication(id: string, reviewerEmail: string): Promise<PublisherRecord> {
+    const existing = await this.registry.get(id);
+    if (existing == null) {
+      throw new Error(`unknown publisher ${id}`);
+    }
+    if (existing.applicationStatus !== 'pending') {
+      throw new ApplicationStateError(
+        `cannot approve: applicationStatus is ${existing.applicationStatus ?? 'undefined'}, expected pending`,
+        existing.applicationStatus,
+      );
+    }
+    const updated: PublisherRecord = {
+      ...existing,
+      applicationStatus: 'approved',
+      enabled: true,
+      reviewedAt: new Date().toISOString(),
+      reviewerEmail,
+      // Clear any prior rejection reason if this is a re-review.
+      rejectionReason: undefined,
+    };
+    await this.registry.upsert(updated);
+    await this.sendApprovalNotification(updated).catch(err => {
+      console.error('[publisherAdminService] approval email failed (state change persists):', err);
+    });
+    return updated;
+  }
+
+  // rejectApplication transitions pending → rejected. Defensive: also clears
+  // enabled. Persists optional reviewer reason (truncated to 500 chars).
+  async rejectApplication(
+    id: string,
+    reviewerEmail: string,
+    reason?: string,
+  ): Promise<PublisherRecord> {
+    const existing = await this.registry.get(id);
+    if (existing == null) {
+      throw new Error(`unknown publisher ${id}`);
+    }
+    if (existing.applicationStatus !== 'pending') {
+      throw new ApplicationStateError(
+        `cannot reject: applicationStatus is ${existing.applicationStatus ?? 'undefined'}, expected pending`,
+        existing.applicationStatus,
+      );
+    }
+    const truncated = typeof reason === 'string'
+      ? reason.slice(0, MAX_REJECTION_REASON_LEN)
+      : undefined;
+    const updated: PublisherRecord = {
+      ...existing,
+      applicationStatus: 'rejected',
+      enabled: false,
+      reviewedAt: new Date().toISOString(),
+      reviewerEmail,
+      rejectionReason: truncated,
+    };
+    await this.registry.upsert(updated);
+    await this.sendRejectionNotification(updated).catch(err => {
+      console.error('[publisherAdminService] rejection email failed (state change persists):', err);
+    });
+    return updated;
+  }
+
+  private async sendApprovalNotification(rec: PublisherRecord): Promise<void> {
+    if (!this.reviewDeps.mail) return;
+    const base = (this.reviewDeps.siteBaseUrl ?? 'https://www.chqcal.org').replace(/\/$/, '');
+    const statusUrl = `${base}/publish/status/`;
+    const loginUrl = `${base}/publish/login/`;
+    await this.reviewDeps.mail.sendApprovalEmail({
+      to: rec.contactEmail,
+      publisherName: rec.name,
+      statusUrl,
+      loginUrl,
+    });
+  }
+
+  private async sendRejectionNotification(rec: PublisherRecord): Promise<void> {
+    if (!this.reviewDeps.mail) return;
+    const base = (this.reviewDeps.siteBaseUrl ?? 'https://www.chqcal.org').replace(/\/$/, '');
+    const applyAgainUrl = `${base}/publish/apply/`;
+    await this.reviewDeps.mail.sendRejectionEmail({
+      to: rec.contactEmail,
+      publisherName: rec.name,
+      reason: rec.rejectionReason,
+      applyAgainUrl,
+    });
   }
 }

--- a/backend/src/services/publisherApplicationService.ts
+++ b/backend/src/services/publisherApplicationService.ts
@@ -128,12 +128,13 @@ export class PublisherApplicationService {
       return { ok: true };
     }
     const matches = await this.deps.registry.getByEmail(normalized);
-    // Prefer an approved row if one exists (a publisher with both an old
-    // approved row and a new pending re-application should still sign in to
-    // their approved account). Otherwise fall back to whichever row matched.
-    const target = matches.find(p => p.applicationStatus !== 'rejected'
-      && (p.applicationStatus === undefined || p.applicationStatus === 'approved'))
-      ?? matches[0];
+    // Prefer an approved (or legacy admin-created, no applicationStatus) row
+    // if one exists — a publisher with both an old approved row and a new
+    // pending re-application should still sign in to their approved account.
+    // Otherwise fall back to whichever row matched (pending or rejected).
+    const target = matches.find(
+      p => p.applicationStatus === undefined || p.applicationStatus === 'approved',
+    ) ?? matches[0];
     if (!target) return { ok: true };
 
     const issued = await this.deps.tokens.issueToken({

--- a/backend/src/services/publisherApplicationService.ts
+++ b/backend/src/services/publisherApplicationService.ts
@@ -11,7 +11,6 @@
 
 import { v4 as uuidv4 } from 'uuid';
 import type { ApplyFormPayload, PublisherRecord } from '../types/publisher';
-import { isApproved } from '../types/publisher';
 import type { PublisherRegistryService } from './publisherRegistryService';
 import type { MagicTokenService } from './magicTokenService';
 import type { MailService } from './mailService';
@@ -112,8 +111,15 @@ export class PublisherApplicationService {
   // ─── Login flow ────────────────────────────────────────────────────────
 
   // Always returns { ok: true } — never reveals whether the email matches a
-  // publisher. If the email DOES match an approved publisher, an email is
-  // sent. Otherwise, no email is sent and the caller cannot tell.
+  // publisher. If the email DOES match ANY publisher row (pending, approved,
+  // or rejected), a login link is sent. Pending and rejected applicants need
+  // to be able to sign in to /publish/status/ to see their review state — if
+  // we filtered to approved only, the status page would be unreachable for
+  // them once their post-apply JWT expires (7 days).
+  //
+  // Phase B selected the first APPROVED row defensively; Phase C broadens
+  // this to "first row of any status" since the status page now handles
+  // pending and rejected explicitly.
   async requestLogin(email: string): Promise<RequestLoginResult> {
     const normalized = (email ?? '').trim().toLowerCase();
     if (!isValidEmail(normalized)) {
@@ -122,7 +128,12 @@ export class PublisherApplicationService {
       return { ok: true };
     }
     const matches = await this.deps.registry.getByEmail(normalized);
-    const target = matches.find(p => isApproved(p));
+    // Prefer an approved row if one exists (a publisher with both an old
+    // approved row and a new pending re-application should still sign in to
+    // their approved account). Otherwise fall back to whichever row matched.
+    const target = matches.find(p => p.applicationStatus !== 'rejected'
+      && (p.applicationStatus === undefined || p.applicationStatus === 'approved'))
+      ?? matches[0];
     if (!target) return { ok: true };
 
     const issued = await this.deps.tokens.issueToken({

--- a/backend/src/services/publisherRegistryService.ts
+++ b/backend/src/services/publisherRegistryService.ts
@@ -2,6 +2,16 @@ import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { GetCommand, PutCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { ApplicationStatus, FetchStatus, PublisherRecord } from '../types/publisher';
 
+// Thrown by setApplicationStatus when the optional `expectedFromStatus` does
+// not match the current row state. Caller should treat as "another writer
+// got there first" — typical UX is to refetch and re-show the row.
+export class ConcurrentApplicationUpdateError extends Error {
+  constructor(public readonly expectedFromStatus: ApplicationStatus) {
+    super(`application status was not '${expectedFromStatus}' at write time`);
+    this.name = 'ConcurrentApplicationUpdateError';
+  }
+}
+
 export class PublisherRegistryService {
   constructor(
     private readonly db: DynamoDBDocumentClient,
@@ -109,22 +119,62 @@ export class PublisherRegistryService {
     return out;
   }
 
+  // setApplicationStatus updates the row's review fields atomically. When
+  // `expectedFromStatus` is supplied the write is conditioned on the row's
+  // current applicationStatus equalling that value — this prevents two
+  // admins from successfully approving/rejecting the same row at the same
+  // time (only the first commit wins). The optional `enabled` flag lets the
+  // approve/reject paths flip the ingest gate in the same write so we don't
+  // leave the row in a half-updated state.
+  //
+  // ConcurrentApplicationUpdateError is thrown on condition fail.
   async setApplicationStatus(
     id: string,
     status: ApplicationStatus,
-    opts: { reviewerEmail?: string; rejectionReason?: string } = {},
+    opts: {
+      reviewerEmail?: string;
+      rejectionReason?: string;
+      expectedFromStatus?: ApplicationStatus;
+      enabled?: boolean;
+    } = {},
   ): Promise<void> {
-    await this.db.send(new UpdateCommand({
-      TableName: this.tableName,
-      Key: { id },
-      UpdateExpression:
-        'SET applicationStatus = :s, reviewedAt = :now, reviewerEmail = :r, rejectionReason = :rr',
-      ExpressionAttributeValues: {
-        ':s': status,
-        ':now': new Date().toISOString(),
-        ':r': opts.reviewerEmail ?? null,
-        ':rr': opts.rejectionReason ?? null,
-      },
-    }));
+    const setParts = [
+      'applicationStatus = :s',
+      'reviewedAt = :now',
+      'reviewerEmail = :r',
+      'rejectionReason = :rr',
+    ];
+    const values: Record<string, unknown> = {
+      ':s': status,
+      ':now': new Date().toISOString(),
+      ':r': opts.reviewerEmail ?? null,
+      ':rr': opts.rejectionReason ?? null,
+    };
+    if (opts.enabled !== undefined) {
+      setParts.push('enabled = :enabled');
+      values[':enabled'] = opts.enabled;
+    }
+    if (opts.expectedFromStatus !== undefined) {
+      values[':expected'] = opts.expectedFromStatus;
+    }
+    try {
+      await this.db.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: { id },
+        UpdateExpression: `SET ${setParts.join(', ')}`,
+        ExpressionAttributeValues: values,
+        ...(opts.expectedFromStatus !== undefined
+          ? { ConditionExpression: 'applicationStatus = :expected' }
+          : {}),
+      }));
+    } catch (err) {
+      // SDK v3 throws ConditionalCheckFailedException by name; check by name
+      // string to avoid coupling to the Dynamo SDK error class import.
+      const name = (err as { name?: string } | undefined)?.name;
+      if (name === 'ConditionalCheckFailedException' && opts.expectedFromStatus !== undefined) {
+        throw new ConcurrentApplicationUpdateError(opts.expectedFromStatus);
+      }
+      throw err;
+    }
   }
 }

--- a/docs/plans/2026-05-03-publisher-portal-phase-c-plan.md
+++ b/docs/plans/2026-05-03-publisher-portal-phase-c-plan.md
@@ -1,0 +1,278 @@
+# Publisher Portal — Phase C implementation plan
+
+**Date:** 2026-05-03
+**Branch:** `feat/publisher-portal-phase-c`
+**Depends on:** Phase A (`/publish/test/`) + Phase B (apply + magic-link auth) — both shipped via PR #83.
+**Design doc:** `docs/plans/2026-05-03-publisher-portal-design.md` (section "Phase C").
+
+## Goal
+
+Close the publisher self-service loop:
+
+1. **Admin** can see pending applications and approve / reject them from the
+   existing `/admin/publishers/` page.
+2. **Publisher** can sign in to `/publish/status/` (via the existing
+   magic-link auth) and see their application status, current publisher
+   record, and recent fetch outcomes.
+3. **Publisher** receives an email when their application is approved or
+   rejected, so they don't have to poll.
+
+## Out of scope (deferred to Phase D)
+
+- Per-publisher feed history beyond the single "last fetch" already on the
+  record (would need a new audit table).
+- Publisher-side "edit my source URL" action — for v1 they email the admin.
+- DNS-rebinding mitigation in `urlGuard`.
+- Per-IP rate-limit moved off in-memory storage.
+- CAPTCHA on apply.
+- "Re-send magic link" UX polish (the existing apply page covers this if a
+  publisher knows their email; we won't add a dedicated re-send button yet).
+
+## Constraints
+
+- Follow project CLAUDE.md: never commit to main, run `npm run validate &&
+  npm run build` before each commit, comprehensive commit messages.
+- Frontend uses Preact (`'preact/hooks'` imports), Vite multi-page setup —
+  every new page needs an `index.html` + entry in `src/entries/` + entry
+  registered in `vite.config.ts`.
+- Backend tests live next to the service / handler, follow the existing
+  Jest pattern (mocked AWS SDK clients via `aws-sdk-client-mock`).
+- Logs MUST redact email addresses (reuse the redaction helper used in
+  `adminHandler.ts`).
+- Admin endpoints sit on the existing `admin_handler` Lambda behind the
+  Google-OAuth-issued JWT (`useAdminAuth` on the frontend).
+- Publisher status endpoint sits on the SAME admin_handler Lambda (we plumb
+  it through `publisherPortalHandler.ts` like the Phase B endpoints) but
+  authenticates with the publisher JWT, not the admin JWT.
+- All four "to add" Terraform resources from Phase B are already live; no
+  new infra in Phase C unless we discover a gap.
+
+## Task breakdown
+
+- [ ] C0 — This plan doc.
+- [ ] C1 — Backend admin endpoints for pending applications.
+- [ ] C2 — Backend approval / rejection emails (extend `mailService`).
+- [ ] C3 — Backend publisher-status endpoint (`GET /api/publisher-status`).
+- [ ] C4 — Frontend admin page extensions (pending list + approve/reject UI).
+- [ ] C5 — Frontend `/publish/login/` page (request magic-link by email).
+- [ ] C6 — Frontend `/publish/status/` page (own status + recent fetch).
+- [ ] C7 — `/publish/verify/` success redirect: login → `/publish/status/`,
+       apply → `/publish/` (existing).
+- [ ] C8 — Build verification + tests pass + open PR.
+
+---
+
+### C1 — Backend admin endpoints for pending applications
+
+**Files:**
+
+- `backend/src/services/publisherAdminService.ts` — new methods:
+  - `listPendingApplications(): Promise<PublisherRecord[]>` → delegates to
+    `registry.listPending()`.
+  - `approveApplication(id, reviewerEmail): Promise<PublisherRecord>` →
+    sets `applicationStatus = 'approved'`, `enabled = true`, persists
+    `reviewedAt + reviewerEmail`, **clears any previous `rejectionReason`**,
+    returns the updated row. Sends approval email (C2 dependency).
+  - `rejectApplication(id, reviewerEmail, reason?): Promise<PublisherRecord>`
+    → sets `applicationStatus = 'rejected'`, `enabled = false` (defensive),
+    persists `reviewedAt + reviewerEmail + rejectionReason`. Sends rejection
+    email (C2 dependency).
+  - **Both methods refuse to act unless** the existing row's
+    `applicationStatus === 'pending'`. Throw a typed error caught by the
+    handler so it can return HTTP 409 instead of 500.
+- `backend/src/handlers/adminHandler.ts` — new routes:
+  - `GET /publisher-applications/pending` → returns `{ applications: [...] }`.
+  - `POST /publisher-applications/:id/approve` → 200 with updated record.
+  - `POST /publisher-applications/:id/reject` → 200 with updated record.
+    Body may include `{ reason?: string }` (truncated to 500 chars).
+  - All three guarded by the existing admin JWT middleware.
+- `backend/src/services/publisherAdminService.test.ts` — tests for the new
+  methods (success, refuse-when-not-pending, registry failure paths).
+- `backend/src/handlers/adminHandler.test.ts` (or the matching test file) —
+  routing tests for the three new paths.
+
+**Edge cases to cover:**
+
+- Approving a publisher whose `id` was admin-created and never had an
+  `applicationStatus` field at all → 409 (not "pending"). The frontend will
+  not surface those rows in the pending section, so this should not happen
+  in normal use; we still want the backend to refuse.
+- Rejecting twice → second call 409.
+- Reason longer than 500 chars → truncated, no error.
+
+### C2 — Approval / rejection emails
+
+**Files:**
+
+- `backend/src/services/mailService.ts` — add two methods:
+  - `sendApprovalEmail({ to, publisherName, statusPageUrl })`.
+  - `sendRejectionEmail({ to, publisherName, reason?, applyAgainUrl })`.
+- Plain-text bodies (the existing `mailService` already sends text-only for
+  magic-link, so we keep parity). Subjects:
+  - "Your Chautauqua Calendar publisher application is approved"
+  - "Update on your Chautauqua Calendar publisher application"
+- The existing `siteBaseUrl` constructor argument feeds the URLs.
+- Tests in `mailService.test.ts` — verify SESv2 client is called with the
+  correct `Destination`, `Subject`, and body content.
+
+**Failure handling:** if the email send throws, the approval/rejection
+state change must still persist (the user can re-trigger by clicking
+approve again — but our pending check would block them). Alternative: log
+the email failure but return 200; admin can re-send manually. Pick the
+**log-and-200** path; surface the email failure in CloudWatch only.
+
+### C3 — Publisher status endpoint
+
+**Files:**
+
+- `backend/src/handlers/publisherPortalHandler.ts` — new export
+  `handlePublisherStatus(event, _body)`:
+  - Extracts `Authorization: Bearer <jwt>` from headers.
+  - Calls `verifyPublisherJwt` from `publisherAuthService`.
+  - On invalid / missing token → 401 `{ error: 'Authentication required' }`.
+  - On valid token: looks up the publisher by `claims.sub`. If the row no
+    longer exists → 404. If found → returns:
+    ```
+    {
+      publisher: { id, name, contactEmail, sourceUrl, sourceType,
+                   applicationStatus, enabled, createdAt,
+                   reviewedAt?, rejectionReason?,
+                   lastFetchedAt?, lastFetchStatus?, lastFetchMessage? }
+    }
+    ```
+  - The fetch outcome fields are already on the row — no extra work.
+  - **NEVER** include the `pendingThresholdHalt` blob; that's an internal
+    operations signal, not for publishers.
+- `backend/src/handlers/adminHandler.ts` — route `GET
+  /api/publisher-status` to the new handler (the route is in the public
+  `/api/...` namespace, mirroring the other Phase A/B publisher routes).
+  This lives **outside** the admin-JWT branch — the publisher JWT check
+  happens inside the handler.
+- Tests: `publisherPortalHandler.test.ts` adds cases for missing token,
+  bad token, expired token, deleted publisher, happy path.
+
+### C4 — Frontend admin page extensions
+
+**Files:**
+
+- `frontend/src/lib/adminPublisherApi.ts` — add:
+  - `listPendingApplications(): Promise<PublisherRecord[]>`.
+  - `approveApplication(id): Promise<PublisherRecord>`.
+  - `rejectApplication(id, reason?): Promise<PublisherRecord>`.
+  - Extend `PublisherRecord` type with `applicationStatus?: 'pending' |
+    'approved' | 'rejected'`, `reviewedAt?: string`, `reviewerEmail?:
+    string`, `rejectionReason?: string`. (The existing rows without these
+    fields stay backwards compatible — `applicationStatus === undefined`
+    is treated as approved/admin-created in the UI.)
+- `frontend/src/app/admin/publishers/page.tsx` — render a **"Pending
+  Applications"** section ABOVE the existing publisher table, only when
+  there are pending rows. Each pending row shows id, name, email,
+  source URL, sourceType, createdAt, plus two buttons:
+  - **Approve** — POST to `approveApplication(id)`, on success refetch
+    both the pending list and the publisher list.
+  - **Reject** — opens an inline textarea + Confirm/Cancel; on Confirm,
+    POST to `rejectApplication(id, reason)`. Reason is optional but
+    encouraged (placeholder text guides the admin).
+- After each action, optimistic UI: while in flight, disable the buttons
+  for that row. Errors render inline in the row.
+- The existing publisher table excludes pending rows (filter
+  `applicationStatus !== 'pending'`).
+- A small "View source" button per pending row opens the URL in a new
+  tab (target="_blank" rel="noreferrer noopener").
+- A "Test feed" link per pending row opens
+  `/publish/test/?url=<encoded>&sourceType=<type>` (the test page already
+  reads URL query params? — verify; if not, this becomes a Phase D follow-up).
+
+**Verification (UI):**
+
+- Approve a pending row → it disappears from the pending section, appears
+  in the main publisher table with `enabled = true`.
+- Reject with reason → disappears from pending, no longer in main table
+  (since enabled is false; user can flip "show disabled" if we add it —
+  for v1 the disabled rows are visible but greyed; that already works).
+
+### C5 — Frontend `/publish/login/` page
+
+**Files:**
+
+- `frontend/publish/login/index.html`
+- `frontend/src/entries/publish-login.tsx`
+- `frontend/src/app/publish/login/page.tsx`
+- `frontend/vite.config.ts` — register the new entry.
+
+The page is a single email input + submit button. On submit, POST to
+`/api/publisher-auth/request` and show an "If your email is on file, you
+will receive a sign-in link" message regardless of outcome (anti-enumeration,
+the backend already enforces this). Disable the button for 60 seconds
+after submit to discourage spamming the SES quota.
+
+If the user is **already authenticated** (`isPublisherAuthenticated()` →
+true) when they land here, redirect to `/publish/status/`.
+
+Add a "Sign in" link to `/publish/` that points here.
+
+### C6 — Frontend `/publish/status/` page
+
+**Files:**
+
+- `frontend/publish/status/index.html`
+- `frontend/src/entries/publish-status.tsx`
+- `frontend/src/app/publish/status/page.tsx`
+- `frontend/src/lib/publisherStatusApi.ts` — `getPublisherStatus()` that
+  reads JWT from `publisherAuthClient`, calls `GET /api/publisher-status`,
+  and on 401 clears the session and redirects to `/publish/login/`.
+- `frontend/vite.config.ts` — register the new entry.
+
+The page renders three states:
+
+1. **Pending review** — friendly message, what happens next, contact email
+   for questions, "Sign out" button.
+2. **Approved** — publisher card showing name/id/source URL/sourceType/
+   trust level/enabled flag, plus "Last fetch" panel (status, timestamp,
+   message). "Sign out" button.
+3. **Rejected** — rejection message + reason (if any), "Apply again" link
+   to `/publish/apply/`, "Sign out" button.
+
+If no JWT or expired → redirect to `/publish/login/` (no flash of content).
+
+### C7 — `/publish/verify/` redirect tweak
+
+In the existing `Success` component, when `purpose === 'login'`, the CTA
+button text changes to "Go to your account" and links to `/publish/status/`
+instead of `/publish/`. The apply path keeps its existing copy and
+`/publish/` link.
+
+(Could also auto-redirect after 1.5s, but explicit click is fine.)
+
+### C8 — Verification + PR
+
+- `cd frontend && npm run validate && npm run build` — clean.
+- `cd backend && npm test` — all green (the Phase B baseline was 338/338;
+  C1-C3 will add ~25-40 more tests).
+- Smoke test in dev: apply → admin approves → status page shows approved.
+- Open PR with summary, test plan, and pointer to design + plan docs.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Approval-email failure leaves admin uncertain about state | Log to CloudWatch; status change still persists; admin sees the publisher row in approved state and can re-send via console for now (Phase D adds a re-send button). |
+| Publisher JWT verification on `/api/publisher-status` slows that endpoint (Secrets Manager fetch) | `publisherSecretCache` already memoizes the JWT secret — the second call onward is hot. |
+| Admin clicks Approve twice in rapid succession | Backend 409 on second click; frontend disables button while in flight. |
+| Pending row has data that fails the existing `PublisherRecord` schema | The list endpoint returns the raw row; the UI defensively `??`-guards optional fields. |
+| Test page doesn't accept URL query params | If true, the "Test feed" link in C4 becomes a tooltip-only "Copy URL" + manual paste; defer the proper deep-link to Phase D. |
+
+## Estimate
+
+| Task | Effort |
+|------|--------|
+| C0 plan | 30 min |
+| C1 admin endpoints + tests | 90 min |
+| C2 emails + tests | 45 min |
+| C3 status endpoint + tests | 60 min |
+| C4 admin frontend | 90 min |
+| C5 login page | 45 min |
+| C6 status page | 90 min |
+| C7 verify tweak | 15 min |
+| C8 smoke + PR | 30 min |
+| **Total** | **~8 hours** |

--- a/frontend/publish/login/index.html
+++ b/frontend/publish/login/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Publisher sign-in — Chautauqua Calendar</title>
+    <link rel="icon" type="image/svg+xml" href="/chq-calendar-icon-256.svg" />
+  </head>
+  <body class="antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/entries/publish-login.tsx"></script>
+  </body>
+</html>

--- a/frontend/publish/status/index.html
+++ b/frontend/publish/status/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My publisher status — Chautauqua Calendar</title>
+    <link rel="icon" type="image/svg+xml" href="/chq-calendar-icon-256.svg" />
+  </head>
+  <body class="antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/entries/publish-status.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/app/admin/publishers/PendingApplications.tsx
+++ b/frontend/src/app/admin/publishers/PendingApplications.tsx
@@ -1,0 +1,250 @@
+// Phase C: pending application review section for /admin/publishers/.
+//
+// Renders only when there are pending rows. Each row exposes an Approve and
+// a Reject control; Reject opens an inline reason textarea before
+// confirming. Buttons disable while a request is in-flight; per-row errors
+// surface inline.
+
+import { useState } from 'preact/hooks';
+import {
+  approveApplication,
+  rejectApplication,
+  type PublisherRecord,
+} from '@/lib/adminPublisherApi';
+
+interface Props {
+  applications: PublisherRecord[];
+  // Called after every successful approve/reject so the parent can refetch
+  // both the pending list and the main publisher list.
+  onChange: () => Promise<void> | void;
+}
+
+type RowState =
+  | { kind: 'idle' }
+  | { kind: 'rejecting'; reason: string }
+  | { kind: 'busy' }
+  | { kind: 'error'; message: string };
+
+const REASON_MAX = 500;
+
+export function PendingApplications({ applications, onChange }: Props) {
+  const [rowStates, setRowStates] = useState<Record<string, RowState>>({});
+
+  if (applications.length === 0) return null;
+
+  const stateFor = (id: string): RowState => rowStates[id] ?? { kind: 'idle' };
+
+  const setState = (id: string, s: RowState) => {
+    setRowStates(prev => ({ ...prev, [id]: s }));
+  };
+
+  const handleApprove = async (id: string) => {
+    setState(id, { kind: 'busy' });
+    try {
+      await approveApplication(id);
+      // Drop our row state; parent's refetch will remove the row.
+      setRowStates(prev => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      await onChange();
+    } catch (err) {
+      setState(id, {
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to approve.',
+      });
+    }
+  };
+
+  const handleReject = async (id: string, reason: string) => {
+    setState(id, { kind: 'busy' });
+    try {
+      await rejectApplication(id, reason.trim() || undefined);
+      setRowStates(prev => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      await onChange();
+    } catch (err) {
+      setState(id, {
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Failed to reject.',
+      });
+    }
+  };
+
+  return (
+    <section className="mb-8">
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+          Pending applications{' '}
+          <span className="ml-2 inline-flex items-center justify-center px-2 py-0.5 text-xs font-bold rounded-full bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300">
+            {applications.length}
+          </span>
+        </h2>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Review feeds before they go live.
+        </p>
+      </div>
+
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">
+        <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+          {applications.map(app => {
+            const state = stateFor(app.id);
+            const busy = state.kind === 'busy';
+            return (
+              <li key={app.id} className="px-6 py-4">
+                <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                        {app.name}
+                      </p>
+                      <span className="text-xs font-mono text-gray-500 dark:text-gray-400 truncate">
+                        {app.id}
+                      </span>
+                    </div>
+                    <dl className="mt-1 text-xs text-gray-600 dark:text-gray-300 space-y-0.5">
+                      <div>
+                        <dt className="inline font-medium">Email:</dt>{' '}
+                        <dd className="inline">{app.contactEmail}</dd>
+                      </div>
+                      {app.organization && (
+                        <div>
+                          <dt className="inline font-medium">Organization:</dt>{' '}
+                          <dd className="inline">{app.organization}</dd>
+                        </div>
+                      )}
+                      <div>
+                        <dt className="inline font-medium">Source:</dt>{' '}
+                        <dd className="inline">
+                          <a
+                            href={app.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer noopener"
+                            className="text-blue-600 dark:text-blue-400 hover:underline break-all"
+                          >
+                            {app.sourceUrl}
+                          </a>{' '}
+                          <span className="uppercase text-[10px] tracking-wide bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 rounded">
+                            {app.sourceType}
+                          </span>
+                        </dd>
+                      </div>
+                      {app.applicantNotes && (
+                        <div>
+                          <dt className="inline font-medium">Notes:</dt>{' '}
+                          <dd className="inline italic">{app.applicantNotes}</dd>
+                        </div>
+                      )}
+                      {app.appliedAt && (
+                        <div>
+                          <dt className="inline font-medium">Applied:</dt>{' '}
+                          <dd className="inline">{new Date(app.appliedAt).toLocaleString()}</dd>
+                        </div>
+                      )}
+                    </dl>
+                  </div>
+
+                  <div className="flex flex-col gap-2 sm:items-end">
+                    {state.kind !== 'rejecting' && (
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => handleApprove(app.id)}
+                          disabled={busy}
+                          className="px-3 py-1.5 text-sm font-medium rounded-md bg-green-600 text-white hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          {busy ? 'Working…' : 'Approve'}
+                        </button>
+                        <button
+                          onClick={() => setState(app.id, { kind: 'rejecting', reason: '' })}
+                          disabled={busy}
+                          className="px-3 py-1.5 text-sm font-medium rounded-md border border-red-600 text-red-700 dark:text-red-300 dark:border-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                          Reject
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {state.kind === 'rejecting' && (
+                  <RejectInline
+                    initialReason={state.reason}
+                    onCancel={() => setState(app.id, { kind: 'idle' })}
+                    onConfirm={reason => handleReject(app.id, reason)}
+                  />
+                )}
+
+                {state.kind === 'error' && (
+                  <div className="mt-2 text-xs text-red-600 dark:text-red-400">
+                    {state.message}{' '}
+                    <button
+                      type="button"
+                      onClick={() => setState(app.id, { kind: 'idle' })}
+                      className="underline"
+                    >
+                      Dismiss
+                    </button>
+                  </div>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+// Inline reason textarea for the Reject confirmation.
+function RejectInline({
+  initialReason,
+  onCancel,
+  onConfirm,
+}: {
+  initialReason: string;
+  onCancel: () => void;
+  onConfirm: (reason: string) => void;
+}) {
+  const [reason, setReason] = useState(initialReason);
+  const remaining = REASON_MAX - reason.length;
+
+  return (
+    <div className="mt-3 p-3 rounded-md bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800">
+      <label className="block text-xs font-medium text-red-700 dark:text-red-300 mb-1">
+        Reason (optional, sent to the applicant)
+      </label>
+      <textarea
+        value={reason}
+        onInput={e => setReason((e.target as HTMLTextAreaElement).value.slice(0, REASON_MAX))}
+        rows={3}
+        placeholder="e.g., Source URL returned non-public events; please re-apply with a corrected feed."
+        className="w-full text-sm rounded-md border border-red-300 dark:border-red-700 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 p-2 focus:outline-none focus:ring-2 focus:ring-red-500"
+      />
+      <div className="mt-1 flex items-center justify-between">
+        <span className="text-[11px] text-gray-500 dark:text-gray-400">
+          {remaining} chars left
+        </span>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-3 py-1 text-xs rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onConfirm(reason)}
+            className="px-3 py-1 text-xs rounded-md bg-red-600 text-white hover:bg-red-700"
+          >
+            Confirm reject
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'preact/hooks';
 import {
   listPublishers,
   createPublisher,

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -3,12 +3,14 @@ import {
   listPublishers,
   createPublisher,
   updatePublisher,
+  listPendingApplications,
   type PublisherRecord,
   type CreatePublisherInput,
 } from '@/lib/adminPublisherApi';
 import { useAdminAuth } from '@/hooks/useAdminAuth';
 import { logout } from '@/lib/auth';
 import { PublisherForm } from './PublisherForm';
+import { PendingApplications } from './PendingApplications';
 
 // Discriminated union for form open/closed state.
 type FormMode =
@@ -21,6 +23,7 @@ const CLOSED: FormMode = { kind: 'closed' };
 export default function PublishersPage() {
   const user = useAdminAuth();
   const [publishers, setPublishers] = useState<PublisherRecord[]>([]);
+  const [pending, setPending] = useState<PublisherRecord[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [formMode, setFormMode] = useState<FormMode>(CLOSED);
@@ -34,10 +37,23 @@ export default function PublishersPage() {
     setLoading(true);
     setError(null);
     try {
-      const data = await listPublishers();
-      setPublishers(data);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to load publishers.');
+      // Fetch both lists in parallel; either failing surfaces an error but
+      // we keep whichever resolved successfully so partial UI still renders.
+      const [allRes, pendingRes] = await Promise.allSettled([
+        listPublishers(),
+        listPendingApplications(),
+      ]);
+      if (allRes.status === 'fulfilled') {
+        setPublishers(allRes.value);
+      }
+      if (pendingRes.status === 'fulfilled') {
+        setPending(pendingRes.value);
+      }
+      const firstError = [allRes, pendingRes].find(r => r.status === 'rejected');
+      if (firstError && firstError.status === 'rejected') {
+        const reason = firstError.reason;
+        setError(reason instanceof Error ? reason.message : 'Failed to load publishers.');
+      }
     } finally {
       setLoading(false);
     }
@@ -90,6 +106,12 @@ export default function PublishersPage() {
   // -------------------------------------------------------------------------
   // Render helpers
   // -------------------------------------------------------------------------
+  // The pending section renders pending applications separately; exclude
+  // them from the main table to avoid duplicate rows.
+  const nonPendingPublishers = publishers.filter(
+    p => p.applicationStatus !== 'pending',
+  );
+
   const isLocalhost =
     typeof window !== 'undefined' &&
     (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
@@ -111,7 +133,7 @@ export default function PublishersPage() {
   // -------------------------------------------------------------------------
   // Loading / unauthenticated guard
   // -------------------------------------------------------------------------
-  if (!user || (loading && publishers.length === 0)) {
+  if (!user || (loading && publishers.length === 0 && pending.length === 0)) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center">
         <div className="text-center">
@@ -149,7 +171,12 @@ export default function PublishersPage() {
                 </div>
               )}
               <div className="text-sm text-gray-600 dark:text-gray-300">
-                {publishers.length} publisher{publishers.length !== 1 ? 's' : ''}
+                {nonPendingPublishers.length} publisher{nonPendingPublishers.length !== 1 ? 's' : ''}
+                {pending.length > 0 && (
+                  <span className="ml-1 text-amber-700 dark:text-amber-400">
+                    · {pending.length} pending
+                  </span>
+                )}
               </div>
               {user && (
                 <div className="flex items-center gap-3">
@@ -204,6 +231,9 @@ export default function PublishersPage() {
           />
         )}
 
+        {/* Pending applications */}
+        <PendingApplications applications={pending} onChange={fetchPublishers} />
+
         {/* Publisher list */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">
           {loading && publishers.length > 0 && (
@@ -212,7 +242,7 @@ export default function PublishersPage() {
             </div>
           )}
 
-          {publishers.length === 0 && !loading ? (
+          {nonPendingPublishers.length === 0 && !loading ? (
             <div className="p-8 text-center text-gray-500 dark:text-gray-400">
               No publishers yet. Click &quot;+ New publisher&quot; to add one.
             </div>
@@ -242,7 +272,7 @@ export default function PublishersPage() {
                   </tr>
                 </thead>
                 <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
-                  {publishers.map(p => (
+                  {nonPendingPublishers.map(p => (
                     <tr key={p.id} className={p.enabled ? '' : 'opacity-60'}>
                       <td className="px-6 py-4">
                         <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{p.name}</div>

--- a/frontend/src/app/publish/login/page.tsx
+++ b/frontend/src/app/publish/login/page.tsx
@@ -8,7 +8,12 @@
  * Anyone already authenticated lands on /publish/status/ instead.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'preact/hooks';
+// Project uses jsx: "react-jsx" with @types/react aliased to preact/compat at
+// runtime. Form-event prop typing flows through React's typings, so we
+// import the type (only) from 'react' and let preact/compat handle the
+// actual event at runtime.
+import type { FormEvent } from 'react';
 import { isPublisherAuthenticated } from '@/lib/publisherAuthClient';
 
 type Status =
@@ -49,7 +54,7 @@ export default function PublishLoginPage() {
     : 0;
   const inCooldown = cooldownRemainingSec > 0;
 
-  async function onSubmit(e: React.FormEvent) {
+  async function onSubmit(e: FormEvent) {
     e.preventDefault();
     if (status.kind === 'submitting' || inCooldown) return;
     const trimmed = email.trim();

--- a/frontend/src/app/publish/login/page.tsx
+++ b/frontend/src/app/publish/login/page.tsx
@@ -1,0 +1,186 @@
+/**
+ * Publisher portal — Sign-in page (Phase C).
+ *
+ * Single email field. POSTs to /api/publisher-auth/request, which always
+ * returns 200 regardless of whether the email matches a known publisher
+ * (anti-enumeration; see PublisherApplicationService.requestLogin).
+ *
+ * Anyone already authenticated lands on /publish/status/ instead.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { isPublisherAuthenticated } from '@/lib/publisherAuthClient';
+
+type Status =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'sent' }
+  | { kind: 'error'; message: string };
+
+const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+
+// Window during which the submit button stays disabled after a successful
+// send, to discourage spamming the SES quota. The backend rate-limits to
+// 10/hour per IP regardless; this is a UX nudge, not a security control.
+const RESEND_COOLDOWN_MS = 60_000;
+
+export default function PublishLoginPage() {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<Status>({ kind: 'idle' });
+  const [cooldownEndsAt, setCooldownEndsAt] = useState<number | null>(null);
+  const [now, setNow] = useState(Date.now());
+
+  // Bounce out if already signed in.
+  useEffect(() => {
+    if (isPublisherAuthenticated()) {
+      window.location.replace('/publish/status/');
+    }
+  }, []);
+
+  // Tick once a second while the cooldown is active so the button label updates.
+  useEffect(() => {
+    if (cooldownEndsAt === null) return;
+    const id = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(id);
+  }, [cooldownEndsAt]);
+
+  const cooldownRemainingSec = cooldownEndsAt
+    ? Math.max(0, Math.ceil((cooldownEndsAt - now) / 1000))
+    : 0;
+  const inCooldown = cooldownRemainingSec > 0;
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (status.kind === 'submitting' || inCooldown) return;
+    const trimmed = email.trim();
+    if (trimmed.length === 0) return;
+
+    setStatus({ kind: 'submitting' });
+    try {
+      const r = await fetch(`${API_BASE}/api/publisher-auth/request`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: trimmed }),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (r.ok) {
+        setStatus({ kind: 'sent' });
+        setCooldownEndsAt(Date.now() + RESEND_COOLDOWN_MS);
+        return;
+      }
+      if (r.status === 429) {
+        setStatus({
+          kind: 'error',
+          message: body?.error ?? 'Too many requests. Please try again later.',
+        });
+        return;
+      }
+      setStatus({
+        kind: 'error',
+        message: body?.error ?? 'Sign-in request failed.',
+      });
+    } catch (err) {
+      setStatus({
+        kind: 'error',
+        message: err instanceof Error ? err.message : 'Network error',
+      });
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <header className="bg-white dark:bg-gray-800 shadow-lg">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center py-4">
+            <a href="/publish/" className="flex items-center hover:opacity-80">
+              <img
+                src="/chq-calendar-icon-256.svg"
+                alt="Chautauqua Calendar Logo"
+                width={32}
+                height={32}
+                className="w-8 h-8 mr-3"
+              />
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                Publisher sign-in
+              </h1>
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-md mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 sm:p-8">
+          <p className="text-sm text-gray-700 dark:text-gray-300 mb-6">
+            Enter the email you applied with. We&apos;ll send a one-time sign-in
+            link to that address — no password needed.
+          </p>
+
+          <form onSubmit={onSubmit} className="space-y-4">
+            <label className="block">
+              <span className="block text-sm font-medium text-gray-900 dark:text-white mb-1">
+                Email address
+              </span>
+              <input
+                type="email"
+                required
+                autoComplete="email"
+                value={email}
+                onInput={e => setEmail((e.target as HTMLInputElement).value)}
+                className="block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                placeholder="you@example.com"
+              />
+            </label>
+
+            <button
+              type="submit"
+              disabled={status.kind === 'submitting' || inCooldown}
+              className="inline-flex items-center justify-center w-full px-4 py-2 rounded-md bg-blue-600 text-white font-medium hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              {status.kind === 'submitting'
+                ? 'Sending…'
+                : inCooldown
+                ? `Resend available in ${cooldownRemainingSec}s`
+                : 'Send sign-in link'}
+            </button>
+          </form>
+
+          {status.kind === 'sent' && (
+            <div className="mt-4 rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 p-3">
+              <p className="text-sm text-green-800 dark:text-green-200">
+                If that email is on file, a sign-in link is on its way. Check
+                your inbox (and your spam folder) within the next minute.
+              </p>
+              <p className="text-xs text-green-700 dark:text-green-300 mt-1">
+                Links expire after 15 minutes. Each link is single-use.
+              </p>
+            </div>
+          )}
+
+          {status.kind === 'error' && (
+            <div className="mt-4 rounded-md bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 p-3">
+              <p className="text-sm text-red-800 dark:text-red-200">{status.message}</p>
+            </div>
+          )}
+
+          <p className="mt-6 text-xs text-gray-500 dark:text-gray-400 text-center">
+            Don&apos;t have an application yet?{' '}
+            <a
+              href="/publish/apply/"
+              className="text-blue-600 dark:text-blue-400 hover:underline"
+            >
+              Apply to publish
+            </a>
+          </p>
+        </div>
+      </main>
+
+      <footer className="bg-gray-800 text-white mt-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
+          <p className="text-gray-400">
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/frontend/src/app/publish/page.tsx
+++ b/frontend/src/app/publish/page.tsx
@@ -114,7 +114,17 @@ export default function PublishLandingPage() {
           </section>
 
           {/* Help / contact */}
-          <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400">
+          <section className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700 text-sm text-gray-600 dark:text-gray-400 space-y-2">
+            <p>
+              Already a publisher?{' '}
+              <a
+                href="/publish/login/"
+                className="text-blue-600 dark:text-blue-400 hover:underline"
+              >
+                Sign in
+              </a>{' '}
+              to view your status and recent fetch history.
+            </p>
             <p>
               Questions? Reach out via the{' '}
               <a

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -11,7 +11,11 @@
  * so this component doesn't need to handle that case explicitly.
  */
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'preact/hooks';
+// `react-jsx` runtime + the project's @types/react alias mean the children
+// slot expects React.ReactNode. Importing the type only keeps the runtime
+// alignment with preact (the `preact/compat` alias handles the actual JSX).
+import type { ReactNode } from 'react';
 import {
   clearPublisherSession,
   getPublisherSession,
@@ -315,7 +319,7 @@ function Detail({
   span,
 }: {
   label: string;
-  value: React.ReactNode;
+  value: ReactNode;
   span?: 2;
 }) {
   return (

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -1,0 +1,329 @@
+/**
+ * Publisher portal — Status page (Phase C).
+ *
+ * Authenticated view of the caller's own publisher record. Three paths:
+ *   - 'pending'  → review-in-progress notice
+ *   - 'approved' → publisher details + last-fetch summary
+ *   - 'rejected' → rejection notice + reason + apply-again CTA
+ *
+ * Authentication is the publisher JWT in localStorage (separate from admin).
+ * On 401 the API client clears the session and redirects to /publish/login/,
+ * so this component doesn't need to handle that case explicitly.
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  clearPublisherSession,
+  getPublisherSession,
+  isPublisherAuthenticated,
+} from '@/lib/publisherAuthClient';
+import {
+  getPublisherStatus,
+  type PublisherStatusRecord,
+} from '@/lib/publisherStatusApi';
+
+type Status =
+  | { kind: 'loading' }
+  | { kind: 'ok'; rec: PublisherStatusRecord }
+  | { kind: 'error'; message: string };
+
+export default function PublishStatusPage() {
+  const [status, setStatus] = useState<Status>({ kind: 'loading' });
+
+  useEffect(() => {
+    if (!isPublisherAuthenticated()) {
+      window.location.replace('/publish/login/');
+      return;
+    }
+    void getPublisherStatus()
+      .then(rec => setStatus({ kind: 'ok', rec }))
+      .catch(err => {
+        setStatus({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Failed to load status.',
+        });
+      });
+  }, []);
+
+  function handleSignOut() {
+    clearPublisherSession();
+    window.location.replace('/publish/');
+  }
+
+  const session = getPublisherSession();
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <header className="bg-white dark:bg-gray-800 shadow-lg">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between py-4">
+            <a href="/publish/" className="flex items-center hover:opacity-80">
+              <img
+                src="/chq-calendar-icon-256.svg"
+                alt="Chautauqua Calendar Logo"
+                width={32}
+                height={32}
+                className="w-8 h-8 mr-3"
+              />
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                Publisher status
+              </h1>
+            </a>
+            {session && (
+              <div className="flex items-center gap-3">
+                <span className="hidden sm:inline text-sm text-gray-600 dark:text-gray-300">
+                  {session.email}
+                </span>
+                <button
+                  onClick={handleSignOut}
+                  className="px-3 py-1 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                  Sign out
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {status.kind === 'loading' && <Loading />}
+        {status.kind === 'error' && <ErrorBlock message={status.message} />}
+        {status.kind === 'ok' && <StatusView rec={status.rec} />}
+      </main>
+
+      <footer className="bg-gray-800 text-white mt-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
+          <p className="text-gray-400">
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+          </p>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+// ── Sub-views ─────────────────────────────────────────────────────────────
+
+function Loading() {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-8 text-center">
+      <div className="mx-auto w-10 h-10 border-4 border-blue-500 border-t-transparent rounded-full animate-spin mb-4" />
+      <p className="text-gray-600 dark:text-gray-300">Loading your status…</p>
+    </div>
+  );
+}
+
+function ErrorBlock({ message }: { message: string }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+      <h2 className="text-lg font-semibold text-red-700 dark:text-red-300 mb-2">
+        Could not load your status
+      </h2>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">{message}</p>
+      <a
+        href="/publish/login/"
+        className="inline-flex items-center px-3 py-1.5 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+      >
+        Back to sign-in
+      </a>
+    </div>
+  );
+}
+
+function StatusView({ rec }: { rec: PublisherStatusRecord }) {
+  // Treat a missing applicationStatus as approved — that's how the backend
+  // treats admin-created rows for ingest, and the same logic should apply
+  // to the publisher-facing view.
+  const applicationStatus = rec.applicationStatus ?? 'approved';
+
+  return (
+    <div className="space-y-6">
+      <StatusBadge status={applicationStatus} />
+
+      {applicationStatus === 'pending' && <PendingNotice />}
+      {applicationStatus === 'rejected' && (
+        <RejectedNotice reason={rec.rejectionReason} />
+      )}
+
+      <PublisherCard rec={rec} />
+
+      {applicationStatus === 'approved' && <LastFetchPanel rec={rec} />}
+    </div>
+  );
+}
+
+function StatusBadge({ status }: { status: 'pending' | 'approved' | 'rejected' }) {
+  const map = {
+    pending: {
+      label: 'Pending review',
+      cls: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
+    },
+    approved: {
+      label: 'Approved',
+      cls: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300',
+    },
+    rejected: {
+      label: 'Not approved',
+      cls: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300',
+    },
+  } as const;
+  const { label, cls } = map[status];
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-4 flex items-center gap-3">
+      <span className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-semibold ${cls}`}>
+        {label}
+      </span>
+      <span className="text-sm text-gray-600 dark:text-gray-300">
+        Application status
+      </span>
+    </div>
+  );
+}
+
+function PendingNotice() {
+  return (
+    <div className="bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-800 rounded-lg p-4">
+      <p className="text-sm text-amber-900 dark:text-amber-200">
+        Your application is in the review queue. We&apos;ll email you when the
+        review is complete (usually within a few days). No action needed
+        right now — feel free to keep iterating on your feed using the{' '}
+        <a href="/publish/test/" className="underline">test tool</a>.
+      </p>
+    </div>
+  );
+}
+
+function RejectedNotice({ reason }: { reason?: string }) {
+  return (
+    <div className="bg-red-50 dark:bg-red-900/10 border border-red-200 dark:border-red-800 rounded-lg p-4">
+      <p className="text-sm text-red-900 dark:text-red-200 mb-3">
+        Your application wasn&apos;t approved at this time.
+      </p>
+      {reason && (
+        <blockquote className="border-l-4 border-red-300 dark:border-red-700 pl-3 text-sm italic text-gray-700 dark:text-gray-300 mb-3">
+          {reason}
+        </blockquote>
+      )}
+      <a
+        href="/publish/apply/"
+        className="inline-flex items-center px-3 py-1.5 rounded-md bg-blue-600 text-white text-sm font-medium hover:bg-blue-700"
+      >
+        Apply again
+      </a>
+    </div>
+  );
+}
+
+function PublisherCard({ rec }: { rec: PublisherStatusRecord }) {
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+        Publisher details
+      </h2>
+      <dl className="grid grid-cols-1 sm:grid-cols-3 gap-y-2 gap-x-4 text-sm">
+        <Detail label="Name" value={rec.name} />
+        <Detail label="Publisher ID" value={<span className="font-mono text-xs">{rec.id}</span>} />
+        <Detail label="Contact email" value={rec.contactEmail} />
+        {rec.organization && <Detail label="Organization" value={rec.organization} />}
+        <Detail
+          label="Source"
+          value={
+            <a
+              href={rec.sourceUrl}
+              target="_blank"
+              rel="noreferrer noopener"
+              className="text-blue-600 dark:text-blue-400 hover:underline break-all"
+            >
+              {rec.sourceUrl}
+            </a>
+          }
+          span={2}
+        />
+        <Detail label="Source type" value={rec.sourceType.toUpperCase()} />
+        <Detail
+          label="Ingest"
+          value={rec.enabled ? 'Active' : 'Paused'}
+        />
+        <Detail
+          label="Created"
+          value={rec.createdAt ? new Date(rec.createdAt).toLocaleString() : '—'}
+        />
+      </dl>
+    </div>
+  );
+}
+
+function LastFetchPanel({ rec }: { rec: PublisherStatusRecord }) {
+  if (!rec.lastFetchedAt) {
+    return (
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+          Last fetch
+        </h2>
+        <p className="text-sm text-gray-600 dark:text-gray-300">
+          Your feed hasn&apos;t been fetched yet. The first scheduled run will
+          ingest your events; check back later.
+        </p>
+      </div>
+    );
+  }
+  const cls = statusColor(rec.lastFetchStatus);
+  return (
+    <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+        Last fetch
+      </h2>
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-y-2 gap-x-4 text-sm">
+        <Detail
+          label="Status"
+          value={
+            <span className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${cls}`}>
+              {rec.lastFetchStatus ?? '—'}
+            </span>
+          }
+        />
+        <Detail
+          label="Fetched at"
+          value={new Date(rec.lastFetchedAt).toLocaleString()}
+        />
+        {rec.lastFetchMessage && (
+          <Detail label="Message" value={<span className="break-words">{rec.lastFetchMessage}</span>} span={2} />
+        )}
+      </dl>
+    </div>
+  );
+}
+
+function statusColor(s: PublisherStatusRecord['lastFetchStatus']): string {
+  switch (s) {
+    case 'ok':
+      return 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300';
+    case 'parse_error':
+    case 'validation_error':
+    case 'network_error':
+    case 'threshold_halt':
+      return 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300';
+    default:
+      return 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300';
+  }
+}
+
+function Detail({
+  label,
+  value,
+  span,
+}: {
+  label: string;
+  value: React.ReactNode;
+  span?: 2;
+}) {
+  return (
+    <div className={span === 2 ? 'sm:col-span-2' : ''}>
+      <dt className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+        {label}
+      </dt>
+      <dd className="mt-0.5 text-gray-900 dark:text-gray-100">{value}</dd>
+    </div>
+  );
+}

--- a/frontend/src/app/publish/verify/page.tsx
+++ b/frontend/src/app/publish/verify/page.tsx
@@ -106,6 +106,12 @@ function Pending() {
 }
 
 function Success({ email, isApply }: { email: string; isApply: boolean }) {
+  // Apply path: send the user back to /publish/ — the form told them to wait
+  // for review, and the home page is the natural landing.
+  // Login path: take them to /publish/status/ where they can see their own
+  // record and any post-approval state.
+  const ctaHref = isApply ? '/publish/' : '/publish/status/';
+  const ctaLabel = isApply ? 'Go to publisher home' : 'Go to your account';
   return (
     <div>
       <div className="mx-auto w-12 h-12 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center mb-4">
@@ -131,10 +137,10 @@ function Success({ email, isApply }: { email: string; isApply: boolean }) {
         Signed in as <span className="font-mono">{email}</span>
       </p>
       <a
-        href="/publish/"
+        href={ctaHref}
         className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium hover:bg-blue-700 transition-colors"
       >
-        Go to publisher home
+        {ctaLabel}
       </a>
     </div>
   );

--- a/frontend/src/entries/publish-login.tsx
+++ b/frontend/src/entries/publish-login.tsx
@@ -1,0 +1,5 @@
+import { render } from 'preact';
+import '@/app/globals.css';
+import PublishLoginPage from '@/app/publish/login/page';
+
+render(<PublishLoginPage />, document.getElementById('root')!);

--- a/frontend/src/entries/publish-status.tsx
+++ b/frontend/src/entries/publish-status.tsx
@@ -1,0 +1,5 @@
+import { render } from 'preact';
+import '@/app/globals.css';
+import PublishStatusPage from '@/app/publish/status/page';
+
+render(<PublishStatusPage />, document.getElementById('root')!);

--- a/frontend/src/lib/adminPublisherApi.ts
+++ b/frontend/src/lib/adminPublisherApi.ts
@@ -5,6 +5,8 @@ import { getAuthToken, removeAuthToken } from '@/lib/auth';
 // Types
 // ---------------------------------------------------------------------------
 
+export type ApplicationStatus = 'pending' | 'approved' | 'rejected';
+
 export interface PublisherRecord {
   id: string;
   name: string;
@@ -21,6 +23,15 @@ export interface PublisherRecord {
     detectedAt: string;
     incomingFeed: { eventCount: number; publisherId: string };
   };
+  // Phase B/C — apply flow. Optional; admin-created rows have no
+  // applicationStatus and are treated as approved by the UI.
+  applicationStatus?: ApplicationStatus;
+  appliedAt?: string;
+  reviewedAt?: string;
+  reviewerEmail?: string;
+  rejectionReason?: string;
+  organization?: string;
+  applicantNotes?: string;
 }
 
 export interface PendingEvent {
@@ -168,3 +179,31 @@ export const approveHalt = async (publisherId: string): Promise<void> => {
 
 export const cancelHalt = (publisherId: string): Promise<void> =>
   req<void>(`/publisher-halts/${encodeURIComponent(publisherId)}/cancel`, { method: 'POST' });
+
+// ---------------------------------------------------------------------------
+// Phase C — pending application review
+// ---------------------------------------------------------------------------
+
+export const listPendingApplications = async (): Promise<PublisherRecord[]> => {
+  const r = await req<{ applications: PublisherRecord[] }>('/publisher-applications/pending');
+  return r.applications;
+};
+
+export const approveApplication = async (id: string): Promise<PublisherRecord> => {
+  const r = await req<{ publisher: PublisherRecord }>(
+    `/publisher-applications/${encodeURIComponent(id)}/approve`,
+    { method: 'POST' },
+  );
+  return r.publisher;
+};
+
+export const rejectApplication = async (
+  id: string,
+  reason?: string,
+): Promise<PublisherRecord> => {
+  const r = await req<{ publisher: PublisherRecord }>(
+    `/publisher-applications/${encodeURIComponent(id)}/reject`,
+    { method: 'POST', body: JSON.stringify({ reason: reason ?? '' }) },
+  );
+  return r.publisher;
+};

--- a/frontend/src/lib/publisherStatusApi.ts
+++ b/frontend/src/lib/publisherStatusApi.ts
@@ -1,0 +1,88 @@
+// Client for the publisher-facing /api/publisher-status endpoint (Phase C).
+// On 401 we clear the local session and bounce to /publish/login/ — the
+// caller doesn't need to handle that case.
+
+import {
+  clearPublisherSession,
+  getPublisherJwt,
+  PUBLISHER_JWT_KEY as _UNUSED_JWT_KEY, // re-exported for completeness
+} from '@/lib/publisherAuthClient';
+
+void _UNUSED_JWT_KEY;
+
+export type ApplicationStatus = 'pending' | 'approved' | 'rejected';
+
+export interface PublisherStatusRecord {
+  id: string;
+  name: string;
+  contactEmail: string;
+  sourceUrl: string;
+  sourceType: 'json' | 'html';
+  trustLevel: 'auto' | 'review' | 'flagged';
+  enabled: boolean;
+  createdAt: string;
+  applicationStatus?: ApplicationStatus;
+  appliedAt?: string;
+  reviewedAt?: string;
+  rejectionReason?: string;
+  organization?: string;
+  applicantNotes?: string;
+  lastFetchedAt?: string;
+  lastFetchStatus?: 'ok' | 'parse_error' | 'validation_error' | 'network_error' | 'threshold_halt';
+  lastFetchMessage?: string;
+}
+
+const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+
+export class PublisherStatusError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+  ) {
+    super(message);
+    this.name = 'PublisherStatusError';
+  }
+}
+
+// Returns the publisher's own record. Throws PublisherStatusError on
+// non-2xx responses (other than 401, which we handle by redirecting).
+//
+// The redirect-on-401 means callers can treat a thrown error as a real
+// "something went wrong" rather than an auth event — auth events take the
+// user straight to /publish/login/ before the throw.
+export async function getPublisherStatus(): Promise<PublisherStatusRecord> {
+  const jwt = getPublisherJwt();
+  if (!jwt) {
+    redirectToLogin();
+    // redirectToLogin replaces the page; throw is reachable only in tests.
+    throw new PublisherStatusError('No publisher session.', 401);
+  }
+  const r = await fetch(`${API_BASE}/api/publisher-status`, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
+  if (r.status === 401) {
+    clearPublisherSession();
+    redirectToLogin();
+    throw new PublisherStatusError('Session expired.', 401);
+  }
+  const body = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    throw new PublisherStatusError(
+      typeof body?.error === 'string' ? body.error : `Request failed (${r.status}).`,
+      r.status,
+    );
+  }
+  if (!body || typeof body.publisher !== 'object' || body.publisher === null) {
+    throw new PublisherStatusError('Malformed response.', 500);
+  }
+  return body.publisher as PublisherStatusRecord;
+}
+
+function redirectToLogin(): void {
+  if (typeof window === 'undefined') return;
+  window.location.replace('/publish/login/');
+}

--- a/frontend/src/lib/publisherStatusApi.ts
+++ b/frontend/src/lib/publisherStatusApi.ts
@@ -2,13 +2,7 @@
 // On 401 we clear the local session and bounce to /publish/login/ — the
 // caller doesn't need to handle that case.
 
-import {
-  clearPublisherSession,
-  getPublisherJwt,
-  PUBLISHER_JWT_KEY as _UNUSED_JWT_KEY, // re-exported for completeness
-} from '@/lib/publisherAuthClient';
-
-void _UNUSED_JWT_KEY;
+import { clearPublisherSession, getPublisherJwt } from '@/lib/publisherAuthClient';
 
 export type ApplicationStatus = 'pending' | 'approved' | 'rejected';
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -98,6 +98,8 @@ export default defineConfig({
         'publish-test': resolve(__dirname, 'publish/test/index.html'),
         'publish-apply': resolve(__dirname, 'publish/apply/index.html'),
         'publish-verify': resolve(__dirname, 'publish/verify/index.html'),
+        'publish-login': resolve(__dirname, 'publish/login/index.html'),
+        'publish-status': resolve(__dirname, 'publish/status/index.html'),
       },
     },
   },


### PR DESCRIPTION
## Summary

Closes the publisher self-service loop. Builds on Phase A (test tool) and Phase B (apply + magic-link auth) shipped in #83.

- **Admin** can list, approve, and reject pending applications from `/admin/publishers/`.
- **Publisher** can sign in to `/publish/status/` (via the existing magic-link auth) to see their application status and recent fetch outcomes.
- **Publisher** receives an email when their application is approved or rejected.

Phase D (DNS-rebinding mitigation, per-IP rate-limit moved off in-memory storage, CAPTCHA, audit history) is **not** in this PR — design lives at `docs/plans/2026-05-03-publisher-portal-design.md`.

Plan doc: `docs/plans/2026-05-03-publisher-portal-phase-c-plan.md`.

## What ships

### Backend (commit `90d5c8a`)

- **PublisherAdminService**: `listPendingApplications`, `approveApplication(id, reviewerEmail)`, `rejectApplication(id, reviewerEmail, reason?)`. Both review methods throw the new `ApplicationStateError` if the row isn't in `pending` state — handlers translate to HTTP 409. Approval clears any prior `rejectionReason` (re-review), rejection truncates reasons to 500 chars and defensively flips `enabled = false`.
- **mailService**: `sendApprovalEmail` and `sendRejectionEmail`. Plain-text + HTML bodies, HTML-escaped user fields, throws on missing `SES_FROM_ADDRESS` (parity with magic-link senders). Email failures are logged and swallowed so state changes always persist.
- **adminHandler routes** (admin JWT required): `GET /publisher-applications/pending`, `POST /publisher-applications/:id/approve`, `POST /publisher-applications/:id/reject`. Reviewer email comes from the authenticated admin user, never the request body.
- **publisherPortalHandler.handlePublisherStatus** routed as `GET /publisher-status` OUTSIDE the admin-JWT branch — auth is the publisher JWT (separate signing key from admin). Returns the publisher's own record sanitized: `pendingThresholdHalt` and `reviewerEmail` are stripped. Uses the authoritative `sub` claim from the JWT (no header spoofing). Has its own DDB-only registry singleton to avoid the SES/Secrets-Manager init cost the application service pays.
- **Tests**: +14 cases on `publisherAdminService.test.ts`, +6 on `mailService.test.ts`, +8 in new `publisherPortalHandler.status.test.ts`. **368/368 passing** (was 338 before).

### Frontend (commit `acde1f8`)

Admin side (`/admin/publishers/`):
- New `PendingApplications.tsx` component. Pending rows render in an amber-badged section above the main table with inline Approve / Reject controls. Reject opens an inline 500-char reason textarea before confirming.
- `adminPublisherApi.ts` gains `listPendingApplications`, `approveApplication`, `rejectApplication`, plus the optional Phase B fields on `PublisherRecord`.
- Main table filters out pending rows so they don't double-render. Header shows `· N pending` annotation. Both lists fetch in parallel via `Promise.allSettled` so a transient failure on one doesn't blank the other.

Publisher side:
- `/publish/login/` — single email field that POSTs to `/api/publisher-auth/request`. Anti-enumeration messaging regardless of outcome. 60-second cooldown after submit. Already-authenticated users are redirected to `/publish/status/`.
- `/publish/status/` — authenticated view of caller's own publisher record. Three paths: pending (review notice), approved (details card + last-fetch panel), rejected (reason + apply-again CTA). Sign-out clears the local session.
- `publisherStatusApi.ts` handles redirect-on-401 so the page doesn't have to.
- `/publish/verify/` success CTA now branches by purpose: apply → `/publish/`, login → `/publish/status/`.
- `/publish/` landing page gains an "Already a publisher? Sign in" link.

Two new Vite entries registered. `npm run validate && npm run build` clean.

## No infrastructure changes

CloudFront already routes `/api/publisher-*` to the admin API origin and forwards `Authorization` (commit `41a9a8f` in PR #83). The new `GET /api/publisher-status` route works automatically. Admin-only endpoints (`/publisher-applications/*`) sit on the existing `/admin/api/*` behavior.

## Security notes

- Admin endpoints take `reviewerEmail` from the authenticated admin JWT, never from the request body — clients can't forge the reviewer identity.
- `/publisher-status` uses the authoritative `sub` claim from the JWT to look up the row. Header values like `X-Publisher-Id` are ignored.
- Sanitized record strips `reviewerEmail` (admin PII) and `pendingThresholdHalt` (ops-internal signal) before returning to the publisher.
- Email bodies HTML-escape the publisher name and reviewer reason. Plain-text bodies pass them through unchanged (text/plain has no execution context).
- Approval/rejection email failures log to CloudWatch but do not roll back the state change — admins can re-issue the email later (Phase D will add a dedicated re-send button).

## Test plan

- [ ] CI green (lint, typecheck, frontend build, backend tests, publisher-ingest E2E).
- [ ] After merge + deploy: smoke-test the apply → approve → status flow against production:
  - apply from `/publish/apply/`, receive + click magic link, see "Application received"
  - admin signs in to `/admin/publishers/`, sees the row in the new "Pending applications" section
  - admin clicks Approve → row disappears from pending, appears in main table with `enabled = true`
  - publisher receives approval email
  - publisher visits `/publish/login/`, requests sign-in link, clicks it, lands on `/publish/status/` showing "Approved"
- [ ] Reject path: similar flow with reason text → publisher sees rejection notice + reason on `/publish/status/`.
- [ ] Re-approve a pending row that was previously rejected (manually flipped back) — verify `rejectionReason` is cleared.
- [ ] Tamper a JWT → `/publish/status/` redirects to `/publish/login/` and clears local session.

## Deferred

Phase D — DNS-rebinding mitigation in `urlGuard`, per-IP rate-limit on DynamoDB (sliding window), optional CAPTCHA on apply, "Re-send magic link" UX, audit history beyond `lastFetchedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)