### PR TITLE
fix(deploy): admin Lambda missing cheerio/ajv runtime deps

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -155,6 +155,10 @@ jobs:
           cd package_temp
 
           # Create a minimal package.json with only admin externalized dependencies (using same versions as main package.json)
+          # cheerio, ajv, ajv-formats are pulled in transitively by @chq-calendar/publisher-format
+          # via the publisher-portal handler that adminHandler delegates to. esbuild leaves
+          # cheerio external (regular import) and ajv/ajv-formats use dynamic runtime requires
+          # that esbuild cannot bundle, so all three must be installed in the Lambda package.
           cat > package.json << 'EOF'
           {
             "name": "lambda-admin",
@@ -164,6 +168,9 @@ jobs:
               "@aws-sdk/lib-dynamodb": "^3.0.0",
               "@aws-sdk/client-secrets-manager": "^3.0.0",
               "@aws-sdk/client-sesv2": "^3.0.0",
+              "ajv": "^8.17.1",
+              "ajv-formats": "^3.0.1",
+              "cheerio": "^1.0.0-rc.12",
               "googleapis": "^153.0.0",
               "jsonwebtoken": "^9.0.2",
               "node-fetch": "^2.7.0",

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -187,6 +187,10 @@ jobs:
           # Copy the original package.json back
           cp package.json package_temp/package.json
 
+          # List what we installed for debugging — matches the calendar deploy step
+          echo "Installed admin dependencies:"
+          ls package_temp/node_modules/ | head -30
+
           # Create package for admin handler (package.json already copied above)
           mkdir -p package_temp/dist
           cp dist/adminHandler.js package_temp/dist/

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -154,11 +154,22 @@ jobs:
           echo "Installing admin handler dependencies with all transitive dependencies..."
           cd package_temp
 
-          # Create a minimal package.json with only admin externalized dependencies (using same versions as main package.json)
-          # cheerio, ajv, ajv-formats are pulled in transitively by @chq-calendar/publisher-format
-          # via the publisher-portal handler that adminHandler delegates to. esbuild leaves
-          # cheerio external (regular import) and ajv/ajv-formats use dynamic runtime requires
-          # that esbuild cannot bundle, so all three must be installed in the Lambda package.
+          # Create a minimal package.json listing only what esbuild leaves as runtime requires.
+          #
+          # Versions for AWS SDK / googleapis / jsonwebtoken / node-fetch / uuid come from
+          # backend/package.json. cheerio is pulled in transitively via
+          # @chq-calendar/publisher-format (used by the publisher-portal handler that
+          # adminHandler delegates to); the version pin matches both backend/package.json
+          # and tools/publisher-format/package.json.
+          #
+          # Why cheerio specifically: esbuild's adminHandler build marks cheerio as
+          # `--external`, so the bundle contains a real `require("cheerio")` that must
+          # resolve at runtime. The publisher-format library also uses ajv/ajv-formats,
+          # but those are fully bundled inline by esbuild — the `require("ajv/dist/...")`
+          # strings visible in the bundle are codegen template literals (set as
+          # `equal.code`, used only for ajv's standalone-mode source generation), not
+          # runtime require() calls. Verified by loading the bundle with only the
+          # dependencies listed below and confirming module evaluation succeeds.
           cat > package.json << 'EOF'
           {
             "name": "lambda-admin",
@@ -168,8 +179,6 @@ jobs:
               "@aws-sdk/lib-dynamodb": "^3.0.0",
               "@aws-sdk/client-secrets-manager": "^3.0.0",
               "@aws-sdk/client-sesv2": "^3.0.0",
-              "ajv": "^8.17.1",
-              "ajv-formats": "^3.0.1",
               "cheerio": "^1.0.0-rc.12",
               "googleapis": "^153.0.0",
               "jsonwebtoken": "^9.0.2",


### PR DESCRIPTION
## Summary

The admin Lambda has been crashing on import with `Cannot find module 'cheerio'`, causing the three admin pages (`/admin/feedback`, `/admin/publishers`, `/admin/publisher-events`) to return 502 `InternalServerErrorException` from API Gateway. The static HTML pages still load (200 from S3/CloudFront), but every API call from those pages fails.

CloudWatch confirms — every invocation since the publisher portal landed shows:

```
Runtime.ImportModuleError: Error: Cannot find module 'cheerio'
Require stack:
- /var/task/dist/adminHandler.js
- /var/runtime/index.mjs
```

## Root cause

Starting with PR #83 (`feat: publisher portal Phase A — admin landing + apply pages`), `adminHandler.ts` began importing from `publisherPortalHandler.ts`, which transitively pulls in `@chq-calendar/publisher-format`. That package depends on `cheerio`, and the admin Lambda's esbuild config marks `cheerio` as `--external`. So the deployed bundle contains a real `require("cheerio")` that needs to resolve at runtime.

`.github/workflows/deploy-production.yml` builds the admin Lambda zip from a minimal `package.json` that listed only the AWS SDK + googleapis + jsonwebtoken + node-fetch + uuid — no cheerio — so the deployed zip never had it in `node_modules` and Lambda failed to import the handler module.

The calendar Lambda's minimal package already lists `cheerio`; this same line was just missing from the admin section.

### Why ajv / ajv-formats are *not* in the fix

The admin bundle also contains literal strings like `require("ajv/dist/runtime/equal")`, but those are **codegen template literals** — they're stored as `equal.code` and used only by ajv's standalone-mode source generation. The actual `ajv` and `ajv-formats` modules are bundled inline by esbuild. Verified by loading the bundle without those packages installed and confirming module evaluation succeeds.

This also explains why publisher-ingest has been running fine without any of these packages installed: its esbuild config doesn't externalize `cheerio` either, so cheerio is bundled inline there.

## Fix

Add `cheerio` to the admin Lambda's minimal dependency set in `deploy-production.yml`, and add a comment block explaining the bundling contract so future maintainers don't have to re-derive it. Also added `ls package_temp/node_modules/ | head -30` after the install so future "Cannot find module" failures show up in the deploy logs (matches the calendar Lambda step).

## Verification

Reproduced the workflow's package step locally:

```bash
mkdir -p /tmp/admin_pkg_test/dist && cp backend/dist/adminHandler.js /tmp/admin_pkg_test/dist/
# write minimal package.json with cheerio added (no ajv, no ajv-formats)
cd /tmp/admin_pkg_test && npm install --omit=dev --no-package-lock
node -e "require('/tmp/admin_pkg_test/dist/adminHandler.js')"
# → handler loaded ok, exports: [ 'handler', 'redactEventForLogging' ]
```

Without the fix, the same `node -e` call reproduces the production error (`Cannot find module 'cheerio'`).

## Test plan

- [ ] CI checks pass on this PR
- [ ] Merge → deploy job runs and produces a fresh admin Lambda zip
- [ ] After deploy, `curl -sI https://www.chqcal.org/admin/api/feedback` returns 401 (auth required) instead of 502
- [ ] Admin user can log in and `/admin/feedback`, `/admin/publishers`, `/admin/publisher-events` load data without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)