### PR TITLE
feat(admin): surface detailed fetch errors on /admin/publishers/

### DIFF
--- a/backend/src/__tests__/publisherFeedFetcher.test.ts
+++ b/backend/src/__tests__/publisherFeedFetcher.test.ts
@@ -73,6 +73,7 @@ describe('fetchAndParseFeed', () => {
     expect(r.fetchStatus).toBe('validation_error');
     expect(r.feed).toBeNull();
     expect(r.report.errors[0].message).toContain('different-id');
+    expect(r.report.errors[0].message).toContain('test-pub');
   });
 
   it('returns network_error when fetch throws', async () => {

--- a/backend/src/__tests__/publisherFeedFetcher.test.ts
+++ b/backend/src/__tests__/publisherFeedFetcher.test.ts
@@ -57,6 +57,22 @@ describe('fetchAndParseFeed', () => {
     );
     expect(r.fetchStatus).toBe('validation_error');
     expect(r.feed).toBeNull();
+    // Mismatch message must spell out both ids — admins triage by reading
+    // this string in the publishers table and need to know what the feed
+    // claims its id is vs. what we have registered.
+    const msg = r.report.errors[0].message;
+    expect(msg).toContain('different-id');
+    expect(msg).toMatch(/test-pub|publisher.id/);
+  });
+
+  it('rejects HTML feed where publisher.id does not match registeredPublisherId', async () => {
+    const r = await fetchAndParseFeed(
+      { url: 'https://x/page.html', sourceType: 'html', registeredPublisherId: 'different-id' },
+      mockFetch(fix('valid-feed-page.html'), 'text/html'),
+    );
+    expect(r.fetchStatus).toBe('validation_error');
+    expect(r.feed).toBeNull();
+    expect(r.report.errors[0].message).toContain('different-id');
   });
 
   it('returns network_error when fetch throws', async () => {
@@ -69,6 +85,66 @@ describe('fetchAndParseFeed', () => {
     );
     expect(r.fetchStatus).toBe('network_error');
     expect(r.report.errors[0].message).toContain('connection refused');
+  });
+
+  it('unwraps err.cause for opaque "fetch failed" network errors', async () => {
+    // Real Node fetch errors look like: top-level message "fetch failed",
+    // with the actual diagnostic on err.cause. Without unwrapping, admins
+    // see no useful info; with it, they see "getaddrinfo ENOTFOUND host".
+    const fetchFn: any = jest.fn(async () => {
+      const err = new Error('fetch failed') as Error & {
+        cause?: { code?: string; message?: string };
+      };
+      err.cause = { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND example.com' };
+      throw err;
+    });
+    const r = await fetchAndParseFeed(
+      { url: 'https://example.com/feed.json', sourceType: 'json', registeredPublisherId: 'test-pub' },
+      fetchFn,
+    );
+    expect(r.fetchStatus).toBe('network_error');
+    const msg = r.report.errors[0].message;
+    expect(msg).toContain('fetch failed');
+    expect(msg).toContain('getaddrinfo ENOTFOUND example.com');
+    // The code must not appear twice — Node's message already includes it,
+    // so a naive `[code, message].join(' ')` would produce a duplicate.
+    expect(msg.match(/ENOTFOUND/g)?.length).toBe(1);
+  });
+
+  it('falls back to err.cause.code when cause has no message', async () => {
+    const fetchFn: any = jest.fn(async () => {
+      const err = new Error('fetch failed') as Error & {
+        cause?: { code?: string; message?: string };
+      };
+      err.cause = { code: 'ECONNREFUSED' };
+      throw err;
+    });
+    const r = await fetchAndParseFeed(
+      { url: 'https://example.com/feed.json', sourceType: 'json', registeredPublisherId: 'test-pub' },
+      fetchFn,
+    );
+    expect(r.fetchStatus).toBe('network_error');
+    expect(r.report.errors[0].message).toContain('ECONNREFUSED');
+  });
+
+  it('returns a clean timeout message on AbortError without leaking cause', async () => {
+    const fetchFn: any = jest.fn(async () => {
+      const err = new Error('The operation was aborted') as Error & {
+        cause?: { name?: string; message?: string };
+      };
+      err.name = 'AbortError';
+      // Some Node versions attach a DOMException-shaped cause; the fetcher
+      // must not append it to the message.
+      err.cause = { name: 'AbortError', message: 'The operation was aborted' };
+      throw err;
+    });
+    const r = await fetchAndParseFeed(
+      { url: 'https://example.com/feed.json', sourceType: 'json', registeredPublisherId: 'test-pub' },
+      fetchFn,
+    );
+    expect(r.fetchStatus).toBe('network_error');
+    expect(r.report.errors[0].message).toMatch(/timed out after \d+ms/);
+    expect(r.report.errors[0].message).not.toContain('aborted');
   });
 
   it('passes an AbortSignal to fetch (timeout protection)', async () => {

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -34,7 +34,13 @@ export async function runIngest(deps: IngestDeps): Promise<void> {
         registeredPublisherId: p.id,
       });
       if (f.fetchStatus !== 'ok' || !f.feed) {
-        const message = f.report.errors.map(e => e.message).join('; ').slice(0, 500);
+        // Prefix each error with its path when it's more specific than the
+        // root ("/") so admins can see which field failed validation. For
+        // network/JSON errors with path === "/", the path is noise — drop it.
+        const message = f.report.errors
+          .map(e => (e.path && e.path !== '/' ? `${e.path}: ${e.message}` : e.message))
+          .join('; ')
+          .slice(0, 500);
         await deps.registry.recordFetchOutcome(p.id, { status: f.fetchStatus, message });
         continue;
       }
@@ -62,9 +68,18 @@ export async function runIngest(deps: IngestDeps): Promise<void> {
     } catch (err) {
       console.error(`[publisher-ingest] publisher ${p.id} failed:`, err);
       try {
+        // Node's fetch wraps the underlying network error (DNS, refused, TLS,
+        // etc.) inside `err.cause`. Surface it so admins see "ENOTFOUND host"
+        // instead of an opaque "fetch failed".
+        const e = err as Error & { cause?: { message?: string; code?: string } };
+        const causeBits = e.cause
+          ? [e.cause.code, e.cause.message].filter(Boolean).join(' ')
+          : '';
+        const baseMsg = e.message ?? String(err);
+        const fullMsg = causeBits ? `${baseMsg} (${causeBits})` : baseMsg;
         await deps.registry.recordFetchOutcome(p.id, {
           status: 'network_error',
-          message: `unhandled error: ${(err as Error).message ?? String(err)}`.slice(0, 500),
+          message: `unhandled error: ${fullMsg}`.slice(0, 500),
         });
       } catch (recordErr) {
         console.error(`[publisher-ingest] failed to record outcome for ${p.id}:`, recordErr);

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -68,18 +68,14 @@ export async function runIngest(deps: IngestDeps): Promise<void> {
     } catch (err) {
       console.error(`[publisher-ingest] publisher ${p.id} failed:`, err);
       try {
-        // Node's fetch wraps the underlying network error (DNS, refused, TLS,
-        // etc.) inside `err.cause`. Surface it so admins see "ENOTFOUND host"
-        // instead of an opaque "fetch failed".
-        const e = err as Error & { cause?: { message?: string; code?: string } };
-        const causeBits = e.cause
-          ? [e.cause.code, e.cause.message].filter(Boolean).join(' ')
-          : '';
-        const baseMsg = e.message ?? String(err);
-        const fullMsg = causeBits ? `${baseMsg} (${causeBits})` : baseMsg;
+        // This catch fires for unhandled throws from the loop body — DDB
+        // errors, reconcile assertion failures, etc. fetchAndParseFeed
+        // already returns network_error with cause-unwrapped messages on
+        // its own, so don't replicate that logic here; just surface the
+        // raw error message.
         await deps.registry.recordFetchOutcome(p.id, {
           status: 'network_error',
-          message: `unhandled error: ${fullMsg}`.slice(0, 500),
+          message: `unhandled error: ${(err as Error).message ?? String(err)}`.slice(0, 500),
         });
       } catch (recordErr) {
         console.error(`[publisher-ingest] failed to record outcome for ${p.id}:`, recordErr);

--- a/backend/src/services/publisherFeedFetcher.ts
+++ b/backend/src/services/publisherFeedFetcher.ts
@@ -41,12 +41,24 @@ export async function fetchAndParseFeed(
       signal: controller.signal,
     });
   } catch (e) {
+    // Node's fetch reports most real network failures (ENOTFOUND, ECONNREFUSED,
+    // certificate errors, AbortError on timeout) only on err.cause — the top
+    // level message is just "fetch failed". Pull the cause out so admins can
+    // actually diagnose what went wrong on the upstream host.
+    const err = e as Error & { cause?: { code?: string; message?: string } };
+    const causeBits = err.cause
+      ? [err.cause.code, err.cause.message].filter(Boolean).join(' ')
+      : '';
+    const baseMsg = err.name === 'AbortError'
+      ? `timed out after ${FETCH_TIMEOUT_MS}ms`
+      : (err.message ?? String(e));
+    const message = causeBits ? `${baseMsg} (${causeBits})` : baseMsg;
     return {
       fetchStatus: 'network_error',
       feed: null,
       report: {
         ok: false,
-        errors: [{ path: '/', message: (e as Error).message }],
+        errors: [{ path: '/', message }],
         warnings: [],
       },
     };
@@ -81,7 +93,10 @@ export async function fetchAndParseFeed(
         feed: null,
         report: {
           ok: false,
-          errors: [{ path: '/publisher/id', message: 'mismatch' }],
+          errors: [{
+            path: '/publisher/id',
+            message: `feed publisher.id "${ex.feed.publisher.id}" does not match registered publisher "${input.registeredPublisherId}"`,
+          }],
           warnings: [],
         },
       };
@@ -118,7 +133,10 @@ export async function fetchAndParseFeed(
       feed: null,
       report: {
         ok: false,
-        errors: [{ path: '/publisher/id', message: 'mismatch' }],
+        errors: [{
+          path: '/publisher/id',
+          message: `feed publisher.id "${report.feed.publisher.id}" does not match registered publisher "${input.registeredPublisherId}"`,
+        }],
         warnings: [],
       },
     };

--- a/backend/src/services/publisherFeedFetcher.ts
+++ b/backend/src/services/publisherFeedFetcher.ts
@@ -41,18 +41,29 @@ export async function fetchAndParseFeed(
       signal: controller.signal,
     });
   } catch (e) {
-    // Node's fetch reports most real network failures (ENOTFOUND, ECONNREFUSED,
-    // certificate errors, AbortError on timeout) only on err.cause — the top
-    // level message is just "fetch failed". Pull the cause out so admins can
-    // actually diagnose what went wrong on the upstream host.
     const err = e as Error & { cause?: { code?: string; message?: string } };
-    const causeBits = err.cause
-      ? [err.cause.code, err.cause.message].filter(Boolean).join(' ')
-      : '';
-    const baseMsg = err.name === 'AbortError'
-      ? `timed out after ${FETCH_TIMEOUT_MS}ms`
-      : (err.message ?? String(e));
-    const message = causeBits ? `${baseMsg} (${causeBits})` : baseMsg;
+    // Timeout has its own deterministic message — the AbortError wrapping is
+    // an implementation detail. Return early so we don't append the
+    // DOMException cause that some Node versions attach to the abort.
+    if (err.name === 'AbortError') {
+      return {
+        fetchStatus: 'network_error',
+        feed: null,
+        report: {
+          ok: false,
+          errors: [{ path: '/', message: `timed out after ${FETCH_TIMEOUT_MS}ms` }],
+          warnings: [],
+        },
+      };
+    }
+    // Node's fetch surfaces real network failures (ENOTFOUND, ECONNREFUSED,
+    // certificate errors) only on err.cause — the top-level message is just
+    // "fetch failed". Prefer cause.message (it usually already includes the
+    // code, e.g. "getaddrinfo ENOTFOUND host"), and fall back to the bare
+    // code only if message is absent — joining both duplicates the code.
+    const causeStr = err.cause ? (err.cause.message || err.cause.code || '') : '';
+    const baseMsg = err.message ?? String(e);
+    const message = causeStr ? `${baseMsg} (${causeStr})` : baseMsg;
     return {
       fetchStatus: 'network_error',
       feed: null,

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -130,6 +130,15 @@ export default function PublishersPage() {
     }
   };
 
+  // Render the ISO timestamp using the user's locale. Falls back to the raw
+  // string if Date parsing fails so we never blank out a valid value.
+  const formatFetchedAt = (iso: string | undefined): string | null => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleString();
+  };
+
   // -------------------------------------------------------------------------
   // Loading / unauthenticated guard
   // -------------------------------------------------------------------------
@@ -293,14 +302,28 @@ export default function PublishersPage() {
                           {p.trustLevel}
                         </span>
                       </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
+                      <td className="px-6 py-4 align-top max-w-md">
                         {p.lastFetchStatus ? (
-                          <span
-                            className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${statusBadgeClass(p.lastFetchStatus)}`}
-                            title={p.lastFetchMessage}
-                          >
-                            {p.lastFetchStatus}
-                          </span>
+                          <div className="space-y-1">
+                            <span
+                              className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${statusBadgeClass(p.lastFetchStatus)}`}
+                            >
+                              {p.lastFetchStatus}
+                            </span>
+                            {p.lastFetchedAt && (
+                              <div className="text-xs text-gray-500 dark:text-gray-400">
+                                {formatFetchedAt(p.lastFetchedAt)}
+                              </div>
+                            )}
+                            {p.lastFetchStatus !== 'ok' && p.lastFetchMessage && (
+                              <div
+                                className="text-xs text-red-700 dark:text-red-400 whitespace-pre-wrap break-words font-mono leading-snug"
+                                title={p.lastFetchMessage}
+                              >
+                                {p.lastFetchMessage}
+                              </div>
+                            )}
+                          </div>
                         ) : (
                           <span className="text-xs text-gray-400 dark:text-gray-500">—</span>
                         )}


### PR DESCRIPTION
## Summary
- The /admin/publishers/ "Last Fetch" column now shows the timestamp and, on non-ok status, the full `lastFetchMessage` inline (previously only visible as a hidden tooltip on the badge).
- Backend stores a more diagnostic message: error paths are prefixed (e.g. `/publisher/id: ...`), and `err.cause` is unwrapped so admins see `ENOTFOUND host` / `ECONNREFUSED` / `timed out after 30000ms` instead of a bare "fetch failed".
- Validation `mismatch` errors now spell out both the feed and registered publisher ids.

## Test plan
- [x] `frontend && npm run validate && npm run build`
- [x] `backend && npm test` (420 tests pass)
- [x] `frontend && npm test` (130 tests pass)
- [ ] After deploy, verify a failing publisher row on /admin/publishers/ shows the detailed message inline (not just in tooltip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)