### PR TITLE
chore(infra): bump AWS provider to ~> 6.0 for nodejs24.x runtime

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
## Summary
- Lambda runtime bump in #91 was rejected by `terraform plan` because the pinned AWS provider (`~> 5.0`, currently 5.100.0) doesn't recognize `nodejs24.x` — that runtime was added to the provider's allow-list in the v6.x line.
- This PR widens the constraint to `~> 6.0` so the `nodejs22.x` → `nodejs24.x` change actually applies.

## How to apply after merge
```bash
git pull
cd infrastructure
terraform init -upgrade   # pulls AWS provider v6.x
terraform plan            # should show 8 in-place updates: runtime nodejs22.x → nodejs24.x
terraform apply
```

## v5 → v6 risk note
AWS provider v6 has some breaking changes (default-tag inheritance for nested resources, a few attribute renames, removal of long-deprecated fields). For this codebase the most likely surface is whatever else `terraform plan` shows after `init -upgrade`. Review the plan output carefully before applying — if anything besides the 8 Lambda runtime updates appears, we should evaluate it before continuing.

## Test plan
- [ ] `terraform init -upgrade` succeeds
- [ ] `terraform plan` shows only the 8 expected Lambda runtime changes (or any extras are reviewed and accepted)
- [ ] `terraform apply` flips runtimes
- [ ] `aws lambda list-functions` confirms all targeted Lambdas are on `nodejs24.x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)