### PR TITLE
chore(ci): enforce per-package line coverage floor

### DIFF
--- a/.coverage-floor.json
+++ b/.coverage-floor.json
@@ -1,0 +1,4 @@
+{
+  "backend": { "lines": 81.1 },
+  "frontend": { "lines": 0 }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,8 @@ npm run dev
 # Verify: events load, search works, filters work, descriptions expand
 ```
 
+Coverage floor enforced via `.coverage-floor.json`; see `docs/coverage.md`.
+
 ## Dependencies
 
 ### Production

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,3 +1,5 @@
+const floor = require('../.coverage-floor.json');
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: './jest-environment.cjs',
@@ -9,8 +11,12 @@ module.exports = {
     '!src/handlers/*.ts', // Exclude AWS Lambda handlers from coverage
     '!src/scripts/*.ts', // Exclude CLI scripts from coverage
   ],
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/', '/refs/', '\\.d\\.ts$', '/__tests__/'],
   coverageDirectory: 'coverage',
   coverageReporters: ['text', 'lcov', 'html'],
+  coverageThreshold: {
+    global: { lines: floor.backend.lines },
+  },
   setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
   testTimeout: 10000,
   moduleNameMapper: {

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -1,0 +1,69 @@
+# Coverage floor policy
+
+The repo enforces a one-way **line-coverage** ratchet on a per-package basis. CI fails if any package's measured line coverage drops below its checked-in floor.
+
+## Where the floor lives
+
+A single file at the repo root:
+
+```
+.coverage-floor.json
+```
+
+```json
+{
+  "backend": { "lines": 81.1 },
+  "frontend": { "lines": 0 }
+}
+```
+
+`frontend.lines: 0` is an explicit "no gate" — it will be raised to a real number once the frontend test infrastructure (Vitest + integration tests) lands.
+
+## How CI enforces it
+
+There is **no separate CI step**. The package's existing test runner reads `.coverage-floor.json` and uses its native threshold mechanism:
+
+- **Backend (Jest)** — `backend/jest.config.js` reads the JSON via `require('../.coverage-floor.json')` and sets `coverageThreshold.global.lines`. The existing `backend && npm run test:ci` job already runs `jest --coverage`, so a drop below the floor causes Jest to exit non-zero and fails the existing test job.
+- **Frontend (Vitest)** — when added, `frontend/vitest.config.ts` will read the JSON and set `test.coverage.thresholds.lines`.
+
+## What's measured
+
+- **Line coverage only.** Branch / function / statement coverage are not gated.
+- **Per-package globals only.** No per-file floors.
+- The backend number is computed over `src/**/*.ts` *minus* the exclusions in `backend/jest.config.js` (`collectCoverageFrom` / `coveragePathIgnorePatterns`):
+  - `src/handlers/*.ts` — Lambda entry points; tested via integration tests, not unit coverage
+  - `src/scripts/*.ts` — CLI scripts
+  - `*.d.ts`, `dist/`, `refs/`, `__tests__/`, `node_modules/`
+
+## How to bump the floor (raise it)
+
+When you add tests that meaningfully raise coverage, edit `.coverage-floor.json` in the **same PR** that adds the tests. The reviewer sees the diff and can sanity-check the new number.
+
+Pick the new floor as `(measured% rounded down to one decimal) − 0.5%`. The 0.5% headroom absorbs day-to-day noise from minor refactors.
+
+Example: PR adds tests that bump backend coverage from 81.62% to 84.31%. New floor = 84.3 − 0.5 = **83.8**.
+
+## How to lower the floor
+
+**Only with explicit reviewer sign-off.** Lowering the floor undoes the ratchet, so:
+
+1. Mention the lowering in the PR description, with a one-line rationale (e.g. "Removed feature X reduces denominator by 4 files").
+2. Get a reviewer to acknowledge the lowered number.
+3. Pick the new floor at `(measured% rounded down to one decimal) − 0.5%` against the new code.
+
+Do **not** lower the floor as a quick fix for a coverage failure. Add tests instead, or revert the change that dropped coverage.
+
+## Local verification
+
+```bash
+# Backend
+cd backend && npm run test:ci
+# Jest exits non-zero with "coverage threshold for lines (X%) not met" if you drop below.
+```
+
+## What's NOT enforced
+
+- Branch / function / statement coverage
+- Per-file thresholds
+- Coverage on Lambda handlers (`src/handlers/*`) — those are covered by integration tests run separately
+- Coverage on CLI scripts (`src/scripts/*`)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -23,7 +23,7 @@ A single file at the repo root:
 
 There is **no separate CI step**. The package's existing test runner reads `.coverage-floor.json` and uses its native threshold mechanism:
 
-- **Backend (Jest)** — `backend/jest.config.js` reads the JSON via `require('../.coverage-floor.json')` and sets `coverageThreshold.global.lines`. The existing `backend && npm run test:ci` job already runs `jest --coverage`, so a drop below the floor causes Jest to exit non-zero and fails the existing test job.
+- **Backend (Jest)** — `backend/jest.config.js` reads the JSON via `require('../.coverage-floor.json')` and sets `coverageThreshold.global.lines`. CI runs `npm run build --workspace=backend` (see `.github/workflows/build-and-test.yml`), which fires the backend package's `prebuild` hook (`npm run test:ci`), which in turn runs `jest --ci --coverage`. A drop below the floor causes Jest to exit non-zero, which fails `prebuild`, which fails the build step.
 - **Frontend (Vitest)** — when added, `frontend/vitest.config.ts` will read the JSON and set `test.coverage.thresholds.lines`.
 
 ## What's measured
@@ -31,7 +31,7 @@ There is **no separate CI step**. The package's existing test runner reads `.cov
 - **Line coverage only.** Branch / function / statement coverage are not gated.
 - **Per-package globals only.** No per-file floors.
 - The backend number is computed over `src/**/*.ts` *minus* the exclusions in `backend/jest.config.js` (`collectCoverageFrom` / `coveragePathIgnorePatterns`):
-  - `src/handlers/*.ts` — Lambda entry points; tested via integration tests, not unit coverage
+  - `src/handlers/*.ts` — excluded from `collectCoverageFrom`. Handler-level Jest tests exist (`backend/src/__tests__/*Handler*.test.ts`) and exercise the routing/error-translation layer directly, but the handlers themselves are thin orchestration over the underlying services. Coverage is gated on the service modules instead, so handler line counts don't dilute the floor.
   - `src/scripts/*.ts` — CLI scripts
   - `*.d.ts`, `dist/`, `refs/`, `__tests__/`, `node_modules/`
 
@@ -65,5 +65,5 @@ cd backend && npm run test:ci
 
 - Branch / function / statement coverage
 - Per-file thresholds
-- Coverage on Lambda handlers (`src/handlers/*`) — those are covered by integration tests run separately
+- Coverage on Lambda handlers (`src/handlers/*`) — excluded via `collectCoverageFrom`; handler-level tests still run, they just don't contribute to the gated number
 - Coverage on CLI scripts (`src/scripts/*`)


### PR DESCRIPTION
## Summary
- New `.coverage-floor.json` at repo root holds per-package line-coverage floors.
- Jest's `coverageThreshold` enforces the backend floor; the existing `test-backend` job fails on drop.
- Backend floor set to **81.1** (today's measured 81.62% minus 0.5% headroom).
- Frontend floor set to **0** (explicit no-gate); will be raised in a follow-up PR once `feat/frontend-portal-integration-tests` lands and produces a real number to floor against.
- New `docs/coverage.md` documents what's enforced, how to bump, and how to lower.
- One-line pointer added to `CLAUDE.md` under Verification Checklist.

Frontend coverage floor will be added in a follow-up PR once `feat/frontend-portal-integration-tests` lands.

## Test plan
- [x] Backend tests pass at current coverage (81.62% > 81.1% floor)
- [x] Backend tests fail when floor is bumped to 99.9 (verified locally — Jest exits non-zero with "coverage threshold for lines (99.9%) not met")
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)