### PR TITLE
chore: cleanup follow-ups — feedback CAPTCHA banner + 'react' import convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ CloudFront CDN → all-events.json → Browser Cache (1hr)
 ### Imports
 - Use `@/` path alias for imports (maps to `./src/`)
 - Example: `import { Event } from '@/lib/types'`
+- **Hooks and React-shaped types may be imported from `'react'`.** `@preact/preset-vite` aliases `'react'` and `'react-dom'` to `'preact/compat'` at build time (and `vitest.config.ts` does the same for tests). Importing `useState`, `createContext`, `useContext`, `React.FormEvent`, `React.ReactNode`, etc. from `'react'` is the accepted convention — `preact/compat` is what installs the `onChange` → `onInput` event normalization that React-style form components rely on, and removing `'react'` imports across the tree silently breaks form handlers in tests and production. New files may import hooks from `'preact/hooks'` if they don't render JSX (e.g. pure `.ts` hook files), but anything that wires DOM event handlers should keep the `'react'` import.
 
 ## Active Optimization Plan
 

--- a/frontend/src/app/feedback/page.tsx
+++ b/frontend/src/app/feedback/page.tsx
@@ -8,6 +8,11 @@ import { API_BASE_URL } from '@/lib/api';
 // submit button. Mirrors /publish/apply behaviour.
 const RECAPTCHA_LOAD_TIMEOUT_MS = 10_000;
 
+// Surfaced when the user submits before reCAPTCHA finishes loading. We
+// clear it explicitly if the load later fails so the yellow banner isn't
+// shown alongside conflicting "wait a moment" guidance.
+const CAPTCHA_LOADING_ERROR = 'Verifying you’re human… try again in a moment.';
+
 export default function FeedbackPage() {
   const [feedback, setFeedback] = useState('');
   const [contactInfo, setContactInfo] = useState('');
@@ -39,6 +44,9 @@ export default function FeedbackPage() {
       if (window.grecaptcha) {
         window.grecaptcha.ready(() => {
           setCaptchaReady(true);
+          // If the timeout already fired and we'd shown the failure
+          // banner, clear it now that the script has actually loaded.
+          setCaptchaFailed(false);
         });
       }
     };
@@ -63,6 +71,16 @@ export default function FeedbackPage() {
     };
   }, [RECAPTCHA_SITE_KEY]);
 
+  // When the captcha-failed banner appears, the transient "verifying
+  // you're human, try again" error becomes outdated — the banner now
+  // tells the user what's actually going on. Clear that specific error
+  // so the UI doesn't present conflicting guidance.
+  useEffect(() => {
+    if (captchaFailed) {
+      setError(prev => (prev === CAPTCHA_LOADING_ERROR ? '' : prev));
+    }
+  }, [captchaFailed]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
@@ -76,7 +94,7 @@ export default function FeedbackPage() {
     // the user has been told to retry/disable a blocker via the banner and
     // we let them submit with no token (backend rejects in prod).
     if (!!RECAPTCHA_SITE_KEY && !captchaReady && !captchaFailed) {
-      setError('Verifying you’re human… try again in a moment.');
+      setError(CAPTCHA_LOADING_ERROR);
       return;
     }
 

--- a/frontend/src/app/feedback/page.tsx
+++ b/frontend/src/app/feedback/page.tsx
@@ -2,6 +2,12 @@ import React, { useState, useEffect } from 'react';
 import { API_BASE_URL } from '@/lib/api';
 // Window.grecaptcha is declared globally by src/types/grecaptcha.d.ts.
 
+// If the reCAPTCHA script doesn't report ready within this many ms (ad
+// blocker, network problem, Google blip), surface a banner so the form
+// stays usable rather than leaving the user staring at a non-responsive
+// submit button. Mirrors /publish/apply behaviour.
+const RECAPTCHA_LOAD_TIMEOUT_MS = 10_000;
+
 export default function FeedbackPage() {
   const [feedback, setFeedback] = useState('');
   const [contactInfo, setContactInfo] = useState('');
@@ -9,6 +15,7 @@ export default function FeedbackPage() {
   const [isSubmitted, setIsSubmitted] = useState(false);
   const [error, setError] = useState('');
   const [captchaReady, setCaptchaReady] = useState(false);
+  const [captchaFailed, setCaptchaFailed] = useState(false);
 
   // reCAPTCHA site key - must be set via environment variable
   const RECAPTCHA_SITE_KEY = import.meta.env.VITE_RECAPTCHA_SITE_KEY;
@@ -27,7 +34,6 @@ export default function FeedbackPage() {
     script.src = `https://www.google.com/recaptcha/api.js?render=${RECAPTCHA_SITE_KEY}`;
     script.async = true;
     script.defer = true;
-    document.head.appendChild(script);
 
     script.onload = () => {
       if (window.grecaptcha) {
@@ -36,8 +42,20 @@ export default function FeedbackPage() {
         });
       }
     };
+    script.onerror = () => {
+      setCaptchaFailed(true);
+    };
+    document.head.appendChild(script);
+
+    // Belt-and-suspenders: if neither onload's ready callback nor onerror
+    // fires (e.g. blocker silently swallows the load), surface the failure
+    // after a timeout so the form stays usable.
+    const timeout = window.setTimeout(() => {
+      setCaptchaFailed(prev => prev || !window.grecaptcha);
+    }, RECAPTCHA_LOAD_TIMEOUT_MS);
 
     return () => {
+      window.clearTimeout(timeout);
       // Cleanup script on unmount - check if script exists first
       if (script && document.head.contains(script)) {
         document.head.removeChild(script);
@@ -53,8 +71,12 @@ export default function FeedbackPage() {
       return;
     }
 
-    if (!!RECAPTCHA_SITE_KEY && !captchaReady) {
-      setError('reCAPTCHA is not ready. Please wait and try again.');
+    // Block briefly if a site key is configured but the script hasn't
+    // finished loading — unless the load has clearly failed, in which case
+    // the user has been told to retry/disable a blocker via the banner and
+    // we let them submit with no token (backend rejects in prod).
+    if (!!RECAPTCHA_SITE_KEY && !captchaReady && !captchaFailed) {
+      setError('Verifying you’re human… try again in a moment.');
       return;
     }
 
@@ -204,10 +226,25 @@ export default function FeedbackPage() {
               </div>
             )}
 
+            {captchaFailed && (
+              <div className="rounded-md bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 p-3">
+                <p className="text-sm text-yellow-800 dark:text-yellow-200">
+                  Couldn&rsquo;t load reCAPTCHA — likely a tracker/ad
+                  blocker or network issue. You can still try submitting,
+                  but we may not be able to verify the request.
+                </p>
+              </div>
+            )}
+
             <div className="flex flex-col sm:flex-row gap-4">
               <button
                 type="submit"
-                disabled={isSubmitting || (!!RECAPTCHA_SITE_KEY && !captchaReady)}
+                // Don't disable on `!captchaReady` alone — if the script
+                // never loads (blocker, network blip), the button would be
+                // permanently dead. The captchaFailed banner above tells
+                // the user what happened and handleSubmit handles the
+                // not-ready case.
+                disabled={isSubmitting}
                 className="flex-1 px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
               >
                 {isSubmitting ? 'Submitting...' : 'Submit Feedback'}

--- a/frontend/src/app/publish/apply/page.tsx
+++ b/frontend/src/app/publish/apply/page.tsx
@@ -54,6 +54,11 @@ const RECAPTCHA_SITE_KEY = (import.meta as any).env?.VITE_RECAPTCHA_SITE_KEY as 
 // a useful error rather than a permanently disabled button.
 const RECAPTCHA_LOAD_TIMEOUT_MS = 10_000;
 
+// Surfaced when the user submits before reCAPTCHA finishes loading. We
+// clear it explicitly if the load later fails so the yellow banner isn't
+// shown alongside conflicting "wait a moment" guidance.
+const CAPTCHA_LOADING_ERROR = 'Verifying you’re human… try again in a moment.';
+
 export default function PublishApplyPage() {
   const [form, setForm] = useState<FormState>(INITIAL);
   const [status, setStatus] = useState<Status>({ kind: 'idle' });
@@ -72,7 +77,12 @@ export default function PublishApplyPage() {
     script.async = true;
     script.defer = true;
     script.onload = () => {
-      window.grecaptcha?.ready(() => setCaptchaReady(true));
+      window.grecaptcha?.ready(() => {
+        setCaptchaReady(true);
+        // If the timeout already fired and we'd shown the failure
+        // banner, clear it now that the script has actually loaded.
+        setCaptchaFailed(false);
+      });
     };
     script.onerror = () => {
       setCaptchaFailed(true);
@@ -92,6 +102,20 @@ export default function PublishApplyPage() {
     };
   }, []);
 
+  // When the captcha-failed banner appears, the transient "verifying
+  // you're human, try again" status becomes outdated — the banner now
+  // tells the user what's actually going on. Clear that specific error
+  // so the UI doesn't present conflicting guidance.
+  useEffect(() => {
+    if (captchaFailed) {
+      setStatus(prev =>
+        prev.kind === 'error' && prev.message === CAPTCHA_LOADING_ERROR
+          ? { kind: 'idle' }
+          : prev,
+      );
+    }
+  }, [captchaFailed]);
+
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
 
@@ -100,7 +124,7 @@ export default function PublishApplyPage() {
     // which case the user has been told to retry/disable a blocker and
     // we let them submit with no token (backend rejects in prod).
     if (RECAPTCHA_SITE_KEY && !captchaReady && !captchaFailed) {
-      setStatus({ kind: 'error', message: 'Verifying you’re human… try again in a moment.' });
+      setStatus({ kind: 'error', message: CAPTCHA_LOADING_ERROR });
       return;
     }
 


### PR DESCRIPTION
Works through the cleanup follow-ups deferred from the 2026-05-03 publisher-format wrap-up and the 2026-05-04 admin-Lambda hotfix session.

## Summary

- **Mirror the `captchaFailed` banner from `/publish/apply` onto `/feedback/`** (was an explicit out-of-scope follow-up from PR #88's review). The submit button no longer hard-disables on `!captchaReady`; an `onerror` handler plus a 10s timeout fallback flip `captchaFailed=true` and surface a yellow banner so an ad blocker / network blip doesn't deadlock the form. Submit-time guard now also short-circuits if `captchaFailed`.
- **Bless the `'react'` import convention in CLAUDE.md.** I attempted the sweep first (flipping `from 'react'` → `from 'preact/hooks'` across ~24 files) and ran into a real bug: `@preact/preset-vite` (and `vitest.config.ts`) alias `'react'` → `'preact/compat'`, and one of preact/compat's load-time side effects is installing the `onChange` → `onInput` event normalization that every React-style form input in this codebase depends on. Removing the `'react'` imports left no module pulling in preact/compat, which silently broke `PublisherForm` (two tests started failing — `expected 'my-pub' to be ''`). Reverting and instead documenting the established convention is the lower-risk path and matches the existing precedent in `frontend/src/app/publish/login/page.tsx`, which already explains the alias.

## Items intentionally out of scope

- `bbtest` test publisher retirement — DynamoDB write against production, the user runs that.
- Local stale-branch sweep / `fix/lambda-payload-base64-encoding` deletion — user wanted to do these manually.
- Auto-disable safety net for `ci-e2e-test` and standing up a staging AWS account — both need their own design and are tracked in `memory/publisher-ingest-e2e-ci-test-status.md`.
- `lib/auth.ts:50` trailing-slash fix — the memory was stale; every `/admin/login` reference in `src/` already has the trailing slash. Verified via `grep`, no change needed.
- The `language-` placeholder class on `CodeBlock` — left in place for future syntax highlighting.

## Test plan

- [x] `npm run validate` passes
- [x] `npm run build` passes (~490ms; bundle sizes unchanged)
- [x] `npm test` — 130/130 tests pass (15 files)
- [ ] Manual: visit `/feedback/`, block `*.google.com` in DevTools, confirm yellow banner appears within 10s and submit button stays enabled
- [ ] Manual: visit `/feedback/` normally, confirm reCAPTCHA loads silently and form behaves as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)