### PR TITLE
fix(deploy): admin Lambda missing publisher-format refs

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -203,6 +203,13 @@ jobs:
           # Create package for admin handler (package.json already copied above)
           mkdir -p package_temp/dist
           cp dist/adminHandler.js package_temp/dist/
+          # Refs (categories, venues) are loaded by @chq-calendar/publisher-format's
+          # loadReferences() at /publisher-test invocation time. The library reads
+          # from `dist/refs/` relative to its own __dirname; without these files
+          # it falls through to a repo path that does not exist inside the Lambda
+          # filesystem, and /publisher-test (delegated from adminHandler) returns
+          # 500 with ENOENT. publisher-ingest already includes this copy.
+          cp -r dist/refs package_temp/dist/refs
 
           cd package_temp
           zip -r ../lambda-admin.zip . -x "*.md" "*/test/*" "*/tests/*" "*/examples/*" "README.md" "CHANGELOG.md"


### PR DESCRIPTION
## Summary

`POST /publisher-test` (the public feed-validator endpoint behind `/publish/test/`) crashes with HTTP 500 because the admin Lambda zip is missing the `dist/refs/` directory that `@chq-calendar/publisher-format`'s `loadReferences()` reads at validation time.

This is the same shape of regression as PR #86 (cheerio missing): the publisher-portal work wired routes into the admin Lambda but the deploy step wasn't updated to include the runtime files those routes depend on.

## How it surfaces

User reports HTTP 500 on `/publish/test` against `https://www.newtontheatrecompany.com/chqcal.html`. CloudWatch confirms:

```
Error: ENOENT: no such file or directory, open '/docs/publisher/categories.json'
    at Object.readFileSync (node:fs:440:20)
    at loadReferences (/var/task/dist/adminHandler.js:24599:34)
    at validateFeed2 (...)
    at fetchAndParseFeed (...)
    at testPublisherFeed (...)
    at handlePublisherTest (...)
    at Runtime.handler (...)
```

Reproduces on every invocation since the publisher portal landed; was previously masked by the cheerio import failure (the handler didn't even load).

## Root cause

`tools/publisher-format/src/references.ts:14-19`:
```ts
const BUNDLED_REFS_DIR = path.resolve(__dirname, 'refs');
const REPO_DOCS_DIR = path.resolve(__dirname, '..', '..', '..', 'docs', 'publisher');
function defaultRefsDir(): string {
  if (fs.existsSync(path.join(BUNDLED_REFS_DIR, 'categories.json'))) return BUNDLED_REFS_DIR;
  return REPO_DOCS_DIR;
}
```

In Lambda, `__dirname` is `/var/task/dist`, so:
- `BUNDLED_REFS_DIR` = `/var/task/dist/refs` — would work, but the deploy step never copies it
- `REPO_DOCS_DIR` = `/docs/publisher` — fallback, doesn't exist, ENOENT

`backend/package.json` build:prod already does `cp -r ../tools/publisher-format/dist/refs dist/refs`, so the files are present in the local `backend/dist/`. The CI deploy step for the admin Lambda just doesn't include them in the zip.

The `publisher-ingest` Lambda's deploy step *does* include them — same library, same reason:
```yaml
# publisher-ingest step (~line 290)
mkdir -p package_temp/dist
cp dist/publisherIngestHandler.js package_temp/dist/
cp -r dist/refs package_temp/dist/refs
```

The admin Lambda's step was just missing this line.

## Fix

Add `cp -r dist/refs package_temp/dist/refs` to the admin Lambda packaging step, with a comment explaining the runtime dependency.

## Verification

After merge + deploy, test:

```bash
# Should return a 200 with fetchStatus / feed / report fields,
# NOT a 500 with "Internal server error".
curl -X POST https://www.chqcal.org/api/publisher-test \
  -H 'Content-Type: application/json' \
  -d '{"url":"https://www.newtontheatrecompany.com/chqcal.html","sourceType":"html"}'
```

User-visible: paste a feed URL into https://www.chqcal.org/publish/test/ and confirm the validator returns results (errors, warnings, or a parsed event preview) instead of a generic "Internal server error".

🤖 Generated with [Claude Code](https://claude.com/claude-code)