### PR TITLE
docs(plans): integration-test program — 5 spec+plan pairs

### DIFF
--- a/docs/plans/2026-05-06-ci-concurrency-dedupe-design.md
+++ b/docs/plans/2026-05-06-ci-concurrency-dedupe-design.md
@@ -1,0 +1,99 @@
+# CI concurrency dedupe (design)
+
+**Date:** 2026-05-06
+**Status:** Approved, ready for implementation plan
+**Origin:** Once `build-and-test.yml` triggers on `push:` (any branch) per the publisher-integration-tests spec, rapid follow-up pushes will queue duplicate runs that test stale commits. Concurrency-cancel is the standard fix.
+
+## Problem
+
+GitHub Actions, by default, queues every triggered run. If a developer pushes commits A, B, C in quick succession, all three runs proceed; the run for A is wasted because nobody cares about its result the moment B exists. With `pull_request` and `push` both enabled, same-repo PRs additionally trigger **two** runs per push (one for each event), doubling the waste.
+
+## Policy
+
+- Cancel superseded runs on the same branch / PR; only the latest commit's run matters.
+- Never cancel runs on `main` — those are post-merge verifications and we want them all to complete (history value).
+- Apply at the workflow level so the policy travels with the workflow file, not as repo-wide settings.
+- Don't dedupe across the `push` and `pull_request` event pair on the same commit — the easiest win is just to scope the duplicate-trigger to one of them.
+
+## Scope
+
+### In
+
+- `.github/workflows/build-and-test.yml` — the workflow that runs on every branch push.
+
+### Out
+
+- `.github/workflows/deploy-production.yml` — already serialized via the GitHub Environment protection or its own concurrency block; touching it is out of scope here.
+- `.github/workflows/claude-code-review.yml`, `.github/workflows/claude.yml` — Claude bot workflows; their semantics differ.
+- `.github/workflows/validate-publisher-examples.yml` — leave alone unless it shows duplicate runs.
+
+## Architecture
+
+Two independent changes, both in `build-and-test.yml`:
+
+### 1. Concurrency block
+
+```yaml
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+```
+
+- `group` keys on `github.ref` so each branch / PR gets its own concurrency lane.
+- `cancel-in-progress` is `true` for branches and `false` for `main` so the post-merge run always completes.
+
+### 2. Avoid double-triggering on same-repo PRs
+
+Two equally good options:
+
+**Option A (recommended):** rely on `push:` for everything in the upstream repo, and have `pull_request:` only fire for forks:
+
+```yaml
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  test-backend:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
+    # ...
+  test-frontend:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
+    # ...
+```
+
+**Option B:** drop `push:` and rely on `pull_request:` only. Loses on-push validation for branches without an open PR.
+
+We pick A — branch pushes without a PR open are still validated, and the `if:` filter cleanly suppresses the duplicate when a same-repo PR exists.
+
+## Verification
+
+After the change is in place:
+
+- Push two quick commits to a branch → only the second run completes; the first shows "Cancelled".
+- Open a PR from a same-repo branch → only the `push`-triggered run runs (the `pull_request` run is skipped via the `if:` filter).
+- Open a PR from a fork → the `pull_request` run runs (forks don't fire `push:` on the upstream repo).
+- Push to `main` (or merge into it) → the run completes and is not cancellable.
+
+## CI integration
+
+This *is* the CI integration. No external dependencies.
+
+## Non-goals
+
+- Cross-workflow dedupe
+- Time-window debouncing (concurrency-cancel is enough)
+- Custom queueing logic
+
+## Risks
+
+- **`if:` filter on jobs vs workflow-level `if`.** Job-level `if` still consumes a runner slot briefly to evaluate. Acceptable; the alternative is a workflow-level filter expression which GitHub doesn't natively support.
+- **Cancelled runs leaving partial coverage artifacts.** Acceptable; the artifact upload step is keyed on `if: always()`. If the artifact is missing, the next successful run produces it.
+- **Required-check status confusion.** When a run is cancelled, GitHub shows it as "Cancelled" not "Failed", which doesn't satisfy a required-check rule. The follow-up successful run (on the new commit) does. Documented in the implementation plan so reviewers know cancelled runs are expected on rapid pushes.
+
+## File counts (estimated)
+
+- One file edit: ~12 lines added to `build-and-test.yml`.
+- Total: ~12 lines.

--- a/docs/plans/2026-05-06-ci-concurrency-dedupe-design.md
+++ b/docs/plans/2026-05-06-ci-concurrency-dedupe-design.md
@@ -92,6 +92,7 @@ This *is* the CI integration. No external dependencies.
 - **`if:` filter on jobs vs workflow-level `if`.** Job-level `if` still consumes a runner slot briefly to evaluate. Acceptable; the alternative is a workflow-level filter expression which GitHub doesn't natively support.
 - **Cancelled runs leaving partial coverage artifacts.** Acceptable; the artifact upload step is keyed on `if: always()`. If the artifact is missing, the next successful run produces it.
 - **Required-check status confusion.** When a run is cancelled, GitHub shows it as "Cancelled" not "Failed", which doesn't satisfy a required-check rule. The follow-up successful run (on the new commit) does. Documented in the implementation plan so reviewers know cancelled runs are expected on rapid pushes.
+- **Matrix-cell skip vs required check.** A matrix job suppressed by `if:` shows as "Skipped" per cell. Skipped cells do **not** satisfy a required-check rule when individual cells (e.g. `test-backend (24)`, `test-backend (25)`) are listed as required. This only affects same-repo PRs (where the `pull_request` event is suppressed) — for those, the corresponding `push` event run produces the satisfying check, so the merge gate is met by a different workflow run on the same SHA. Required: the same-repo PR's `push`-event run must complete green; the cancelled-and-skipped `pull_request` run is harmless. Fork PRs always run via `pull_request` (forks don't fire `push:` against the upstream repo) so all cells run normally and the gate works the obvious way.
 
 ## File counts (estimated)
 

--- a/docs/plans/2026-05-06-ci-concurrency-dedupe-plan.md
+++ b/docs/plans/2026-05-06-ci-concurrency-dedupe-plan.md
@@ -104,7 +104,7 @@
 
 - [ ] **Step 1: Squash the test commits**
 
-  If the verification commits in Task 3 are still on the branch, squash them down to one meaningful commit:
+  Only do this **after** the cancel verification in Task 3 has been observed in the GitHub Actions UI (otherwise you cancel the very runs you were verifying against). If the verification commits are still on the branch:
 
   ```bash
   git reset --soft origin/main

--- a/docs/plans/2026-05-06-ci-concurrency-dedupe-plan.md
+++ b/docs/plans/2026-05-06-ci-concurrency-dedupe-plan.md
@@ -1,0 +1,135 @@
+# CI concurrency dedupe (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop `build-and-test.yml` from running duplicate jobs on rapid pushes and on same-repo PRs once the workflow triggers on every branch push.
+
+**Spec:** `docs/plans/2026-05-06-ci-concurrency-dedupe-design.md`
+
+**Architecture:** Single-file edit. Add a workflow-level `concurrency:` block keyed on `github.ref` with `cancel-in-progress` enabled for non-`main` refs. Add an `if:` filter on each job to suppress the `pull_request` event when the source branch lives in the upstream repo (no duplicate with `push:`).
+
+**Tech Stack:** GitHub Actions YAML.
+
+**Branch:** create `chore/ci-concurrency-dedupe` off `main`.
+
+**Prerequisite:** none, but most useful to land *together with* or *immediately after* `publisher-integration-tests-plan` Task 10 (which adds `push:` trigger).
+
+---
+
+## Task 1: Add concurrency block
+
+**Files:**
+- Modify: `.github/workflows/build-and-test.yml`
+
+- [ ] **Step 1: Edit the workflow**
+
+  Below the `on:` block and before `jobs:`, add:
+
+  ```yaml
+  concurrency:
+    group: build-and-test-${{ github.ref }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  ```
+
+- [ ] **Step 2: Confirm syntax**
+
+  ```bash
+  npx --yes @action-validator/cli .github/workflows/build-and-test.yml
+  ```
+
+  Or open in any YAML linter. Must parse without error.
+
+---
+
+## Task 2: Suppress duplicate runs on same-repo PRs
+
+**Files:**
+- Modify: `.github/workflows/build-and-test.yml`
+
+- [ ] **Step 1: Add the `if:` filter to both jobs**
+
+  Under `test-backend:` and `test-frontend:`, immediately after `runs-on:`, add:
+
+  ```yaml
+  if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
+  ```
+
+  This skips the `pull_request`-triggered run for same-repo PRs (the corresponding `push` run still executes). Fork PRs continue to trigger via `pull_request` (forks don't fire `push:` against the upstream repo).
+
+- [ ] **Step 2: Limit `pull_request` event types**
+
+  Under the `pull_request:` trigger, narrow to the events that matter:
+
+  ```yaml
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  ```
+
+  This avoids extra runs on label / assignee / review-state changes.
+
+---
+
+## Task 3: Verify behavior
+
+- [ ] **Step 1: Push two commits in quick succession on a branch**
+
+  Create a tiny no-op commit, push, immediately add another no-op, push again:
+
+  ```bash
+  git checkout -b chore/ci-concurrency-dedupe
+  git commit --allow-empty -m "ci: test concurrency dedupe (1)"
+  git push -u origin chore/ci-concurrency-dedupe
+  git commit --allow-empty -m "ci: test concurrency dedupe (2)"
+  git push
+  ```
+
+  In GitHub Actions, expected: the run for commit (1) shows "Cancelled"; the run for (2) completes.
+
+- [ ] **Step 2: Open a same-repo PR**
+
+  ```bash
+  gh pr create --title "chore(ci): concurrency dedupe" --body "Test PR for dedupe verification"
+  ```
+
+  In GitHub Actions, expected: only the `push`-triggered run is visible. The `pull_request` run is skipped via the `if:` filter (it shows up as "Skipped" in the checks list).
+
+- [ ] **Step 3: Push to `main`** (only after PR merge)
+
+  After this PR merges, observe the post-merge run on `main`. Expected: completes without being cancellable, even if a follow-on commit lands shortly after.
+
+---
+
+## Task 4: Final commit + PR
+
+- [ ] **Step 1: Squash the test commits**
+
+  If the verification commits in Task 3 are still on the branch, squash them down to one meaningful commit:
+
+  ```bash
+  git reset --soft origin/main
+  git commit -m "ci: dedupe build-and-test runs via concurrency-cancel + same-repo PR filter"
+  git push --force-with-lease
+  ```
+
+- [ ] **Step 2: Update PR description**
+
+  ```bash
+  gh pr edit --body "$(cat <<'EOF'
+## Summary
+- Adds `concurrency:` block keyed on ref; cancels superseded runs on every branch except `main`.
+- Adds `if:` filter to suppress duplicate `pull_request` runs for same-repo PRs (the `push` run already covers them); fork PRs still run normally.
+- Narrows `pull_request:` trigger to `[opened, synchronize, reopened]`.
+
+## Verification
+- [x] Two rapid pushes → first run cancelled, second completes
+- [x] Same-repo PR → only push-triggered run visible
+- [ ] After merge, post-merge run on main completes uninterrupted
+
+## Risk
+- Cancelled runs show as "Cancelled" not "Failed" — they don't satisfy a required-check rule, but the next commit's run does. Documented in design.
+EOF
+  )"
+  ```
+
+- [ ] **Step 3: Wait for green CI; iterate per global PR-iteration rules**

--- a/docs/plans/2026-05-06-ci-coverage-floor-design.md
+++ b/docs/plans/2026-05-06-ci-coverage-floor-design.md
@@ -1,0 +1,130 @@
+# CI coverage floor (design)
+
+**Date:** 2026-05-06
+**Status:** Approved, ready for implementation plan
+**Origin:** Backend tests already produce coverage (`test:ci` runs with `--coverage` and uploads the artifact). Frontend tests are arriving via the frontend-portal-integration-tests spec. We have no enforcement that new code carries tests; coverage can drift quietly downward.
+
+## Problem
+
+Coverage is reported but not enforced. New code with no tests is indistinguishable in CI from new code with tests. The quickest way to establish discipline without writing exhaustive policy is a per-PR check that fails when line coverage drops below a baseline measured the moment we turn the gate on.
+
+## Policy
+
+- Treat coverage as a one-way ratchet: today's number is the floor; drops fail.
+- Floor lives in a checked-in config file, not as workflow inline magic, so it's diff-reviewable and bumps are visible.
+- Apply the floor per-package (backend, frontend) — they have different baselines and different test stacks.
+- Allow a tight per-PR negative tolerance (e.g. -0.5%) to avoid flapping on tiny refactors that change branch counts; PRs that genuinely lower coverage must raise the floor or add tests.
+- Block the merge via the existing required-check mechanism (no new check needed; the existing `test-backend` / `test-frontend` jobs fail).
+
+## Scope
+
+### In
+
+- Line coverage (the metric Jest already produces).
+- Backend (`backend/`).
+- Frontend (`frontend/`) — once the frontend-portal-integration-tests spec lands. If frontend tests aren't in place yet when this is implemented, frontend gating is added in a follow-up commit, not deferred indefinitely.
+
+### Out
+
+- Per-file or per-directory floors (operationally noisy).
+- Branch / function / statement coverage (line is the simplest signal; can be added later if line coverage proves insufficient).
+- Mutation testing (separate concern).
+- Codecov / Coveralls integration (we don't need a third-party dashboard for this; the CI log is enough).
+
+## Architecture
+
+```
+.coverage-floor.json                     # checked in; the floor numbers
+backend/jest.config.js                   # add coverageThreshold block referencing the floor
+frontend/vitest.config.ts                # add coverage.threshold block referencing the floor
+.github/workflows/build-and-test.yml     # no change required if Jest/Vitest enforces it
+```
+
+`.coverage-floor.json`:
+
+```json
+{
+  "backend": { "lines": 78.0 },
+  "frontend": { "lines": 65.0 }
+}
+```
+
+(Numbers will be set during implementation by reading the actual current coverage on `main` and rounding down by 0.5%.)
+
+### Enforcement mechanism
+
+Jest:
+
+```js
+// backend/jest.config.js
+const floor = require('../.coverage-floor.json').backend;
+module.exports = {
+  // ... existing config
+  coverageThreshold: {
+    global: { lines: floor.lines },
+  },
+};
+```
+
+Vitest (frontend, when wired):
+
+```ts
+// frontend/vitest.config.ts
+import floor from '../.coverage-floor.json';
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      thresholds: { lines: floor.frontend.lines },
+    },
+  },
+});
+```
+
+If coverage drops below the floor, Jest/Vitest exits non-zero and the existing CI job fails. No new workflow step.
+
+### Updating the floor
+
+Two paths:
+
+1. **Manual bump** (preferred for big jumps): edit `.coverage-floor.json` in the same PR that adds tests.
+2. **Auto-bump on `main` merge** (optional follow-up — out of this spec): a workflow that, after a successful `main` merge, computes coverage and PRs the new floor. Not built here; mentioned only so it's not forgotten.
+
+### What if a refactor genuinely lowers coverage?
+
+Author manually lowers the floor in `.coverage-floor.json` in the same PR. Reviewer sees the diff and decides whether the drop is acceptable. The point is *visibility*, not absolutism.
+
+## Implementation order
+
+The implementation plan should:
+
+1. Add `.coverage-floor.json` with backend floor only.
+2. Wire Jest's `coverageThreshold`.
+3. Verify CI runs the coverage report (the existing `test:ci` script already does).
+4. Document in CLAUDE.md or a new `docs/coverage.md` how to bump the floor.
+5. (Frontend portion) Once frontend tests exist, add `frontend.lines` to the JSON and wire Vitest's threshold.
+
+## CI integration
+
+No workflow file changes required. The check rides on the existing `test-backend` / `test-frontend` jobs already invoked by `npm run build`. Threshold violations fail the existing required check.
+
+## Non-goals
+
+- Coverage badges
+- Coverage trend graphs
+- Per-PR coverage diff comments
+- Mutation testing
+
+## Risks
+
+- **Floor flapping on tiny PRs.** Mitigation: pick the floor 0.5% below current; reassess if flapping appears.
+- **Generated code dragging coverage down.** Mitigation: ensure `coveragePathIgnorePatterns` excludes `dist/`, `node_modules/`, `**/refs/`, generated `.d.ts`, etc. Check `backend/jest.config.js` already has reasonable excludes; add to it if not.
+- **Floor never raises.** Mitigation: documented runbook step: when the test PR adds significant coverage, raise the floor in the same PR.
+
+## File counts (estimated)
+
+- New JSON file: 5 lines
+- Jest config edit: 5 lines
+- Vitest config edit (when applicable): 5 lines
+- Doc page: 30–40 lines
+- Total: ~50–60 lines

--- a/docs/plans/2026-05-06-ci-coverage-floor-plan.md
+++ b/docs/plans/2026-05-06-ci-coverage-floor-plan.md
@@ -1,0 +1,223 @@
+# CI coverage floor (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Establish a one-way line-coverage ratchet for backend (and frontend, when applicable) that fails CI when coverage drops below a checked-in floor.
+
+**Spec:** `docs/plans/2026-05-06-ci-coverage-floor-design.md`
+
+**Architecture:** A single `.coverage-floor.json` at the repo root holds per-package floor numbers. Jest and Vitest read it via their own `coverageThreshold` / `coverage.thresholds` configs. No new CI step.
+
+**Tech Stack:** Jest (backend), Vitest (frontend, optional), JSON config.
+
+**Branch:** create `chore/ci-coverage-floor` off `main`.
+
+**Prerequisite for the frontend portion:** the `frontend-portal-integration-tests` plan must have landed and produced a real frontend coverage number to floor against. Backend portion has no prerequisites.
+
+---
+
+## Task 1: Measure today's backend coverage
+
+- [ ] **Step 1: Run coverage on `main`**
+
+  ```bash
+  git checkout main && git pull
+  cd backend && npm run test:ci
+  ```
+
+  Open `backend/coverage/coverage-summary.json` (or `lcov-report/index.html`). Record:
+  - Lines: `__.__%`
+
+  If the integration tests from `publisher-integration-tests-plan` have landed, this number will be higher; that's the right baseline to floor against. If they haven't landed, decide whether to wait or floor at the lower number — the design spec recommends *picking the floor 0.5% below the current measurement either way*.
+
+- [ ] **Step 2: Pick the floor**
+
+  Round down to one decimal place, then subtract 0.5%. Example: measured 78.42% → floor = 77.9.
+
+  Record in this plan as `BACKEND_FLOOR_LINES`.
+
+---
+
+## Task 2: Add `.coverage-floor.json`
+
+**Files:**
+- New: `.coverage-floor.json` (repo root)
+
+- [ ] **Step 1: Create the file**
+
+  ```json
+  {
+    "backend": { "lines": 77.9 },
+    "frontend": { "lines": null }
+  }
+  ```
+
+  (Replace 77.9 with the value from Task 1.)
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  git checkout -b chore/ci-coverage-floor
+  git add .coverage-floor.json
+  git commit -m "chore(ci): add coverage floor config"
+  ```
+
+---
+
+## Task 3: Wire Jest's `coverageThreshold`
+
+**Files:**
+- Modify: `backend/jest.config.js`
+
+- [ ] **Step 1: Read existing config**
+
+  Confirm coverage settings (collectCoverageFrom, coveragePathIgnorePatterns) are reasonable. Add to `coveragePathIgnorePatterns` if missing:
+
+  ```js
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/refs/', '\\.d\\.ts$', '/__tests__/']
+  ```
+
+- [ ] **Step 2: Add `coverageThreshold`**
+
+  At the top of the file:
+
+  ```js
+  const floor = require('../.coverage-floor.json');
+  ```
+
+  In the export:
+
+  ```js
+  coverageThreshold: {
+    global: { lines: floor.backend.lines },
+  },
+  ```
+
+- [ ] **Step 3: Verify it enforces**
+
+  Confirm the threshold passes today:
+
+  ```bash
+  cd backend && npm run test:ci
+  ```
+
+  Then *temporarily* bump the floor to 99.9, rerun, and confirm Jest exits non-zero with a coverage-threshold message. Revert.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add backend/jest.config.js
+  git commit -m "chore(ci): enforce backend line coverage floor via Jest"
+  ```
+
+---
+
+## Task 4: Document the floor and how to bump it
+
+**Files:**
+- New: `docs/coverage.md`
+- Modify: `CLAUDE.md` (add a one-liner pointer)
+
+- [ ] **Step 1: Write `docs/coverage.md`**
+
+  Cover:
+  - What the floor means (line coverage, per-package, one-way ratchet)
+  - Where it's stored (`.coverage-floor.json`)
+  - How CI enforces it (Jest/Vitest threshold; no separate workflow step)
+  - How to bump it: edit the JSON in the same PR that adds the tests; reviewer sees the diff
+  - When to lower it: only with explicit reviewer sign-off; mention it in the PR description
+  - What's *not* enforced (branch / function / statement coverage; per-file floors)
+
+- [ ] **Step 2: Add a pointer in CLAUDE.md**
+
+  Under the "Verification Checklist" section, add a bullet:
+  - "Coverage floor enforced via `.coverage-floor.json`; see `docs/coverage.md`."
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add docs/coverage.md CLAUDE.md
+  git commit -m "docs(ci): coverage floor policy and bump procedure"
+  ```
+
+---
+
+## Task 5: Frontend portion (gated on frontend tests existing)
+
+**Files (only if frontend tests exist):**
+- Modify: `.coverage-floor.json` (set `frontend.lines`)
+- Modify: `frontend/vitest.config.ts`
+
+- [ ] **Step 1: Check whether frontend tests exist**
+
+  ```bash
+  ls frontend/src/__tests__/integration 2>/dev/null && echo "exists" || echo "skip"
+  ```
+
+  If "skip", stop here and proceed to Task 6. The frontend portion lands in a separate PR after the `frontend-portal-integration-tests` plan completes.
+
+- [ ] **Step 2: Measure frontend coverage**
+
+  ```bash
+  cd frontend && npm run test:ci
+  ```
+
+  Floor = measured% - 0.5%, rounded down to one decimal.
+
+- [ ] **Step 3: Update JSON + Vitest config**
+
+  ```json
+  "frontend": { "lines": 64.5 }
+  ```
+
+  In `vitest.config.ts`:
+
+  ```ts
+  import floor from '../.coverage-floor.json';
+
+  export default defineConfig({
+    test: {
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json-summary'],
+        thresholds: { lines: floor.frontend.lines },
+      },
+    },
+  });
+  ```
+
+- [ ] **Step 4: Verify enforcement**
+
+  Bump to 99.9 temporarily, confirm `npm run test:ci --workspace=frontend` fails, revert.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add .coverage-floor.json frontend/vitest.config.ts
+  git commit -m "chore(ci): enforce frontend line coverage floor via Vitest"
+  ```
+
+---
+
+## Task 6: Push and open PR
+
+- [ ] **Step 1: Push and PR**
+
+  ```bash
+  git push -u origin chore/ci-coverage-floor
+  gh pr create --title "chore(ci): enforce per-package line coverage floor" --body "$(cat <<'EOF'
+## Summary
+- New `.coverage-floor.json` at repo root holds per-package floors.
+- Jest's `coverageThreshold` enforces the backend floor; existing `test-backend` job fails on drop.
+- (If included) Vitest enforces the frontend floor.
+- Floor numbers picked at 0.5% below today's measured coverage.
+
+## Test plan
+- [ ] Backend tests pass at current coverage
+- [ ] Backend tests fail when floor is bumped to 99.9 (verified locally)
+- [ ] CI green on this PR
+EOF
+  )"
+  ```
+
+- [ ] **Step 2: Iterate per global PR-iteration rules**

--- a/docs/plans/2026-05-06-ci-coverage-floor-plan.md
+++ b/docs/plans/2026-05-06-ci-coverage-floor-plan.md
@@ -28,6 +28,8 @@
   Open `backend/coverage/coverage-summary.json` (or `lcov-report/index.html`). Record:
   - Lines: `__.__%`
 
+  **Note on what's measured:** `backend/jest.config.js` already excludes `src/handlers/*.ts` and `src/scripts/*.ts` from `collectCoverageFrom`. The recorded number is over services + utils + types only. Don't try to floor handlers via this mechanism — they're tested via integration tests, not coverage gates. Document this in the runbook (Task 4) so future contributors don't wonder why handlers aren't gated.
+
   If the integration tests from `publisher-integration-tests-plan` have landed, this number will be higher; that's the right baseline to floor against. If they haven't landed, decide whether to wait or floor at the lower number — the design spec recommends *picking the floor 0.5% below the current measurement either way*.
 
 - [ ] **Step 2: Pick the floor**
@@ -48,11 +50,11 @@
   ```json
   {
     "backend": { "lines": 77.9 },
-    "frontend": { "lines": null }
+    "frontend": { "lines": 0 }
   }
   ```
 
-  (Replace 77.9 with the value from Task 1.)
+  (Replace 77.9 with the value from Task 1. `frontend.lines: 0` is an explicit "no gate" — Vitest accepts 0 as a threshold and treats it as always-passing. Bumped to a real number when the frontend portion lands in Task 5. Do NOT use `null` — Vitest behavior on `null` is implementation-defined.)
 
 - [ ] **Step 2: Commit**
 
@@ -79,7 +81,7 @@
 
 - [ ] **Step 2: Add `coverageThreshold`**
 
-  At the top of the file:
+  At the top of the file (`jest.config.js` is CommonJS, so `require()` is fine — no `resolveJsonModule` needed because Jest doesn't go through TypeScript here):
 
   ```js
   const floor = require('../.coverage-floor.json');
@@ -92,6 +94,8 @@
     global: { lines: floor.backend.lines },
   },
   ```
+
+  For the frontend Vitest config in Task 5, the JSON import goes through TypeScript, so verify `frontend/tsconfig.json` has `"resolveJsonModule": true` (already true as of this plan's date).
 
 - [ ] **Step 3: Verify it enforces**
 
@@ -130,7 +134,7 @@
 
 - [ ] **Step 2: Add a pointer in CLAUDE.md**
 
-  Under the "Verification Checklist" section, add a bullet:
+  Under the existing `## Verification Checklist` section (line 279 as of this plan's date — confirm the exact heading before editing), add a bullet:
   - "Coverage floor enforced via `.coverage-floor.json`; see `docs/coverage.md`."
 
 - [ ] **Step 3: Commit**

--- a/docs/plans/2026-05-06-frontend-portal-integration-tests-design.md
+++ b/docs/plans/2026-05-06-frontend-portal-integration-tests-design.md
@@ -1,0 +1,158 @@
+# Frontend portal integration tests (design)
+
+**Date:** 2026-05-06
+**Status:** Approved, ready for implementation plan
+**Origin:** The publisher portal frontend (Phases A–D, PRs #83–#85, #88, plus self-service PR #98) ships UI for `/publish/apply/`, `/publish/test/`, `/publisher-portal/`, `/admin/publishers/`. None of it has automated test coverage. Test pages are hand-checked today.
+
+## Problem
+
+The backend handlers backing the publisher portal are well-tested. The frontend pages that drive them have no tests at all, so a publisher-facing regression — broken form handler, missing field, mis-rendered status, mis-routed admin action — only surfaces when a user hits it. The CLAUDE.md note about the `'react'` import convention is the canonical example: that gotcha exists *because* there's no test that would have caught the form silently breaking.
+
+## Policy
+
+- Test the page state machine, not the visual styling.
+- Use `fireEvent`/`userEvent` against rendered Preact components; no Playwright / browser automation in this spec.
+- Mock `fetch` at the boundary; never make a real network call.
+- Don't snapshot — assertions target user-observable behavior (text content, disabled state, redirect URL) so a CSS tweak doesn't bust tests.
+- Verify the `'react'` import convention works end-to-end by exercising at least one form submission per page (regression for CLAUDE.md gotcha).
+
+## Scope
+
+### In
+
+- `frontend/src/app/publish/apply/page.tsx` — apply form (CAPTCHA, validation, submit, success and error states)
+- `frontend/src/app/publish/test/page.tsx` — feed-test form (URL paste, fetch, error display)
+- `frontend/src/app/publisher-portal/page.tsx` — authenticated portal (status load, profile edit, email change request, pause/resume, fetch-now, self-disable typed-confirmation)
+- `frontend/src/app/publisher-portal/login/page.tsx` — magic-link request + verify
+- `frontend/src/app/publisher-portal/email-change/page.tsx` — magic-link confirm screens
+- `frontend/src/app/admin/publishers/page.tsx` — admin list, detail expansion, run-ingest button, pause/disable actions, individual event approve/reject
+
+### Out
+
+- The main calendar page (`page.tsx` for `/`) — covered by separate spec if/when needed
+- `/admin/feedback/`, `/admin/login/` — out of scope for the publisher work
+- Service-worker behavior (PR #101) — needs its own approach
+- Visual regression / screenshot diffing
+- E2E across real backend (covered by `post-deploy-publisher-smoke-test` spec)
+
+## Architecture
+
+```
+frontend/
+├── vitest.config.ts                  # already exists per CLAUDE.md note
+├── src/
+│   ├── app/.../page.tsx              # under test
+│   └── __tests__/integration/
+│       ├── helpers/
+│       │   ├── render.tsx            # wraps render() with Preact context providers
+│       │   ├── fetchMock.ts          # typed fetch mock with route-based responses
+│       │   └── auth.ts               # localStorage session helpers
+│       ├── apply.test.tsx
+│       ├── publishTest.test.tsx
+│       ├── portal.test.tsx
+│       ├── portalLogin.test.tsx
+│       ├── portalEmailChange.test.tsx
+│       └── adminPublishers.test.tsx
+```
+
+### Test runner
+
+Vitest + `@testing-library/preact` + happy-dom (already a Vite-friendly stack). If `vitest.config.ts` doesn't exist, the implementation plan adds it; configuration aliases match `vite.config.ts` (the `react` → `preact/compat` alias is critical — without it form handlers break exactly as CLAUDE.md warns).
+
+### Fetch mock
+
+A small `fetchMock` helper that registers `(method, urlPattern) → response` rules. Default response is `404` so unhandled routes fail loudly. Each test sets up only the routes it needs; the helper exposes `.calls(urlPattern)` for assertions on what was sent.
+
+### Auth helper
+
+`loginAs({ email, publisherId, jwt })` writes the session token to `localStorage` exactly the way `frontend/src/lib/auth.ts` does in production. Tests that exercise authenticated portals call this in `beforeEach`.
+
+### What we assert
+
+For each page test:
+
+- The expected fields render (by label / role).
+- Filling and submitting the form sends the expected `fetch(url, { method, body })`.
+- Success responses transition the UI to the success state (text, disabled buttons, redirect call).
+- Error responses (400, 401, 429, 500) show the right error text and don't navigate away.
+- Validation rejects bad input *without* sending a request.
+
+## Test plan (one or two `it(...)` per bullet)
+
+### apply.test.tsx
+
+- Renders all required fields and CAPTCHA placeholder.
+- CAPTCHA missing → submit blocked, no fetch.
+- Invalid email → inline error, no fetch.
+- Successful apply → POST `/publisher-apply-request` fires; "check your email" success state renders.
+- Server returns `EmailAlreadyInUseError` → friendly error renders; user can edit and retry.
+- Server returns 429 (rate limit) → backoff message renders.
+
+### publishTest.test.tsx
+
+- Pasting URL + clicking Test fires POST `/publisher-test`.
+- Successful response renders parsed event count and warnings list.
+- Validation errors render under each event with index + path.
+- Network/parse error renders banner.
+
+### portal.test.tsx
+
+- Without session → redirects to `/publisher-portal/login`.
+- With session → `GET /publisher-status` populates publisher row, lastFetchMessage, current state badges (paused / disabled / active).
+- Profile edit: change name → PATCH `/publisher-profile` → success toast; row updates in place.
+- Email-change request: submit new email → POST `/publisher-email-change-request` → success state explaining magic link sent.
+- Pause toggle: click pause → POST `/publisher-pause` → row badge flips; click resume → POST `/publisher-resume`.
+- Fetch-now: click → POST `/publisher-fetch-now`; success message replaces button label until refetch.
+- Self-disable: typed-slug input must match displayed slug; mismatch keeps button disabled; correct slug + click fires POST `/publisher-disable`; on success page navigates to a "disabled" terminal state.
+- Form submission (any single one) — verifies `'react'` import convention so onChange/onInput work. Regression for CLAUDE.md note.
+
+### portalLogin.test.tsx
+
+- Email entry → POST `/publisher-auth-request` → "check your email" state.
+- 404 (unknown email) renders generic message (no email enumeration).
+- Magic-link verify URL with token → POST `/publisher-auth-verify` → on success writes session and redirects to `/publisher-portal`.
+- Magic-link verify with bad token → error state; no session written.
+
+### portalEmailChange.test.tsx
+
+- `/publisher-portal/email-change?token=...` → POST `/publisher-email-change-verify` → success page.
+- Bad token → error page.
+- Cancel-by-old route → POST `/publisher-email-change-cancel` → success page.
+
+### adminPublishers.test.tsx
+
+- Without admin session → redirects to admin login.
+- With session → GET applications and publishers; renders both lists.
+- Approve application → POST `/admin/publisher-applications/:id/approve` → row moves from applications to publishers list.
+- Reject application → POST reject → row disappears with reject reason.
+- Detail expansion shows lastFetchMessage, fetchStatus, recent events.
+- Run-ingest button → POST `/admin/publisher-run-ingest` → loading state → refresh.
+- Pause / disable actions on a publisher row → POST → row badge updates.
+- Per-event approve / reject buttons → POST → state pill updates inline.
+
+## CI integration
+
+Tests run inside `frontend`'s build pipeline:
+
+- Add `"test": "vitest run"` script in `frontend/package.json` (if not already present).
+- Add `"test:ci": "vitest run --coverage"` for the CI step.
+- Update `npm run build` (frontend) to run `npm run test:ci` first, mirroring backend's `prebuild → test:ci` pattern. Or add a dedicated CI step in `build-and-test.yml` for `npm run test:ci --workspace=frontend`.
+
+## Non-goals
+
+- Visual regression
+- Cross-browser
+- Real backend
+- E2E with real Lambda
+
+## Risks
+
+- **Preact-vs-React behavioral drift in tests.** Mitigation: use `@testing-library/preact` (not `@testing-library/react`) and the same `vite.config.ts` aliases. Add a smoke test that verifies the `react` alias resolves to `preact/compat` at test time.
+- **Tests coupled to copy strings break on UI tweaks.** Mitigation: assert on roles/labels and aria attributes; only assert text strings when the test is specifically about the message.
+
+## File counts (estimated)
+
+- Helpers: ~150 lines
+- Six test files: 600–900 lines combined
+- `vitest.config.ts` (if new): ~25 lines
+- Total: ~775–1,075 lines

--- a/docs/plans/2026-05-06-frontend-portal-integration-tests-design.md
+++ b/docs/plans/2026-05-06-frontend-portal-integration-tests-design.md
@@ -57,7 +57,7 @@ frontend/
 
 ### Test runner
 
-Vitest + `@testing-library/preact` + happy-dom (already a Vite-friendly stack). If `vitest.config.ts` doesn't exist, the implementation plan adds it; configuration aliases match `vite.config.ts` (the `react` → `preact/compat` alias is critical — without it form handlers break exactly as CLAUDE.md warns).
+Vitest + `@testing-library/preact` + **jsdom**. `frontend/vitest.config.ts` already exists, already specifies `environment: 'jsdom'`, already declares the `react` → `preact/compat` aliases (which is the critical bit for the CLAUDE.md gotcha), and already points `setupFiles` at `./src/__tests__/setup.ts`. The implementation plan therefore adds tests *into* this config, not on top of a new one. We deliberately keep `jsdom` (not `happy-dom`) because the existing config already chose it — switching environments is a breaking change for any other Vitest tests that may land in parallel and provides no concrete benefit here.
 
 ### Fetch mock
 
@@ -66,6 +66,10 @@ A small `fetchMock` helper that registers `(method, urlPattern) → response` ru
 ### Auth helper
 
 `loginAs({ email, publisherId, jwt })` writes the session token to `localStorage` exactly the way `frontend/src/lib/auth.ts` does in production. Tests that exercise authenticated portals call this in `beforeEach`.
+
+### Redirect / navigation seam
+
+Several portal tests need to assert that a page navigates (e.g. unauthenticated → `/publisher-portal/login`, post-self-disable → terminal page). The portal pages perform navigation via `window.location.href = ...` or `route(...)` from preact-router. Tests stub the navigation seam in one place — `helpers/render.tsx` exposes `installNavigationStub()` that replaces the seam with a recorder, and `getNavigations()` returns the URLs that were navigated to. Each navigation test asserts on `getNavigations()` rather than on `window.location` directly, so the same pattern works whether the page uses `location.href` or a router.
 
 ### What we assert
 

--- a/docs/plans/2026-05-06-frontend-portal-integration-tests-plan.md
+++ b/docs/plans/2026-05-06-frontend-portal-integration-tests-plan.md
@@ -1,0 +1,339 @@
+# Frontend portal integration tests (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Vitest-based integration tests for every publisher-portal frontend page, mocking `fetch` and exercising the full state machine of each page.
+
+**Spec:** `docs/plans/2026-05-06-frontend-portal-integration-tests-design.md`
+
+**Architecture:** New `frontend/src/__tests__/integration/` directory. Vitest + `@testing-library/preact` + happy-dom. A small `fetchMock` harness routes API calls to canned responses. A `loginAs` helper writes session tokens to `localStorage` exactly the way `frontend/src/lib/auth.ts` does.
+
+**Tech Stack:** TypeScript, Vitest, happy-dom, `@testing-library/preact`, `@testing-library/user-event`, Preact (via `@preact/preset-vite`).
+
+**Branch:** create `feat/frontend-portal-integration-tests` off `main`.
+
+**Prerequisite:** none — this can land independently of the backend integration tests plan.
+
+---
+
+## Task 1: Wire up Vitest
+
+**Files:**
+- New (or modify): `frontend/vitest.config.ts`
+- Modify: `frontend/package.json` (scripts + dev deps)
+
+- [ ] **Step 1: Check whether `vitest.config.ts` already exists**
+
+  ```bash
+  ls frontend/vitest.config.ts 2>/dev/null
+  ```
+
+  If missing, create it:
+
+  ```ts
+  import { defineConfig } from 'vitest/config';
+  import preact from '@preact/preset-vite';
+  import path from 'node:path';
+
+  export default defineConfig({
+    plugins: [preact()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+        // CRITICAL: matches vite.config.ts. Without this, react-imported
+        // hooks resolve to real React in tests and form handlers behave
+        // differently than in production (see CLAUDE.md note).
+        react: 'preact/compat',
+        'react-dom': 'preact/compat',
+      },
+    },
+    test: {
+      environment: 'happy-dom',
+      globals: true,
+      setupFiles: ['./src/__tests__/integration/helpers/setup.ts'],
+    },
+  });
+  ```
+
+  If it already exists, confirm the `react` → `preact/compat` aliases are present; add them if not. This is the gotcha called out in CLAUDE.md.
+
+- [ ] **Step 2: Add scripts and dev deps**
+
+  In `frontend/package.json`, under `scripts`:
+
+  ```json
+  "test": "vitest run",
+  "test:watch": "vitest",
+  "test:ci": "vitest run --coverage"
+  ```
+
+  Add devDependencies (`npm i -D --workspace=frontend`):
+
+  ```
+  vitest @vitest/coverage-v8 happy-dom
+  @testing-library/preact @testing-library/user-event @testing-library/jest-dom
+  ```
+
+- [ ] **Step 3: Setup file**
+
+  Create `frontend/src/__tests__/integration/helpers/setup.ts`:
+
+  ```ts
+  import '@testing-library/jest-dom/vitest';
+  import { afterEach } from 'vitest';
+  import { cleanup } from '@testing-library/preact';
+  afterEach(() => { cleanup(); localStorage.clear(); });
+  ```
+
+- [ ] **Step 4: Smoke test**
+
+  Create `frontend/src/__tests__/integration/smoke.test.tsx`:
+
+  ```ts
+  import { render } from '@testing-library/preact';
+  import { describe, it, expect } from 'vitest';
+
+  describe('vitest smoke', () => {
+    it('renders a div with preact and finds it via testing-library', () => {
+      const { getByText } = render(<div>hello</div>);
+      expect(getByText('hello')).toBeInTheDocument();
+    });
+  });
+  ```
+
+  Run:
+
+  ```bash
+  cd frontend && npm run test
+  ```
+
+  Must pass.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add frontend/vitest.config.ts frontend/package.json frontend/package-lock.json \
+          frontend/src/__tests__/integration/helpers/setup.ts \
+          frontend/src/__tests__/integration/smoke.test.tsx
+  git commit -m "test(frontend): vitest scaffolding with preact + happy-dom"
+  ```
+
+---
+
+## Task 2: Build the helpers — fetchMock, render, auth
+
+**Files:**
+- New: `frontend/src/__tests__/integration/helpers/fetchMock.ts`
+- New: `frontend/src/__tests__/integration/helpers/render.tsx`
+- New: `frontend/src/__tests__/integration/helpers/auth.ts`
+
+- [ ] **Step 1: fetchMock**
+
+  Implement an `installFetchMock()` helper that replaces `globalThis.fetch` with a typed router:
+
+  ```ts
+  type Route = { method: string; url: string | RegExp; respond: (req: Request) => Response | Promise<Response> };
+  export function installFetchMock(): {
+    on(method: string, url: string | RegExp, response: number | object | ((r: Request) => any)): void;
+    calls(url?: string | RegExp): Request[];
+    reset(): void;
+    uninstall(): void;
+  };
+  ```
+
+  Default response when no route matches: `404` plus a thrown error in `console` so unhandled requests fail loudly.
+
+- [ ] **Step 2: render helper**
+
+  ```ts
+  export function renderPage(node: VNode): RenderResult;
+  ```
+
+  Wraps `@testing-library/preact`'s render with whatever context providers the portal needs (none currently, but reserve the seam).
+
+- [ ] **Step 3: auth helper**
+
+  Read `frontend/src/lib/auth.ts` to learn the exact localStorage key + value shape used by `loginAs`. Mirror it:
+
+  ```ts
+  export function loginAs(opts: { publisherId: string; email: string; jwt?: string }): void;
+  export function loginAsAdmin(opts: { email: string; jwt?: string }): void;
+  export function logout(): void;
+  ```
+
+- [ ] **Step 4: Self-test the helpers**
+
+  Add `helpers/__tests__/fetchMock.test.ts` covering: route matching by URL string, by regex, default 404, calls() returning the request, reset() clearing routes, uninstall() restoring the original fetch.
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add frontend/src/__tests__/integration/helpers/
+  git commit -m "test(frontend): integration helpers (fetchMock, render, auth)"
+  ```
+
+---
+
+## Task 3: Apply page tests
+
+**Files:**
+- New: `frontend/src/__tests__/integration/apply.test.tsx`
+
+- [ ] **Step 1: Read the apply page**
+
+  Open `frontend/src/app/publish/apply/page.tsx`. Identify field labels, the CAPTCHA component, the success state, and which API endpoint it POSTs to.
+
+- [ ] **Step 2: Write the tests**
+
+  Six `it(...)` blocks per the design doc, Test plan → apply.test.tsx. Each:
+  - Renders the page
+  - Configures the fetchMock
+  - Drives input via `userEvent`
+  - Asserts on rendered text + on `fetchMock.calls(url)` payload
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  cd frontend && npm run test -- apply
+  git add frontend/src/__tests__/integration/apply.test.tsx
+  git commit -m "test(frontend): apply page integration tests"
+  ```
+
+---
+
+## Task 4: Test page tests (publish/test)
+
+**Files:**
+- New: `frontend/src/__tests__/integration/publishTest.test.tsx`
+
+- [ ] **Step 1: Implement the four `it(...)` blocks** per the design doc.
+
+- [ ] **Step 2: Run and commit**
+
+  ```bash
+  cd frontend && npm run test -- publishTest
+  git add frontend/src/__tests__/integration/publishTest.test.tsx
+  git commit -m "test(frontend): publish/test page integration tests"
+  ```
+
+---
+
+## Task 5: Portal page tests
+
+**Files:**
+- New: `frontend/src/__tests__/integration/portal.test.tsx`
+
+- [ ] **Step 1: Read `frontend/src/app/publisher-portal/page.tsx`**, capture all sub-flows: status load, profile edit, email change, pause/resume, fetch-now, self-disable.
+
+- [ ] **Step 2: Implement the eight `it(...)` blocks** per the design doc. Critical: include the form-submission regression test (any single submit) to verify the `react` → `preact/compat` alias is working.
+
+- [ ] **Step 3: Run and commit**
+
+  ```bash
+  cd frontend && npm run test -- portal
+  git add frontend/src/__tests__/integration/portal.test.tsx
+  git commit -m "test(frontend): portal page integration tests"
+  ```
+
+---
+
+## Task 6: Login + email-change page tests
+
+**Files:**
+- New: `frontend/src/__tests__/integration/portalLogin.test.tsx`
+- New: `frontend/src/__tests__/integration/portalEmailChange.test.tsx`
+
+- [ ] **Step 1: Implement** all `it(...)` blocks for both files per the design doc.
+
+- [ ] **Step 2: Run and commit (one commit each)**
+
+  ```bash
+  cd frontend && npm run test -- portalLogin
+  git add frontend/src/__tests__/integration/portalLogin.test.tsx
+  git commit -m "test(frontend): portal login page integration tests"
+
+  cd frontend && npm run test -- portalEmailChange
+  git add frontend/src/__tests__/integration/portalEmailChange.test.tsx
+  git commit -m "test(frontend): portal email-change page integration tests"
+  ```
+
+---
+
+## Task 7: Admin publishers page tests
+
+**Files:**
+- New: `frontend/src/__tests__/integration/adminPublishers.test.tsx`
+
+- [ ] **Step 1: Read `frontend/src/app/admin/publishers/page.tsx`** to map every action button to its endpoint.
+
+- [ ] **Step 2: Implement the eight `it(...)` blocks** per the design doc.
+
+- [ ] **Step 3: Run and commit**
+
+  ```bash
+  cd frontend && npm run test -- adminPublishers
+  git add frontend/src/__tests__/integration/adminPublishers.test.tsx
+  git commit -m "test(frontend): admin publishers page integration tests"
+  ```
+
+---
+
+## Task 8: Wire frontend tests into CI
+
+**Files:**
+- Modify: `frontend/package.json` (build script)
+- Modify: `.github/workflows/build-and-test.yml` (test-frontend job)
+
+- [ ] **Step 1: Make `npm run build --workspace=frontend` fail when tests fail**
+
+  Two options:
+
+  - Edit `frontend/package.json` `"build"` to chain: `"build": "npm run test:ci && vite build"`. Mirrors backend's `prebuild → test:ci` flow.
+  - OR add a separate CI step in `build-and-test.yml`'s `test-frontend` job:
+
+    ```yaml
+    - name: Run frontend tests
+      run: npm run test:ci --workspace=frontend
+    ```
+
+  Pick the script-chaining option for symmetry with backend.
+
+- [ ] **Step 2: Verify the build fails when a test fails**
+
+  Temporarily add a `expect(true).toBe(false)` in the smoke test, run `npm run build --workspace=frontend`, confirm exit code is non-zero, then revert.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add frontend/package.json
+  git commit -m "ci(frontend): make build fail on test failure"
+  ```
+
+---
+
+## Task 9: Push and open PR
+
+- [ ] **Step 1: Push**
+
+  ```bash
+  git push -u origin feat/frontend-portal-integration-tests
+  ```
+
+- [ ] **Step 2: Open PR**
+
+  ```bash
+  gh pr create --title "test(frontend): publisher portal integration tests" --body "$(cat <<'EOF'
+## Summary
+- Vitest + happy-dom + `@testing-library/preact` test suite for every publisher portal frontend page (apply, publish/test, portal, login, email-change, admin).
+- Each test mocks fetch and drives the page state machine through user events.
+- One form-submission test in `portal.test.tsx` pins the `react` → `preact/compat` alias gotcha called out in CLAUDE.md.
+
+## Test plan
+- [ ] `npm run test --workspace=frontend` passes locally
+- [ ] `npm run build --workspace=frontend` runs tests and fails on test failure
+- [ ] CI green on this PR
+EOF
+  )"
+  ```
+
+- [ ] **Step 3: Wait for CI and iterate per global CLAUDE.md PR-iteration rules**

--- a/docs/plans/2026-05-06-frontend-portal-integration-tests-plan.md
+++ b/docs/plans/2026-05-06-frontend-portal-integration-tests-plan.md
@@ -19,43 +19,38 @@
 ## Task 1: Wire up Vitest
 
 **Files:**
-- New (or modify): `frontend/vitest.config.ts`
+- Confirm: `frontend/vitest.config.ts` (already exists with jsdom + react aliases + setupFiles)
+- Modify (probably): `frontend/src/__tests__/setup.ts`
 - Modify: `frontend/package.json` (scripts + dev deps)
 
-- [ ] **Step 1: Check whether `vitest.config.ts` already exists**
+- [ ] **Step 1: Confirm the existing `vitest.config.ts` is suitable**
 
-  ```bash
-  ls frontend/vitest.config.ts 2>/dev/null
-  ```
-
-  If missing, create it:
+  Read it. As of this plan's date it contains:
 
   ```ts
-  import { defineConfig } from 'vitest/config';
-  import preact from '@preact/preset-vite';
-  import path from 'node:path';
-
-  export default defineConfig({
-    plugins: [preact()],
-    resolve: {
-      alias: {
-        '@': path.resolve(__dirname, './src'),
-        // CRITICAL: matches vite.config.ts. Without this, react-imported
-        // hooks resolve to real React in tests and form handlers behave
-        // differently than in production (see CLAUDE.md note).
-        react: 'preact/compat',
-        'react-dom': 'preact/compat',
-      },
-    },
-    test: {
-      environment: 'happy-dom',
-      globals: true,
-      setupFiles: ['./src/__tests__/integration/helpers/setup.ts'],
-    },
-  });
+  // existing
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/__tests__/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  }
   ```
 
-  If it already exists, confirm the `react` → `preact/compat` aliases are present; add them if not. This is the gotcha called out in CLAUDE.md.
+  with `react` → `preact/compat` aliases already in place. **Do not switch environments to happy-dom** — jsdom is the existing baseline and switching is a breaking change for any other Vitest tests that land in parallel.
+
+  Add a `coverage` block so `test:ci --coverage` produces the report Plan 4 (coverage floor) reads:
+
+  ```ts
+  test: {
+    // ...existing
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'json-summary'],   // json-summary is what Plan 4 reads
+      exclude: ['out/**', 'src/**/__tests__/**', '**/*.test.{ts,tsx}'],
+    },
+  }
+  ```
 
 - [ ] **Step 2: Add scripts and dev deps**
 
@@ -70,13 +65,15 @@
   Add devDependencies (`npm i -D --workspace=frontend`):
 
   ```
-  vitest @vitest/coverage-v8 happy-dom
+  vitest @vitest/coverage-v8 jsdom
   @testing-library/preact @testing-library/user-event @testing-library/jest-dom
   ```
 
-- [ ] **Step 3: Setup file**
+  (jsdom listed for clarity — it's the env we're keeping; it may already be installed.)
 
-  Create `frontend/src/__tests__/integration/helpers/setup.ts`:
+- [ ] **Step 3: Confirm/extend the existing setup file**
+
+  `frontend/src/__tests__/setup.ts` already exists. Read it. Confirm it imports `@testing-library/jest-dom/vitest` and runs `cleanup()` in `afterEach`. If either is missing, add:
 
   ```ts
   import '@testing-library/jest-dom/vitest';
@@ -84,6 +81,8 @@
   import { cleanup } from '@testing-library/preact';
   afterEach(() => { cleanup(); localStorage.clear(); });
   ```
+
+  The integration tests we add live under `src/__tests__/integration/`; the existing `setupFiles` path covers them.
 
 - [ ] **Step 4: Smoke test**
 

--- a/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-design.md
+++ b/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-design.md
@@ -1,0 +1,159 @@
+# Post-deploy publisher smoke test (design)
+
+**Date:** 2026-05-06
+**Status:** Approved, ready for implementation plan
+**Origin:** A `bbtest` test publisher already exists in production (per the cleanup-followups memory). Each prod deploy currently relies on humans noticing breakage. We want an automated end-to-end check of the publisher lifecycle right after every prod deploy.
+
+## Problem
+
+The integration tests verify behavior in-process against a fake DDB. They don't catch problems that only show up against the real stack: misconfigured IAM, missing env vars on a Lambda, an SES sandbox restriction, an API Gateway route that didn't deploy, a CloudFront cache rule that swallowed a response. Every recent infra hotfix in the git log (`#97 ConditionCheckItem`, `#99 magic-tokens Scan`, `#94 GSI migration`) is the kind of issue that would have been caught by a smoke test that walks the lifecycle through real APIs.
+
+## Policy
+
+- Run automatically on every prod deploy, immediately after the deploy step.
+- Use a dedicated, idempotent test publisher (`bbtest`) — never affects real publisher data.
+- Self-clean: every test run leaves the test publisher in the same starting state, regardless of where it failed.
+- Fail loudly: a smoke-test failure marks the deploy job red. No silent passes.
+- One round-trip max — under 5 minutes wall-clock so it doesn't dominate deploy time.
+
+## Scope
+
+### In
+
+A single scripted journey that exercises the highest-risk surfaces:
+
+1. Apply (with real CAPTCHA bypass via test-only header — see Risks)
+2. Magic-link verify (mailbox poll via Gmail API on the bbtest mailbox, OR test-only handler that returns the token directly to authorized callers)
+3. Admin approve (using a CI-issued service token, not Google OAuth)
+4. Portal status check
+5. Pause + ingest run + verify skip
+6. Resume + ingest run + verify publish
+7. Self-disable + ingest run + verify retraction
+8. Re-enable + reset back to baseline state
+
+Every step asserts the API response shape and the side-effect (DDB row, sidecar JSON, sent mail count).
+
+### Out
+
+- Frontend rendering (the page tests cover that)
+- CAPTCHA itself (bypassed by test path)
+- Real Google OAuth admin sign-in (a CI-only signed token does the admin role)
+- Performance benchmarks
+- Multi-publisher concurrency
+
+## Architecture
+
+```
+scripts/
+└── smoke/
+    ├── publisher-lifecycle.ts        # main entry
+    ├── lib/
+    │   ├── apiClient.ts              # typed wrappers for /publisher-*, /admin/*
+    │   ├── mailbox.ts                # poll for magic link (Gmail API or mailcatcher)
+    │   ├── adminAuth.ts              # signs CI service token
+    │   └── reset.ts                  # idempotent teardown for bbtest
+    └── publisher-lifecycle.test.ts   # the journey, written as Jest test for parity with build-and-test reporting
+```
+
+### Where it runs
+
+`.github/workflows/deploy-production.yml` already exists with post-deploy verification. Add a step after the existing deploy step:
+
+```yaml
+- name: Post-deploy publisher lifecycle smoke
+  run: npm run smoke:publisher
+  env:
+    SMOKE_API_BASE: https://www.chqcal.org
+    SMOKE_BBTEST_EMAIL: ${{ secrets.SMOKE_BBTEST_EMAIL }}
+    SMOKE_BBTEST_GMAIL_REFRESH_TOKEN: ${{ secrets.SMOKE_BBTEST_GMAIL_REFRESH_TOKEN }}
+    SMOKE_ADMIN_SIGNING_KEY: ${{ secrets.SMOKE_ADMIN_SIGNING_KEY }}
+    SMOKE_CAPTCHA_BYPASS_TOKEN: ${{ secrets.SMOKE_CAPTCHA_BYPASS_TOKEN }}
+```
+
+`npm run smoke:publisher` calls `jest --config=jest.smoke.config.js scripts/smoke/publisher-lifecycle.test.ts` so test output appears alongside other Jest output in the deploy log.
+
+### Test-only backend hooks needed
+
+To keep the smoke test simple without weakening prod security:
+
+1. **CAPTCHA bypass.** `verifyCaptcha` already returns `{ ok: true }` when a request carries header `X-Smoke-Bypass: <secret>` matching env `CAPTCHA_BYPASS_TOKEN`. Secret stored in CI and Lambda env. Time-window checks should still apply.
+2. **Admin service token.** `adminHandler` already accepts `Authorization: Bearer <jwt>` from Google OAuth. Add a separate verifier branch: a JWT signed with an HS256 key (env `ADMIN_SMOKE_SIGNING_KEY`) and `sub: 'smoke-bot'` is accepted as admin **only** for routes used by the smoke test (approve application, run ingest, list publishers, disable, re-enable, reset). Other routes reject the smoke token.
+3. **Magic-link out-of-band fetch.** Mail is sent via real SES to `bbtest-<random>@<owned-domain>`. The smoke script polls the bbtest Gmail inbox via Gmail API for the new message and parses the link. Alternative: `MagicTokenService` exposes a test-only DDB lookup-by-email endpoint authorized by the smoke admin token. We pick the second — Gmail polling is fragile.
+
+The first two of these already exist (per memory note about CAPTCHA and admin auth shape). The third is a new test-only endpoint, ~50 lines.
+
+### Idempotent reset
+
+Before the journey runs, `reset.ts` calls a smoke-only admin endpoint `POST /admin/smoke-reset-bbtest` that:
+
+- Deletes any application rows for the bbtest email.
+- Deletes the bbtest publisher's events.
+- Sets the bbtest publisher row to baseline (`enabled=true`, `state='active'`, `trustLevel='auto'`).
+- Clears any in-flight magic-token and email-change rows for the bbtest email.
+
+If the bbtest publisher doesn't exist, reset is a no-op. After the journey, reset runs again so the next run starts clean.
+
+## Test plan (single Jest test, multiple assertions)
+
+```ts
+describe('post-deploy publisher lifecycle', () => {
+  beforeAll(reset);
+  afterAll(reset);
+
+  it('walks bbtest through apply → approve → publish → disable → retract → reset', async () => {
+    const { applicationId } = await api.publisher.apply({ email: bbtestEmail, ... });
+    await api.publisher.verifyApplyMagicLink({ email: bbtestEmail });
+    const { publisherId } = await api.admin.approveApplication(applicationId);
+
+    expect(await api.admin.listPublishers()).toContainEqual(expect.objectContaining({ id: publisherId, enabled: true }));
+
+    await api.admin.runIngest({ publisherId });
+    const publishedCount = await api.admin.eventCount({ publisherId });
+    expect(publishedCount).toBeGreaterThan(0);
+
+    await api.publisher.pause(publisherId);
+    await api.admin.runIngest({ publisherId });
+    expect(await api.admin.eventCount({ publisherId })).toBe(publishedCount);  // unchanged
+
+    await api.publisher.resume(publisherId);
+    await api.publisher.selfDisable(publisherId, { confirmSlug: 'bbtest' });
+    await api.admin.runIngest({ publisherId });
+    expect(await api.admin.eventCount({ publisherId })).toBe(0);  // retracted
+  }, 5 * 60 * 1000);
+});
+```
+
+## CI integration
+
+Belongs only in `deploy-production.yml`, NOT in `build-and-test.yml`. Reasons:
+
+- The journey calls real APIs and can't run on every PR push.
+- Production traffic during the test run sees the real bbtest publisher's transitions; we accept that bbtest events appear/disappear from the live calendar briefly.
+- A failed smoke is a *deploy* failure, not a *PR* failure.
+
+If the smoke fails, the deploy job is marked red. Rollback is a separate decision (the deploy already succeeded; what failed is the verification). The plan adds a runbook entry on what to check when smoke goes red.
+
+## Non-goals
+
+- Synthetic load
+- Cross-region failover
+- Service-worker or browser-cache verification (different test type)
+
+## Risks
+
+- **CAPTCHA bypass token leaking.** Mitigation: bypass token is a high-entropy secret in CI/Lambda env only; rotates with infra; bypass header is logged as a tagged event so misuse is auditable. The bypass works only on the apply route.
+- **Admin smoke signing key leaking.** Mitigation: HS256 key separate from Google OAuth path; smoke token is rejected on routes the smoke test does not need; usage tagged in CloudWatch with `sub: 'smoke-bot'`.
+- **Real-mail flakiness.** Mitigation: prefer the test-only DDB lookup path over Gmail polling (less moving parts).
+- **bbtest leaks into real calendar.** Acceptable: bbtest events are clearly labeled and live <5min during a deploy. The reset step removes them at end.
+- **Smoke runs concurrently with itself.** Mitigation: `concurrency:` on the deploy workflow already serializes deploys, so two smokes can't run at once.
+
+## File counts (estimated)
+
+- Test-only backend endpoints (smoke-reset, magic-token-by-email-for-smoke): ~120 lines + IAM + Terraform if separate route.
+- Smoke script + helpers: ~250 lines.
+- Workflow YAML changes: ~15 lines.
+- Total: ~400 lines plus secret provisioning.
+
+## Open question for implementation phase
+
+Whether to add a separate Lambda function URL for smoke endpoints or piggy-back on `adminHandler` with the dedicated verifier branch. Recommendation: piggy-back, gated by signing-key check; new Lambda is unwarranted infra.

--- a/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-design.md
+++ b/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-design.md
@@ -65,22 +65,21 @@ scripts/
   env:
     SMOKE_API_BASE: https://www.chqcal.org
     SMOKE_BBTEST_EMAIL: ${{ secrets.SMOKE_BBTEST_EMAIL }}
-    SMOKE_BBTEST_GMAIL_REFRESH_TOKEN: ${{ secrets.SMOKE_BBTEST_GMAIL_REFRESH_TOKEN }}
     SMOKE_ADMIN_SIGNING_KEY: ${{ secrets.SMOKE_ADMIN_SIGNING_KEY }}
     SMOKE_CAPTCHA_BYPASS_TOKEN: ${{ secrets.SMOKE_CAPTCHA_BYPASS_TOKEN }}
 ```
+
+(No Gmail refresh token — we use the in-band `/admin/smoke-magic-token-by-email` endpoint instead of mailbox polling.)
 
 `npm run smoke:publisher` calls `jest --config=jest.smoke.config.js scripts/smoke/publisher-lifecycle.test.ts` so test output appears alongside other Jest output in the deploy log.
 
 ### Test-only backend hooks needed
 
-To keep the smoke test simple without weakening prod security:
+All three are NEW additions; none currently exist in the codebase. Implementation order and tasks are in the plan doc.
 
-1. **CAPTCHA bypass.** `verifyCaptcha` already returns `{ ok: true }` when a request carries header `X-Smoke-Bypass: <secret>` matching env `CAPTCHA_BYPASS_TOKEN`. Secret stored in CI and Lambda env. Time-window checks should still apply.
-2. **Admin service token.** `adminHandler` already accepts `Authorization: Bearer <jwt>` from Google OAuth. Add a separate verifier branch: a JWT signed with an HS256 key (env `ADMIN_SMOKE_SIGNING_KEY`) and `sub: 'smoke-bot'` is accepted as admin **only** for routes used by the smoke test (approve application, run ingest, list publishers, disable, re-enable, reset). Other routes reject the smoke token.
-3. **Magic-link out-of-band fetch.** Mail is sent via real SES to `bbtest-<random>@<owned-domain>`. The smoke script polls the bbtest Gmail inbox via Gmail API for the new message and parses the link. Alternative: `MagicTokenService` exposes a test-only DDB lookup-by-email endpoint authorized by the smoke admin token. We pick the second — Gmail polling is fragile.
-
-The first two of these already exist (per memory note about CAPTCHA and admin auth shape). The third is a new test-only endpoint, ~50 lines.
+1. **CAPTCHA bypass.** New behavior in `verifyCaptcha`: when env `CAPTCHA_BYPASS_TOKEN` is set AND the request carries header `X-Smoke-Bypass` matching it, return early with success. Today's signature is `verifyCaptcha(token, action) → Promise<boolean>` — the change must either (a) add a `headers` parameter and thread it through every callsite, or (b) gate via a wrapper that consumes the header before calling `verifyCaptcha`. The plan picks (b) to avoid touching every callsite. Secret stored in CI and Lambda env.
+2. **Admin service token.** New verifier branch in `adminHandler`'s auth resolution: after the Google OAuth check fails, fall through to an HS256 JWT verifier (env `ADMIN_SMOKE_SIGNING_KEY`) with `sub: 'smoke-bot'`. Accepted as admin **only** for the smoke route allowlist (approve application, run ingest, list publishers, disable, re-enable, smoke-reset, smoke-magic-token-by-email, event-count). Other routes 403 even with a valid smoke token.
+3. **Magic-link in-band fetch.** Real SES still sends mail (so the production path is exercised), but the smoke script never reads mail. Instead, a new endpoint `POST /admin/smoke-magic-token-by-email` (admin-allowlisted) returns the latest unverified magic-token row for an email. ~50 lines.
 
 ### Idempotent reset
 
@@ -116,6 +115,9 @@ describe('post-deploy publisher lifecycle', () => {
     expect(await api.admin.eventCount({ publisherId })).toBe(publishedCount);  // unchanged
 
     await api.publisher.resume(publisherId);
+    await api.admin.runIngest({ publisherId });
+    expect(await api.admin.eventCount({ publisherId })).toBeGreaterThan(0);   // republished after resume
+
     await api.publisher.selfDisable(publisherId, { confirmSlug: 'bbtest' });
     await api.admin.runIngest({ publisherId });
     expect(await api.admin.eventCount({ publisherId })).toBe(0);  // retracted

--- a/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-plan.md
+++ b/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-plan.md
@@ -1,0 +1,326 @@
+# Post-deploy publisher smoke test (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an automated end-to-end smoke test that runs after every prod deploy, walking the `bbtest` publisher through apply → approve → publish → pause → self-disable → retract → reset against the real production stack.
+
+**Spec:** `docs/plans/2026-05-06-post-deploy-publisher-smoke-test-design.md`
+
+**Architecture:** Three pieces — (1) test-only backend hooks for CAPTCHA bypass, smoke-admin signing, and idempotent reset; (2) a Jest-shaped smoke script under `scripts/smoke/`; (3) a step in `deploy-production.yml` that runs the smoke after deploy.
+
+**Tech Stack:** TypeScript, Jest (smoke runner), AWS SDK only where unavoidable (Gmail API not used — the design uses a test-only token-by-email lookup instead).
+
+**Branch:** create `feat/post-deploy-publisher-smoke` off `main`.
+
+**Prerequisite (recommended):** the publisher-integration-tests plan landed first, so the `_setXxxForTests` injection patterns and journey shape are already familiar.
+
+---
+
+## Task 1: Decide on the bbtest publisher's stable identity
+
+- [ ] **Step 1: Confirm bbtest exists and capture its current state**
+
+  Per the user's memory note about bbtest cleanup pending, verify what currently exists:
+
+  ```bash
+  aws dynamodb scan --table-name chautauqua-calendar-publishers \
+    --filter-expression 'contains(contactEmail, :v)' \
+    --expression-attribute-values '{":v":{"S":"bbtest"}}'
+  ```
+
+  Record:
+  - The bbtest publisher ID (if any)
+  - Its slug
+  - Its current `enabled` / `state` / `trustLevel`
+
+  If multiple bbtest rows exist, decide which is canonical and delete the others now.
+
+- [ ] **Step 2: Pick a stable email for the smoke**
+
+  Use a domain you control (e.g. `bbtest@chqcal.org` or a Gmail subaddress like `bbtest+smoke@gmail.com`). Record the choice in this plan as `SMOKE_BBTEST_EMAIL` for downstream tasks.
+
+---
+
+## Task 2: Add CAPTCHA bypass
+
+**Files:**
+- Modify: `backend/src/services/captchaService.ts`
+- Modify: `backend/src/__tests__/captchaService.test.ts`
+
+- [ ] **Step 1: Add the bypass branch**
+
+  At the top of `verifyCaptcha`, before any HTTP call:
+
+  ```ts
+  const bypassToken = process.env.CAPTCHA_BYPASS_TOKEN;
+  if (bypassToken && bypassHeader && bypassHeader === bypassToken) {
+    console.info('[captcha] bypass accepted', { source: 'smoke', requestId });
+    return { ok: true, score: 1 };
+  }
+  ```
+
+  The function signature already takes a `headers` map (or add one if missing); read `X-Smoke-Bypass`. If `CAPTCHA_BYPASS_TOKEN` is unset (production-without-smoke or local dev), the bypass is permanently disabled regardless of header.
+
+- [ ] **Step 2: Tests**
+
+  Add to `captchaService.test.ts`:
+  - Bypass accepted when env + header match
+  - Bypass rejected when env unset (header ignored)
+  - Bypass rejected when header doesn't match env
+  - Bypass log line emitted on accept (assert via spy on `console.info`)
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add backend/src/services/captchaService.ts backend/src/__tests__/captchaService.test.ts
+  git commit -m "feat(captcha): test-only bypass via X-Smoke-Bypass header"
+  ```
+
+---
+
+## Task 3: Add smoke-admin signing-key auth
+
+**Files:**
+- Modify: `backend/src/handlers/adminHandler.ts`
+- New: `backend/src/services/smokeAdminAuth.ts`
+- New: `backend/src/__tests__/smokeAdminAuth.test.ts`
+
+- [ ] **Step 1: Define the smoke admin verifier**
+
+  In `smokeAdminAuth.ts`:
+
+  ```ts
+  export function verifySmokeAdminToken(authHeader: string | undefined): { sub: string } | null;
+  ```
+
+  Reads env `ADMIN_SMOKE_SIGNING_KEY`. Verifies HS256 JWT with claims `{ sub: 'smoke-bot', iss: 'smoke', exp: <future> }`. Returns `null` on missing env, missing header, bad signature, or expired token.
+
+- [ ] **Step 2: Wire into adminHandler.ts**
+
+  In the auth-resolution flow, after the Google OAuth check fails, fall through to `verifySmokeAdminToken`. Allow only on this route allowlist:
+
+  ```ts
+  const SMOKE_ADMIN_ROUTE_ALLOWLIST = new Set([
+    'POST /admin/publisher-applications/{id}/approve',
+    'POST /admin/publisher-run-ingest',
+    'GET  /admin/publishers',
+    'POST /admin/publishers/{id}/disable',
+    'POST /admin/publishers/{id}/enable',
+    'POST /admin/smoke-reset-bbtest',
+    'POST /admin/smoke-magic-token-by-email',
+    'POST /admin/publishers/{id}/events/count',
+  ]);
+  ```
+
+  Other routes return 403 even with a valid smoke token. Tag CloudWatch logs with `adminSubject: 'smoke-bot'` whenever this branch fires.
+
+- [ ] **Step 3: Tests**
+
+  In `smokeAdminAuth.test.ts`:
+  - Valid token + allowlisted route → admin context returned
+  - Valid token + non-allowlisted route → null
+  - Invalid signature → null
+  - Expired → null
+  - Missing env → null even with valid-looking token
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add backend/src/services/smokeAdminAuth.ts \
+          backend/src/__tests__/smokeAdminAuth.test.ts \
+          backend/src/handlers/adminHandler.ts
+  git commit -m "feat(admin): smoke-bot signing-key auth for post-deploy tests"
+  ```
+
+---
+
+## Task 4: Add smoke-only endpoints
+
+**Files:**
+- Modify: `backend/src/handlers/adminHandler.ts`
+- New: `backend/src/services/smokeReset.ts`
+- New: `backend/src/__tests__/smokeReset.test.ts`
+- Modify: `infrastructure/<the file that defines admin Lambda env vars>`
+
+- [ ] **Step 1: `POST /admin/smoke-reset-bbtest`**
+
+  In `smokeReset.ts`, export `resetBbtest({ registry, eventStore, applications, magicTokens, bbtestEmail })`:
+
+  - Delete all application rows for `bbtestEmail`.
+  - Delete all magic-token rows for `bbtestEmail`.
+  - For any publisher with `contactEmail === bbtestEmail`:
+    - Delete all events for that publisher (call `eventStore.deleteAllForPublisher`).
+    - Set `enabled=true`, `state='active'`, `trustLevel='auto'`.
+
+  Idempotent: if no bbtest rows exist, the function is a no-op and returns `{ rowsAffected: 0 }`.
+
+- [ ] **Step 2: `POST /admin/smoke-magic-token-by-email`**
+
+  Body: `{ email }`. Looks up the most recent unverified magic token for that email and returns the token string. Used by the smoke script to skip the SES round-trip. Smoke-admin allowlisted only.
+
+- [ ] **Step 3: `POST /admin/publishers/{id}/events/count`**
+
+  Returns `{ count: number }` for that publisher's events. Smoke-admin allowlisted; admins get this through `GET /admin/publishers` already.
+
+- [ ] **Step 4: Add `ADMIN_SMOKE_SIGNING_KEY` and `CAPTCHA_BYPASS_TOKEN` to admin Lambda env**
+
+  In Terraform (`infrastructure/`), add both vars to the admin Lambda's `environment.variables` block, sourcing from a new `aws_ssm_parameter` or `aws_secretsmanager_secret` for each. Apply.
+
+- [ ] **Step 5: Tests + commit**
+
+  Tests in `smokeReset.test.ts` cover empty-state idempotency, populated-state cleanup, and partial cleanup (e.g. when only a magic-token row exists).
+
+  ```bash
+  git add backend/src/services/smokeReset.ts \
+          backend/src/__tests__/smokeReset.test.ts \
+          backend/src/handlers/adminHandler.ts \
+          infrastructure/
+  git commit -m "feat(admin): smoke-only endpoints (reset, token-by-email, event-count)"
+  ```
+
+---
+
+## Task 5: Smoke script
+
+**Files:**
+- New: `scripts/smoke/lib/apiClient.ts`
+- New: `scripts/smoke/lib/adminAuth.ts`
+- New: `scripts/smoke/lib/reset.ts`
+- New: `scripts/smoke/publisher-lifecycle.test.ts`
+- New: `scripts/smoke/jest.smoke.config.js`
+- Modify: `package.json` (root) — add `"smoke:publisher"` script
+
+- [ ] **Step 1: API client**
+
+  Thin typed wrappers around `fetch(SMOKE_API_BASE + path)` for every endpoint the smoke uses. Each method takes typed params, parses JSON, throws `SmokeApiError(status, body)` on non-2xx.
+
+- [ ] **Step 2: Admin token signer**
+
+  ```ts
+  export function signSmokeAdminToken(opts: { ttlSec?: number }): string;
+  ```
+
+  Uses `jsonwebtoken` to HS256-sign with `process.env.SMOKE_ADMIN_SIGNING_KEY`. Default TTL 5 minutes.
+
+- [ ] **Step 3: Reset helper**
+
+  Calls `POST /admin/smoke-reset-bbtest`. Logs the result.
+
+- [ ] **Step 4: The journey test**
+
+  In `publisher-lifecycle.test.ts`, write a single `it(...)` matching the design doc's Test Plan code block. Use a 5-minute timeout.
+
+- [ ] **Step 5: Jest config**
+
+  In `jest.smoke.config.js`:
+
+  ```js
+  module.exports = {
+    rootDir: __dirname,
+    testMatch: ['<rootDir>/*.test.ts'],
+    transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/../../backend/tsconfig.json' }] },
+    testTimeout: 5 * 60 * 1000,
+  };
+  ```
+
+- [ ] **Step 6: Root script**
+
+  In root `package.json`:
+
+  ```json
+  "scripts": {
+    "smoke:publisher": "jest --config=scripts/smoke/jest.smoke.config.js"
+  }
+  ```
+
+- [ ] **Step 7: Local dry-run against staging or a personal stack (optional but recommended)**
+
+  If the user has a personal stack: `SMOKE_API_BASE=https://staging.chqcal.org npm run smoke:publisher`. Confirm green; confirm reset cleans up.
+
+- [ ] **Step 8: Commit**
+
+  ```bash
+  git add scripts/smoke/ package.json
+  git commit -m "test(smoke): publisher-lifecycle smoke script"
+  ```
+
+---
+
+## Task 6: Wire into deploy-production.yml
+
+**Files:**
+- Modify: `.github/workflows/deploy-production.yml`
+
+- [ ] **Step 1: Add post-deploy smoke step**
+
+  After the existing deploy step, add:
+
+  ```yaml
+  - name: Post-deploy publisher lifecycle smoke
+    run: npm run smoke:publisher
+    env:
+      SMOKE_API_BASE: https://www.chqcal.org
+      SMOKE_BBTEST_EMAIL: ${{ secrets.SMOKE_BBTEST_EMAIL }}
+      SMOKE_ADMIN_SIGNING_KEY: ${{ secrets.SMOKE_ADMIN_SIGNING_KEY }}
+      SMOKE_CAPTCHA_BYPASS_TOKEN: ${{ secrets.SMOKE_CAPTCHA_BYPASS_TOKEN }}
+  ```
+
+- [ ] **Step 2: Provision the GitHub secrets**
+
+  In the GitHub repo settings, add secrets:
+  - `SMOKE_BBTEST_EMAIL` — the bbtest email picked in Task 1
+  - `SMOKE_ADMIN_SIGNING_KEY` — the same value provisioned to the Lambda env
+  - `SMOKE_CAPTCHA_BYPASS_TOKEN` — the same value provisioned to the Lambda env
+
+  These can't be set from a workflow file; the user does it in the UI.
+
+- [ ] **Step 3: Commit + open PR**
+
+  ```bash
+  git add .github/workflows/deploy-production.yml
+  git commit -m "ci(deploy): run publisher-lifecycle smoke after prod deploy"
+  git push -u origin feat/post-deploy-publisher-smoke
+  gh pr create --title "test(smoke): post-deploy publisher lifecycle smoke" --body "$(cat <<'EOF'
+## Summary
+- New `scripts/smoke/publisher-lifecycle.test.ts` walks bbtest through apply → approve → publish → pause → self-disable → retract → reset against the real prod stack after every deploy.
+- Test-only backend hooks: CAPTCHA bypass header, smoke-admin signing-key auth, smoke reset endpoint.
+
+## Manual follow-up after merge
+- Provision Lambda env: `CAPTCHA_BYPASS_TOKEN`, `ADMIN_SMOKE_SIGNING_KEY`.
+- Provision GitHub secrets: `SMOKE_BBTEST_EMAIL`, `SMOKE_ADMIN_SIGNING_KEY`, `SMOKE_CAPTCHA_BYPASS_TOKEN`.
+- Trigger a deploy and verify the smoke step runs and passes.
+
+## Risk
+- Bypass tokens are high-entropy secrets; rotate via Terraform if leaked.
+- Smoke-admin token is allowlisted to a small set of routes (see `smokeAdminAuth.ts`).
+
+## Test plan
+- [ ] All new unit tests green
+- [ ] Local dry-run of `scripts/smoke/publisher-lifecycle.test.ts` against staging passes
+- [ ] First post-merge deploy runs the smoke and reports green
+EOF
+  )"
+  ```
+
+---
+
+## Task 7: Runbook entry
+
+**Files:**
+- New (or modify): `docs/runbooks/publisher-smoke-failed.md`
+
+- [ ] **Step 1: Write the runbook**
+
+  Cover:
+  - What the smoke does
+  - How to interpret each step's failure
+  - How to reset bbtest manually (`POST /admin/smoke-reset-bbtest`)
+  - How to disable the smoke step temporarily if it's flaking
+  - Rotation steps for the bypass token and signing key
+
+- [ ] **Step 2: Commit**
+
+  ```bash
+  git add docs/runbooks/publisher-smoke-failed.md
+  git commit -m "docs(runbooks): publisher smoke-failure recovery"
+  ```

--- a/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-plan.md
+++ b/docs/plans/2026-05-06-post-deploy-publisher-smoke-test-plan.md
@@ -32,8 +32,19 @@
   - The bbtest publisher ID (if any)
   - Its slug
   - Its current `enabled` / `state` / `trustLevel`
+  - Its `sourceUrl`
 
   If multiple bbtest rows exist, decide which is canonical and delete the others now.
+
+- [ ] **Step 1a: Confirm the bbtest feed serves at least one valid event**
+
+  Hit the recorded `sourceUrl` and confirm the JSON parses against the publisher-format schema and contains ≥ 1 future event:
+
+  ```bash
+  curl -fsSL "<sourceUrl>" | jq '.events | length'
+  ```
+
+  If empty or unreachable, the smoke's `expect(publishedCount).toBeGreaterThan(0)` will fail every run. Either fix the feed (point bbtest at a synthetic always-on JSON we host in S3) or stop and bring this back to the user. Do NOT proceed past Task 1 with a dead feed.
 
 - [ ] **Step 2: Pick a stable email for the smoke**
 
@@ -47,27 +58,38 @@
 - Modify: `backend/src/services/captchaService.ts`
 - Modify: `backend/src/__tests__/captchaService.test.ts`
 
-- [ ] **Step 1: Add the bypass branch**
+- [ ] **Step 1: Add the bypass branch — wrapper approach (no signature change)**
 
-  At the top of `verifyCaptcha`, before any HTTP call:
+  Today's signature is `verifyCaptcha(token: string, action?: string): Promise<boolean>`. We don't want to widen it (that touches every callsite). Instead, add a sibling wrapper that consumes the bypass header and falls through to `verifyCaptcha`:
 
   ```ts
-  const bypassToken = process.env.CAPTCHA_BYPASS_TOKEN;
-  if (bypassToken && bypassHeader && bypassHeader === bypassToken) {
-    console.info('[captcha] bypass accepted', { source: 'smoke', requestId });
-    return { ok: true, score: 1 };
+  // backend/src/services/captchaService.ts
+  export async function verifyCaptchaWithBypass(
+    token: string,
+    action: string | undefined,
+    headers: { [k: string]: string | undefined },
+  ): Promise<boolean> {
+    const bypassToken = process.env.CAPTCHA_BYPASS_TOKEN;
+    const bypassHeader = headers['x-smoke-bypass'] ?? headers['X-Smoke-Bypass'];
+    if (bypassToken && bypassHeader && bypassHeader === bypassToken) {
+      console.info('[captcha] bypass accepted', { source: 'smoke' });
+      return true;
+    }
+    return verifyCaptcha(token, action);
   }
   ```
 
-  The function signature already takes a `headers` map (or add one if missing); read `X-Smoke-Bypass`. If `CAPTCHA_BYPASS_TOKEN` is unset (production-without-smoke or local dev), the bypass is permanently disabled regardless of header.
+  Then update only the apply route (the single callsite the smoke needs to bypass) to call `verifyCaptchaWithBypass(token, action, event.headers)` instead of `verifyCaptcha(token, action)`. All other callsites keep using `verifyCaptcha` and are unaffected.
+
+  If `CAPTCHA_BYPASS_TOKEN` is unset (production-without-smoke or local dev), the bypass is permanently disabled regardless of header — `verifyCaptcha` runs as today.
 
 - [ ] **Step 2: Tests**
 
-  Add to `captchaService.test.ts`:
-  - Bypass accepted when env + header match
-  - Bypass rejected when env unset (header ignored)
-  - Bypass rejected when header doesn't match env
-  - Bypass log line emitted on accept (assert via spy on `console.info`)
+  Add to `captchaService.test.ts` (covering the new `verifyCaptchaWithBypass` wrapper):
+  - Bypass accepted when env + header match → returns `true`, no fetch made
+  - Bypass rejected when env unset (header ignored) → falls through to `verifyCaptcha`
+  - Bypass rejected when header doesn't match env → falls through
+  - Bypass log line emitted on accept. **Note:** `backend/src/__tests__/setup.ts` replaces `global.console.info` with a `jest.fn()`. To assert on the log, read directly from that mock: `expect((global.console.info as jest.Mock).mock.calls).toContainEqual(...)` rather than spying anew with `jest.spyOn(console, 'info')`.
 
 - [ ] **Step 3: Commit**
 
@@ -212,13 +234,23 @@
 
 - [ ] **Step 5: Jest config**
 
-  In `jest.smoke.config.js`:
+  In `jest.smoke.config.js` — use an inline tsconfig override so the smoke is decoupled from `backend/tsconfig.json` (changes to backend's `target`, `lib`, or `moduleResolution` shouldn't silently break the smoke):
 
   ```js
   module.exports = {
     rootDir: __dirname,
     testMatch: ['<rootDir>/*.test.ts'],
-    transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/../../backend/tsconfig.json' }] },
+    transform: {
+      '^.+\\.ts$': ['ts-jest', {
+        tsconfig: {
+          target: 'ES2022',
+          module: 'commonjs',
+          esModuleInterop: true,
+          resolveJsonModule: true,
+          strict: true,
+        },
+      }],
+    },
     testTimeout: 5 * 60 * 1000,
   };
   ```
@@ -314,7 +346,12 @@ EOF
   Cover:
   - What the smoke does
   - How to interpret each step's failure
-  - How to reset bbtest manually (`POST /admin/smoke-reset-bbtest`)
+  - How to reset bbtest manually (`POST /admin/smoke-reset-bbtest`) — include a working `curl` example using a smoke admin token signed locally with the rotated signing key, e.g.:
+    ```bash
+    TOKEN=$(node -e "console.log(require('jsonwebtoken').sign({sub:'smoke-bot',iss:'smoke'}, process.env.ADMIN_SMOKE_SIGNING_KEY, {algorithm:'HS256', expiresIn:'5m'}))")
+    curl -fsSL -X POST -H "Authorization: Bearer $TOKEN" https://www.chqcal.org/admin/smoke-reset-bbtest
+    ```
+  - Recovery for stale bbtest state when CI was killed mid-journey before `afterAll(reset)` fired (manual reset call above + `gh run list --workflow=deploy-production.yml` to confirm last run).
   - How to disable the smoke step temporarily if it's flaking
   - Rotation steps for the bypass token and signing key
 

--- a/docs/plans/2026-05-06-publisher-integration-tests-design.md
+++ b/docs/plans/2026-05-06-publisher-integration-tests-design.md
@@ -1,0 +1,179 @@
+# Publisher self-service & ingest — backend integration tests (design)
+
+**Date:** 2026-05-06
+**Status:** Approved, ready for implementation plan
+**Origin:** User request to integration-test publisher self-service plus the recent reconciler-clobber (PR #100) and self-disable-retracts (PR #78) regressions, ahead of relying on these flows in production.
+
+## Problem
+
+The backend has thorough per-handler unit tests, but only one true cross-handler integration test (`publisherIngestHandler.integration.test.ts`) and even that one mocks every collaborator. There is no test that wires `publisherPortalHandler` + `adminHandler` + `publisherIngestHandler` against shared state and walks a full publisher journey. Two recent bugs — admin approvals clobbered on re-ingest (PR #100) and self-disable not retracting events (PR #78) — would have been caught by such tests.
+
+A previous attempt at integration tests using DynamoDB Local was removed because of "service container complexity" (see footer of `.github/workflows/build-and-test.yml`). The plan here uses an **in-process in-memory DynamoDB fake** instead, sidestepping that operational cost while preserving the same end-to-end coverage.
+
+## Policy
+
+- "Integration" means: real handler routing, real services, single shared in-memory DDB. The only mocks are true externals — SES mail, Lambda invoker, the CAPTCHA verifier, the JWT signer's clock-source.
+- Tests are journey-shaped, not endpoint-shaped: each `it(...)` walks a publisher through several handler calls and asserts end state on the shared store.
+- Test failures should pinpoint behavior, not implementation. Assertions read against the actor API (`harness.events.statesOf(publisherId)`), not raw DDB rows.
+- The in-memory DDB fake fails loudly on any unsupported command shape — better a missing case break a test than silently produce wrong data.
+
+## Scope
+
+### In
+
+End-to-end coverage of:
+
+- Application lifecycle (apply → admin approve / reject → portal access)
+- Self-service portal actions (profile update, email change with magic-link, pause, resume, fetch-now, self-disable)
+- Admin actions (pause, disable, approve event, reject event, run-ingest button)
+- Ingest behavior (auto-trust publish, review-trust pending, retraction on disable, sticky `published` across re-ingest)
+- Feed edge cases (network error, schema-invalid feed, unchanged `lastModified`, threshold halt)
+- Auth/abuse (CAPTCHA toggle, magic-token replay/expiry, per-IP rate-limit window)
+- DNS-rebinding guard on fetch-now (PR #85 regression)
+
+### Out
+
+- Frontend code, service-worker (covered by separate spec)
+- Real DynamoDB / docker-compose
+- Real SES, real Lambda invocation
+- Google OAuth admin sign-in (admin actions go through `PublisherAdminService` with a fake admin identity)
+- Frontend portal pages (covered by separate spec — `frontend-portal-integration-tests`)
+
+## Architecture
+
+```
+backend/src/__tests__/integration/
+├── harness/
+│   ├── inMemoryDocClient.ts     # Fake DynamoDBDocumentClient.send()
+│   ├── fakes.ts                 # MailCapture, FakeFeedFetcher, FakeLambdaInvoker, ClockController, CaptchaToggle
+│   ├── harness.ts               # createHarness({ now }) — wires real services, injects via _setXxxForTests
+│   └── actors.ts                # publisher / admin / ingest action helpers
+├── lifecycle.test.ts
+├── selfService.test.ts
+├── adminControls.test.ts
+├── ingestEdgeCases.test.ts
+└── authAndLimits.test.ts
+```
+
+### In-memory DDB fake
+
+Implements the `.send(cmd)` shape of `DynamoDBDocumentClient`. Storage is `Map<tableName, Map<keyJson, item>>`. Supported commands: `Get`, `Put`, `Update`, `Delete`, `Query`, `Scan`, `BatchGet`, `BatchWrite`, `TransactWrite` (including `ConditionCheck` items). `ExpressionAttributeNames`/`Values` substitution and these condition operators: `attribute_exists`, `attribute_not_exists`, `=`, `<>`, `<`, `>`, `<=`, `>=`, `AND`, `OR`. On condition fail, throws an error whose `name` is `'ConditionalCheckFailedException'` so service code that catches by name keeps working.
+
+GSI support: each table can declare GSIs at construction time; `Query` against an `IndexName` scans the map for items whose hash/sort match. Fine for test volumes (hundreds of items at most).
+
+The fake **does not** implement: streams, TTL, transactions across tables (it does support cross-table within a single `TransactWrite`), pagination beyond `LastEvaluatedKey` echo, server-side filters that aren't `KeyConditionExpression`/`FilterExpression` literals.
+
+### Wiring
+
+`createHarness({ now })` returns:
+
+```ts
+{
+  now: ClockController,                  // .advance(ms) | .set(date)
+  feeds: FakeFeedFetcher,                // .set(publisherId, FetchResult)
+  mail: MailCapture,                     // .lastTo(addr) | .all() | .clear()
+  invoker: FakeLambdaInvoker,            // routes to runIngest() in-process
+  captcha: CaptchaToggle,                // .pass() | .fail()
+  events: { statesOf(pubId): Record<eventId,state>, count(pubId): number },
+  publisher: { apply, verifyApplyMagicLink, login, status, updateProfile,
+               requestEmailChange, confirmEmailChange,
+               pause, resume, fetchNow, selfDisable },
+  admin: { approveApplication, rejectApplication, listPublishers,
+           pause, resume, disable, approveEvent, rejectEvent, runIngest },
+  ingest: { run() }                      // direct call to publisherIngestHandler.runIngest
+}
+```
+
+Each actor builds an `APIGatewayProxyEvent`, optionally signs a session JWT with the harness-owned secret, and invokes the handler. Errors are unwrapped from the JSON response and re-thrown as typed errors so `expect(...).rejects.toThrow(...)` works.
+
+### Handler wiring approach
+
+Real services are constructed against the fake doc client and injected through the existing `_setXxxForTests` hooks:
+
+- `publisherPortalHandler._setStatusRegistryForTests`
+- `publisherPortalHandler._setAppServiceForTests`
+- `publisherPortalHandler._setEmailChangeServiceForTests`
+- `publisherPortalHandler._setSelfDisableActionForTests` / `_setSelfDisableDepsForTests`
+- `publisherPortalHandler._setRateLimiterForTests`
+- `adminHandler._setPublisherAdminForTests`
+- `adminHandler._setLambdaClientForTests`
+
+Module-level mocks (one per file, declared at top):
+
+- `../services/publisherAuthService.verifyPublisherJwt` — accepts a stub session created by the harness
+- `../services/captchaService.verifyCaptcha` — wired to `CaptchaToggle`
+- `../services/mailService.SesMailService` — wired to `MailCapture`
+- `../services/publisherIngestInvoker.lambdaClient.send` — routed to in-process `runIngest`
+
+`setup.ts` mocks `@aws-sdk/lib-dynamodb` globally; integration files start with `jest.unmock('@aws-sdk/lib-dynamodb')` so the SDK type exists but our services receive the *fake* client by constructor (the SDK is never actually called).
+
+## Test plan
+
+### lifecycle.test.ts
+
+1. Auto-trust publisher: apply → verify magic-link → admin approve → ingest publishes events as `published`.
+2. Review-trust publisher: apply → admin approve → ingest creates `pending` events → admin approves event → re-ingest with bumped `lastModified` keeps state `published`. **(PR #100 regression — sticky approvals.)**
+3. Application rejection: applicant gets reject email; no publisher row created; portal login attempt 401s.
+4. Application duplicate-email: second apply with same email returns `EmailAlreadyInUseError`.
+
+### selfService.test.ts
+
+5. Pause: portal pause → next ingest skips that publisher (no `applyDiff`, no sidecar publish) → resume → ingest publishes.
+6. Profile update: name + contact change persists on registry; invalid input (empty name, malformed URL) returns 400 without writing.
+7. Email change: request → magic-link confirm with new email → portal login with new email succeeds; re-using the magic link returns 400.
+8. Email change cancellation by old-email link works; later confirm with the same token fails.
+9. Self-disable: portal disable with correct typed slug → `enabled=false`; next ingest retracts events. **(PR #78 regression.)**
+10. Self-disable typed-slug mismatch returns 400; publisher remains enabled; no events affected.
+11. Fetch-now: portal call invokes ingest in-process via `FakeLambdaInvoker`; new feed events appear within the same test step.
+
+### adminControls.test.ts
+
+12. Admin disable → next ingest retracts events.
+13. Admin pause → next ingest skips.
+14. Admin reject event → re-ingest preserves `rejected` state (no clobber).
+15. Admin approve event idempotent: approving an already-published event is a no-op.
+16. Admin "Run ingest now" button (PR #96) routes through `_setLambdaClientForTests` and triggers a single ingest cycle.
+
+### ingestEdgeCases.test.ts
+
+17. Fetch network error: `recordFetchOutcome` records `network_error`; no diff applied; prior events preserved.
+18. Schema-invalid feed: `recordFetchOutcome` records `validation_failed`; no diff.
+19. Unchanged feed (`lastModified` same on every event): no `applyDiff`, no sidecar publish.
+20. Threshold halt: feed shrinks from N events to <50% of N → `setThresholdHalt` called; events untouched until admin clears.
+21. Disabled publisher in registry: ingest skips entirely.
+
+### authAndLimits.test.ts
+
+22. Apply with failing CAPTCHA returns 400; no application created.
+23. Apply with passing CAPTCHA succeeds.
+24. Magic token: replay rejected; expired (clock advanced past TTL) rejected; valid one-shot succeeds.
+25. Per-IP rate limit on portal POST: 5 succeed, 6th in window returns 429; advance clock past window → succeeds again.
+26. DNS-rebinding guard on fetch-now: `0.0.0.0`, `127.0.0.1`, `169.254.169.254` source URLs rejected with 400 (PR #85 regression).
+
+## CI integration
+
+Tests live under the existing Jest config and run as part of `npm run build --workspace=backend` (which runs `prebuild → test:ci`). No new Jest project. The CI workflow change is to broaden the trigger from `pull_request: [main]` only to `push:` on any branch, plus a `concurrency:` block to dedupe rapid re-pushes (the latter is covered by a separate spec — `ci-concurrency-dedupe`).
+
+Required-check enforcement is a GitHub repo settings change (Settings → Branches → main → Require status checks). Documented in the implementation plan but not modifiable from a workflow file.
+
+## Non-goals
+
+- Performance / load testing
+- Mutation testing
+- Property-based fuzzing of feed parsing
+- Coverage floor enforcement (separate spec — `ci-coverage-floor`)
+- Frontend portal coverage (separate spec — `frontend-portal-integration-tests`)
+- Production smoke tests (separate spec — `post-deploy-publisher-smoke-test`)
+
+## Risks
+
+- **In-memory DDB fake drift from real DDB.** Mitigation: keep the supported-command surface narrow and fail loudly on anything else; review the fake against real-DDB behavior whenever a service starts using a new command shape.
+- **Module-mocked auth/captcha could mask real vulnerabilities.** Mitigation: per-module unit tests for `verifyPublisherJwt`, `verifyCaptcha` already exist and stay in place.
+- **Test-only injection hooks add API surface.** Already accepted pattern in this repo; no new hooks needed for this spec.
+
+## File counts (estimated)
+
+- In-memory DDB fake: 250–350 lines
+- Harness + actors + fakes: 300–400 lines
+- Five test files: 800–1,200 lines combined
+- Total: ~1,400–1,950 lines, single PR

--- a/docs/plans/2026-05-06-publisher-integration-tests-design.md
+++ b/docs/plans/2026-05-06-publisher-integration-tests-design.md
@@ -61,7 +61,7 @@ Implements the `.send(cmd)` shape of `DynamoDBDocumentClient`. Storage is `Map<t
 
 GSI support: each table can declare GSIs at construction time; `Query` against an `IndexName` scans the map for items whose hash/sort match. Fine for test volumes (hundreds of items at most).
 
-The fake **does not** implement: streams, TTL, transactions across tables (it does support cross-table within a single `TransactWrite`), pagination beyond `LastEvaluatedKey` echo, server-side filters that aren't `KeyConditionExpression`/`FilterExpression` literals.
+The fake **does** commit a single `TransactWrite` atomically across in-memory tables (all items succeed or none do, including items targeting different tables in the same call). It **does not** implement: streams, TTL, distributed ACID guarantees beyond a single `TransactWrite` call, `TransactGetItems`, PartiQL (`ExecuteStatement`), pagination beyond `LastEvaluatedKey` echo, server-side filters that aren't `KeyConditionExpression`/`FilterExpression` literals.
 
 ### Wiring
 

--- a/docs/plans/2026-05-06-publisher-integration-tests-plan.md
+++ b/docs/plans/2026-05-06-publisher-integration-tests-plan.md
@@ -1,0 +1,454 @@
+# Publisher self-service & ingest — backend integration tests (implementation plan)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add backend integration tests that wire `publisherPortalHandler` + `adminHandler` + `publisherIngestHandler` together against a shared in-memory DynamoDB fake, walking full publisher journeys end-to-end. Wire these tests into CI so they gate every push.
+
+**Spec:** `docs/plans/2026-05-06-publisher-integration-tests-design.md`
+
+**Architecture:** New `backend/src/__tests__/integration/` directory with a harness that constructs real services against a fake `DynamoDBDocumentClient` and injects them via the existing `_setXxxForTests` hooks on each handler. Tests are journey-shaped (`it('walks ...', async () => ...)`).
+
+**Tech Stack:** TypeScript, Jest, Node 24, in-process fake DDB, no docker.
+
+**Branch:** create `feat/publisher-integration-tests` off `main`.
+
+---
+
+## Task 1: Build the in-memory DynamoDB fake
+
+**Files:**
+- New: `backend/src/__tests__/integration/harness/inMemoryDocClient.ts`
+- New: `backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts`
+
+The fake must implement enough of `DynamoDBDocumentClient.send(cmd)` for all services in `backend/src/services/` to round-trip Get/Put/Update/Delete/Query/Scan/BatchGet/BatchWrite/TransactWrite. Conditional expressions cover `attribute_exists`, `attribute_not_exists`, `=`, `<>`, `<`, `>`, `<=`, `>=`, `AND`, `OR`. On condition failure, throw an error whose `name === 'ConditionalCheckFailedException'`.
+
+- [ ] **Step 1: Survey actual command usage**
+
+  Run from repo root and record the result in a comment at the top of `inMemoryDocClient.ts`:
+
+  ```bash
+  grep -rE '(Get|Put|Update|Delete|Query|Scan|BatchGet|BatchWrite|TransactWrite)Command' backend/src/services backend/src/handlers | sort -u
+  ```
+
+  Use the result to ensure every command type seen in production code has a fake implementation.
+
+- [ ] **Step 2: Implement the fake**
+
+  Create `inMemoryDocClient.ts` exporting:
+
+  ```ts
+  export interface TableSpec {
+    name: string;
+    hashKey: string;
+    sortKey?: string;
+    gsis?: { name: string; hashKey: string; sortKey?: string }[];
+  }
+  export class InMemoryDocClient {
+    constructor(specs: TableSpec[]);
+    send(cmd: any): Promise<any>;
+    /** Test helpers: */
+    dump(table: string): unknown[];
+    seed(table: string, items: unknown[]): void;
+    clear(): void;
+  }
+  ```
+
+  Backing storage: `Map<table, Map<keyJson, item>>` where `keyJson` is `JSON.stringify({ [hashKey]: ..., [sortKey]: ... })`. GSIs scan all items, filter by hash, optionally sort by sort key.
+
+  Condition-expression evaluator: tokenize on whitespace and operators, substitute `ExpressionAttributeNames` (`#name`) and `ExpressionAttributeValues` (`:val`), then walk an AST. Keep the AST minimal — just function-calls and binary operators in the supported set.
+
+- [ ] **Step 3: Write a self-test that validates the fake**
+
+  In `inMemoryDocClient.test.ts`:
+
+  - Put + Get round-trip with hash-only key
+  - Put + Get round-trip with hash+sort key
+  - Put with `attribute_not_exists(pk)` succeeds on empty, fails on existing → throws `ConditionalCheckFailedException`
+  - Update with `SET #x = :v` updates one attribute
+  - Update with `ADD #x :n` increments a number
+  - Query with `KeyConditionExpression: '#pk = :pk'` returns matching items
+  - Query against a GSI returns matching items, sorted ascending by sort key
+  - Scan with `FilterExpression` filters items
+  - TransactWrite with three Puts atomically commits; if one Put has a failing condition, none commit
+  - BatchWrite with both Puts and Deletes processes all
+  - Unsupported command shape (e.g. ProjectionExpression) throws a clear error
+
+  Run:
+
+  ```bash
+  cd backend && npx jest inMemoryDocClient
+  ```
+
+  All tests must pass before continuing.
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add backend/src/__tests__/integration/harness/inMemoryDocClient.ts \
+          backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
+  git commit -m "test(integration): in-memory DynamoDB fake for backend integration tests"
+  ```
+
+---
+
+## Task 2: Build the harness — fakes, clock, mail capture
+
+**Files:**
+- New: `backend/src/__tests__/integration/harness/fakes.ts`
+- New: `backend/src/__tests__/integration/harness/harness.ts`
+
+- [ ] **Step 1: Implement the fakes module**
+
+  In `fakes.ts`:
+
+  ```ts
+  export class ClockController {
+    constructor(now: Date);
+    get now(): Date;
+    advance(ms: number): void;
+    set(date: Date | string): void;
+  }
+  export class MailCapture {
+    constructor();
+    sendMail(params: SendMailParams): Promise<void>;
+    all(): SentMail[];
+    lastTo(email: string): SentMail | undefined;
+    clear(): void;
+  }
+  export class FakeFeedFetcher {
+    set(publisherId: string, result: FetchResult): void;
+    /** matches publisherFeedFetcher signature */
+    fetch(publisher: PublisherRecord): Promise<FetchResult>;
+  }
+  export class FakeLambdaInvoker {
+    constructor(private readonly run: () => Promise<void>);
+    /** matches lambdaClient.send shape */
+    send(cmd: InvokeCommand): Promise<{ StatusCode: 202 }>;
+  }
+  export class CaptchaToggle {
+    pass(): void;
+    fail(): void;
+    /** module-mock target */
+    verify(token: string): Promise<{ ok: boolean }>;
+  }
+  ```
+
+- [ ] **Step 2: Implement `createHarness({ now })`**
+
+  In `harness.ts`, build the wiring. Constructs the fake DDB with the table specs that match production (publishers, publisher-events, applications, magic-tokens, rate-limit). Constructs real services against it. Mints a per-harness JWT secret; provides a `signSession({ publisherId })` helper.
+
+  Calls each `_setXxxForTests` injection point. Stores the call set so `harness.dispose()` resets them all to `null`.
+
+  Module-mocks (declared once in each test file, since `jest.mock` is hoisted):
+
+  ```ts
+  jest.mock('../../services/publisherAuthService');
+  jest.mock('../../services/captchaService');
+  jest.mock('../../services/mailService');
+  jest.mock('../../services/publisherIngestInvoker');
+  jest.unmock('@aws-sdk/lib-dynamodb');  // override setup.ts
+  ```
+
+  In `harness.ts`, wire the mocked module exports to the fakes (`MailCapture.sendMail`, `CaptchaToggle.verify`, etc.) so handler calls flow through them.
+
+- [ ] **Step 3: Smoke-test the harness**
+
+  Add `harness.smoke.test.ts`:
+
+  ```ts
+  it('creates a harness, signs a session, applies, advances time', async () => {
+    const h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+    const { applicationId } = await h.publisher.apply({
+      email: 'pub@example.com', name: 'X', sourceUrl: 'https://x', sourceType: 'json',
+    });
+    expect(applicationId).toMatch(/^app-/);
+    h.now.advance(60_000);
+    h.dispose();
+  });
+  ```
+
+  Run:
+
+  ```bash
+  cd backend && npx jest harness.smoke
+  ```
+
+- [ ] **Step 4: Commit**
+
+  ```bash
+  git add backend/src/__tests__/integration/harness/
+  git commit -m "test(integration): harness with fakes, clock, mail capture"
+  ```
+
+---
+
+## Task 3: Actor API
+
+**Files:**
+- New: `backend/src/__tests__/integration/harness/actors.ts`
+- Modify: `backend/src/__tests__/integration/harness/harness.ts` (export actor instances)
+
+- [ ] **Step 1: Implement actors**
+
+  In `actors.ts`, build typed wrappers around `APIGatewayProxyEvent`. Each wrapper:
+
+  - Builds the event (path, method, headers, body).
+  - Calls the handler via `import('../../handlers/publisherPortalHandler').handlePublisherX(event)`.
+  - Parses the response body. On non-2xx, throws `new HandlerError(statusCode, body)`.
+
+  Three actor objects: `publisher`, `admin`, `ingest`. Methods listed in the design doc, Architecture → Wiring section.
+
+- [ ] **Step 2: Verify each actor with a one-line test**
+
+  In `actors.smoke.test.ts`, hit each method once with valid inputs and assert it doesn't throw. This is plumbing verification, not behavior verification.
+
+  Run:
+
+  ```bash
+  cd backend && npx jest actors.smoke
+  ```
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add backend/src/__tests__/integration/harness/actors.ts \
+          backend/src/__tests__/integration/harness/actors.smoke.test.ts
+  git commit -m "test(integration): actor API for publisher/admin/ingest journeys"
+  ```
+
+---
+
+## Task 4: Lifecycle tests
+
+**Files:**
+- New: `backend/src/__tests__/integration/lifecycle.test.ts`
+
+- [ ] **Step 1: Write the lifecycle journeys**
+
+  Implement the four `it(...)` blocks listed in the design doc, Test plan → lifecycle.test.ts. Each test reads top-to-bottom as a single user journey; assertions are interleaved with actions.
+
+  The PR #100 regression test (`it('preserves admin-approved state across re-ingest with bumped lastModified')`) must:
+  - Apply with `trustLevel: 'review'`
+  - Approve the application
+  - Set a feed with one event, run ingest → state is `pending`
+  - Admin approves the event → state is `published`
+  - Set the same feed with bumped `lastModified` on the event, run ingest
+  - Assert state is still `published`
+
+- [ ] **Step 2: Run**
+
+  ```bash
+  cd backend && npx jest integration/lifecycle
+  ```
+
+  All four must pass.
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add backend/src/__tests__/integration/lifecycle.test.ts
+  git commit -m "test(integration): publisher lifecycle journeys (apply, approve, sticky published)"
+  ```
+
+---
+
+## Task 5: Self-service tests
+
+**Files:**
+- New: `backend/src/__tests__/integration/selfService.test.ts`
+
+- [ ] **Step 1: Write the self-service journeys**
+
+  Implement the seven `it(...)` blocks in the design doc, Test plan → selfService.test.ts. The PR #78 regression test (`self-disable retracts events on next ingest`) must:
+  - Approve a publisher with events already published
+  - Self-disable via the portal with the correct typed slug
+  - Run ingest
+  - Assert the event store has 0 events for that publisher
+
+- [ ] **Step 2: Run and commit**
+
+  ```bash
+  cd backend && npx jest integration/selfService
+  git add backend/src/__tests__/integration/selfService.test.ts
+  git commit -m "test(integration): self-service portal journeys (pause, profile, email, self-disable)"
+  ```
+
+---
+
+## Task 6: Admin-controls tests
+
+**Files:**
+- New: `backend/src/__tests__/integration/adminControls.test.ts`
+
+- [ ] **Step 1: Write the admin-controls journeys**
+
+  Five `it(...)` blocks per the design doc. The "admin reject event preserved across re-ingest" test mirrors the sticky-published test: reject the event, bump `lastModified`, run ingest, assert state is still `rejected`.
+
+- [ ] **Step 2: Run and commit**
+
+  ```bash
+  cd backend && npx jest integration/adminControls
+  git add backend/src/__tests__/integration/adminControls.test.ts
+  git commit -m "test(integration): admin controls (pause, disable, approve/reject, run-ingest)"
+  ```
+
+---
+
+## Task 7: Ingest edge-case tests
+
+**Files:**
+- New: `backend/src/__tests__/integration/ingestEdgeCases.test.ts`
+
+- [ ] **Step 1: Write the edge-case journeys**
+
+  Five `it(...)` blocks per the design doc. Threshold halt: configure the fake feed to return N events, run ingest once to seed, then return <50% of N, run again, assert `setThresholdHalt` was called.
+
+- [ ] **Step 2: Run and commit**
+
+  ```bash
+  cd backend && npx jest integration/ingestEdgeCases
+  git add backend/src/__tests__/integration/ingestEdgeCases.test.ts
+  git commit -m "test(integration): ingest edge cases (network error, unchanged, threshold halt)"
+  ```
+
+---
+
+## Task 8: Auth & limits tests
+
+**Files:**
+- New: `backend/src/__tests__/integration/authAndLimits.test.ts`
+
+- [ ] **Step 1: Write the auth-and-limits journeys**
+
+  Five `it(...)` blocks per the design doc. Magic-token expiry: set `now`, request a magic link (which writes a token row), advance the clock past TTL, attempt to verify, assert rejection.
+
+  The DNS-rebinding guard test uses URLs `http://0.0.0.0/`, `http://127.0.0.1/`, `http://169.254.169.254/` and asserts `handlePublisherFetchNow` returns 400.
+
+- [ ] **Step 2: Run and commit**
+
+  ```bash
+  cd backend && npx jest integration/authAndLimits
+  git add backend/src/__tests__/integration/authAndLimits.test.ts
+  git commit -m "test(integration): auth and limits (CAPTCHA, magic-token, rate-limit, DNS guard)"
+  ```
+
+---
+
+## Task 9: Verify the whole integration suite passes
+
+- [ ] **Step 1: Run the full suite**
+
+  ```bash
+  cd backend && npx jest integration/ --coverage=false
+  ```
+
+  Expected: all integration tests green, runtime under 10 seconds.
+
+- [ ] **Step 2: Run the full backend suite to confirm no regressions**
+
+  ```bash
+  cd backend && npm run test:ci
+  ```
+
+  Expected: all unit + integration tests green. Confirm coverage report still uploads.
+
+- [ ] **Step 3: Build to confirm the deployment path works**
+
+  ```bash
+  cd backend && npm run build
+  ```
+
+---
+
+## Task 10: Wire into CI — `push` trigger
+
+**Files:**
+- Modify: `.github/workflows/build-and-test.yml`
+
+- [ ] **Step 1: Update the workflow trigger**
+
+  Change the top of `build-and-test.yml` from:
+
+  ```yaml
+  on:
+    pull_request:
+      branches: [main]
+    workflow_dispatch:
+  ```
+
+  to:
+
+  ```yaml
+  on:
+    push:
+    pull_request:
+      branches: [main]
+    workflow_dispatch:
+  ```
+
+  Note: this will cause same-repo PRs to run the workflow twice per push. The follow-on `ci-concurrency-dedupe` plan suppresses one of them. If that plan is being landed in the same PR, apply both changes together; otherwise accept the temporary duplication.
+
+- [ ] **Step 2: Update the trailing comment**
+
+  Replace the comment at the bottom that says "Integration tests removed due to DynamoDB service container complexity" with:
+
+  ```yaml
+  # Integration tests run as part of test-backend (Jest test:ci picks up
+  # backend/src/__tests__/integration/). They use an in-process in-memory
+  # DynamoDB fake, not docker — see
+  # docs/plans/2026-05-06-publisher-integration-tests-design.md.
+  ```
+
+- [ ] **Step 3: Push the branch and confirm CI runs**
+
+  ```bash
+  git add .github/workflows/build-and-test.yml
+  git commit -m "ci: trigger build-and-test on every branch push"
+  git push -u origin feat/publisher-integration-tests
+  ```
+
+  Watch the run in GitHub Actions. Confirm the integration tests appear in the Jest output.
+
+---
+
+## Task 11: Document the manual repo-settings step
+
+**Files:**
+- Modify: `docs/plans/2026-05-06-publisher-integration-tests-plan.md` (this file — append a "Post-merge" section)
+
+- [ ] **Step 1: Tell the user what to flip in GitHub UI**
+
+  After this PR merges, the user must update branch protection on `main`:
+
+  - Settings → Branches → Branch protection rules → `main` → Edit
+  - Under "Require status checks to pass before merging", add: `test-backend (24)`, `test-backend (25)`, `test-frontend (24)`, `test-frontend (25)`.
+  - Save.
+
+  This cannot be done from the workflow file. Note this in the PR description so it's not forgotten.
+
+---
+
+## Task 12: Open the PR
+
+- [ ] **Step 1: Push and open**
+
+  ```bash
+  git push -u origin feat/publisher-integration-tests
+  gh pr create --title "test(integration): publisher self-service & ingest backend integration tests" --body "$(cat <<'EOF'
+## Summary
+- New `backend/src/__tests__/integration/` suite covers publisher lifecycle, self-service portal, admin controls, ingest edge cases, and auth/limits — all journey-shaped, all running against an in-memory DDB fake.
+- Pins the PR #100 (sticky `published`) and PR #78 (self-disable retracts) regressions so they can't recur.
+- CI: `build-and-test.yml` now triggers on every branch push so this gates merges.
+
+## Manual follow-up after merge
+Add `test-backend (24)`, `test-backend (25)`, `test-frontend (24)`, `test-frontend (25)` to required status checks under main's branch protection.
+
+## Test plan
+- [ ] `npm run test:ci --workspace=backend` passes locally
+- [ ] CI green on this PR
+- [ ] CI red if I deliberately revert the PR #100 fix (regression catches it)
+EOF
+  )"
+  ```
+
+- [ ] **Step 2: Wait for CI to pass and request review**

--- a/docs/plans/2026-05-06-publisher-integration-tests-plan.md
+++ b/docs/plans/2026-05-06-publisher-integration-tests-plan.md
@@ -8,7 +8,7 @@
 
 **Architecture:** New `backend/src/__tests__/integration/` directory with a harness that constructs real services against a fake `DynamoDBDocumentClient` and injects them via the existing `_setXxxForTests` hooks on each handler. Tests are journey-shaped (`it('walks ...', async () => ...)`).
 
-**Tech Stack:** TypeScript, Jest, Node 24, in-process fake DDB, no docker.
+**Tech Stack:** TypeScript, Jest, Node 24+ (CI matrix runs 24 and 25), in-process fake DDB, no docker.
 
 **Branch:** create `feat/publisher-integration-tests` off `main`.
 
@@ -71,7 +71,7 @@ The fake must implement enough of `DynamoDBDocumentClient.send(cmd)` for all ser
   - Scan with `FilterExpression` filters items
   - TransactWrite with three Puts atomically commits; if one Put has a failing condition, none commit
   - BatchWrite with both Puts and Deletes processes all
-  - Unsupported command shape (e.g. ProjectionExpression) throws a clear error
+  - Unsupported command shape (e.g. `TransactGetItems` or `ExecuteStatement`/PartiQL — commands the fake explicitly won't implement) throws a clear error. (`ProjectionExpression` is a real DDB parameter and must NOT throw — it can be a no-op or applied to the projected result.)
 
   Run:
 
@@ -128,8 +128,8 @@ The fake must implement enough of `DynamoDBDocumentClient.send(cmd)` for all ser
   export class CaptchaToggle {
     pass(): void;
     fail(): void;
-    /** module-mock target */
-    verify(token: string): Promise<{ ok: boolean }>;
+    /** module-mock target — matches verifyCaptcha(token, action) → Promise<boolean> */
+    verify(token: string, action?: string): Promise<boolean>;
   }
   ```
 
@@ -193,7 +193,8 @@ The fake must implement enough of `DynamoDBDocumentClient.send(cmd)` for all ser
   In `actors.ts`, build typed wrappers around `APIGatewayProxyEvent`. Each wrapper:
 
   - Builds the event (path, method, headers, body).
-  - Calls the handler via `import('../../handlers/publisherPortalHandler').handlePublisherX(event)`.
+  - Calls a statically-imported handler (e.g. `handlePublisherStatus(event)`).
+    **Important:** use static `import { handlePublisherX } from '../../handlers/publisherPortalHandler'` at the top of the file — NOT a dynamic `import(...)` expression inside the function. Dynamic imports re-evaluate the module on every call, bypass Jest's module registry, and break the `jest.mock()` setup wired in `harness.ts`.
   - Parses the response body. On non-2xx, throws `new HandlerError(statusCode, body)`.
 
   Three actor objects: `publisher`, `admin`, `ingest`. Methods listed in the design doc, Architecture → Wiring section.


### PR DESCRIPTION
## Summary

Splits the publisher self-service integration-test ask into five independently-executable spec+plan pairs under `docs/plans/`, so each can be picked up in a separate session by name. No code changes — docs only.

| # | Topic | Files |
|---|---|---|
| 1 | **Backend integration tests + `push:` CI trigger** (the main ask) | `2026-05-06-publisher-integration-tests-{design,plan}.md` |
| 2 | Frontend portal integration tests (Vitest + happy-dom + @testing-library/preact) | `2026-05-06-frontend-portal-integration-tests-{design,plan}.md` |
| 3 | Post-deploy bbtest smoke against prod | `2026-05-06-post-deploy-publisher-smoke-test-{design,plan}.md` |
| 4 | CI coverage floor (`.coverage-floor.json`) | `2026-05-06-ci-coverage-floor-{design,plan}.md` |
| 5 | CI concurrency dedupe | `2026-05-06-ci-concurrency-dedupe-{design,plan}.md` |

## Highlights

- **Plan 1** uses an in-process in-memory DynamoDB fake (sidesteps the "service container complexity" that killed the previous integration-test attempt — see footer of `build-and-test.yml`). Journey-shaped tests across portal + admin + ingest handlers. Pins the PR #100 sticky-published and PR #78 self-disable-retracts regressions.
- **Plan 2** includes a form-submission test that pins the CLAUDE.md `react`→`preact/compat` alias gotcha.
- **Plan 3** uses a CAPTCHA-bypass header + smoke-admin signing-key auth (route-allowlisted) instead of Gmail polling. Idempotent reset endpoint cleans bbtest before and after each run.
- **Plan 4** is a one-way coverage ratchet enforced via Jest/Vitest `coverageThreshold` — no new CI step.
- **Plan 5** adds `concurrency:` cancel + an `if:` filter so same-repo PRs don't double-run.

## Independence

Plans 1, 2, 3 are independent and can be picked up in any order. Plan 4's frontend portion is gated on plan 2 having shipped. Plan 5 is most useful landed with or right after plan 1 (which adds the `push:` trigger).

## Test plan

- [x] Spec self-review pass on all 5 specs (placeholders / contradictions / scope / ambiguity)
- [ ] User reviews specs before any plan is executed

## Manual follow-up after plan 1 merges

Add `test-backend (24)`, `test-backend (25)`, `test-frontend (24)`, `test-frontend (25)` to required status checks under main's branch protection. Cannot be automated from a workflow file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)