### PR TITLE
fix(infra): grant dynamodb:ConditionCheckItem to publisher IAM policies

### DIFF
--- a/infrastructure/publisher-ingest.tf
+++ b/infrastructure/publisher-ingest.tf
@@ -102,7 +102,8 @@ resource "aws_iam_role_policy" "publisher_ingest_scoped" {
           "dynamodb:PutItem",
           "dynamodb:UpdateItem",
           "dynamodb:DeleteItem",
-          "dynamodb:TransactWriteItems"
+          "dynamodb:TransactWriteItems",
+          "dynamodb:ConditionCheckItem"
         ],
         Resource = [
           aws_dynamodb_table.publishers.arn,
@@ -200,7 +201,8 @@ resource "aws_iam_role_policy" "admin_publisher_access" {
         "dynamodb:PutItem",
         "dynamodb:UpdateItem",
         "dynamodb:DeleteItem",
-        "dynamodb:TransactWriteItems"
+        "dynamodb:TransactWriteItems",
+        "dynamodb:ConditionCheckItem"
       ],
       Resource = [
         aws_dynamodb_table.publishers.arn,


### PR DESCRIPTION
## Summary
- Adds `dynamodb:ConditionCheckItem` to `publisher_ingest_scoped` (publisher-ingest Lambda) and `admin_publisher_access` (admin Lambda) IAM policies.
- Both policies already grant `dynamodb:TransactWriteItems`, but transactions that include `ConditionCheck` items require `ConditionCheckItem` as a *separate* IAM action — that gap caused every per-publisher fetch to fail in the hourly ingest and from the `/admin/publishers/` Run-ingest button.

## Why this surfaced now
The PR #96 IAM split landed in code but wasn't applied until today (apply ran from this session). With the new role in place, the publisher-ingest Lambda started exercising the `TransactWriteItems` + `ConditionCheck` path against `chautauqua-calendar-publishers` and tripped the missing action.

## State of live infra
Already applied via `terraform apply` from this session — 2 policies updated. `terraform plan` against `main` post-merge will report no changes. This PR brings the repo back in sync with deployed AWS state.

## Test plan
- [ ] Click **Run ingest now** on `/admin/publishers/` and confirm the per-row `lastFetchMessage` no longer shows AccessDeniedException for `dynamodb:ConditionCheckItem`.
- [ ] CloudWatch logs for `chautauqua-calendar-publisher-ingest` show successful per-publisher fetches.
- [ ] Wait for next hourly EventBridge run and confirm the same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)