### PR TITLE
feat: CAPTCHA on publisher-apply form + public /publish/docs/ page

### DIFF
--- a/backend/src/__tests__/captchaService.test.ts
+++ b/backend/src/__tests__/captchaService.test.ts
@@ -102,5 +102,16 @@ describe('verifyCaptcha', () => {
       const ok = await verifyCaptcha('tok', 'publisher_apply');
       expect(ok).toBe(false);
     });
+
+    it('returns false when siteverify times out (AbortError path)', async () => {
+      // The 8s AbortController timeout protects the Lambda from a slow or
+      // unreachable Google endpoint. When the controller aborts, fetch
+      // throws an AbortError; this test asserts the catch branch handles
+      // it cleanly and returns false rather than propagating.
+      const abortErr = Object.assign(new Error('aborted'), { name: 'AbortError' });
+      mockFetch.mockRejectedValueOnce(abortErr);
+      const ok = await verifyCaptcha('tok', 'publisher_apply');
+      expect(ok).toBe(false);
+    });
   });
 });

--- a/backend/src/__tests__/captchaService.test.ts
+++ b/backend/src/__tests__/captchaService.test.ts
@@ -1,0 +1,106 @@
+// Tests for the shared captcha service. node-fetch is mocked so we don't
+// hit Google's siteverify endpoint.
+
+import { verifyCaptcha } from '../services/captchaService';
+
+jest.mock('node-fetch', () => jest.fn());
+import fetch from 'node-fetch';
+
+const mockFetch = fetch as unknown as jest.Mock;
+
+const ORIGINAL_ENV = { ...process.env };
+
+function mockResponse(body: Record<string, unknown>) {
+  mockFetch.mockResolvedValueOnce({
+    json: () => Promise.resolve(body),
+  });
+}
+
+describe('verifyCaptcha', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    process.env = { ...ORIGINAL_ENV };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  describe('without RECAPTCHA_SECRET_KEY', () => {
+    it('returns true in non-production (test/dev pass-through)', async () => {
+      delete process.env.RECAPTCHA_SECRET_KEY;
+      process.env.ENVIRONMENT = 'dev';
+      const ok = await verifyCaptcha('any-token', 'submit_feedback');
+      expect(ok).toBe(true);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns false in production (fail closed)', async () => {
+      delete process.env.RECAPTCHA_SECRET_KEY;
+      process.env.ENVIRONMENT = 'prod';
+      const ok = await verifyCaptcha('any-token', 'submit_feedback');
+      expect(ok).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with RECAPTCHA_SECRET_KEY configured', () => {
+    beforeEach(() => {
+      process.env.RECAPTCHA_SECRET_KEY = 'test-secret';
+      process.env.ENVIRONMENT = 'prod';
+    });
+
+    it('rejects empty tokens without contacting Google', async () => {
+      const ok = await verifyCaptcha('', 'publisher_apply');
+      expect(ok).toBe(false);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns true on successful verification with matching action and good score', async () => {
+      mockResponse({ success: true, score: 0.9, action: 'publisher_apply' });
+      const ok = await verifyCaptcha('tok', 'publisher_apply');
+      expect(ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://www.google.com/recaptcha/api/siteverify',
+        expect.objectContaining({ method: 'POST' }),
+      );
+    });
+
+    it('returns false when score is below threshold even with matching action', async () => {
+      mockResponse({ success: true, score: 0.3, action: 'publisher_apply' });
+      const ok = await verifyCaptcha('tok', 'publisher_apply');
+      expect(ok).toBe(false);
+    });
+
+    it('returns false on action mismatch even when the score is fine', async () => {
+      // Token minted for `submit_feedback` should not be valid against
+      // `publisher_apply` — prevents cross-form token replay.
+      mockResponse({ success: true, score: 0.9, action: 'submit_feedback' });
+      const ok = await verifyCaptcha('tok', 'publisher_apply');
+      expect(ok).toBe(false);
+    });
+
+    it('returns false when Google reports success=false', async () => {
+      mockResponse({
+        success: false,
+        score: 0.9,
+        action: 'publisher_apply',
+        'error-codes': ['invalid-input-response'],
+      });
+      const ok = await verifyCaptcha('bad-tok', 'publisher_apply');
+      expect(ok).toBe(false);
+    });
+
+    it('falls back to result.success when no score is present (v2 compatibility)', async () => {
+      mockResponse({ success: true });
+      const ok = await verifyCaptcha('tok', 'publisher_apply');
+      expect(ok).toBe(true);
+    });
+
+    it('returns false when fetch throws', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('network down'));
+      const ok = await verifyCaptcha('tok', 'publisher_apply');
+      expect(ok).toBe(false);
+    });
+  });
+});

--- a/backend/src/__tests__/publisherPortalHandler.apply.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.apply.test.ts
@@ -1,6 +1,10 @@
 // Handler-level tests for the four Phase B routes. The application service
 // is stubbed via _setAppServiceForTests so we don't hit DynamoDB / SES /
-// Secrets Manager.
+// Secrets Manager. CAPTCHA verification is mocked so we don't hit Google.
+
+jest.mock('../services/captchaService', () => ({
+  verifyCaptcha: jest.fn(),
+}));
 
 import type { APIGatewayProxyEvent } from 'aws-lambda';
 import {
@@ -11,6 +15,9 @@ import {
   _setAppServiceForTests,
   _resetPublisherAuthRateLimitForTests,
 } from '../handlers/publisherPortalHandler';
+import { verifyCaptcha } from '../services/captchaService';
+
+const mockVerifyCaptcha = verifyCaptcha as jest.MockedFunction<typeof verifyCaptcha>;
 
 const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
   body: '',
@@ -36,8 +43,20 @@ const mkApp = () => ({
 });
 
 describe('handlePublisherApplyRequest', () => {
+  // A valid-shape body used by every test that isn't asserting validation errors.
+  // The captchaToken value is arbitrary — verifyCaptcha is mocked.
+  const validBody = {
+    name: 'A',
+    email: 'a@b.com',
+    sourceUrl: 'https://x.test/feed',
+    sourceType: 'json',
+    captchaToken: 'test-captcha-token',
+  };
+
   beforeEach(() => {
     _resetPublisherAuthRateLimitForTests();
+    mockVerifyCaptcha.mockReset();
+    mockVerifyCaptcha.mockResolvedValue(true);
   });
   afterEach(() => {
     _setAppServiceForTests(null);
@@ -47,18 +66,44 @@ describe('handlePublisherApplyRequest', () => {
     const stub = mkApp();
     stub.requestApply.mockResolvedValue({ ok: true });
     _setAppServiceForTests(stub as any);
-    const r = await handlePublisherApplyRequest(evt(), {
-      name: 'A', email: 'a@b.com', sourceUrl: 'https://x.test/feed', sourceType: 'json',
-    });
+    const r = await handlePublisherApplyRequest(evt(), validBody);
     expect(r.statusCode).toBe(200);
     expect(JSON.parse(r.body)).toEqual({ ok: true });
     expect(stub.requestApply).toHaveBeenCalled();
+    expect(mockVerifyCaptcha).toHaveBeenCalledWith('test-captcha-token', 'publisher_apply');
   });
 
-  it('returns 400 on missing fields', async () => {
+  it('returns 400 with captcha field when captchaToken is missing', async () => {
     const stub = mkApp();
     _setAppServiceForTests(stub as any);
-    const r = await handlePublisherApplyRequest(evt(), { name: 'A' });
+    const { captchaToken: _drop, ...withoutToken } = validBody;
+    const r = await handlePublisherApplyRequest(evt(), withoutToken);
+    expect(r.statusCode).toBe(400);
+    const body = JSON.parse(r.body);
+    expect(body.field).toBe('captcha');
+    expect(stub.requestApply).not.toHaveBeenCalled();
+    expect(mockVerifyCaptcha).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with captcha field when verifyCaptcha returns false', async () => {
+    const stub = mkApp();
+    _setAppServiceForTests(stub as any);
+    mockVerifyCaptcha.mockResolvedValue(false);
+    const r = await handlePublisherApplyRequest(evt(), validBody);
+    expect(r.statusCode).toBe(400);
+    const body = JSON.parse(r.body);
+    expect(body.field).toBe('captcha');
+    expect(body.error).toMatch(/CAPTCHA/);
+    expect(stub.requestApply).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on missing fields (after captcha passes)', async () => {
+    const stub = mkApp();
+    _setAppServiceForTests(stub as any);
+    const r = await handlePublisherApplyRequest(evt(), {
+      name: 'A',
+      captchaToken: 'test-captcha-token',
+    });
     expect(r.statusCode).toBe(400);
     expect(stub.requestApply).not.toHaveBeenCalled();
   });
@@ -70,7 +115,8 @@ describe('handlePublisherApplyRequest', () => {
     });
     _setAppServiceForTests(stub as any);
     const r = await handlePublisherApplyRequest(evt(), {
-      name: 'A', email: 'a@b.com', sourceUrl: 'http://localhost', sourceType: 'json',
+      ...validBody,
+      sourceUrl: 'http://localhost',
     });
     expect(r.statusCode).toBe(400);
     const body = JSON.parse(r.body);
@@ -82,12 +128,11 @@ describe('handlePublisherApplyRequest', () => {
     const stub = mkApp();
     stub.requestApply.mockResolvedValue({ ok: true });
     _setAppServiceForTests(stub as any);
-    const body = { name: 'A', email: 'a@b.com', sourceUrl: 'https://x.test/feed', sourceType: 'json' };
     for (let i = 0; i < 10; i++) {
-      const r = await handlePublisherApplyRequest(evt(), body);
+      const r = await handlePublisherApplyRequest(evt(), validBody);
       expect(r.statusCode).toBe(200);
     }
-    const limited = await handlePublisherApplyRequest(evt(), body);
+    const limited = await handlePublisherApplyRequest(evt(), validBody);
     expect(limited.statusCode).toBe(429);
     expect(limited.headers?.['Retry-After']).toBeTruthy();
   });

--- a/backend/src/__tests__/publisherPortalHandler.apply.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.apply.test.ts
@@ -73,16 +73,19 @@ describe('handlePublisherApplyRequest', () => {
     expect(mockVerifyCaptcha).toHaveBeenCalledWith('test-captcha-token', 'publisher_apply');
   });
 
-  it('returns 400 with captcha field when captchaToken is missing', async () => {
+  it('passes empty token through to verifyCaptcha when captchaToken is missing', async () => {
+    // The handler no longer rejects up-front on missing token — it lets
+    // captchaService decide based on environment / secret config. In dev
+    // with no secret it returns true; in prod it short-circuits empty
+    // tokens to false. This test asserts the delegation; the
+    // verifyCaptcha-returns-false case is covered by the next test.
     const stub = mkApp();
+    stub.requestApply.mockResolvedValue({ ok: true });
     _setAppServiceForTests(stub as any);
     const { captchaToken: _drop, ...withoutToken } = validBody;
     const r = await handlePublisherApplyRequest(evt(), withoutToken);
-    expect(r.statusCode).toBe(400);
-    const body = JSON.parse(r.body);
-    expect(body.field).toBe('captcha');
-    expect(stub.requestApply).not.toHaveBeenCalled();
-    expect(mockVerifyCaptcha).not.toHaveBeenCalled();
+    expect(r.statusCode).toBe(200);
+    expect(mockVerifyCaptcha).toHaveBeenCalledWith('', 'publisher_apply');
   });
 
   it('returns 400 with captcha field when verifyCaptcha returns false', async () => {
@@ -97,7 +100,7 @@ describe('handlePublisherApplyRequest', () => {
     expect(stub.requestApply).not.toHaveBeenCalled();
   });
 
-  it('returns 400 on missing fields (after captcha passes)', async () => {
+  it('returns 400 on missing fields without calling verifyCaptcha', async () => {
     const stub = mkApp();
     _setAppServiceForTests(stub as any);
     const r = await handlePublisherApplyRequest(evt(), {
@@ -106,6 +109,10 @@ describe('handlePublisherApplyRequest', () => {
     });
     expect(r.statusCode).toBe(400);
     expect(stub.requestApply).not.toHaveBeenCalled();
+    // Field-shape errors must be surfaced before the Google round-trip so
+    // legitimate users see actionable feedback and we don't burn calls to
+    // siteverify on malformed submissions.
+    expect(mockVerifyCaptcha).not.toHaveBeenCalled();
   });
 
   it('returns 400 with field name on app-service validation failure', async () => {

--- a/backend/src/handlers/calendarHandler.ts
+++ b/backend/src/handlers/calendarHandler.ts
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { format, parseISO } from 'date-fns';
 import fetch from 'node-fetch';
 import { MultiLayerCacheService, CacheConfig } from '../services/multiLayerCacheService';
+import { verifyCaptcha } from '../services/captchaService';
 
 // DynamoDB client
 const dynamoClient = new DynamoDBClient({
@@ -24,7 +25,6 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const EVENTS_TABLE_NAME = process.env.EVENTS_TABLE_NAME || 'chautauqua-calendar-events';
 const DATA_SOURCES_TABLE_NAME = process.env.DATA_SOURCES_TABLE_NAME || 'chautauqua-calendar-data-sources';
 const FEEDBACK_TABLE_NAME = process.env.FEEDBACK_TABLE_NAME || 'chautauqua-calendar-feedback';
-const RECAPTCHA_SECRET_KEY = process.env.RECAPTCHA_SECRET_KEY;
 
 // Cache configuration
 const CACHE_S3_BUCKET = process.env.CACHE_S3_BUCKET || 'chautauqua-calendar-cache';
@@ -121,63 +121,6 @@ const createResponse = (statusCode: number, body: any, headers: Record<string, s
     },
     body: typeof body === 'string' ? body : JSON.stringify(body)
   };
-};
-
-// Helper function to verify reCAPTCHA token
-const verifyCaptcha = async (token: string): Promise<boolean> => {
-  if (!RECAPTCHA_SECRET_KEY) {
-    const isProduction = process.env.ENVIRONMENT === 'prod';
-    if (isProduction) {
-      console.error('RECAPTCHA_SECRET_KEY not configured in production - rejecting request');
-      return false; // Fail closed in production
-    } else {
-      console.warn('RECAPTCHA_SECRET_KEY not configured, skipping CAPTCHA verification in non-production');
-      return true; // Allow in development/testing only
-    }
-  }
-
-  try {
-    const response = await fetch('https://www.google.com/recaptcha/api/siteverify', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-      body: new URLSearchParams({
-        secret: RECAPTCHA_SECRET_KEY,
-        response: token,
-      }),
-    });
-
-    const result = await response.json() as {
-      success: boolean;
-      score?: number;
-      action?: string;
-      'error-codes'?: string[];
-      challenge_ts?: string;
-      hostname?: string;
-    };
-
-    console.log(`reCAPTCHA verification result:`, {
-      success: result.success,
-      score: result.score,
-      action: result.action || 'submit_feedback',
-      errorCodes: result['error-codes'],
-      challengeTimestamp: result.challenge_ts,
-      hostname: result.hostname
-    });
-
-    // For reCAPTCHA v3, we should check the score as well
-    if (result.score !== undefined) {
-      const isValid = result.success && result.score > 0.5; // Threshold for human vs bot
-      console.log(`reCAPTCHA score validation: ${result.score} > 0.5 = ${isValid}`);
-      return isValid;
-    }
-
-    return result.success;
-  } catch (error) {
-    console.error('Error verifying CAPTCHA:', error);
-    return false;
-  }
 };
 
 // Helper function to transform database events to the expected Event format
@@ -433,7 +376,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
 
       // Verify CAPTCHA if token is provided
       if (captchaToken) {
-        const isCaptchaValid = await verifyCaptcha(captchaToken);
+        const isCaptchaValid = await verifyCaptcha(captchaToken, 'submit_feedback');
         if (!isCaptchaValid) {
           return createResponse(400, { error: 'CAPTCHA verification failed' });
         }
@@ -684,7 +627,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
 
       // Verify CAPTCHA if token is provided
       if (captchaToken) {
-        const isCaptchaValid = await verifyCaptcha(captchaToken);
+        const isCaptchaValid = await verifyCaptcha(captchaToken, 'submit_feedback');
         if (!isCaptchaValid) {
           return createResponse(400, { error: 'CAPTCHA verification failed' });
         }

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -25,6 +25,7 @@ import { SesMailService } from '../services/mailService';
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherApplicationService } from '../services/publisherApplicationService';
 import { verifyPublisherJwt } from '../services/publisherAuthService';
+import { verifyCaptcha } from '../services/captchaService';
 import {
   DynamoRateLimiter,
   InMemoryRateLimiter,
@@ -295,6 +296,11 @@ export async function handlePublisherApplyRequest(
   const limited = await applyAuthRateLimit(event);
   if (limited) return limited;
 
+  const captchaToken = typeof requestBody?.captchaToken === 'string' ? requestBody.captchaToken : '';
+  if (!captchaToken) {
+    return json(400, { error: 'CAPTCHA token is required.', field: 'captcha' });
+  }
+
   const payload = requestBody as Partial<ApplyFormPayload>;
   if (
     typeof payload?.name !== 'string' ||
@@ -303,6 +309,15 @@ export async function handlePublisherApplyRequest(
     typeof payload?.sourceType !== 'string'
   ) {
     return json(400, { error: 'Missing or invalid fields. Required: name, email, sourceUrl, sourceType.' });
+  }
+
+  // CAPTCHA gates the apply form to deter scripted abuse. Verified after the
+  // rate-limit check (so attackers can't burn quota with bogus tokens) and
+  // after the basic shape check (so legitimate users see field errors first
+  // when their submission is malformed).
+  const captchaOk = await verifyCaptcha(captchaToken, 'publisher_apply');
+  if (!captchaOk) {
+    return json(400, { error: 'CAPTCHA verification failed. Please refresh and try again.', field: 'captcha' });
   }
 
   try {

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -296,11 +296,6 @@ export async function handlePublisherApplyRequest(
   const limited = await applyAuthRateLimit(event);
   if (limited) return limited;
 
-  const captchaToken = typeof requestBody?.captchaToken === 'string' ? requestBody.captchaToken : '';
-  if (!captchaToken) {
-    return json(400, { error: 'CAPTCHA token is required.', field: 'captcha' });
-  }
-
   const payload = requestBody as Partial<ApplyFormPayload>;
   if (
     typeof payload?.name !== 'string' ||
@@ -311,10 +306,22 @@ export async function handlePublisherApplyRequest(
     return json(400, { error: 'Missing or invalid fields. Required: name, email, sourceUrl, sourceType.' });
   }
 
-  // CAPTCHA gates the apply form to deter scripted abuse. Verified after the
-  // rate-limit check (so attackers can't burn quota with bogus tokens) and
-  // after the basic shape check (so legitimate users see field errors first
-  // when their submission is malformed).
+  // CAPTCHA gates the apply form to deter scripted abuse. Order matters:
+  //   1. Rate-limit check (above) — first, so attackers can't burn quota
+  //      with bogus tokens before any verification work.
+  //   2. Basic shape check (above) — next, so legitimate users with a
+  //      malformed submission see field errors instead of a generic
+  //      captcha failure.
+  //   3. Captcha verification (here) — last, so the round-trip to Google
+  //      only happens for well-formed submissions.
+  //
+  // The token is passed through unconditionally; verifyCaptcha decides
+  // what to do based on environment + secret config. In dev with no
+  // VITE_RECAPTCHA_SITE_KEY the frontend sends no token, captchaService
+  // returns true because no RECAPTCHA_SECRET_KEY is configured, and the
+  // request proceeds. In production the secret is set and an empty or
+  // bad token is rejected.
+  const captchaToken = typeof requestBody?.captchaToken === 'string' ? requestBody.captchaToken : '';
   const captchaOk = await verifyCaptcha(captchaToken, 'publisher_apply');
   if (!captchaOk) {
     return json(400, { error: 'CAPTCHA verification failed. Please refresh and try again.', field: 'captcha' });

--- a/backend/src/services/captchaService.ts
+++ b/backend/src/services/captchaService.ts
@@ -1,0 +1,74 @@
+import fetch from 'node-fetch';
+
+interface SiteVerifyResponse {
+  success: boolean;
+  score?: number;
+  action?: string;
+  'error-codes'?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+}
+
+const SITE_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
+
+// reCAPTCHA v3 score threshold. Below this we treat the request as bot-like.
+// Matches the historical threshold used by the feedback endpoint.
+const SCORE_THRESHOLD = 0.5;
+
+/**
+ * Verify a reCAPTCHA v3 token against Google's siteverify endpoint.
+ *
+ * Returns true on success, false on failure. Behaviour when
+ * RECAPTCHA_SECRET_KEY is unset:
+ *   - production (`ENVIRONMENT === 'prod'`): fail closed (returns false)
+ *   - any other environment: log a warning, return true so local dev /
+ *     unit tests don't require a real Google round-trip.
+ *
+ * The optional `action` argument is included in the result-log line for
+ * easier triage; it is *not* checked against the response (we trust the
+ * score gate instead). Pass it to make the logs self-explanatory.
+ */
+export async function verifyCaptcha(
+  token: string,
+  action: string = 'submit',
+): Promise<boolean> {
+  const secret = process.env.RECAPTCHA_SECRET_KEY;
+  if (!secret) {
+    if (process.env.ENVIRONMENT === 'prod') {
+      console.error('RECAPTCHA_SECRET_KEY not configured in production - rejecting request');
+      return false;
+    }
+    console.warn('RECAPTCHA_SECRET_KEY not configured, skipping CAPTCHA verification in non-production');
+    return true;
+  }
+
+  try {
+    const response = await fetch(SITE_VERIFY_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ secret, response: token }),
+    });
+
+    const result = (await response.json()) as SiteVerifyResponse;
+
+    console.log('reCAPTCHA verification result:', {
+      success: result.success,
+      score: result.score,
+      action: result.action || action,
+      errorCodes: result['error-codes'],
+      challengeTimestamp: result.challenge_ts,
+      hostname: result.hostname,
+    });
+
+    if (result.score !== undefined) {
+      const isValid = result.success && result.score > SCORE_THRESHOLD;
+      console.log(`reCAPTCHA score validation: ${result.score} > ${SCORE_THRESHOLD} = ${isValid}`);
+      return isValid;
+    }
+
+    return result.success;
+  } catch (error) {
+    console.error('Error verifying CAPTCHA:', error);
+    return false;
+  }
+}

--- a/backend/src/services/captchaService.ts
+++ b/backend/src/services/captchaService.ts
@@ -15,6 +15,12 @@ const SITE_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
 // Matches the historical threshold used by the feedback endpoint.
 const SCORE_THRESHOLD = 0.5;
 
+// Cap the round-trip to Google so a slow/unreachable siteverify endpoint
+// can't hold the Lambda for the full platform default (~30 s). 8 s is well
+// above siteverify's median latency but short enough to fail fast under
+// network trouble.
+const SITE_VERIFY_TIMEOUT_MS = 8000;
+
 /**
  * Verify a reCAPTCHA v3 token against Google's siteverify endpoint.
  *
@@ -22,11 +28,13 @@ const SCORE_THRESHOLD = 0.5;
  * RECAPTCHA_SECRET_KEY is unset:
  *   - production (`ENVIRONMENT === 'prod'`): fail closed (returns false)
  *   - any other environment: log a warning, return true so local dev /
- *     unit tests don't require a real Google round-trip.
+ *     unit tests don't require a real Google round-trip. Token may be
+ *     empty in this case (frontend skips reCAPTCHA when no site key).
  *
- * The optional `action` argument is included in the result-log line for
- * easier triage; it is *not* checked against the response (we trust the
- * score gate instead). Pass it to make the logs self-explanatory.
+ * The `action` argument is checked against `result.action` from Google's
+ * response. v3 tokens are minted per-action; rejecting on mismatch prevents
+ * an attacker from replaying a token issued for a different form (e.g. a
+ * `submit_feedback` token reused against `publisher_apply`).
  */
 export async function verifyCaptcha(
   token: string,
@@ -42,11 +50,23 @@ export async function verifyCaptcha(
     return true;
   }
 
+  // Empty token in production with secret configured: short-circuit. Sending
+  // an empty `response` to Google would be a wasted round-trip — siteverify
+  // returns success=false with `missing-input-response` in that case.
+  if (!token) {
+    console.warn('verifyCaptcha called with empty token; rejecting without contacting Google');
+    return false;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SITE_VERIFY_TIMEOUT_MS);
+
   try {
     const response = await fetch(SITE_VERIFY_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ secret, response: token }),
+      signal: controller.signal,
     });
 
     const result = (await response.json()) as SiteVerifyResponse;
@@ -54,11 +74,21 @@ export async function verifyCaptcha(
     console.log('reCAPTCHA verification result:', {
       success: result.success,
       score: result.score,
-      action: result.action || action,
+      expectedAction: action,
+      action: result.action,
       errorCodes: result['error-codes'],
       challengeTimestamp: result.challenge_ts,
       hostname: result.hostname,
     });
+
+    // Reject action mismatches even if the score gate would otherwise pass —
+    // a token minted for a different action can't safely be used here.
+    if (result.action !== undefined && result.action !== action) {
+      console.warn(
+        `reCAPTCHA action mismatch: expected "${action}", got "${result.action}"`,
+      );
+      return false;
+    }
 
     if (result.score !== undefined) {
       const isValid = result.success && result.score > SCORE_THRESHOLD;
@@ -68,7 +98,13 @@ export async function verifyCaptcha(
 
     return result.success;
   } catch (error) {
-    console.error('Error verifying CAPTCHA:', error);
+    if ((error as { name?: string })?.name === 'AbortError') {
+      console.error(`reCAPTCHA verification timed out after ${SITE_VERIFY_TIMEOUT_MS}ms`);
+    } else {
+      console.error('Error verifying CAPTCHA:', error);
+    }
     return false;
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/docs/plans/2026-05-04-publisher-portal-captcha-and-docs-plan.md
+++ b/docs/plans/2026-05-04-publisher-portal-captcha-and-docs-plan.md
@@ -1,0 +1,80 @@
+# Plan — CAPTCHA on apply form + public publisher docs page
+
+**Date:** 2026-05-04
+**Origin:** User request after publisher portal Phases A–D shipped — "Add public docs for publishers. Also add captcha to apply form."
+**Branch:** `feat/publisher-apply-captcha-and-public-docs`
+
+## Goals
+
+1. **CAPTCHA on `/api/publisher-apply/request`** — gate the apply submission with reCAPTCHA v3 to deter abuse, matching the existing pattern used by the feedback form.
+2. **Public publisher docs page** — render the existing internal `docs/publisher/AUTHORING.md` content (or a derived version) at `/publish/docs/` so prospective publishers can read the format spec without leaving the site, and link it from `/publish/`.
+
+Both ship in a single PR — they're independent UX-level additions with no shared code, but small enough to bundle.
+
+## CAPTCHA on apply
+
+### Existing pattern (feedback form)
+
+- **Frontend** (`frontend/src/app/feedback/page.tsx`): loads `https://www.google.com/recaptcha/api.js?render=${VITE_RECAPTCHA_SITE_KEY}` on mount, calls `grecaptcha.execute(siteKey, { action: '...' })` on submit, sends `captchaToken` in the body.
+- **Backend** (`backend/src/handlers/calendarHandler.ts`): `verifyCaptcha(token)` POSTs to `https://www.google.com/recaptcha/api/siteverify` with `RECAPTCHA_SECRET_KEY`. Fails closed in production (`ENVIRONMENT === 'prod'`); allows in dev when secret is unset.
+- **Infra** (`infrastructure/main.tf:796`): `RECAPTCHA_SECRET_KEY` is wired into the calendar Lambda's env vars but **not** the admin Lambda. The admin Lambda hosts the publisher-portal routes (delegated to `publisherPortalHandler.ts`) and so needs the secret added.
+
+### Changes
+
+1. **`backend/src/services/captchaService.ts`** (new) — extract `verifyCaptcha` from `calendarHandler.ts` into a shared service so both Lambdas can use the same code. Behaviour is unchanged: same fail-closed-in-prod semantics, same logging.
+2. **`backend/src/handlers/calendarHandler.ts`** — replace the local `verifyCaptcha` with `import { verifyCaptcha } from '../services/captchaService'`.
+3. **`backend/src/handlers/publisherPortalHandler.ts`** — `handlePublisherApplyRequest` now requires `captchaToken` in the body. After rate-limit check and basic-fields validation, call `verifyCaptcha(token)`. Reject with `400 { error: 'CAPTCHA verification failed', field: 'captcha' }` on failure.
+4. **`infrastructure/main.tf`** (admin Lambda env) — add `RECAPTCHA_SECRET_KEY = var.recaptcha_secret_key` to the admin Lambda's env block.
+5. **`frontend/src/app/publish/apply/page.tsx`** — add the same reCAPTCHA loading + execute pattern as feedback. Send `captchaToken` in the request body. Disable submit button while `captchaReady` is false.
+6. **Tests** — add a `publisherPortalHandler` test that asserts apply rejects when captcha verification fails. Use a stubbed `verifyCaptcha`.
+
+### Anti-regression
+
+- Existing apply tests need a stubbed `captchaToken` to keep passing. Use a jest `__mocks__` shim for the captcha module so we don't actually call Google.
+- The CI E2E test in `infrastructure/ci-e2e-publisher.tf` exercises the publisher-ingest path, **not** the apply path — so no CI test changes are needed.
+
+## Public publisher docs page
+
+### Structure
+
+- **Route:** `/publish/docs/`
+- **Source of truth:** `docs/publisher/AUTHORING.md` (138 lines, complete reference). We don't duplicate the content — we render the markdown in the page itself, or transcribe it once into a Preact component.
+
+### Decision: transcribe (don't fetch markdown)
+
+Two viable approaches:
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Fetch `AUTHORING.md` at runtime, render with markdown library | Single source of truth | Adds 30–50KB markdown lib + remark deps, runtime fetch latency, requires copying MD into the bundle path |
+| Transcribe content into a Preact component | No runtime cost, full styling control, works offline | Two copies (MD for repo browsers, JSX for the public site); risk of drift |
+
+The drift risk is small (this is reference doc, low edit frequency) and the bundle-cost win is meaningful for a static informational page. **Pick option 2** — transcribe, with a top-of-file comment in `AUTHORING.md` and the new page noting they should be kept in sync.
+
+### Files to add
+
+- `frontend/publish/docs/index.html` — HTML entry, mirrors `frontend/publish/apply/index.html`.
+- `frontend/src/entries/publish-docs.tsx` — Vite entry, mirrors `publish-apply.tsx`.
+- `frontend/src/app/publish/docs/page.tsx` — Preact component rendering the docs content.
+- `frontend/vite.config.ts` — add `'publish-docs': resolve(__dirname, 'publish/docs/index.html')` to `rollupOptions.input`.
+
+### Files to update
+
+- `frontend/src/app/publish/page.tsx` — add a "Read the format docs" link that points at `/publish/docs/`.
+- `docs/publisher/AUTHORING.md` — top-of-file note: "If you edit this file, also update `frontend/src/app/publish/docs/page.tsx`."
+- `frontend/src/app/publish/apply/page.tsx` — surface a "See the format docs" link near the source-type field.
+
+## Test plan
+
+- [ ] `npm run validate` (frontend) and `npm test` (backend) pass.
+- [ ] Local dev: `npm run dev`, hit `/publish/apply/`, confirm reCAPTCHA badge appears in dev (only when `VITE_RECAPTCHA_SITE_KEY` is set).
+- [ ] `/publish/docs/` renders the docs content with proper styling (light + dark mode).
+- [ ] After deploy: submit a real apply request and confirm it succeeds when the reCAPTCHA token is fresh.
+- [ ] After deploy: confirm a request without a `captchaToken` is rejected with 400.
+
+## Out of scope
+
+- CAPTCHA on `/publisher-test` — that's an idempotent diagnostic endpoint already protected by a 10-req / 5-min rate limit; not currently abused.
+- CAPTCHA on `/publisher-auth/request` (login) — login is rate-limited (10 req / hr), and adding CAPTCHA to login is a meaningful UX cost; defer until/unless abuse appears.
+- Markdown rendering library — explicitly rejected above.
+- Renaming AUTHORING.md to something more public-facing — file path is already linked from the schema, leave alone.

--- a/docs/publisher/AUTHORING.md
+++ b/docs/publisher/AUTHORING.md
@@ -1,5 +1,11 @@
 # Publishing Events to chqcal.org
 
+> **Keep in sync:** the public version of this guide lives at
+> `frontend/src/app/publish/docs/page.tsx` and is rendered at
+> https://www.chqcal.org/publish/docs/. If you edit field names, examples,
+> or structural sections here, mirror the same change in that page (and
+> vice-versa).
+
 If you run an organization, group, or page in the Chautauqua orbit, you can publish your events to chqcal.org by serving a small JSON file (or by embedding a few HTML comments on a page you already have). We fetch your feed on a schedule and merge new and updated events into the calendar. You stay the author; we stay the aggregator.
 
 This guide covers the minimum-viable setup, the field reference, and how to validate your feed locally before submitting.

--- a/frontend/publish/docs/index.html
+++ b/frontend/publish/docs/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Publisher Format Docs — Chautauqua Calendar</title>
+    <meta name="description" content="Reference docs for the chqcal.org publisher feed format — fields, examples, validation, and how to publish your events." />
+    <link rel="icon" type="image/svg+xml" href="/chq-calendar-icon-256.svg" />
+    <link rel="apple-touch-icon" href="/chq-calendar-icon-256.svg" />
+  </head>
+  <body class="antialiased">
+    <div id="root"></div>
+    <script type="module" src="/src/entries/publish-docs.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/app/feedback/page.tsx
+++ b/frontend/src/app/feedback/page.tsx
@@ -1,15 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { API_BASE_URL } from '@/lib/api';
-
-// Declare the global grecaptcha object
-declare global {
-  interface Window {
-    grecaptcha: {
-      ready: (callback: () => void) => void;
-      execute: (siteKey: string, options: { action: string }) => Promise<string>;
-    };
-  }
-}
+// Window.grecaptcha is declared globally by src/types/grecaptcha.d.ts.
 
 export default function FeedbackPage() {
   const [feedback, setFeedback] = useState('');

--- a/frontend/src/app/publish/apply/page.tsx
+++ b/frontend/src/app/publish/apply/page.tsx
@@ -8,9 +8,21 @@
  * Validation is done server-side; client-side we only enforce required-ness
  * and basic HTML5 patterns. The server's response carries field-specific
  * errors that we surface inline.
+ *
+ * The form is gated by reCAPTCHA v3 (action: `publisher_apply`). The site
+ * key is loaded via VITE_RECAPTCHA_SITE_KEY at build time. When the site
+ * key is unset (local dev with no .env.local) the captcha layer is skipped
+ * and the request is sent without a token — the backend allows this in
+ * non-production environments and fails closed in prod.
  */
 
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
+
+// `Window.grecaptcha` is declared (non-optional) in
+// frontend/src/app/feedback/page.tsx. We share that global declaration
+// rather than redeclaring (TS errors on conflicting modifiers). Call sites
+// guard with `window.grecaptcha &&` because the script may not have loaded
+// on this page yet.
 
 type SourceType = 'json' | 'html';
 
@@ -39,14 +51,57 @@ type Status =
   | { kind: 'error'; message: string; field?: string };
 
 const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const RECAPTCHA_SITE_KEY = (import.meta as any).env?.VITE_RECAPTCHA_SITE_KEY as string | undefined;
 
 export default function PublishApplyPage() {
   const [form, setForm] = useState<FormState>(INITIAL);
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
+  const [captchaReady, setCaptchaReady] = useState(false);
+
+  // Lazy-load the reCAPTCHA script when a site key is configured. When it
+  // isn't (e.g. local dev with no .env.local), captchaReady stays false and
+  // we send the request without a token — the backend's captchaService
+  // allows that in non-production environments.
+  useEffect(() => {
+    if (!RECAPTCHA_SITE_KEY) return;
+
+    const script = document.createElement('script');
+    script.src = `https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => {
+      window.grecaptcha?.ready(() => setCaptchaReady(true));
+    };
+    document.head.appendChild(script);
+
+    return () => {
+      if (document.head.contains(script)) document.head.removeChild(script);
+    };
+  }, []);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
+
+    // Block the submit briefly if a site key is configured but the script
+    // hasn't finished loading yet — better than sending an empty token.
+    if (RECAPTCHA_SITE_KEY && !captchaReady) {
+      setStatus({ kind: 'error', message: 'Verifying you’re human… try again in a moment.' });
+      return;
+    }
+
     setStatus({ kind: 'submitting' });
+
+    let captchaToken = '';
+    if (RECAPTCHA_SITE_KEY && captchaReady && window.grecaptcha) {
+      try {
+        captchaToken = await window.grecaptcha.execute(RECAPTCHA_SITE_KEY, {
+          action: 'publisher_apply',
+        });
+      } catch (err) {
+        console.warn('reCAPTCHA execute failed:', err);
+        // fall through — backend will reject if token is missing in prod
+      }
+    }
 
     const payload = {
       name: form.name.trim(),
@@ -55,6 +110,7 @@ export default function PublishApplyPage() {
       sourceUrl: form.sourceUrl.trim(),
       sourceType: form.sourceType,
       notes: form.notes.trim() || undefined,
+      captchaToken: captchaToken || undefined,
     };
 
     try {
@@ -124,6 +180,16 @@ export default function PublishApplyPage() {
                 send a verification link to your email — click it within 15
                 minutes to complete your application. An admin will review and
                 approve before your events appear on chqcal.org.
+              </p>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
+                Not sure what your feed should look like? Read the{' '}
+                <a
+                  href="/publish/docs/"
+                  className="text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  publisher format docs
+                </a>{' '}
+                first.
               </p>
 
               <form onSubmit={onSubmit} className="space-y-4">
@@ -233,13 +299,27 @@ export default function PublishApplyPage() {
                   </a>
                   <button
                     type="submit"
-                    disabled={status.kind === 'submitting'}
+                    disabled={status.kind === 'submitting' || (!!RECAPTCHA_SITE_KEY && !captchaReady)}
                     className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
                   >
                     {status.kind === 'submitting' ? 'Sending…' : 'Send verification email'}
                   </button>
                 </div>
               </form>
+
+              {RECAPTCHA_SITE_KEY && (
+                <p className="mt-6 text-xs text-gray-500 dark:text-gray-400">
+                  This form is protected by reCAPTCHA and the Google{' '}
+                  <a href="https://policies.google.com/privacy" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-700 dark:hover:text-gray-300">
+                    Privacy Policy
+                  </a>{' '}
+                  and{' '}
+                  <a href="https://policies.google.com/terms" target="_blank" rel="noopener noreferrer" className="underline hover:text-gray-700 dark:hover:text-gray-300">
+                    Terms of Service
+                  </a>{' '}
+                  apply.
+                </p>
+              )}
             </>
           )}
         </div>

--- a/frontend/src/app/publish/apply/page.tsx
+++ b/frontend/src/app/publish/apply/page.tsx
@@ -17,12 +17,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-
-// `Window.grecaptcha` is declared (non-optional) in
-// frontend/src/app/feedback/page.tsx. We share that global declaration
-// rather than redeclaring (TS errors on conflicting modifiers). Call sites
-// guard with `window.grecaptcha &&` because the script may not have loaded
-// on this page yet.
+// Window.grecaptcha is declared globally by src/types/grecaptcha.d.ts.
 
 type SourceType = 'json' | 'html';
 
@@ -53,10 +48,17 @@ type Status =
 const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
 const RECAPTCHA_SITE_KEY = (import.meta as any).env?.VITE_RECAPTCHA_SITE_KEY as string | undefined;
 
+// If the reCAPTCHA script doesn't report ready within this many ms (ad
+// blocker, network problem, Google blip), give up waiting and let the user
+// submit anyway — the backend will reject in production but the user sees
+// a useful error rather than a permanently disabled button.
+const RECAPTCHA_LOAD_TIMEOUT_MS = 10_000;
+
 export default function PublishApplyPage() {
   const [form, setForm] = useState<FormState>(INITIAL);
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
   const [captchaReady, setCaptchaReady] = useState(false);
+  const [captchaFailed, setCaptchaFailed] = useState(false);
 
   // Lazy-load the reCAPTCHA script when a site key is configured. When it
   // isn't (e.g. local dev with no .env.local), captchaReady stays false and
@@ -72,9 +74,20 @@ export default function PublishApplyPage() {
     script.onload = () => {
       window.grecaptcha?.ready(() => setCaptchaReady(true));
     };
+    script.onerror = () => {
+      setCaptchaFailed(true);
+    };
     document.head.appendChild(script);
 
+    // Belt-and-suspenders: if neither onload's ready callback nor onerror
+    // fires (e.g. blocker silently swallows the load), surface the failure
+    // after a timeout so the form stays usable.
+    const timeout = window.setTimeout(() => {
+      setCaptchaFailed(prev => prev || !window.grecaptcha);
+    }, RECAPTCHA_LOAD_TIMEOUT_MS);
+
     return () => {
+      window.clearTimeout(timeout);
       if (document.head.contains(script)) document.head.removeChild(script);
     };
   }, []);
@@ -83,8 +96,10 @@ export default function PublishApplyPage() {
     e.preventDefault();
 
     // Block the submit briefly if a site key is configured but the script
-    // hasn't finished loading yet — better than sending an empty token.
-    if (RECAPTCHA_SITE_KEY && !captchaReady) {
+    // hasn't finished loading yet — unless the load has clearly failed, in
+    // which case the user has been told to retry/disable a blocker and
+    // we let them submit with no token (backend rejects in prod).
+    if (RECAPTCHA_SITE_KEY && !captchaReady && !captchaFailed) {
       setStatus({ kind: 'error', message: 'Verifying you’re human… try again in a moment.' });
       return;
     }
@@ -290,6 +305,16 @@ export default function PublishApplyPage() {
                   </div>
                 )}
 
+                {captchaFailed && (
+                  <div className="rounded-md bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 p-3">
+                    <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                      Couldn&rsquo;t load reCAPTCHA — likely a tracker/ad
+                      blocker or network issue. You can still try submitting,
+                      but we may not be able to verify the request.
+                    </p>
+                  </div>
+                )}
+
                 <div className="flex items-center justify-between pt-2">
                   <a
                     href="/publish/"
@@ -299,7 +324,12 @@ export default function PublishApplyPage() {
                   </a>
                   <button
                     type="submit"
-                    disabled={status.kind === 'submitting' || (!!RECAPTCHA_SITE_KEY && !captchaReady)}
+                    // Don't disable on `!captchaReady` alone — if the
+                    // script never loads (blocker, network blip), the
+                    // button would be permanently dead. Instead the
+                    // captchaFailed banner above tells the user what
+                    // happened and onSubmit handles the not-ready case.
+                    disabled={status.kind === 'submitting'}
                     className="inline-flex items-center px-4 py-2 rounded-md bg-blue-600 text-white font-medium hover:bg-blue-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
                   >
                     {status.kind === 'submitting' ? 'Sending…' : 'Send verification email'}

--- a/frontend/src/app/publish/docs/page.tsx
+++ b/frontend/src/app/publish/docs/page.tsx
@@ -297,14 +297,12 @@ export default function PublishDocsPage() {
           text-decoration-color: rgba(37, 99, 235, 0.4);
         }
         .link:hover { text-decoration-color: currentColor; }
-        .dark .link { color: rgb(96 165 250); }
         .subhead {
           font-weight: 600;
           margin-top: 1.25rem;
           margin-bottom: 0.5rem;
           color: rgb(17 24 39);
         }
-        .dark .subhead { color: rgb(243 244 246); }
         .prose-styles code {
           font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
           font-size: 0.875em;
@@ -312,12 +310,20 @@ export default function PublishDocsPage() {
           padding: 0.05em 0.35em;
           border-radius: 3px;
         }
-        .dark .prose-styles code {
-          background: rgba(255, 255, 255, 0.08);
-        }
         .prose-styles pre code {
           background: none;
           padding: 0;
+        }
+        /*
+         * Dark mode is driven by prefers-color-scheme on this site (no
+         * \`.dark\` class is added to the DOM), so the dark-mode overrides
+         * for these hand-authored rules must live in a media query rather
+         * than a \`.dark X\` selector.
+         */
+        @media (prefers-color-scheme: dark) {
+          .link { color: rgb(96 165 250); }
+          .subhead { color: rgb(243 244 246); }
+          .prose-styles code { background: rgba(255, 255, 255, 0.08); }
         }
       `}</style>
     </div>

--- a/frontend/src/app/publish/docs/page.tsx
+++ b/frontend/src/app/publish/docs/page.tsx
@@ -1,0 +1,393 @@
+/**
+ * Publisher format reference — public docs page at /publish/docs/.
+ *
+ * IMPORTANT — keep in sync with `docs/publisher/AUTHORING.md`.
+ * Both files describe the same format. The markdown file is the source of
+ * truth for repo browsers and contributors; this page is the public-facing
+ * version on chqcal.org. If you edit one, mirror the change in the other.
+ */
+
+import type { ReactNode } from 'react';
+
+const MINIMAL_FEED_JSON = `{
+  "formatVersion": "1.0",
+  "publisher": {
+    "id": "example-pub",
+    "name": "Example Publisher",
+    "contactEmail": "events@example.org"
+  },
+  "events": [
+    {
+      "id": "ev-2026-07-04-talk",
+      "title": "Sample Talk on Civic Life",
+      "startDate": "2026-07-04T18:00:00-04:00",
+      "endDate":   "2026-07-04T19:00:00-04:00",
+      "category": "Special Lectures",
+      "venueId":  "hall-of-philosophy",
+      "lastModified": "2026-05-01T12:00:00-04:00"
+    }
+  ]
+}`;
+
+const HTML_EMBED_EXAMPLE = `<!-- chq-publisher
+{ "id": "example-pub", "name": "Example Publisher", "contactEmail": "events@example.org" }
+-->
+
+<article>
+  <h2>Keynote: The Civic Imagination</h2>
+  <!-- chq-event
+  {
+    "id": "ev-2026-07-04-keynote",
+    "title": "Keynote: The Civic Imagination",
+    "startDate": "2026-07-04T18:00:00-04:00",
+    "endDate":   "2026-07-04T19:30:00-04:00",
+    "category": "Special Lectures",
+    "venueId":  "hall-of-philosophy",
+    "lastModified": "2026-05-01T12:00:00-04:00"
+  }
+  -->
+</article>`;
+
+const FREE_VENUE_EXAMPLE = `"venue": { "name": "Smith Memorial Library", "address": "Bestor Plaza" }`;
+
+export default function PublishDocsPage() {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <header className="bg-white dark:bg-gray-800 shadow-lg">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center py-4">
+            <a href="/publish/" className="flex items-center hover:opacity-80">
+              <img
+                src="/chq-calendar-icon-256.svg"
+                alt="Chautauqua Calendar Logo"
+                width={32}
+                height={32}
+                className="w-8 h-8 mr-3"
+              />
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                Publisher Format Docs
+              </h1>
+            </a>
+          </div>
+        </div>
+      </header>
+
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <article className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 sm:p-8 prose-styles">
+          <p className="text-gray-700 dark:text-gray-300 mb-4">
+            If you run an organization, group, or page in the Chautauqua orbit,
+            you can publish your events to{' '}
+            <a href="https://www.chqcal.org" className="link">chqcal.org</a> by
+            serving a small JSON file (or by embedding a few HTML comments on
+            a page you already have). We fetch your feed on a schedule and
+            merge new and updated events into the calendar. You stay the
+            author; we stay the aggregator.
+          </p>
+          <p className="text-gray-700 dark:text-gray-300 mb-6">
+            This guide covers the minimum-viable setup, the field reference,
+            and how to validate your feed locally before submitting.
+          </p>
+
+          <Section id="minimal" title="The Minimum-Viable Feed">
+            <p>Publish a JSON document that looks like this:</p>
+            <CodeBlock language="json" code={MINIMAL_FEED_JSON} />
+            <p>
+              A copy-pasteable version lives at{' '}
+              <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/examples/minimal-feed.json">
+                <code>examples/minimal-feed.json</code>
+              </a>
+              . A version using every optional field is at{' '}
+              <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/examples/full-feed.json">
+                <code>examples/full-feed.json</code>
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section id="fields" title="Field Reference">
+            <h3 className="subhead">Top level</h3>
+            <FieldTable
+              rows={[
+                ['formatVersion', 'yes', <>Always <code>"1.0"</code> for now.</>],
+                ['publisher', 'yes', 'See below.'],
+                ['events', 'yes', <>An array. May be empty (means &ldquo;no events right now&rdquo;).</>],
+              ]}
+            />
+
+            <h3 className="subhead">publisher</h3>
+            <FieldTable
+              rows={[
+                ['id', 'yes', <>A stable lowercase slug we register for you (<code>a-z0-9-</code> only).</>],
+                ['name', 'yes', 'Display name shown to readers.'],
+                ['contactEmail', 'yes', 'We email here if your feed breaks.'],
+                ['url', 'optional', 'Link back to your homepage.'],
+              ]}
+            />
+
+            <h3 className="subhead">events[]</h3>
+            <FieldTable
+              rows={[
+                ['id', 'yes', <><strong>Stable</strong> per-event identifier (any string). <strong>Never reuse for a different event.</strong></>],
+                ['title', 'yes', 'Plain text, no HTML.'],
+                ['startDate', 'yes', <>ISO 8601 with timezone offset, e.g. <code>2026-07-04T18:00:00-04:00</code>.</>],
+                ['endDate', 'yes', <>Same format. Must be ≥ <code>startDate</code>.</>],
+                ['category', 'yes', <>Must be one of the names listed in <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/categories.json"><code>categories.json</code></a>.</>],
+                ['lastModified', 'yes', 'ISO 8601 with offset. Bump this when you change anything else about the event.'],
+                ['status', 'optional', <><code>"scheduled"</code> (default), <code>"cancelled"</code>, or <code>"rescheduled"</code>.</>],
+                ['description', 'optional', <>Light HTML allowed: <code>&lt;p&gt;</code>, <code>&lt;br&gt;</code>, <code>&lt;strong&gt;</code>, <code>&lt;em&gt;</code>, <code>&lt;a href&gt;</code>, <code>&lt;ul&gt;</code>, <code>&lt;ol&gt;</code>, <code>&lt;li&gt;</code>. Rest stripped.</>],
+                ['venueId', 'one of', <>Slug from <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/venues.json"><code>venues.json</code></a>. <strong>Use this when the event is at a known CHQ venue.</strong></>],
+                ['venue', 'one of', <>Free-form <code>{'{ name, address?, url? }'}</code> for venues we haven&rsquo;t catalogued.</>],
+                ['tags', 'optional', 'Array of strings.'],
+                ['presenter', 'optional', 'Speaker, performer, etc.'],
+                ['url', 'optional', 'Link to your event page.'],
+                ['cost', 'optional', <>Free-form (&ldquo;Free with gate ticket&rdquo;, &ldquo;$15&rdquo;, etc.).</>],
+                ['attachments', 'optional', <>Array of <code>{'{ url, type, isImage }'}</code>.</>],
+              ]}
+            />
+            <p className="mt-4">
+              You must supply <strong>either</strong> <code>venueId</code>{' '}
+              <strong>or</strong> <code>venue</code>, never both, never
+              neither.
+            </p>
+          </Section>
+
+          <Section id="category" title="Choosing a Category">
+            <p>
+              See{' '}
+              <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/categories.json">
+                <code>categories.json</code>
+              </a>{' '}
+              for the canonical list. Use the exact <code>name</code>, e.g.{' '}
+              <code>&quot;Chamber Music&quot;</code>, not the slug. If nothing
+              fits, email us — adding a category is a one-line change.
+            </p>
+          </Section>
+
+          <Section id="venue" title="Choosing a Venue">
+            <p>
+              See{' '}
+              <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/venues.json">
+                <code>venues.json</code>
+              </a>
+              . Use the <code>id</code> (slug), e.g.{' '}
+              <code>&quot;hall-of-philosophy&quot;</code>. If your event is
+              somewhere not in the list, use the free-form <code>venue</code>{' '}
+              object instead:
+            </p>
+            <CodeBlock language="json" code={FREE_VENUE_EXAMPLE} />
+          </Section>
+
+          <Section id="dates" title="Date and Time Format">
+            <p>
+              Always include a timezone offset.{' '}
+              <code>2026-07-04T18:00:00</code> (no offset) is rejected.
+              Chautauqua is <code>-04:00</code> from June through October
+              (EDT) and <code>-05:00</code> the rest of the year (EST).
+            </p>
+          </Section>
+
+          <Section id="html" title="The HTML-Embedded Variant">
+            <p>
+              If you&rsquo;d rather embed events into pages you already
+              maintain, drop HTML comments. One <code>chq-publisher</code>{' '}
+              comment per page identifies who you are; one or more{' '}
+              <code>chq-event</code> comments carry the events:
+            </p>
+            <CodeBlock language="html" code={HTML_EMBED_EXAMPLE} />
+            <p>
+              A full example is at{' '}
+              <a className="link" href="https://github.com/bbernstein/chq-calendar/blob/main/docs/publisher/examples/aggregator-page.html">
+                <code>examples/aggregator-page.html</code>
+              </a>
+              . You can also use a single <code>chq-events</code> comment
+              containing <code>{'{ publisher, events: [...] }'}</code> if
+              that&rsquo;s easier.
+            </p>
+          </Section>
+
+          <Section id="updates" title="Updating, Cancelling, and Rescheduling Events">
+            <ul className="list-disc list-inside space-y-1">
+              <li>
+                <strong>Update</strong>: change anything you like, then bump{' '}
+                <code>lastModified</code>. We re-ingest on the next fetch.
+              </li>
+              <li>
+                <strong>Reschedule</strong>: update <code>startDate</code> /{' '}
+                <code>endDate</code> and bump <code>lastModified</code>.
+                Optionally set <code>status: &quot;rescheduled&quot;</code> to
+                surface a banner.
+              </li>
+              <li>
+                <strong>Cancel</strong>: either drop the event from your feed
+                (silent removal) or set <code>status: &quot;cancelled&quot;</code>{' '}
+                so we show a &ldquo;Cancelled&rdquo; treatment.
+              </li>
+              <li>
+                <strong>Stable IDs</strong>: never recycle an <code>id</code>{' '}
+                for a different event. If it&rsquo;s a new event, give it a
+                new <code>id</code>.
+              </li>
+            </ul>
+          </Section>
+
+          <Section id="validate" title="Validating Locally">
+            <p>Run the validator against your file or URL:</p>
+            <CodeBlock
+              language="bash"
+              code={'npx -p @chq-calendar/publisher-format chq-validate-feed <path-or-url>'}
+            />
+            <p>
+              It prints <code>OK</code> plus the event count, or a list of
+              errors with JSON-Pointer paths into the offending field. Fix
+              and re-run until it&rsquo;s green; we run the same validator
+              at ingest.
+            </p>
+            <p className="mt-3">
+              You can also paste a URL into our hosted{' '}
+              <a className="link" href="/publish/test/">
+                feed test tool
+              </a>{' '}
+              to see validation errors and an event preview without
+              installing anything.
+            </p>
+          </Section>
+
+          <Section id="register" title="Registering Your Publisher">
+            <p>
+              Once your feed validates cleanly,{' '}
+              <a className="link" href="/publish/apply/">
+                apply to be a registered publisher
+              </a>
+              . You&rsquo;ll get a verification email; click the link, and an
+              admin will review and approve. After that, your feed is fetched
+              hourly and your events appear on chqcal.org alongside the rest
+              of the season.
+            </p>
+          </Section>
+
+          <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700 flex items-center justify-between text-sm">
+            <a href="/publish/" className="link">
+              ← Back to publisher portal
+            </a>
+            <a href="/publish/apply/" className="link">
+              Apply to publish →
+            </a>
+          </div>
+        </article>
+      </main>
+
+      <footer className="bg-gray-800 text-white mt-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
+          <p className="text-gray-400">
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+          </p>
+        </div>
+      </footer>
+
+      {/*
+       * Local utility classes used in this page only. Tailwind 4 lets us
+       * compose with @apply at the source level, but for a one-page reuse
+       * inline styles via a <style> tag are simpler and avoid touching
+       * globals.css.
+       */}
+      <style>{`
+        .link {
+          color: rgb(37 99 235);
+          text-decoration: underline;
+          text-decoration-color: rgba(37, 99, 235, 0.4);
+        }
+        .link:hover { text-decoration-color: currentColor; }
+        .dark .link { color: rgb(96 165 250); }
+        .subhead {
+          font-weight: 600;
+          margin-top: 1.25rem;
+          margin-bottom: 0.5rem;
+          color: rgb(17 24 39);
+        }
+        .dark .subhead { color: rgb(243 244 246); }
+        .prose-styles code {
+          font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+          font-size: 0.875em;
+          background: rgba(15, 23, 42, 0.06);
+          padding: 0.05em 0.35em;
+          border-radius: 3px;
+        }
+        .dark .prose-styles code {
+          background: rgba(255, 255, 255, 0.08);
+        }
+        .prose-styles pre code {
+          background: none;
+          padding: 0;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+interface SectionProps {
+  id: string;
+  title: string;
+  children: ReactNode;
+}
+
+function Section({ id, title, children }: SectionProps) {
+  return (
+    <section id={id} className="mt-8">
+      <h2 className="text-xl font-bold text-gray-900 dark:text-white mb-3">
+        {title}
+      </h2>
+      <div className="text-gray-700 dark:text-gray-300 space-y-3">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function CodeBlock({ language, code }: { language: string; code: string }) {
+  return (
+    <pre className="my-3 p-4 rounded-md bg-gray-900 text-gray-100 dark:bg-black/40 overflow-x-auto text-sm leading-relaxed">
+      <code className={`language-${language}`}>{code}</code>
+    </pre>
+  );
+}
+
+interface FieldTableProps {
+  rows: Array<[string, string, ReactNode]>;
+}
+
+function FieldTable({ rows }: FieldTableProps) {
+  return (
+    <div className="my-3 overflow-x-auto">
+      <table className="min-w-full text-sm border border-gray-200 dark:border-gray-700">
+        <thead className="bg-gray-50 dark:bg-gray-700/40">
+          <tr>
+            <th className="px-3 py-2 text-left font-semibold text-gray-900 dark:text-white">
+              Field
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-gray-900 dark:text-white whitespace-nowrap">
+              Required
+            </th>
+            <th className="px-3 py-2 text-left font-semibold text-gray-900 dark:text-white">
+              Notes
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(([field, required, notes]) => (
+            <tr key={field} className="border-t border-gray-200 dark:border-gray-700">
+              <td className="px-3 py-2 font-mono whitespace-nowrap text-gray-900 dark:text-gray-100">
+                {field}
+              </td>
+              <td className="px-3 py-2 whitespace-nowrap text-gray-700 dark:text-gray-300">
+                {required}
+              </td>
+              <td className="px-3 py-2 text-gray-700 dark:text-gray-300">
+                {notes}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/app/publish/page.tsx
+++ b/frontend/src/app/publish/page.tsx
@@ -86,6 +86,19 @@ export default function PublishLandingPage() {
           {/* CTAs */}
           <section className="grid sm:grid-cols-2 gap-4">
             <a
+              href="/publish/docs/"
+              className="block p-5 border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+            >
+              <h4 className="text-lg font-semibold text-blue-900 dark:text-blue-200 mb-1">
+                Read the format docs
+              </h4>
+              <p className="text-sm text-blue-800 dark:text-blue-300">
+                Field reference, JSON and HTML examples, and how to validate
+                your feed locally before submitting.
+              </p>
+            </a>
+
+            <a
               href="/publish/test/"
               className="block p-5 border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
             >
@@ -100,7 +113,7 @@ export default function PublishLandingPage() {
 
             <a
               href="/publish/apply/"
-              className="block p-5 border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors"
+              className="block p-5 border border-blue-200 dark:border-blue-800 bg-blue-50 dark:bg-blue-900/20 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/30 transition-colors sm:col-span-2"
             >
               <h4 className="text-lg font-semibold text-blue-900 dark:text-blue-200 mb-1">
                 Apply to be a publisher

--- a/frontend/src/entries/publish-docs.tsx
+++ b/frontend/src/entries/publish-docs.tsx
@@ -1,0 +1,5 @@
+import { render } from 'preact';
+import '@/app/globals.css';
+import PublishDocsPage from '@/app/publish/docs/page';
+
+render(<PublishDocsPage />, document.getElementById('root')!);

--- a/frontend/src/types/grecaptcha.d.ts
+++ b/frontend/src/types/grecaptcha.d.ts
@@ -1,0 +1,16 @@
+// Shared global type for Google reCAPTCHA v3. Loaded by pages that gate
+// submissions with a captcha (frontend/src/app/feedback/page.tsx and
+// frontend/src/app/publish/apply/page.tsx). Declaring here once avoids
+// the "All declarations of 'grecaptcha' must have identical modifiers"
+// TS error that two divergent inline declarations would cause.
+//
+// This is an ambient declaration file: TypeScript picks it up
+// automatically because it lives under src/ and ends in .d.ts. No
+// `import` is required from consumers.
+
+interface Window {
+  grecaptcha: {
+    ready: (callback: () => void) => void;
+    execute: (siteKey: string, options: { action: string }) => Promise<string>;
+  };
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -97,6 +97,7 @@ export default defineConfig({
         publish: resolve(__dirname, 'publish/index.html'),
         'publish-test': resolve(__dirname, 'publish/test/index.html'),
         'publish-apply': resolve(__dirname, 'publish/apply/index.html'),
+        'publish-docs': resolve(__dirname, 'publish/docs/index.html'),
         'publish-verify': resolve(__dirname, 'publish/verify/index.html'),
         'publish-login': resolve(__dirname, 'publish/login/index.html'),
         'publish-status': resolve(__dirname, 'publish/status/index.html'),

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -833,6 +833,11 @@ resource "aws_lambda_function" "admin_handler" {
       # publisher-test + apply/login endpoints. When unset (e.g. local
       # tests with no DDB), the handler falls back to an in-memory limiter.
       PUBLISHER_RATE_LIMIT_TABLE_NAME   = aws_dynamodb_table.publisher_rate_limit.name
+      # reCAPTCHA v3 secret for the publisher-apply form (and any future
+      # captcha-gated endpoints on this Lambda). Same secret used by the
+      # calendar Lambda for the public feedback form. When unset, the shared
+      # captchaService fails closed in prod and is permissive in dev/test.
+      RECAPTCHA_SECRET_KEY              = var.recaptcha_secret_key
     }
   }
 }


### PR DESCRIPTION
## Summary

Two related additions to the publisher portal (requested by the user after Phases A–D shipped):

1. **CAPTCHA on `/api/publisher-apply/request`** — gates the apply form with reCAPTCHA v3 (action: \`publisher_apply\`), matching the existing pattern used by the public feedback form.
2. **Public publisher docs page** at \`/publish/docs/\` — renders the publisher format reference (fields, JSON + HTML examples, validation steps) so prospective publishers can self-serve before applying.

Plan: \`docs/plans/2026-05-04-publisher-portal-captcha-and-docs-plan.md\`.

## CAPTCHA changes

### Backend
- \`backend/src/services/captchaService.ts\` (new) — extracts the existing \`verifyCaptcha\` helper out of \`calendarHandler.ts\` so both Lambdas share it. Behaviour preserved exactly: fail-closed in prod, permissive in dev/test, score gate at 0.5 for v3.
- \`backend/src/handlers/calendarHandler.ts\` — replaces the local \`verifyCaptcha\` with the shared service. Both call sites pass the explicit action name \`'submit_feedback'\` so log messages stay identical.
- \`backend/src/handlers/publisherPortalHandler.ts\` — \`handlePublisherApplyRequest\` now requires \`captchaToken\` in the body. Verified after the rate-limit check (so attackers can't burn quota with bogus tokens) and after the basic-shape check (so legitimate users see field errors first when their submission is malformed). Failures return \`400 { error, field: 'captcha' }\`.

### Frontend
- \`frontend/src/app/publish/apply/page.tsx\` — lazy-loads the reCAPTCHA script when \`VITE_RECAPTCHA_SITE_KEY\` is set, calls \`grecaptcha.execute(..., { action: 'publisher_apply' })\` on submit, includes the Google privacy/terms attribution required by reCAPTCHA's TOS, and disables the submit button until the script reports ready.

### Infra
- \`infrastructure/main.tf\` — adds \`RECAPTCHA_SECRET_KEY = var.recaptcha_secret_key\` to the admin Lambda env block. The variable already exists for the calendar Lambda; we just hadn't wired it into the admin Lambda before now.

### Tests
- Existing apply tests updated to provide a \`captchaToken\` and \`jest.mock('../services/captchaService')\` so we don't hit Google.
- Two new tests cover the missing-token (no \`verifyCaptcha\` call, 400 captcha field) and verification-failure (verifyCaptcha returns false, 400 captcha field, app service NOT called) paths.

## Public docs page

- \`frontend/publish/docs/index.html\` + \`frontend/src/entries/publish-docs.tsx\` + \`frontend/src/app/publish/docs/page.tsx\` (new) — Preact page rendering the format reference. Mirrors \`docs/publisher/AUTHORING.md\`; both files now have keep-in-sync notes at the top.
- \`frontend/vite.config.ts\` — registers \`publish-docs\` in \`rollupOptions.input\`.
- \`frontend/src/app/publish/page.tsx\` — adds \"Read the format docs\" CTA to the publish landing page (now a 3-card layout with apply spanning two columns).
- \`frontend/src/app/publish/apply/page.tsx\` — adds a \"Not sure what your feed should look like?\" link to the docs page above the form.

### Why transcribe instead of fetch markdown?

Two viable approaches:

| Approach | Pros | Cons |
|----------|------|------|
| Fetch \`AUTHORING.md\` at runtime, render with markdown library | Single source of truth | +30–50KB markdown lib, runtime fetch latency, MD has to be served from a path the bundle can reach |
| Transcribe content into a Preact component | No runtime cost, full styling control, works offline | Two copies; minor drift risk |

The drift risk is small (this is a reference doc with low edit frequency) and the bundle savings matter for a static informational page. The keep-in-sync notes in both files mitigate the risk.

## Out of scope

- CAPTCHA on \`/publisher-test\` — already protected by 10-req/5-min rate limit, idempotent, no abuse observed.
- CAPTCHA on \`/publisher-auth/request\` (login) — login is already rate-limited (10/hr); CAPTCHA on login is a meaningful UX cost; defer until/unless abuse appears.
- A Markdown rendering library (explicitly rejected above).

## Test plan

- [ ] CI checks pass on this PR.
- [ ] Local dev: \`npm run dev\`, hit \`/publish/apply/\`, confirm reCAPTCHA badge appears (only when \`VITE_RECAPTCHA_SITE_KEY\` is set in \`.env.local\`); without the key, the form still submits cleanly.
- [ ] Local dev: \`/publish/docs/\` renders cleanly in light + dark mode; all anchor links resolve to GitHub for the JSON ref files.
- [ ] After deploy: submit a real apply request and confirm it succeeds with a fresh reCAPTCHA token.
- [ ] After deploy: a request without \`captchaToken\` returns 400 \`{ field: 'captcha' }\`.

## Related

- Depends on PR #87 being merged first so \`/publish/test/\` works again — the testing flow on the docs page links there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)