### PR TITLE
feat(approval-email): include assigned publisher ID in welcome email

### DIFF
--- a/backend/src/__tests__/mailService.test.ts
+++ b/backend/src/__tests__/mailService.test.ts
@@ -65,12 +65,13 @@ describe('SesMailService', () => {
 
   // ─── Phase C: approval / rejection emails ─────────────────────────────
 
-  it('sendApprovalEmail uses approval subject and embeds login + status URLs', async () => {
+  it('sendApprovalEmail uses approval subject and embeds publisherId + login + status URLs', async () => {
     mockSend.mockResolvedValue({ MessageId: 'mid-app-1' });
     const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
     const out = await svc.sendApprovalEmail({
       to: 'pub@example.com',
       publisherName: 'Acme Concerts',
+      publisherId: 'acme-concerts',
       statusUrl: 'https://x.test/publish/status/',
       loginUrl: 'https://x.test/publish/login/',
     });
@@ -80,19 +81,27 @@ describe('SesMailService', () => {
     expect(cmd.input.Content.Simple.Subject.Data).toMatch(/approved/i);
     const text = cmd.input.Content.Simple.Body.Text.Data;
     expect(text).toContain('Acme Concerts');
+    // The publisher slug is required to make the feed go live; surface it
+    // prominently with surrounding context so a recipient can act on it.
+    expect(text).toContain('acme-concerts');
+    expect(text).toMatch(/publisher\.id/);
     expect(text).toContain('https://x.test/publish/login/');
     expect(text).toContain('https://x.test/publish/status/');
     const html = cmd.input.Content.Simple.Body.Html.Data;
     expect(html).toContain('Acme Concerts');
+    expect(html).toContain('acme-concerts');
     expect(html).toContain('https://x.test/publish/login/');
   });
 
-  it('sendApprovalEmail HTML-escapes the publisher name', async () => {
+  it('sendApprovalEmail HTML-escapes the publisher name and publisher id', async () => {
     mockSend.mockResolvedValue({ MessageId: 'mid-app-2' });
     const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
     await svc.sendApprovalEmail({
       to: 'p@x.com',
       publisherName: '<script>alert(1)</script>',
+      // publisherId is admin-controlled (a slug), but we escape it
+      // defensively so an unusual value can't break the email rendering.
+      publisherId: 'pub-<bad>',
       statusUrl: 'https://x.test/s',
       loginUrl: 'https://x.test/l',
     });
@@ -100,6 +109,8 @@ describe('SesMailService', () => {
     const html: string = cmd.input.Content.Simple.Body.Html.Data;
     expect(html).not.toContain('<script>alert');
     expect(html).toContain('&lt;script&gt;');
+    expect(html).not.toContain('pub-<bad>');
+    expect(html).toContain('pub-&lt;bad&gt;');
   });
 
   it('sendRejectionEmail includes reviewer reason when supplied', async () => {
@@ -153,7 +164,7 @@ describe('SesMailService', () => {
   it('approval/rejection emails throw if SES_FROM_ADDRESS is empty', async () => {
     const svc = new SesMailService(mockClient, '');
     await expect(
-      svc.sendApprovalEmail({ to: 'a@b.com', publisherName: 'X', statusUrl: 'https://x', loginUrl: 'https://x' }),
+      svc.sendApprovalEmail({ to: 'a@b.com', publisherName: 'X', publisherId: 'x', statusUrl: 'https://x', loginUrl: 'https://x' }),
     ).rejects.toThrow(/SES_FROM_ADDRESS/);
     await expect(
       svc.sendRejectionEmail({ to: 'a@b.com', publisherName: 'X', applyAgainUrl: 'https://x' }),

--- a/backend/src/__tests__/mailService.test.ts
+++ b/backend/src/__tests__/mailService.test.ts
@@ -90,7 +90,14 @@ describe('SesMailService', () => {
     const html = cmd.input.Content.Simple.Body.Html.Data;
     expect(html).toContain('Acme Concerts');
     expect(html).toContain('acme-concerts');
+    // Symmetric with the text body assertion above — the same instruction
+    // text must appear in HTML so a recipient reading either format
+    // understands what to do with the slug.
+    expect(html).toMatch(/publisher\.id/);
     expect(html).toContain('https://x.test/publish/login/');
+    // <pre> gives reliable monospace rendering across email clients
+    // (notably Outlook 2010–2016 which strips font-family from <p>).
+    expect(html).toContain('<pre');
   });
 
   it('sendApprovalEmail HTML-escapes the publisher name and publisher id', async () => {

--- a/backend/src/__tests__/publisherAdminService.test.ts
+++ b/backend/src/__tests__/publisherAdminService.test.ts
@@ -396,6 +396,9 @@ describe('PublisherAdminService', () => {
       expect(mail.sendApprovalEmail).toHaveBeenCalledWith({
         to: 'pub@example.com',
         publisherName: 'Acme',
+        // The publisher's assigned slug — must be in the email so they
+        // know which value to put in their feed's `publisher.id`.
+        publisherId: 'pub-pending',
         statusUrl: 'https://x.test/publish/status/',
         loginUrl: 'https://x.test/publish/login/',
       });

--- a/backend/src/services/mailService.ts
+++ b/backend/src/services/mailService.ts
@@ -174,7 +174,14 @@ function loginHtml(url: string): string {
   ].join('');
 }
 
+// Empty-id fallback — defensive only. publisherId is set from rec.id at
+// record creation time and is never empty in practice; using a placeholder
+// instead of rendering blank avoids a confusing email if the invariant
+// ever drifts.
+const PUBLISHER_ID_PLACEHOLDER = '(missing — contact us)';
+
 function approvalText(o: ApprovalEmailOpts): string {
+  const id = o.publisherId || PUBLISHER_ID_PLACEHOLDER;
   return [
     `Hi ${o.publisherName || 'there'},`,
     '',
@@ -182,7 +189,7 @@ function approvalText(o: ApprovalEmailOpts): string {
     '',
     'Your assigned publisher ID is:',
     '',
-    `    ${o.publisherId}`,
+    `    ${id}`,
     '',
     'You MUST include this exact value as `publisher.id` in your feed (or in the',
     '`chq-publisher` HTML comment) for your events to appear on chqcal.org. Without',
@@ -202,15 +209,20 @@ function approvalText(o: ApprovalEmailOpts): string {
 
 function approvalHtml(o: ApprovalEmailOpts): string {
   const safeName = escapeHtml(o.publisherName || 'there');
-  const safeId = escapeHtml(o.publisherId);
+  const safeId = escapeHtml(o.publisherId || PUBLISHER_ID_PLACEHOLDER);
   const safeLogin = encodeURI(o.loginUrl);
   const safeStatus = encodeURI(o.statusUrl);
+  // Wrap the publisher ID in <pre> rather than a styled <p> + <code>: Outlook
+  // 2010–2016 strips font-family from <p>, so an inline-styled <p><code> would
+  // render in the body font (defeating the "stand-out monospace" intent).
+  // <pre> defaults to monospace in every email client we care about, with no
+  // CSS dependency.
   return [
     '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
     `<p>Hi ${safeName},</p>`,
     '<p>Good news — your Chautauqua Calendar publisher application has been <strong>approved</strong>.</p>',
     '<p>Your assigned publisher ID is:</p>',
-    `<p style="margin:0.5em 0 0.5em 1em;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:1.1em"><code>${safeId}</code></p>`,
+    `<pre style="margin:0.5em 0 0.5em 1em;font-size:1.05em">${safeId}</pre>`,
     '<p>You <strong>must</strong> include this exact value as <code>publisher.id</code> in your feed (or in the <code>chq-publisher</code> HTML comment) for your events to appear on chqcal.org. Without it the feed validates but no events go live.</p>',
     '<p>Once your feed lists this ID, the next ingest run will pick up your events.</p>',
     `<p>Sign in to view your status and recent fetch history: <a href="${safeLogin}">${safeLogin}</a></p>`,

--- a/backend/src/services/mailService.ts
+++ b/backend/src/services/mailService.ts
@@ -26,10 +26,13 @@ export interface MailService {
 export interface ApprovalEmailOpts {
   to: string;
   publisherName: string;
-  // The slug the admin assigned to this publisher. The publisher must
-  // include this exact value as `publisher.id` in their feed (or in the
-  // `chq-publisher` HTML comment) for the ingest pipeline to recognise
-  // their events. Without it the feed validates but no events go live.
+  // The publisher's unique ID. Auto-generated as `pub-<uuid4>` at
+  // apply-verify time (publisherApplicationService.ts), not assigned by
+  // the admin during review — the admin's only review actions are
+  // approve / reject. The publisher must include this exact value as
+  // `publisher.id` in their feed (or in the `chq-publisher` HTML
+  // comment) for the ingest pipeline to recognise their events.
+  // Without it the feed validates but no events go live.
   publisherId: string;
   statusUrl: string;
   loginUrl: string;

--- a/backend/src/services/mailService.ts
+++ b/backend/src/services/mailService.ts
@@ -26,6 +26,11 @@ export interface MailService {
 export interface ApprovalEmailOpts {
   to: string;
   publisherName: string;
+  // The slug the admin assigned to this publisher. The publisher must
+  // include this exact value as `publisher.id` in their feed (or in the
+  // `chq-publisher` HTML comment) for the ingest pipeline to recognise
+  // their events. Without it the feed validates but no events go live.
+  publisherId: string;
   statusUrl: string;
   loginUrl: string;
 }
@@ -174,7 +179,16 @@ function approvalText(o: ApprovalEmailOpts): string {
     `Hi ${o.publisherName || 'there'},`,
     '',
     'Good news — your Chautauqua Calendar publisher application has been approved.',
-    'Your feed is now in the ingest schedule and your events will start appearing on chqcal.org after the next sync.',
+    '',
+    'Your assigned publisher ID is:',
+    '',
+    `    ${o.publisherId}`,
+    '',
+    'You MUST include this exact value as `publisher.id` in your feed (or in the',
+    '`chq-publisher` HTML comment) for your events to appear on chqcal.org. Without',
+    'it the feed validates but no events go live.',
+    '',
+    'Once your feed lists this ID, the next ingest run will pick up your events.',
     '',
     'Sign in to view your status and recent fetch history:',
     o.loginUrl,
@@ -188,13 +202,17 @@ function approvalText(o: ApprovalEmailOpts): string {
 
 function approvalHtml(o: ApprovalEmailOpts): string {
   const safeName = escapeHtml(o.publisherName || 'there');
+  const safeId = escapeHtml(o.publisherId);
   const safeLogin = encodeURI(o.loginUrl);
   const safeStatus = encodeURI(o.statusUrl);
   return [
     '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
     `<p>Hi ${safeName},</p>`,
     '<p>Good news — your Chautauqua Calendar publisher application has been <strong>approved</strong>.</p>',
-    '<p>Your feed is now in the ingest schedule and your events will start appearing on chqcal.org after the next sync.</p>',
+    '<p>Your assigned publisher ID is:</p>',
+    `<p style="margin:0.5em 0 0.5em 1em;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:1.1em"><code>${safeId}</code></p>`,
+    '<p>You <strong>must</strong> include this exact value as <code>publisher.id</code> in your feed (or in the <code>chq-publisher</code> HTML comment) for your events to appear on chqcal.org. Without it the feed validates but no events go live.</p>',
+    '<p>Once your feed lists this ID, the next ingest run will pick up your events.</p>',
     `<p>Sign in to view your status and recent fetch history: <a href="${safeLogin}">${safeLogin}</a></p>`,
     `<p>You can check your status anytime here: <a href="${safeStatus}">${safeStatus}</a></p>`,
     '<p>— Chautauqua Calendar</p>',

--- a/backend/src/services/publisherAdminService.ts
+++ b/backend/src/services/publisherAdminService.ts
@@ -242,6 +242,7 @@ export class PublisherAdminService {
     await this.reviewDeps.mail.sendApprovalEmail({
       to: rec.contactEmail,
       publisherName: rec.name,
+      publisherId: rec.id,
       statusUrl,
       loginUrl,
     });


### PR DESCRIPTION
## Summary

When an admin approves a publisher application, the welcome email confirms approval but never tells the publisher their assigned slug. That slug is required as \`publisher.id\` in the feed (or as the \`id\` in the \`chq-publisher\` HTML comment) for ingest to recognise their events. Without it the feed validates cleanly but no events appear on chqcal.org, and the publisher has no way to know what value to put in their feed.

Surfaced during manual end-to-end testing of the apply → approve flow on 2026-05-04 (right after PR #88 merged): user approved a test publisher, then realised the slug had only been visible in the admin UI.

## Changes

- \`ApprovalEmailOpts.publisherId\` added to the \`MailService\` interface.
- Approval **text** template adds:
  > Your assigned publisher ID is:
  >
  >     acme-concerts
  >
  > You MUST include this exact value as \`publisher.id\` in your feed (or in the \`chq-publisher\` HTML comment) for your events to appear on chqcal.org. Without it the feed validates but no events go live.
- Approval **HTML** template adds the same content with the slug in a monospace block. Slug is escaped via the existing \`escapeHtml\` helper — admin-controlled but cheap to harden.
- \`publisherAdminService.sendApprovalNotification\` now passes \`rec.id\` through.
- Tests updated:
  - \`mailService.test.ts\` — asserts the slug appears in both text and HTML bodies, asserts the surrounding \`publisher.id\` instruction text is present, adds an HTML-escape assertion for an unusual slug (\`pub-<bad>\`).
  - \`publisherAdminService.test.ts\` — asserts the new \`publisherId: 'pub-pending'\` field flows through to \`sendApprovalEmail\`.
- Out of scope: rejection emails (no slug to share), magic-link or login emails (publisher slug is mailed elsewhere — those flows already either don't have a slug yet or the recipient already knows it).

## Test plan

- [ ] CI checks pass.
- [ ] After merge + deploy, approve a fresh test publisher application from \`/admin/publishers/\` and confirm the approval email contains the assigned slug both in plain text and the HTML body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)