### PR TITLE
chore(ci): dedupe build-and-test runs via concurrency + same-repo PR filter

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,13 +1,20 @@
 name: Build and Test
 
 on:
+  push:
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [main]
   workflow_dispatch:
+
+concurrency:
+  group: build-and-test-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   test-backend:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +48,7 @@ jobs:
 
   test-frontend:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,7 @@ name: Build and Test
 
 on:
   push:
+    branches: ['**']
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]


### PR DESCRIPTION
## Summary
- Adds workflow-level `concurrency:` block keyed on `github.ref`; cancels superseded runs on every ref except `main`.
- Adds `if:` filter to both `test-backend` and `test-frontend` jobs to suppress the duplicate `pull_request` run for same-repo PRs (the `push` run already covers the same SHA). Fork PRs continue to run via `pull_request`.
- Narrows `pull_request:` trigger to `[opened, synchronize, reopened]` to avoid extra runs on label / assignee / review-state changes.
- Adds `push:` trigger so branch pushes without an open PR are still validated.

## Note on `push:` trigger overlap
Plan 1 (`publisher-integration-tests`) is being executed in parallel and also adds `push:` to this same workflow. Either merge order works — both PRs are individually correct, and the second to land will produce a trivial textual conflict on the `on:` block that resolves to the same final state.

## Spec / Plan
- Design: `docs/plans/2026-05-06-ci-concurrency-dedupe-design.md`
- Plan: `docs/plans/2026-05-06-ci-concurrency-dedupe-plan.md`

## Verification
Empirical verification of cancel-in-progress and the same-repo skip behavior is **deferred** until this PR is open and starts running CI — it requires observing the GitHub Actions UI on rapid follow-up pushes.

- [ ] Two rapid pushes on a branch → first run shows "Cancelled", second completes
- [ ] Same-repo PR → only the `push`-triggered run executes; the `pull_request` run is skipped
- [ ] Post-merge run on `main` completes uninterrupted even with a follow-on commit
- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] `on:` block contains `push:`, narrowed `pull_request:`, and `workflow_dispatch:`
- [x] `concurrency:` block keyed on `github.ref` with `cancel-in-progress` gated on non-main
- [x] `if:` filter present on both `test-backend` and `test-frontend`

## Risk
- Cancelled runs show as "Cancelled" not "Failed" — they don't satisfy a required-check rule, but the next commit's run does. Documented in design.
- Skipped `pull_request` cells on same-repo PRs do not satisfy required-check rules — the corresponding `push` event run produces the satisfying check on the same SHA. Fork PRs run via `pull_request` only and pass the gate normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)