### PR TITLE
fix(infra): grant dynamodb:Scan on magic-tokens table

### DIFF
--- a/infrastructure/publisher-portal.tf
+++ b/infrastructure/publisher-portal.tf
@@ -130,12 +130,20 @@ resource "aws_iam_role_policy" "publisher_portal_access" {
         Resource = aws_secretsmanager_secret.publisher_jwt_secret.arn
       },
       {
+        # Scan is required by the email-change flow:
+        #   - queryActiveEmailChangeByNewEmail (uniqueness gate on initiate)
+        #   - scanEmailChangeRowsByPublisher (find/delete pending pair)
+        # The table has no GSI on publisherId or emailChangePayload.newEmail,
+        # so these lookups have to scan. The table is small and bounded by a
+        # 24h TTL, so Scan is acceptable here (see the comment on
+        # magicTokenService.ts:237).
         Effect = "Allow",
         Action = [
           "dynamodb:GetItem",
           "dynamodb:PutItem",
           "dynamodb:DeleteItem",
-          "dynamodb:UpdateItem"
+          "dynamodb:UpdateItem",
+          "dynamodb:Scan"
         ],
         Resource = aws_dynamodb_table.publisher_magic_tokens.arn
       },


### PR DESCRIPTION
## Summary
- POST /publisher-email-change returns 500 (AccessDenied) because PR #98 introduced \`ScanCommand\` calls in \`magicTokenService.ts\` (uniqueness check + pending-pair lookup), but \`infrastructure/publisher-portal.tf\` only granted item-level actions on the magic-tokens table.
- Same root cause silently breaks \`findActiveEmailChangeByPublisher\` in \`/publisher-status\`, so \`pendingEmailChange\` never surfaces in the portal UI.
- Fix: add \`dynamodb:Scan\` to the existing magic-tokens statement on the \`publisher_portal_access\` role policy. The table has no GSI on \`publisherId\` or \`emailChangePayload.newEmail\`, so Scan is the intended access pattern (see comment at \`magicTokenService.ts:237\` — table is small and bounded by 24h TTL).

CloudWatch evidence: \`_MagicTokenService.queryActiveEmailChangeByNewEmail\` → \`AccessDeniedException ... dynamodb:Scan on chautauqua-calendar-publisher-magic-tokens\`.

\`terraform plan -target=aws_iam_role_policy.publisher_portal_access\`: \`Plan: 0 to add, 1 to change, 0 to destroy.\` Diff is exactly \`+ "dynamodb:Scan"\` on the magic-tokens statement.

## Test plan
- [ ] Merge, then \`terraform apply\` (Lambda code unchanged — IAM-only).
- [ ] On \`/publish/status/\`, change contact email; verify 200 and that the verify+warning emails are dispatched.
- [ ] After initiating, refresh \`/publish/status/\` and confirm the pending-email-change banner now renders (proves the second silent-Scan path is also unblocked).
- [ ] Check CloudWatch on the admin Lambda for any remaining AccessDenied lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)