### PR TITLE
test(smoke): post-deploy publisher lifecycle smoke

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -806,6 +806,31 @@ jobs:
 
           echo "✅ Publisher single-publisher mode E2E test passed"
 
+      - name: Post-deploy publisher-lifecycle smoke
+        # Runs scripts/smoke/publisher-lifecycle.test.ts against the
+        # just-deployed prod stack. Walks bbtest through apply → approve →
+        # publish → pause → resume → self-disable → retract end-to-end,
+        # exercising real DDB / SES / API Gateway / Lambda / sidecar.
+        #
+        # If this fails, the deploy job is marked red. Rollback is a
+        # separate decision — the deploy itself succeeded; what's red is
+        # the post-deploy verification. See
+        # docs/runbooks/publisher-smoke-failed.md for triage.
+        #
+        # Required GitHub repo secrets (set in repo Settings → Secrets and
+        # variables → Actions):
+        #   - SMOKE_BBTEST_EMAIL
+        #   - SMOKE_ADMIN_SIGNING_KEY     (matches Lambda env ADMIN_SMOKE_SIGNING_KEY)
+        #   - SMOKE_CAPTCHA_BYPASS_TOKEN  (matches Lambda env CAPTCHA_BYPASS_TOKEN)
+        # Until those are populated this step skips loudly (the test
+        # describe() returns describe.skip and the job stays green).
+        run: npm run smoke:publisher
+        env:
+          SMOKE_API_BASE: https://www.chqcal.org
+          SMOKE_BBTEST_EMAIL: ${{ secrets.SMOKE_BBTEST_EMAIL }}
+          SMOKE_ADMIN_SIGNING_KEY: ${{ secrets.SMOKE_ADMIN_SIGNING_KEY }}
+          SMOKE_CAPTCHA_BYPASS_TOKEN: ${{ secrets.SMOKE_CAPTCHA_BYPASS_TOKEN }}
+
       - name: Trigger calendar data sync
         continue-on-error: true
         run: |

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -806,6 +806,18 @@ jobs:
 
           echo "✅ Publisher single-publisher mode E2E test passed"
 
+      - name: Reinstall dev dependencies for smoke step
+        # The earlier "Deploy admin/calendar/sync/publisher-ingest Lambda"
+        # steps each run `npm ci --omit=dev` inside ./backend. In a
+        # workspaces monorepo that prunes hoisted devDependencies from
+        # the top-level node_modules — including jest and ts-jest, which
+        # the smoke step (npm run smoke:publisher) needs. Re-run the full
+        # install at the repo root to restore them. This is faster than
+        # rearranging the deploy steps and keeps each step's contract
+        # local: deploy steps assume a pruned tree, the smoke step assumes
+        # a full tree.
+        run: npm ci
+
       - name: Post-deploy publisher-lifecycle smoke
         # Runs scripts/smoke/publisher-lifecycle.test.ts against the
         # just-deployed prod stack. Walks bbtest through apply → approve →

--- a/backend/src/__tests__/adminHandler.smokeRoutes.test.ts
+++ b/backend/src/__tests__/adminHandler.smokeRoutes.test.ts
@@ -1,0 +1,214 @@
+// Handler-level tests for the smoke-bot endpoints in adminHandler.ts.
+//
+// Two security gates are exercised here:
+//   1. SMOKE_ADMIN_ROUTE_ALLOWLIST — covered indirectly: any non-allowlisted
+//      smoke-bot route returns 403 (the route below would even need to
+//      exist on the allowlist). The dedicated allowlist regex test lives
+//      in adminHandler.publishers.test.ts adjacent suites.
+//   2. SMOKE_BBTEST_EMAIL hard-gate — defense-in-depth against a leaked
+//      signing key. The email-keyed smoke routes (/smoke-reset-bbtest and
+//      /smoke-magic-token-by-email) refuse any request whose body email
+//      does not exactly match process.env.SMOKE_BBTEST_EMAIL.
+
+import type { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import jwt from 'jsonwebtoken';
+import {
+  handler,
+  _setSmokeRouteDepsForTests,
+} from '../handlers/adminHandler';
+
+const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
+  body: null,
+  headers: {},
+  multiValueHeaders: {},
+  httpMethod: 'POST',
+  isBase64Encoded: false,
+  path: '/',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  stageVariables: null,
+  requestContext: { identity: { sourceIp: '203.0.113.1' } } as any,
+  resource: '/',
+  ...overrides,
+});
+
+const ctx = {} as Context;
+
+const SIGNING_KEY = 'test-signing-key-very-secret';
+const BBTEST_EMAIL = 'bbtest@chqcal.org';
+
+function makeSmokeBotToken(): string {
+  return jwt.sign({ sub: 'smoke-bot', iss: 'smoke' }, SIGNING_KEY, {
+    algorithm: 'HS256',
+    expiresIn: '5m',
+  });
+}
+
+const PRIOR = {
+  ADMIN_SMOKE_SIGNING_KEY: process.env.ADMIN_SMOKE_SIGNING_KEY,
+  SMOKE_BBTEST_EMAIL: process.env.SMOKE_BBTEST_EMAIL,
+  NODE_ENV: process.env.NODE_ENV,
+  ENVIRONMENT: process.env.ENVIRONMENT,
+  DEV_AUTH_BYPASS: process.env.DEV_AUTH_BYPASS,
+};
+
+beforeAll(() => {
+  process.env.ADMIN_SMOKE_SIGNING_KEY = SIGNING_KEY;
+  process.env.SMOKE_BBTEST_EMAIL = BBTEST_EMAIL;
+  // Smoke fallback only triggers when no admin user is authenticated.
+  delete process.env.NODE_ENV;
+  delete process.env.ENVIRONMENT;
+  delete process.env.DEV_AUTH_BYPASS;
+});
+
+afterAll(() => {
+  for (const [k, v] of Object.entries(PRIOR)) {
+    if (v === undefined) delete (process.env as Record<string, string | undefined>)[k];
+    else (process.env as Record<string, string | undefined>)[k] = v;
+  }
+});
+
+afterEach(() => {
+  _setSmokeRouteDepsForTests(null);
+});
+
+describe('POST /smoke-reset-bbtest — bbtest email gate', () => {
+  it('returns 403 when the body email does not match SMOKE_BBTEST_EMAIL', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const r = await handler(
+      evt({
+        path: '/smoke-reset-bbtest',
+        httpMethod: 'POST',
+        headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+        body: JSON.stringify({ email: 'attacker@example.com' }),
+      }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(403);
+    expect(JSON.parse(r.body).error).toMatch(/configured smoke bbtest email/);
+    logSpy.mockRestore();
+  });
+
+  it('accepts the request when the body email matches SMOKE_BBTEST_EMAIL', async () => {
+    const resetImpl = jest.fn(async () => ({
+      rowsAffected: 0,
+      applicationsDeleted: 0,
+      publishersDeleted: 0,
+      eventsDeleted: 0,
+      magicTokensDeleted: 0,
+    }));
+    _setSmokeRouteDepsForTests({
+      registry: {} as any,
+      eventStore: {} as any,
+      magicTokensTableName: 'unused-in-this-test',
+      resetImpl,
+    });
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const r = await handler(
+      evt({
+        path: '/smoke-reset-bbtest',
+        httpMethod: 'POST',
+        headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+        body: JSON.stringify({ email: BBTEST_EMAIL }),
+      }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(200);
+    expect(resetImpl).toHaveBeenCalledTimes(1);
+    logSpy.mockRestore();
+  });
+
+  it('matches case-insensitively (mixed-case body still matches lowercased env)', async () => {
+    const resetImpl = jest.fn(async () => ({
+      rowsAffected: 0,
+      applicationsDeleted: 0,
+      publishersDeleted: 0,
+      eventsDeleted: 0,
+      magicTokensDeleted: 0,
+    }));
+    _setSmokeRouteDepsForTests({
+      registry: {} as any,
+      eventStore: {} as any,
+      magicTokensTableName: 'unused-in-this-test',
+      resetImpl,
+    });
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const r = await handler(
+      evt({
+        path: '/smoke-reset-bbtest',
+        httpMethod: 'POST',
+        headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+        body: JSON.stringify({ email: '  BBTest@CHQCAL.ORG  ' }),
+      }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(200);
+    expect(resetImpl).toHaveBeenCalledTimes(1);
+    logSpy.mockRestore();
+  });
+
+  it('returns 403 when SMOKE_BBTEST_EMAIL is unset on the Lambda', async () => {
+    const prior = process.env.SMOKE_BBTEST_EMAIL;
+    delete process.env.SMOKE_BBTEST_EMAIL;
+    try {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+      const r = await handler(
+        evt({
+          path: '/smoke-reset-bbtest',
+          httpMethod: 'POST',
+          headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+          body: JSON.stringify({ email: BBTEST_EMAIL }),
+        }),
+        ctx,
+      );
+      expect(r.statusCode).toBe(403);
+      expect(JSON.parse(r.body).error).toMatch(/not configured/);
+      logSpy.mockRestore();
+    } finally {
+      if (prior !== undefined) process.env.SMOKE_BBTEST_EMAIL = prior;
+    }
+  });
+});
+
+describe('POST /smoke-magic-token-by-email — bbtest email gate', () => {
+  it('returns 403 when the body email does not match SMOKE_BBTEST_EMAIL', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+    const r = await handler(
+      evt({
+        path: '/smoke-magic-token-by-email',
+        httpMethod: 'POST',
+        headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+        body: JSON.stringify({ email: 'attacker@example.com' }),
+      }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(403);
+    expect(JSON.parse(r.body).error).toMatch(/configured smoke bbtest email/);
+    logSpy.mockRestore();
+  });
+
+  it('returns 403 when SMOKE_BBTEST_EMAIL is unset on the Lambda', async () => {
+    const prior = process.env.SMOKE_BBTEST_EMAIL;
+    delete process.env.SMOKE_BBTEST_EMAIL;
+    try {
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(() => undefined);
+      const r = await handler(
+        evt({
+          path: '/smoke-magic-token-by-email',
+          httpMethod: 'POST',
+          headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+          body: JSON.stringify({ email: BBTEST_EMAIL }),
+        }),
+        ctx,
+      );
+      expect(r.statusCode).toBe(403);
+      expect(JSON.parse(r.body).error).toMatch(/not configured/);
+      logSpy.mockRestore();
+    } finally {
+      if (prior !== undefined) process.env.SMOKE_BBTEST_EMAIL = prior;
+    }
+  });
+});

--- a/backend/src/__tests__/captchaService.test.ts
+++ b/backend/src/__tests__/captchaService.test.ts
@@ -1,7 +1,7 @@
 // Tests for the shared captcha service. node-fetch is mocked so we don't
 // hit Google's siteverify endpoint.
 
-import { verifyCaptcha } from '../services/captchaService';
+import { verifyCaptcha, verifyCaptchaWithBypass } from '../services/captchaService';
 
 jest.mock('node-fetch', () => jest.fn());
 import fetch from 'node-fetch';
@@ -113,5 +113,77 @@ describe('verifyCaptcha', () => {
       const ok = await verifyCaptcha('tok', 'publisher_apply');
       expect(ok).toBe(false);
     });
+  });
+});
+
+// Bypass wrapper for the post-deploy publisher smoke test. The bypass fires
+// only when CAPTCHA_BYPASS_TOKEN is provisioned AND the inbound request
+// carries a matching X-Smoke-Bypass header — every other path falls through
+// to verifyCaptcha unchanged.
+describe('verifyCaptchaWithBypass', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    process.env = { ...ORIGINAL_ENV };
+    // Force the production verify path so the fall-through tests below
+    // would actually round-trip to Google if the bypass weren't taken.
+    process.env.RECAPTCHA_SECRET_KEY = 'test-secret';
+    process.env.ENVIRONMENT = 'prod';
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns true and logs when env + header match (no fetch made)', async () => {
+    process.env.CAPTCHA_BYPASS_TOKEN = 'super-secret-smoke';
+    const ok = await verifyCaptchaWithBypass('any-tok', 'publisher_apply', {
+      'x-smoke-bypass': 'super-secret-smoke',
+    });
+    expect(ok).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
+    // The setup file replaces global.console.info with a jest.fn() —
+    // assert directly on the mock rather than spying anew on console.
+    const infoMock = global.console.info as unknown as jest.Mock;
+    expect(infoMock.mock.calls).toContainEqual(
+      expect.arrayContaining(['[captcha] bypass accepted', { source: 'smoke' }]),
+    );
+  });
+
+  it('falls through to verifyCaptcha when CAPTCHA_BYPASS_TOKEN is unset', async () => {
+    delete process.env.CAPTCHA_BYPASS_TOKEN;
+    mockResponse({ success: true, score: 0.9, action: 'publisher_apply' });
+    const ok = await verifyCaptchaWithBypass('tok', 'publisher_apply', {
+      'x-smoke-bypass': 'whatever',
+    });
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to verifyCaptcha when header value does not match env', async () => {
+    process.env.CAPTCHA_BYPASS_TOKEN = 'super-secret-smoke';
+    // Wrong header value — must NOT bypass; should hit Google instead.
+    mockResponse({ success: true, score: 0.9, action: 'publisher_apply' });
+    const ok = await verifyCaptchaWithBypass('tok', 'publisher_apply', {
+      'x-smoke-bypass': 'wrong-value',
+    });
+    expect(ok).toBe(true); // verifyCaptcha returns true via fetch, not via bypass
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to verifyCaptcha when the header is missing', async () => {
+    process.env.CAPTCHA_BYPASS_TOKEN = 'super-secret-smoke';
+    mockResponse({ success: true, score: 0.9, action: 'publisher_apply' });
+    const ok = await verifyCaptchaWithBypass('tok', 'publisher_apply', {});
+    expect(ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the canonical-cased X-Smoke-Bypass header form', async () => {
+    process.env.CAPTCHA_BYPASS_TOKEN = 'super-secret-smoke';
+    const ok = await verifyCaptchaWithBypass('tok', 'publisher_apply', {
+      'X-Smoke-Bypass': 'super-secret-smoke',
+    });
+    expect(ok).toBe(true);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/__tests__/publisherEventStore.test.ts
+++ b/backend/src/__tests__/publisherEventStore.test.ts
@@ -32,6 +32,34 @@ describe('PublisherEventStore', () => {
     expect(mockSend).toHaveBeenCalledTimes(2);
   });
 
+  it('countForPublisher issues a Select=COUNT Query and sums Count across pages', async () => {
+    mockSend
+      .mockResolvedValueOnce({ Count: 7, LastEvaluatedKey: { x: 1 } })
+      .mockResolvedValueOnce({ Count: 4 });
+    const total = await store.countForPublisher('p');
+    expect(total).toBe(11);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.KeyConditionExpression).toContain('publisherId');
+    expect(cmd.input.ExpressionAttributeValues[':p']).toBe('p');
+    expect(cmd.input.Select).toBe('COUNT');
+    // The COUNT query MUST NOT request items — that would defeat the point.
+    // DDB returns Count only when Select='COUNT'; the Items array (if
+    // present) is empty in that mode.
+  });
+
+  it('countForPublisher returns 0 when DDB reports Count=0 with no pagination', async () => {
+    mockSend.mockResolvedValueOnce({ Count: 0 });
+    expect(await store.countForPublisher('p')).toBe(0);
+  });
+
+  it('countForPublisher tolerates an absent Count field (treats as 0)', async () => {
+    // Defensive: the SDK's typing has Count optional. Make sure we don't
+    // NaN out if a stub or a future SDK version omits it.
+    mockSend.mockResolvedValueOnce({});
+    expect(await store.countForPublisher('p')).toBe(0);
+  });
+
   it('applyDiff issues TransactWriteItems with inserts + updates + deletes', async () => {
     mockSend.mockResolvedValue({});
     const ins: StoredPublisherEvent = {

--- a/backend/src/__tests__/publisherPortalHandler.apply.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.apply.test.ts
@@ -4,6 +4,11 @@
 
 jest.mock('../services/captchaService', () => ({
   verifyCaptcha: jest.fn(),
+  // The apply route now calls the bypass-aware wrapper so it can short-circuit
+  // the Google round-trip when CAPTCHA_BYPASS_TOKEN + X-Smoke-Bypass match.
+  // We mock both — most tests drive verifyCaptchaWithBypass directly; one
+  // test below pins the wrapper's call signature.
+  verifyCaptchaWithBypass: jest.fn(),
 }));
 
 import type { APIGatewayProxyEvent } from 'aws-lambda';
@@ -16,9 +21,9 @@ import {
   _resetPublisherAuthRateLimitForTests,
 } from '../handlers/publisherPortalHandler';
 import { EmailAlreadyInUseError } from '../services/publisherApplicationService';
-import { verifyCaptcha } from '../services/captchaService';
+import { verifyCaptchaWithBypass } from '../services/captchaService';
 
-const mockVerifyCaptcha = verifyCaptcha as jest.MockedFunction<typeof verifyCaptcha>;
+const mockVerifyCaptcha = verifyCaptchaWithBypass as jest.MockedFunction<typeof verifyCaptchaWithBypass>;
 
 const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
   body: '',
@@ -71,7 +76,11 @@ describe('handlePublisherApplyRequest', () => {
     expect(r.statusCode).toBe(200);
     expect(JSON.parse(r.body)).toEqual({ ok: true });
     expect(stub.requestApply).toHaveBeenCalled();
-    expect(mockVerifyCaptcha).toHaveBeenCalledWith('test-captcha-token', 'publisher_apply');
+    expect(mockVerifyCaptcha).toHaveBeenCalledWith(
+      'test-captcha-token',
+      'publisher_apply',
+      expect.any(Object),
+    );
   });
 
   it('passes empty token through to verifyCaptcha when captchaToken is missing', async () => {
@@ -86,7 +95,7 @@ describe('handlePublisherApplyRequest', () => {
     const { captchaToken: _drop, ...withoutToken } = validBody;
     const r = await handlePublisherApplyRequest(evt(), withoutToken);
     expect(r.statusCode).toBe(200);
-    expect(mockVerifyCaptcha).toHaveBeenCalledWith('', 'publisher_apply');
+    expect(mockVerifyCaptcha).toHaveBeenCalledWith('', 'publisher_apply', expect.any(Object));
   });
 
   it('returns 400 with captcha field when verifyCaptcha returns false', async () => {

--- a/backend/src/__tests__/smokeAdminAuth.test.ts
+++ b/backend/src/__tests__/smokeAdminAuth.test.ts
@@ -1,0 +1,101 @@
+// Tests for the smoke-bot admin verifier. The verifier is what lets the
+// post-deploy publisher-lifecycle smoke test authenticate against admin
+// routes without going through Google OAuth — see services/smokeAdminAuth.ts
+// for the security model.
+
+import jwt from 'jsonwebtoken';
+import { verifySmokeAdminToken } from '../services/smokeAdminAuth';
+
+const ORIGINAL_ENV = { ...process.env };
+const KEY = 'super-secret-test-key';
+
+function sign(payload: Record<string, unknown>, opts: jwt.SignOptions = {}): string {
+  return jwt.sign(payload, KEY, { algorithm: 'HS256', ...opts });
+}
+
+describe('verifySmokeAdminToken', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.ADMIN_SMOKE_SIGNING_KEY = KEY;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+  });
+
+  it('returns the smoke principal on a valid bearer token', () => {
+    const token = sign({ sub: 'smoke-bot', iss: 'smoke' }, { expiresIn: '5m' });
+    const r = verifySmokeAdminToken(`Bearer ${token}`);
+    expect(r).toEqual({ sub: 'smoke-bot', iss: 'smoke' });
+  });
+
+  it('accepts a bare token without "Bearer " prefix (X-Auth-Token style)', () => {
+    // adminHandler forwards the bare token from X-Auth-Token. The verifier
+    // must accept both shapes so a single helper works on either header.
+    const token = sign({ sub: 'smoke-bot', iss: 'smoke' }, { expiresIn: '5m' });
+    const r = verifySmokeAdminToken(token);
+    expect(r).toEqual({ sub: 'smoke-bot', iss: 'smoke' });
+  });
+
+  it('returns null when ADMIN_SMOKE_SIGNING_KEY is unset (smoke not provisioned)', () => {
+    // Without the env var, the bypass path is permanently inactive — even a
+    // structurally-valid token signed with the actual key cannot be
+    // accepted, because there's no key to verify against. This matters in
+    // local dev / staging where smoke isn't wired up.
+    delete process.env.ADMIN_SMOKE_SIGNING_KEY;
+    const token = sign({ sub: 'smoke-bot', iss: 'smoke' }, { expiresIn: '5m' });
+    expect(verifySmokeAdminToken(`Bearer ${token}`)).toBeNull();
+  });
+
+  it('returns null on missing header', () => {
+    expect(verifySmokeAdminToken(undefined)).toBeNull();
+  });
+
+  it('returns null on empty header', () => {
+    expect(verifySmokeAdminToken('')).toBeNull();
+    expect(verifySmokeAdminToken('Bearer ')).toBeNull();
+  });
+
+  it('returns null on a token signed with the wrong key', () => {
+    const token = jwt.sign({ sub: 'smoke-bot', iss: 'smoke' }, 'attacker-key', {
+      algorithm: 'HS256',
+      expiresIn: '5m',
+    });
+    expect(verifySmokeAdminToken(`Bearer ${token}`)).toBeNull();
+  });
+
+  it('returns null on an expired token', () => {
+    // jsonwebtoken auto-rejects expired tokens during verify(); a negative
+    // expiresIn is the easiest way to mint one without faking the clock.
+    const token = sign({ sub: 'smoke-bot', iss: 'smoke' }, { expiresIn: -10 });
+    expect(verifySmokeAdminToken(`Bearer ${token}`)).toBeNull();
+  });
+
+  it('returns null when sub is not "smoke-bot"', () => {
+    // Even a valid signature must be rejected if the principal isn't the
+    // smoke bot — defends against an attacker reusing the smoke key
+    // signing path to forge another identity.
+    const token = sign({ sub: 'someone-else', iss: 'smoke' }, { expiresIn: '5m' });
+    expect(verifySmokeAdminToken(`Bearer ${token}`)).toBeNull();
+  });
+
+  it('returns null when iss is not "smoke"', () => {
+    const token = sign({ sub: 'smoke-bot', iss: 'production' }, { expiresIn: '5m' });
+    expect(verifySmokeAdminToken(`Bearer ${token}`)).toBeNull();
+  });
+
+  it('returns null on a non-HS256 algorithm', () => {
+    // The verifier pins algorithms: ['HS256']. A token presenting itself
+    // as HS512 (or any other alg) must be rejected — otherwise an
+    // attacker could fork the verification to a key-confusion path.
+    const token = jwt.sign({ sub: 'smoke-bot', iss: 'smoke' }, KEY, {
+      algorithm: 'HS512',
+      expiresIn: '5m',
+    });
+    expect(verifySmokeAdminToken(`Bearer ${token}`)).toBeNull();
+  });
+
+  it('returns null on a malformed token string', () => {
+    expect(verifySmokeAdminToken('Bearer not-a-jwt')).toBeNull();
+  });
+});

--- a/backend/src/__tests__/smokeReset.test.ts
+++ b/backend/src/__tests__/smokeReset.test.ts
@@ -18,14 +18,21 @@ function makeRegistryFake(rowsByEmail: PublisherRecord[]): {
   registryCalls: { upsert: PublisherRecord[]; delete: string[] };
 } {
   const calls = { upsert: [] as PublisherRecord[], delete: [] as string[] };
+  // Local copy so delete() actually mutates the result of subsequent
+  // getByEmail calls — needed for the post-reset requestApply assertion.
+  const rows = [...rowsByEmail];
   return {
     registryCalls: calls,
     registry: {
       getByEmail: jest.fn(async (e: string) => {
         // Mirror the real service's normalize-on-read.
-        return rowsByEmail.filter(r => r.contactEmail === e.toLowerCase().trim());
+        return rows.filter(r => r.contactEmail === e.toLowerCase().trim());
       }),
-      delete: jest.fn(async (id: string) => { calls.delete.push(id); }),
+      delete: jest.fn(async (id: string) => {
+        calls.delete.push(id);
+        const idx = rows.findIndex(r => r.id === id);
+        if (idx >= 0) rows.splice(idx, 1);
+      }),
       upsert: jest.fn(async (rec: PublisherRecord) => { calls.upsert.push(rec); }),
     } as unknown as jest.Mocked<Pick<PublisherRegistryService, 'getByEmail' | 'delete' | 'upsert'>>,
   };
@@ -112,7 +119,7 @@ describe('resetBbtest', () => {
     expect(r).toEqual({
       rowsAffected: 0,
       applicationsDeleted: 0,
-      publishersResetInPlace: 0,
+      publishersDeleted: 0,
       eventsDeleted: 0,
       magicTokensDeleted: 0,
     });
@@ -124,7 +131,12 @@ describe('resetBbtest', () => {
     expect(dbCalls.scans).toBe(1);
   });
 
-  it('resets an approved publisher in place to baseline state', async () => {
+  it('hard-deletes approved publisher rows (so requestApply can re-issue)', async () => {
+    // The contract enforced here: after reset, no publisher row maps to
+    // bbtest's email. requestApply refuses any email that maps to ANY
+    // publisher row regardless of applicationStatus, so a row left in
+    // place — even a pristinely-baseline-state one — would break the
+    // smoke's step 1 on the next run.
     const dirty: PublisherRecord = {
       ...baselinePublisher,
       paused: true,
@@ -140,19 +152,11 @@ describe('resetBbtest', () => {
     const r = await resetBbtest(deps, BBTEST_EMAIL);
 
     expect(eventStoreCalls.deleteAllForPublisher).toEqual(['pub-bbtest']);
-    expect(registryCalls.upsert).toHaveLength(1);
-    const reset = registryCalls.upsert[0];
-    expect(reset.id).toBe('pub-bbtest');
-    expect(reset.enabled).toBe(true);
-    expect(reset.paused).toBe(false);
-    expect(reset.applicationStatus).toBe('approved');
-    expect(reset.trustLevel).toBe('auto');
-    expect(reset.selfPausedAt).toBeUndefined();
-    expect(reset.selfDisabledAt).toBeUndefined();
-    expect(reset.pendingThresholdHalt).toBeUndefined();
-    expect(registryCalls.delete).toEqual([]);
+    // Approved row is hard-deleted, NOT reset-in-place.
+    expect(registryCalls.delete).toEqual(['pub-bbtest']);
+    expect(registryCalls.upsert).toEqual([]);
     expect(r.rowsAffected).toBe(6); // 5 events + 1 publisher
-    expect(r.publishersResetInPlace).toBe(1);
+    expect(r.publishersDeleted).toBe(1);
     expect(r.eventsDeleted).toBe(5);
   });
 
@@ -228,8 +232,8 @@ describe('resetBbtest', () => {
     // Pass a mixed-case version of the email — the reset must lowercase
     // before scanning so the match still hits.
     const r = await resetBbtest(deps, '  BBTest@CHQCAL.ORG  ');
-    expect(registryCalls.upsert).toHaveLength(1);
-    expect(r.publishersResetInPlace).toBe(1);
+    expect(registryCalls.delete).toEqual(['pub-bbtest']);
+    expect(r.publishersDeleted).toBe(1);
   });
 
   it('rejects an empty email outright (would otherwise scan-delete everything)', async () => {
@@ -243,22 +247,48 @@ describe('resetBbtest', () => {
       ...baselinePublisher,
       paused: true,
     };
-    // After the first reset upserts the cleaned row, a re-fetch via getByEmail
-    // would return the cleaned row — which is idempotent (the upsert is
-    // exactly the same shape) but still touches 1 row and any of its events.
-    // In the smoke runtime, the second call (afterAll) typically sees a
-    // baseline-state row + no events, which yields rowsAffected = 1
-    // (re-upsert). To assert true 0-row idempotency we test the empty case,
-    // which the first test above already covers.
     const { deps } = commonDeps({
       publishers: [dirty],
       eventsPerPublisher: { 'pub-bbtest': 0 },
     });
     const first = await resetBbtest(deps, BBTEST_EMAIL);
-    expect(first.publishersResetInPlace).toBe(1);
+    expect(first.publishersDeleted).toBe(1);
 
-    const { deps: deps2 } = commonDeps({}); // post-first-reset world: row was reset, so subsequent getByEmail returns []
+    // Post-first-reset world: row was deleted, so subsequent getByEmail returns [].
+    const { deps: deps2 } = commonDeps({});
     const second = await resetBbtest(deps2, BBTEST_EMAIL);
     expect(second.rowsAffected).toBe(0);
+  });
+
+  it('after reset, requestApply (PublisherApplicationService) succeeds for the bbtest email', async () => {
+    // Integration-style assertion: the contract that motivates "delete the
+    // approved row, don't reset-in-place" is that
+    // PublisherApplicationService.requestApply must succeed on the next
+    // smoke run. We exercise that contract directly here against an
+    // in-memory registry.
+    const reg = makeRegistryFake([baselinePublisher]).registry;
+    // Wire the fake into the resetBbtest deps. The eventStore and db can
+    // be the same shared fakes — they don't matter for the post-reset
+    // requestApply call.
+    const dbFake = makeDbFake([]);
+    const eventStoreFake = makeEventStoreFake({ 'pub-bbtest': 0 });
+    const deps = {
+      registry: reg as unknown as PublisherRegistryService,
+      eventStore: eventStoreFake.eventStore as unknown as PublisherEventStore,
+      db: dbFake.db as never,
+      magicTokensTableName: TOKENS_TABLE,
+    };
+
+    // Pre-reset: getByEmail returns the approved row, so any logical
+    // requestApply call would refuse.
+    const before = await reg.getByEmail(BBTEST_EMAIL);
+    expect(before).toHaveLength(1);
+
+    await resetBbtest(deps, BBTEST_EMAIL);
+
+    // Post-reset: getByEmail returns [], so the requestApply uniqueness
+    // gate (registry.getByEmail(email).length > 0) does NOT fire.
+    const after = await reg.getByEmail(BBTEST_EMAIL);
+    expect(after).toEqual([]);
   });
 });

--- a/backend/src/__tests__/smokeReset.test.ts
+++ b/backend/src/__tests__/smokeReset.test.ts
@@ -1,0 +1,264 @@
+// Tests for the bbtest reset path used by the post-deploy publisher
+// smoke. The reset is idempotent (no-op on empty state, full cleanup on
+// populated state, partial cleanup if only some rows exist) — each of
+// those branches is covered below.
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+
+import { resetBbtest } from '../services/smokeReset';
+import type { PublisherRegistryService } from '../services/publisherRegistryService';
+import type { PublisherEventStore } from '../services/publisherEventStore';
+import type { PublisherRecord } from '../types/publisher';
+
+const BBTEST_EMAIL = 'bbtest@chqcal.org';
+const TOKENS_TABLE = 'chq-magic-tokens';
+
+function makeRegistryFake(rowsByEmail: PublisherRecord[]): {
+  registry: jest.Mocked<Pick<PublisherRegistryService, 'getByEmail' | 'delete' | 'upsert'>>;
+  registryCalls: { upsert: PublisherRecord[]; delete: string[] };
+} {
+  const calls = { upsert: [] as PublisherRecord[], delete: [] as string[] };
+  return {
+    registryCalls: calls,
+    registry: {
+      getByEmail: jest.fn(async (e: string) => {
+        // Mirror the real service's normalize-on-read.
+        return rowsByEmail.filter(r => r.contactEmail === e.toLowerCase().trim());
+      }),
+      delete: jest.fn(async (id: string) => { calls.delete.push(id); }),
+      upsert: jest.fn(async (rec: PublisherRecord) => { calls.upsert.push(rec); }),
+    } as unknown as jest.Mocked<Pick<PublisherRegistryService, 'getByEmail' | 'delete' | 'upsert'>>,
+  };
+}
+
+function makeEventStoreFake(eventsPerPublisher: Record<string, number>): {
+  eventStore: jest.Mocked<Pick<PublisherEventStore, 'deleteAllForPublisher'>>;
+  eventStoreCalls: { deleteAllForPublisher: string[] };
+} {
+  const calls = { deleteAllForPublisher: [] as string[] };
+  return {
+    eventStoreCalls: calls,
+    eventStore: {
+      deleteAllForPublisher: jest.fn(async (id: string) => {
+        calls.deleteAllForPublisher.push(id);
+        return eventsPerPublisher[id] ?? 0;
+      }),
+    } as unknown as jest.Mocked<Pick<PublisherEventStore, 'deleteAllForPublisher'>>,
+  };
+}
+
+function makeDbFake(magicTokenRows: { tokenHash: string; email: string }[]): {
+  db: { send: jest.Mock };
+  dbCalls: { scans: number; deletes: string[] };
+} {
+  const calls = { scans: 0, deletes: [] as string[] };
+  const send = jest.fn(async (cmd: { constructor: { name: string }; input?: Record<string, unknown> }) => {
+    const name = cmd.constructor?.name;
+    const input = cmd.input ?? {};
+    if (name === 'ScanCommand') {
+      calls.scans += 1;
+      const filter = (input as { ExpressionAttributeValues?: { ':e'?: string } })
+        .ExpressionAttributeValues?.[':e'];
+      const matches = magicTokenRows.filter(r => r.email === filter);
+      return { Items: matches };
+    }
+    if (name === 'DeleteCommand') {
+      const key = (input as { Key?: { tokenHash?: string } }).Key;
+      if (key?.tokenHash) calls.deletes.push(key.tokenHash);
+      return {};
+    }
+    throw new Error(`unexpected DDB command in test: ${name}`);
+  });
+  return { db: { send }, dbCalls: calls };
+}
+
+function commonDeps(opts: {
+  publishers?: PublisherRecord[];
+  eventsPerPublisher?: Record<string, number>;
+  magicTokens?: { tokenHash: string; email: string }[];
+}) {
+  const reg = makeRegistryFake(opts.publishers ?? []);
+  const es = makeEventStoreFake(opts.eventsPerPublisher ?? {});
+  const dbFake = makeDbFake(opts.magicTokens ?? []);
+  return {
+    deps: {
+      registry: reg.registry as unknown as PublisherRegistryService,
+      eventStore: es.eventStore as unknown as PublisherEventStore,
+      db: dbFake.db as never,
+      magicTokensTableName: TOKENS_TABLE,
+    },
+    registryCalls: reg.registryCalls,
+    eventStoreCalls: es.eventStoreCalls,
+    dbCalls: dbFake.dbCalls,
+  };
+}
+
+const baselinePublisher: PublisherRecord = {
+  id: 'pub-bbtest',
+  name: 'bbtest',
+  contactEmail: BBTEST_EMAIL,
+  sourceUrl: 'https://example.com/bbtest.json',
+  sourceType: 'json',
+  trustLevel: 'auto',
+  enabled: true,
+  applicationStatus: 'approved',
+  createdAt: '2026-01-01T00:00:00Z',
+};
+
+describe('resetBbtest', () => {
+  it('is a no-op when nothing exists for the email', async () => {
+    const { deps, registryCalls, eventStoreCalls, dbCalls } = commonDeps({});
+    const r = await resetBbtest(deps, BBTEST_EMAIL);
+    expect(r).toEqual({
+      rowsAffected: 0,
+      applicationsDeleted: 0,
+      publishersResetInPlace: 0,
+      eventsDeleted: 0,
+      magicTokensDeleted: 0,
+    });
+    expect(registryCalls.delete).toEqual([]);
+    expect(registryCalls.upsert).toEqual([]);
+    expect(eventStoreCalls.deleteAllForPublisher).toEqual([]);
+    expect(dbCalls.deletes).toEqual([]);
+    // One scan still happens (we have to ask the magic-tokens table).
+    expect(dbCalls.scans).toBe(1);
+  });
+
+  it('resets an approved publisher in place to baseline state', async () => {
+    const dirty: PublisherRecord = {
+      ...baselinePublisher,
+      paused: true,
+      selfPausedAt: '2026-01-02T00:00:00Z',
+      selfDisabledAt: '2026-01-03T00:00:00Z',
+      enabled: false, // self-disabled
+      pendingThresholdHalt: { detectedAt: 'x', incomingFeed: { eventCount: 0, publisherId: 'pub-bbtest' } },
+    };
+    const { deps, registryCalls, eventStoreCalls } = commonDeps({
+      publishers: [dirty],
+      eventsPerPublisher: { 'pub-bbtest': 5 },
+    });
+    const r = await resetBbtest(deps, BBTEST_EMAIL);
+
+    expect(eventStoreCalls.deleteAllForPublisher).toEqual(['pub-bbtest']);
+    expect(registryCalls.upsert).toHaveLength(1);
+    const reset = registryCalls.upsert[0];
+    expect(reset.id).toBe('pub-bbtest');
+    expect(reset.enabled).toBe(true);
+    expect(reset.paused).toBe(false);
+    expect(reset.applicationStatus).toBe('approved');
+    expect(reset.trustLevel).toBe('auto');
+    expect(reset.selfPausedAt).toBeUndefined();
+    expect(reset.selfDisabledAt).toBeUndefined();
+    expect(reset.pendingThresholdHalt).toBeUndefined();
+    expect(registryCalls.delete).toEqual([]);
+    expect(r.rowsAffected).toBe(6); // 5 events + 1 publisher
+    expect(r.publishersResetInPlace).toBe(1);
+    expect(r.eventsDeleted).toBe(5);
+  });
+
+  it('hard-deletes pending application rows (vs resetting them in place)', async () => {
+    const pending: PublisherRecord = {
+      ...baselinePublisher,
+      id: 'pub-bbtest-pending',
+      enabled: false,
+      applicationStatus: 'pending',
+    };
+    const { deps, registryCalls, eventStoreCalls } = commonDeps({
+      publishers: [pending],
+    });
+    const r = await resetBbtest(deps, BBTEST_EMAIL);
+
+    expect(registryCalls.delete).toEqual(['pub-bbtest-pending']);
+    expect(registryCalls.upsert).toEqual([]); // never reset-in-place
+    // Pending rows have no events to delete (smoke design — they were
+    // never approved, never ingested), but the function does NOT call
+    // deleteAllForPublisher for them either. The contract is "events are
+    // tied to approved publishers."
+    expect(eventStoreCalls.deleteAllForPublisher).toEqual([]);
+    expect(r.applicationsDeleted).toBe(1);
+    expect(r.rowsAffected).toBe(1);
+  });
+
+  it('hard-deletes rejected application rows', async () => {
+    const rejected: PublisherRecord = {
+      ...baselinePublisher,
+      id: 'pub-bbtest-rejected',
+      enabled: false,
+      applicationStatus: 'rejected',
+    };
+    const { deps, registryCalls } = commonDeps({ publishers: [rejected] });
+    const r = await resetBbtest(deps, BBTEST_EMAIL);
+    expect(registryCalls.delete).toEqual(['pub-bbtest-rejected']);
+    expect(r.applicationsDeleted).toBe(1);
+  });
+
+  it('cleans up magic-token rows by email', async () => {
+    const { deps, dbCalls } = commonDeps({
+      magicTokens: [
+        { tokenHash: 'h1', email: BBTEST_EMAIL },
+        { tokenHash: 'h2', email: BBTEST_EMAIL },
+        { tokenHash: 'other', email: 'someone-else@example.com' }, // must NOT be touched
+      ],
+    });
+    const r = await resetBbtest(deps, BBTEST_EMAIL);
+    expect(dbCalls.deletes.sort()).toEqual(['h1', 'h2']); // 'other' excluded
+    expect(r.magicTokensDeleted).toBe(2);
+  });
+
+  it('handles partial state (only magic-token rows exist, no publisher)', async () => {
+    // This shape happens when an apply request was sent (token issued + email
+    // dispatched) but the user never clicked through. The reset must still
+    // clean up the orphaned token row so the next smoke run can issue fresh
+    // ones without colliding.
+    const { deps, registryCalls, dbCalls } = commonDeps({
+      magicTokens: [{ tokenHash: 'orphan', email: BBTEST_EMAIL }],
+    });
+    const r = await resetBbtest(deps, BBTEST_EMAIL);
+    expect(registryCalls.upsert).toEqual([]);
+    expect(registryCalls.delete).toEqual([]);
+    expect(dbCalls.deletes).toEqual(['orphan']);
+    expect(r.magicTokensDeleted).toBe(1);
+    expect(r.rowsAffected).toBe(1);
+  });
+
+  it('normalizes the email before querying', async () => {
+    const { deps, registryCalls } = commonDeps({
+      publishers: [baselinePublisher], // contactEmail = lowercased BBTEST_EMAIL
+    });
+    // Pass a mixed-case version of the email — the reset must lowercase
+    // before scanning so the match still hits.
+    const r = await resetBbtest(deps, '  BBTest@CHQCAL.ORG  ');
+    expect(registryCalls.upsert).toHaveLength(1);
+    expect(r.publishersResetInPlace).toBe(1);
+  });
+
+  it('rejects an empty email outright (would otherwise scan-delete everything)', async () => {
+    const { deps } = commonDeps({});
+    await expect(resetBbtest(deps, '')).rejects.toThrow(/non-empty/);
+    await expect(resetBbtest(deps, '   ')).rejects.toThrow(/non-empty/);
+  });
+
+  it('is idempotent — second call after the first has rowsAffected=0', async () => {
+    const dirty: PublisherRecord = {
+      ...baselinePublisher,
+      paused: true,
+    };
+    // After the first reset upserts the cleaned row, a re-fetch via getByEmail
+    // would return the cleaned row — which is idempotent (the upsert is
+    // exactly the same shape) but still touches 1 row and any of its events.
+    // In the smoke runtime, the second call (afterAll) typically sees a
+    // baseline-state row + no events, which yields rowsAffected = 1
+    // (re-upsert). To assert true 0-row idempotency we test the empty case,
+    // which the first test above already covers.
+    const { deps } = commonDeps({
+      publishers: [dirty],
+      eventsPerPublisher: { 'pub-bbtest': 0 },
+    });
+    const first = await resetBbtest(deps, BBTEST_EMAIL);
+    expect(first.publishersResetInPlace).toBe(1);
+
+    const { deps: deps2 } = commonDeps({}); // post-first-reset world: row was reset, so subsequent getByEmail returns []
+    const second = await resetBbtest(deps2, BBTEST_EMAIL);
+    expect(second.rowsAffected).toBe(0);
+  });
+});

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -15,6 +15,8 @@ import { ApplicationStateError, PublisherAdminService } from '../services/publis
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherEventStore } from '../services/publisherEventStore';
 import { SesMailService } from '../services/mailService';
+import { signPublisherJwt } from '../services/publisherAuthService';
+import { v4 as uuidv4 } from 'uuid';
 import {
   handlePublisherTest,
   handlePublisherApplyRequest,
@@ -74,6 +76,58 @@ function publisherAdmin(): PublisherAdminService {
 // to the lazily-constructed real instance.
 export function _setPublisherAdminForTests(svc: PublisherAdminService | null): void {
   _publisherAdmin = svc;
+}
+
+// Smoke-bot route plumbing. Lazy singletons + an injection point so the
+// adminHandler tests can drive the smoke routes without standing up real
+// DDB connections. The smoke endpoints share the underlying registry +
+// event-store with publisherAdmin(), but it's cleaner to construct them
+// independently than to expose private members of PublisherAdminService.
+import type { SmokeResetResult } from '../services/smokeReset';
+import { resetBbtest as _resetBbtestImpl } from '../services/smokeReset';
+
+interface SmokeRouteDeps {
+  registry: PublisherRegistryService;
+  eventStore: PublisherEventStore;
+  magicTokensTableName: string;
+  // Override hook for tests — defaults to the production resetBbtest
+  // implementation. We re-bind through this seam so a unit test can
+  // assert "the route called resetBbtest with these args" without having
+  // to spin up a fake DDB.
+  resetImpl?: (
+    deps: {
+      registry: PublisherRegistryService;
+      eventStore: PublisherEventStore;
+      db: DynamoDBDocumentClient;
+      magicTokensTableName: string;
+    },
+    bbtestEmail: string,
+  ) => Promise<SmokeResetResult>;
+}
+
+let _smokeRouteDeps: SmokeRouteDeps | null = null;
+function smokeRouteDeps(): SmokeRouteDeps {
+  if (!_smokeRouteDeps) {
+    _smokeRouteDeps = {
+      registry: new PublisherRegistryService(
+        docClient,
+        process.env.PUBLISHERS_TABLE_NAME ?? 'chautauqua-calendar-publishers',
+      ),
+      eventStore: new PublisherEventStore(
+        docClient,
+        process.env.PUBLISHER_EVENTS_TABLE_NAME ?? 'chautauqua-calendar-publisher-events',
+      ),
+      magicTokensTableName:
+        process.env.PUBLISHER_MAGIC_TOKEN_TABLE_NAME
+          ?? 'chautauqua-calendar-publisher-magic-tokens',
+    };
+  }
+  return _smokeRouteDeps;
+}
+
+// Test-only: inject smoke-route plumbing. Pass null to revert.
+export function _setSmokeRouteDepsForTests(deps: SmokeRouteDeps | null): void {
+  _smokeRouteDeps = deps;
 }
 
 // Environment variables
@@ -741,6 +795,155 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       } catch (error) {
         console.error('Error cancelling threshold halt:', error);
         return createResponse(500, { error: 'Failed to cancel threshold halt' });
+      }
+    }
+
+    // ─── Smoke-bot endpoints ───────────────────────────────────────────
+    //
+    // Three test-only routes used exclusively by the post-deploy
+    // publisher-lifecycle smoke. All three are also gated by
+    // SMOKE_ADMIN_ROUTE_ALLOWLIST above — Google-OAuth admins are NOT
+    // expected to hit these (they have richer dashboards), but the
+    // allowlist + signing-key check is what blocks an attacker with a
+    // forged smoke token from driving anything outside the smoke's needs.
+    //
+    // The smoke runs against real production DDB; even if these endpoints
+    // are accidentally hit by something else, the bbtest-email scoping
+    // means the blast radius is limited to one publisher.
+    if (path === '/smoke-reset-bbtest' && httpMethod === 'POST') {
+      try {
+        const email = typeof requestBody?.email === 'string' ? requestBody.email : '';
+        if (!email) {
+          return createResponse(400, { error: 'email is required' });
+        }
+        const deps = smokeRouteDeps();
+        const reset = deps.resetImpl ?? _resetBbtestImpl;
+        const result = await reset(
+          {
+            registry: deps.registry,
+            eventStore: deps.eventStore,
+            db: docClient,
+            magicTokensTableName: deps.magicTokensTableName,
+          },
+          email,
+        );
+        console.log('[smoke] reset complete', { adminSubject: 'smoke-bot', email, result });
+        return createResponse(200, result);
+      } catch (error) {
+        console.error('Error in smoke-reset-bbtest:', error);
+        const message = error instanceof Error ? error.message : 'unknown error';
+        return createResponse(500, { error: `smoke reset failed: ${message}` });
+      }
+    }
+
+    if (path === '/smoke-magic-token-by-email' && httpMethod === 'POST') {
+      // Smoke-only "consume the apply magic-link by email lookup" path.
+      //
+      // The real magic-token store only persists the SHA-256 hash of the
+      // raw token (raw tokens go out via SES, never written to DDB), so
+      // an email-keyed lookup CANNOT recover the raw token to feed
+      // /publisher-apply/verify. Instead, this endpoint replays the
+      // verifyApply effects directly: find the most-recent apply row for
+      // the email, materialize the publisher row from its applyPayload,
+      // delete the token row, and return the publisher id + JWT.
+      //
+      // The production SES delivery still happens upstream — apply mail
+      // is sent every smoke run, exercising real SES — but the smoke
+      // reads no mailbox.
+      //
+      // Allowlisted to smoke-bot only (SMOKE_ADMIN_ROUTE_ALLOWLIST). NEVER
+      // reachable without a valid smoke-bot signed token.
+      try {
+        const email = typeof requestBody?.email === 'string' ? requestBody.email : '';
+        if (!email) {
+          return createResponse(400, { error: 'email is required' });
+        }
+        const normalized = email.trim().toLowerCase();
+        const deps = smokeRouteDeps();
+        type SmokeTokenRow = {
+          tokenHash: string;
+          createdAt: string;
+          purpose: string;
+          email: string;
+          applyPayload?: {
+            name: string;
+            email: string;
+            sourceUrl: string;
+            sourceType: 'json' | 'html';
+            organization?: string;
+            notes?: string;
+          };
+        };
+        let last: Record<string, unknown> | undefined;
+        let latest: SmokeTokenRow | null = null;
+        do {
+          const r = await docClient.send(new ScanCommand({
+            TableName: deps.magicTokensTableName,
+            FilterExpression: 'email = :e AND purpose = :p',
+            ExpressionAttributeValues: { ':e': normalized, ':p': 'apply' },
+            ExclusiveStartKey: last,
+          }));
+          for (const item of (r.Items ?? []) as SmokeTokenRow[]) {
+            if (!latest || item.createdAt > latest.createdAt) {
+              latest = item;
+            }
+          }
+          last = r.LastEvaluatedKey;
+        } while (last);
+        if (!latest || !latest.applyPayload) {
+          return createResponse(404, { error: 'no apply token found' });
+        }
+
+        // Materialize the publisher row from the apply payload (mirrors
+        // PublisherApplicationService.verifyApply) and delete the magic-
+        // token row so it can't be reused.
+        const publisherId = `pub-${uuidv4()}`;
+        const nowIso = new Date().toISOString();
+        await deps.registry.upsert({
+          id: publisherId,
+          name: latest.applyPayload.name,
+          contactEmail: normalized,
+          sourceUrl: latest.applyPayload.sourceUrl,
+          sourceType: latest.applyPayload.sourceType,
+          trustLevel: 'review',
+          enabled: false,
+          createdAt: nowIso,
+          applicationStatus: 'pending',
+          appliedAt: nowIso,
+          organization: latest.applyPayload.organization,
+          applicantNotes: latest.applyPayload.notes,
+        });
+        await docClient.send(new DeleteCommand({
+          TableName: deps.magicTokensTableName,
+          Key: { tokenHash: latest.tokenHash },
+        }));
+
+        const publisherJwt = await signPublisherJwt({
+          publisherId,
+          email: normalized,
+          tokenVersion: 0,
+        });
+        return createResponse(200, { jwt: publisherJwt, publisherId, email: normalized });
+      } catch (error) {
+        console.error('Error in smoke-magic-token-by-email:', error);
+        return createResponse(500, { error: 'smoke token lookup failed' });
+      }
+    }
+
+    const matchEventCount = path.match(/^\/publishers\/([^/]+)\/events\/count$/);
+    if (matchEventCount && httpMethod === 'POST') {
+      // Smoke uses this to count published events between ingest runs.
+      // Could be GET, but we use POST to keep symmetry with the other
+      // smoke endpoints (all of which are POST) and to leave room for
+      // optional filter args in the body without breaking caching rules.
+      try {
+        const publisherId = decodeURIComponent(matchEventCount[1]);
+        const deps = smokeRouteDeps();
+        const events = await deps.eventStore.listForPublisher(publisherId);
+        return createResponse(200, { count: events.length });
+      } catch (error) {
+        console.error('Error in smoke event count:', error);
+        return createResponse(500, { error: 'smoke event count failed' });
       }
     }
 

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -271,16 +271,24 @@ const SMOKE_ADMIN_ROUTE_ALLOWLIST: ReadonlyArray<{ method: string; pattern: RegE
   { method: 'POST',  pattern: /^\/publisher-applications\/[^/]+\/approve$/ },
   // Trigger an immediate publisher-ingest run (async invoke).
   { method: 'POST',  pattern: /^\/publishers\/run-ingest$/ },
-  // List all publishers (smoke needs to assert the bbtest row's state).
+  // List all publishers — the smoke asserts the just-approved bbtest row
+  // appears in the list with enabled=true. This route exposes contact
+  // emails, so the value of "smoke-bot can read it" is weighed against
+  // "leaked smoke key + this route = email list dump" — we accept that
+  // tradeoff because (a) the same data is already reachable via real
+  // admin auth, and (b) the smoke needs a way to confirm the approve
+  // step actually persisted.
   { method: 'GET',   pattern: /^\/publishers$/ },
-  // Admin disable/enable of a publisher row uses PATCH /publishers/{id}.
-  // Smoke uses this to drive the pause / resume / re-enable transitions
-  // for bbtest after self-disable retraction.
-  { method: 'PATCH', pattern: /^\/publishers\/[^/]+$/ },
   // Smoke-only endpoints (defined in this handler below).
   { method: 'POST',  pattern: /^\/smoke-reset-bbtest$/ },
   { method: 'POST',  pattern: /^\/smoke-magic-token-by-email$/ },
   { method: 'POST',  pattern: /^\/publishers\/[^/]+\/events\/count$/ },
+  // NOTE: PATCH /publishers/{id} is intentionally NOT on this allowlist.
+  // Pause/resume/self-disable transitions in the smoke go through the
+  // publisher-JWT routes (/publisher-pause, /publisher-resume,
+  // /publisher-disable), not the admin PATCH. Keeping PATCH off the
+  // allowlist means a leaked smoke key cannot mutate arbitrary publisher
+  // rows (e.g. flip another publisher's trustLevel or contactEmail).
 ];
 
 function routeMatchesSmokeAllowlist(method: string, path: string): boolean {
@@ -807,14 +815,30 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
     // allowlist + signing-key check is what blocks an attacker with a
     // forged smoke token from driving anything outside the smoke's needs.
     //
-    // The smoke runs against real production DDB; even if these endpoints
-    // are accidentally hit by something else, the bbtest-email scoping
-    // means the blast radius is limited to one publisher.
+    // Defense-in-depth: the email-keyed routes (smoke-reset-bbtest and
+    // smoke-magic-token-by-email) ALSO hard-gate the supplied email
+    // against process.env.SMOKE_BBTEST_EMAIL. A leaked signing key would
+    // otherwise let an attacker mint reset/JWT actions for arbitrary
+    // emails. With this gate, the blast radius is limited to the single
+    // configured bbtest mailbox even on key compromise. If
+    // SMOKE_BBTEST_EMAIL is unset (e.g. in environments where the smoke
+    // is intentionally not provisioned), both routes return 403.
     if (path === '/smoke-reset-bbtest' && httpMethod === 'POST') {
       try {
-        const email = typeof requestBody?.email === 'string' ? requestBody.email : '';
+        const expectedEmail = (process.env.SMOKE_BBTEST_EMAIL ?? '').trim().toLowerCase();
+        if (!expectedEmail) {
+          console.log('[admin] smoke-reset-bbtest rejected: SMOKE_BBTEST_EMAIL not configured');
+          return createResponse(403, { error: 'Smoke bbtest email is not configured on this Lambda' });
+        }
+        const email = typeof requestBody?.email === 'string' ? requestBody.email.trim().toLowerCase() : '';
         if (!email) {
           return createResponse(400, { error: 'email is required' });
+        }
+        if (email !== expectedEmail) {
+          console.log('[admin] smoke-reset-bbtest rejected: email does not match SMOKE_BBTEST_EMAIL', {
+            adminSubject: 'smoke-bot',
+          });
+          return createResponse(403, { error: 'Email does not match the configured smoke bbtest email' });
         }
         const deps = smokeRouteDeps();
         const reset = deps.resetImpl ?? _resetBbtestImpl;
@@ -852,13 +876,26 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       // reads no mailbox.
       //
       // Allowlisted to smoke-bot only (SMOKE_ADMIN_ROUTE_ALLOWLIST). NEVER
-      // reachable without a valid smoke-bot signed token.
+      // reachable without a valid smoke-bot signed token. ALSO hard-gated
+      // to process.env.SMOKE_BBTEST_EMAIL so a leaked signing key cannot
+      // mint a JWT for an arbitrary email.
       try {
+        const expectedEmail = (process.env.SMOKE_BBTEST_EMAIL ?? '').trim().toLowerCase();
+        if (!expectedEmail) {
+          console.log('[admin] smoke-magic-token-by-email rejected: SMOKE_BBTEST_EMAIL not configured');
+          return createResponse(403, { error: 'Smoke bbtest email is not configured on this Lambda' });
+        }
         const email = typeof requestBody?.email === 'string' ? requestBody.email : '';
         if (!email) {
           return createResponse(400, { error: 'email is required' });
         }
         const normalized = email.trim().toLowerCase();
+        if (normalized !== expectedEmail) {
+          console.log('[admin] smoke-magic-token-by-email rejected: email does not match SMOKE_BBTEST_EMAIL', {
+            adminSubject: 'smoke-bot',
+          });
+          return createResponse(403, { error: 'Email does not match the configured smoke bbtest email' });
+        }
         const deps = smokeRouteDeps();
         type SmokeTokenRow = {
           tokenHash: string;
@@ -939,8 +976,10 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       try {
         const publisherId = decodeURIComponent(matchEventCount[1]);
         const deps = smokeRouteDeps();
-        const events = await deps.eventStore.listForPublisher(publisherId);
-        return createResponse(200, { count: events.length });
+        // Use a DDB Query with Select=COUNT so we never hydrate event
+        // payloads into Lambda memory — see PublisherEventStore.countForPublisher.
+        const count = await deps.eventStore.countForPublisher(publisherId);
+        return createResponse(200, { count });
       } catch (error) {
         console.error('Error in smoke event count:', error);
         return createResponse(500, { error: 'smoke event count failed' });

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -10,6 +10,7 @@ import {
 } from '../services/publisherIngestInvoker';
 import jwt from 'jsonwebtoken';
 import { google } from 'googleapis';
+import { verifySmokeAdminToken } from '../services/smokeAdminAuth';
 import { ApplicationStateError, PublisherAdminService } from '../services/publisherAdminService';
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherEventStore } from '../services/publisherEventStore';
@@ -196,6 +197,43 @@ const isAuthorizedEmail = (email: string): boolean => {
   const whitelist = ADMIN_EMAIL_WHITELIST.split(',').map(e => e.trim());
   return whitelist.includes(email);
 };
+
+// ─── Smoke-bot allowlist ──────────────────────────────────────────────
+//
+// Routes the post-deploy publisher-lifecycle smoke is allowed to call when
+// authenticated as `smoke-bot` via verifySmokeAdminToken (a separate signing
+// key from the Google OAuth path — see services/smokeAdminAuth.ts).
+//
+// Format: `${HTTP_METHOD} ${path-template}`. Path templates use `{id}` for
+// dynamic segments and are matched against the actual path via the regex
+// helpers below — keep this in sync with routeMatchesSmokeAllowlist.
+//
+// The smoke MUST NOT be able to call any route outside this set, even with
+// a valid signing-key JWT — leaking the key should not let an attacker
+// drive arbitrary admin actions. Every existing admin-only route stays
+// gated to Google-OAuth admins.
+const SMOKE_ADMIN_ROUTE_ALLOWLIST: ReadonlyArray<{ method: string; pattern: RegExp }> = [
+  // Approve a pending publisher application.
+  { method: 'POST',  pattern: /^\/publisher-applications\/[^/]+\/approve$/ },
+  // Trigger an immediate publisher-ingest run (async invoke).
+  { method: 'POST',  pattern: /^\/publishers\/run-ingest$/ },
+  // List all publishers (smoke needs to assert the bbtest row's state).
+  { method: 'GET',   pattern: /^\/publishers$/ },
+  // Admin disable/enable of a publisher row uses PATCH /publishers/{id}.
+  // Smoke uses this to drive the pause / resume / re-enable transitions
+  // for bbtest after self-disable retraction.
+  { method: 'PATCH', pattern: /^\/publishers\/[^/]+$/ },
+  // Smoke-only endpoints (defined in this handler below).
+  { method: 'POST',  pattern: /^\/smoke-reset-bbtest$/ },
+  { method: 'POST',  pattern: /^\/smoke-magic-token-by-email$/ },
+  { method: 'POST',  pattern: /^\/publishers\/[^/]+\/events\/count$/ },
+];
+
+function routeMatchesSmokeAllowlist(method: string, path: string): boolean {
+  return SMOKE_ADMIN_ROUTE_ALLOWLIST.some(
+    ({ method: m, pattern }) => m === method && pattern.test(path),
+  );
+}
 
 // Authentication middleware for Lambda
 const authenticateRequest = (event: APIGatewayProxyEvent): { email: string; name: string } | null => {
@@ -456,7 +494,7 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
     let user = authenticateRequest(event);
     console.log('Authentication result:', user ? `authenticated as "${user.name}"` : 'unauthenticated');
     console.log('Request path:', path);
-    
+
     // In local development, bypass authentication and use dummy user.
     // Requires explicit opt-in via DEV_AUTH_BYPASS=true to prevent accidental bypass in staging.
     const isDevelopment = !isProduction && process.env.DEV_AUTH_BYPASS === 'true';
@@ -464,7 +502,42 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
       console.log('Local development mode: bypassing authentication with dummy user');
       user = { email: 'dev@localhost.local', name: 'Local Dev User' };
     }
-    
+
+    // Smoke-bot fallback for the post-deploy publisher-lifecycle smoke test.
+    // Falls through to a smoke-signing-key JWT only when the regular admin
+    // auth produced no user. Even with a valid smoke token, we 403 routes
+    // outside SMOKE_ADMIN_ROUTE_ALLOWLIST — a leaked key cannot drive
+    // arbitrary admin actions. CloudWatch logs include `adminSubject:
+    // 'smoke-bot'` so smoke-driven mutations are auditable.
+    if (!user) {
+      const smokeAuthHeader =
+        event.headers.Authorization
+        || event.headers.authorization
+        || event.headers['X-Auth-Token']
+        || event.headers['x-auth-token'];
+      const smokePrincipal = verifySmokeAdminToken(smokeAuthHeader);
+      if (smokePrincipal) {
+        if (!routeMatchesSmokeAllowlist(httpMethod, path)) {
+          console.log('[admin] smoke-bot token rejected for non-allowlisted route', {
+            adminSubject: 'smoke-bot',
+            method: httpMethod,
+            path,
+          });
+          return createResponse(403, { error: 'Smoke route not permitted' });
+        }
+        console.log('[admin] smoke-bot authenticated', {
+          adminSubject: 'smoke-bot',
+          method: httpMethod,
+          path,
+        });
+        // Surface a synthetic email so downstream code that audits
+        // `user.email` (e.g. approveApplication's reviewerEmail) records
+        // the smoke run rather than crashing. The email is a non-routable
+        // sentinel — receiving mail to it is not possible.
+        user = { email: 'smoke-bot@chqcal.invalid', name: 'smoke-bot' };
+      }
+    }
+
     if (!user) {
       return createResponse(401, { error: 'Authentication required' });
     }

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -30,7 +30,7 @@ import { SesMailService } from '../services/mailService';
 import { PublisherNotFoundError, PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherApplicationService, EmailAlreadyInUseError } from '../services/publisherApplicationService';
 import { requirePublisherSession } from '../services/publisherSession';
-import { verifyCaptcha } from '../services/captchaService';
+import { verifyCaptchaWithBypass } from '../services/captchaService';
 import {
   updatePublisherProfile,
   ProfileValidationError,
@@ -374,7 +374,13 @@ export async function handlePublisherApplyRequest(
   // request proceeds. In production the secret is set and an empty or
   // bad token is rejected.
   const captchaToken = typeof requestBody?.captchaToken === 'string' ? requestBody.captchaToken : '';
-  const captchaOk = await verifyCaptcha(captchaToken, 'publisher_apply');
+  // Use the bypass-aware wrapper here — the post-deploy smoke test sets
+  // X-Smoke-Bypass with a high-entropy secret so it can drive the apply
+  // flow against the real production stack without needing a real reCAPTCHA
+  // round-trip. Other captcha callsites (calendarHandler feedback) remain
+  // on plain verifyCaptcha — the apply route is the only one the smoke
+  // exercises.
+  const captchaOk = await verifyCaptchaWithBypass(captchaToken, 'publisher_apply', event.headers);
   if (!captchaOk) {
     return json(400, { error: 'CAPTCHA verification failed. Please refresh and try again.', field: 'captcha' });
   }

--- a/backend/src/services/captchaService.ts
+++ b/backend/src/services/captchaService.ts
@@ -108,3 +108,37 @@ export async function verifyCaptcha(
     clearTimeout(timeout);
   }
 }
+
+/**
+ * Wrapper around verifyCaptcha that admits a test-only bypass header for the
+ * post-deploy publisher smoke test (scripts/smoke/publisher-lifecycle.test.ts).
+ *
+ * The bypass fires ONLY when both:
+ *   - process.env.CAPTCHA_BYPASS_TOKEN is non-empty (i.e. infra explicitly
+ *     provisioned a smoke-bypass secret on this Lambda), AND
+ *   - the caller sent header `X-Smoke-Bypass` (case-insensitive) matching
+ *     that secret exactly.
+ *
+ * If either condition fails we fall through to verifyCaptcha — production
+ * traffic without CAPTCHA_BYPASS_TOKEN provisioned cannot use this path no
+ * matter what header values it sends, and a wrong header value short-circuits
+ * back to the real verification.
+ *
+ * Auditability: each accepted bypass is logged with a fixed source tag so
+ * misuse is greppable in CloudWatch.
+ */
+export async function verifyCaptchaWithBypass(
+  token: string,
+  action: string | undefined,
+  headers: { [k: string]: string | undefined },
+): Promise<boolean> {
+  const bypassToken = process.env.CAPTCHA_BYPASS_TOKEN;
+  // Pull both common-cased forms — API Gateway lowercases inbound header
+  // names but reflective lookups by the original casing are still safe.
+  const bypassHeader = headers['x-smoke-bypass'] ?? headers['X-Smoke-Bypass'];
+  if (bypassToken && bypassHeader && bypassHeader === bypassToken) {
+    console.info('[captcha] bypass accepted', { source: 'smoke' });
+    return true;
+  }
+  return verifyCaptcha(token, action);
+}

--- a/backend/src/services/publisherEventStore.ts
+++ b/backend/src/services/publisherEventStore.ts
@@ -31,6 +31,30 @@ export class PublisherEventStore {
     return out;
   }
 
+  // Count events for a publisher without loading their payloads. Uses DDB's
+  // `Select: 'COUNT'` so the response carries only `Count` per page — no
+  // item payloads ever cross the wire. This matters for the smoke's
+  // events/count endpoint, which polls during ingest and would otherwise
+  // pull every event row into Lambda memory just to call .length on it.
+  // Pagination still applies (DDB caps each Query at ~1MB scanned), so
+  // the loop sums Count across pages.
+  async countForPublisher(publisherId: string): Promise<number> {
+    let total = 0;
+    let last: Record<string, unknown> | undefined;
+    do {
+      const r = await this.db.send(new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'publisherId = :p',
+        ExpressionAttributeValues: { ':p': publisherId },
+        Select: 'COUNT',
+        ExclusiveStartKey: last,
+      }));
+      total += r.Count ?? 0;
+      last = r.LastEvaluatedKey;
+    } while (last);
+    return total;
+  }
+
   async listAllPublished(): Promise<StoredPublisherEvent[]> {
     const out: StoredPublisherEvent[] = [];
     let last: Record<string, unknown> | undefined;

--- a/backend/src/services/smokeAdminAuth.ts
+++ b/backend/src/services/smokeAdminAuth.ts
@@ -1,0 +1,77 @@
+// Smoke-bot admin auth verifier for the post-deploy publisher-lifecycle
+// smoke test (scripts/smoke/publisher-lifecycle.test.ts).
+//
+// The smoke runs against the real production stack and needs to drive a
+// handful of admin-only endpoints (approve application, list publishers,
+// run ingest, smoke reset, etc.) without going through the Google OAuth
+// flow. Rather than minting a per-run service-account credential, we issue
+// a short-lived HS256 JWT signed with a shared secret (env
+// ADMIN_SMOKE_SIGNING_KEY) that's provisioned to:
+//   - the admin Lambda's environment, AND
+//   - the deploy-production.yml workflow as a GitHub secret.
+//
+// The signing key NEVER overlaps with the regular admin JWT_SECRET (which
+// signs Google-OAuth-derived sessions). A leak of the smoke key cannot
+// forge a normal admin session.
+//
+// Security envelope:
+//   - HS256 with a 256-bit-random secret (provisioned via Terraform).
+//   - sub claim MUST equal 'smoke-bot'. iss claim MUST equal 'smoke'.
+//   - Token MUST be unexpired.
+//   - Even when the verifier admits the token, the caller (adminHandler)
+//     MUST cross-check `route` against SMOKE_ADMIN_ROUTE_ALLOWLIST. The
+//     verifier returns the principal; route gating is the caller's job.
+//     This split is intentional: routing context is in the handler, not
+//     here, and we want the route allowlist to live next to the routes
+//     it gates.
+
+import jwt from 'jsonwebtoken';
+
+export interface SmokeAdminPrincipal {
+  sub: 'smoke-bot';
+  iss: 'smoke';
+}
+
+/**
+ * Returns the smoke principal when the bearer token is a valid, unexpired
+ * smoke-bot HS256 JWT. Returns `null` for every other case (no env, no
+ * header, malformed header, bad signature, wrong claims, expired) — the
+ * caller treats `null` as "smoke auth not applicable" and either
+ * proceeds to the next auth strategy or returns 401.
+ *
+ * `authHeader` is the raw Authorization header value (e.g. "Bearer eyJ..."),
+ * NOT the bare token. Mirrors the pattern in adminHandler.authenticateRequest.
+ */
+export function verifySmokeAdminToken(
+  authHeader: string | undefined,
+): SmokeAdminPrincipal | null {
+  const key = process.env.ADMIN_SMOKE_SIGNING_KEY;
+  if (!key) return null;
+  if (typeof authHeader !== 'string' || authHeader.length === 0) return null;
+
+  // Accept both "Bearer <jwt>" and a bare jwt — adminHandler's existing
+  // X-Auth-Token path forwards the bare token, and we want a single
+  // verifier helper either way.
+  const token = authHeader.startsWith('Bearer ')
+    ? authHeader.slice('Bearer '.length).trim()
+    : authHeader.trim();
+  if (token.length === 0) return null;
+
+  let decoded: jwt.JwtPayload | string;
+  try {
+    decoded = jwt.verify(token, key, { algorithms: ['HS256'] });
+  } catch {
+    // jsonwebtoken throws TokenExpiredError, JsonWebTokenError, etc. We
+    // intentionally collapse all of them to a single null return — the
+    // caller cannot act on the distinction (the smoke doesn't produce
+    // user-facing error messages here) and exposing the reason to logs
+    // would just provide attackers with a side-channel into key state.
+    return null;
+  }
+
+  if (typeof decoded !== 'object' || decoded === null) return null;
+  if (decoded.sub !== 'smoke-bot') return null;
+  if (decoded.iss !== 'smoke') return null;
+
+  return { sub: 'smoke-bot', iss: 'smoke' };
+}

--- a/backend/src/services/smokeReset.ts
+++ b/backend/src/services/smokeReset.ts
@@ -2,26 +2,28 @@
 // publisher-lifecycle smoke test.
 //
 // Why a dedicated reset path (instead of running the smoke against a fresh
-// publisher each time): bbtest already exists in production and survives
-// across deploys. Provisioning a fresh publisher per smoke run would add
-// real DDB rows and SES traffic for what is fundamentally a deploy
-// verification — and would force the smoke to invent a different email
-// every run. Instead, the smoke asserts that bbtest's lifecycle works
-// end-to-end starting from a known baseline.
+// publisher each time): the smoke walks the bbtest email through a full
+// apply → approve → publish → ... lifecycle. Without an idempotent reset,
+// killed runs would leave half-baked state (a pending application, an
+// approved-but-paused publisher row, half-ingested events) that the next
+// run would trip over.
 //
-// Baseline (after reset): bbtest publisher row exists with
-//   { enabled: true, applicationStatus: 'approved', trustLevel: 'auto',
-//     paused: false, selfPausedAt: null, selfDisabledAt: null }
-// ...and zero events for the publisher, zero application rows, zero
-// magic-token rows for the bbtest email.
+// Baseline (after reset): there are NO publisher rows for the bbtest
+// email — neither approved nor pending. This is required for the smoke's
+// step 1 (apply): PublisherApplicationService.requestApply() rejects any
+// email that already maps to a publisher row regardless of its
+// applicationStatus, so the row MUST be gone for the next apply to
+// succeed. Magic-token rows for the email are also fully cleaned.
 //
 // Idempotency: every step is a delete-or-no-op. Running reset twice in a
 // row (e.g. afterAll fires while beforeAll is still running on a retry) is
 // always safe — the second invocation just sees nothing to clean up.
 //
-// Why not piggy-back on PublisherAdminService.deletePublisher: that method
-// hard-deletes the row, which would break our "bbtest always exists"
-// invariant. We reset state in place instead.
+// Why not piggy-back on PublisherAdminService.deletePublisher: that
+// method's signature requires us to know the publisher's id (we look it
+// up by email here), and it has admin-side concerns (audit trail, etc.)
+// that aren't relevant to a smoke teardown. We hard-delete via the
+// registry directly instead.
 
 import {
   ScanCommand,
@@ -38,7 +40,10 @@ export interface SmokeResetResult {
   rowsAffected: number;
   // Per-domain counters for observability.
   applicationsDeleted: number;
-  publishersResetInPlace: number;
+  // Publisher rows deleted (any applicationStatus). Renamed from
+  // publishersResetInPlace because we now hard-delete approved rows too —
+  // requestApply rejects any email already attached to ANY publisher row.
+  publishersDeleted: number;
   eventsDeleted: number;
   magicTokensDeleted: number;
 }
@@ -58,14 +63,14 @@ export interface SmokeResetDeps {
  * Resets bbtest state to baseline. See file header for the contract.
  *
  * Step order matters:
- *   1. Delete events first (cheap, doesn't depend on publisher row state).
- *   2. Reset publisher row in place (preserves the row's identity so
- *      smoke assertions like `expect(listPublishers).toContain(bbtest)`
- *      remain meaningful).
- *   3. Delete pending application rows for the email (these are different
- *      DDB rows in the publishers table — applications-as-pending-publishers
- *      that were never approved).
- *   4. Delete magic-token rows last — if a magic token survives a row
+ *   1. For each publisher row matching the email, delete its events first
+ *      (cheap, doesn't depend on the publisher row state) and then
+ *      hard-delete the publisher row itself. We delete approved rows too
+ *      (not just pending/rejected) — PublisherApplicationService
+ *      .requestApply() refuses to issue a magic link for any email that
+ *      already maps to ANY publisher row, so leaving an approved row
+ *      around would break the smoke's apply step on the very next run.
+ *   2. Delete magic-token rows last — if a magic token survives a row
  *      cleanup, the next smoke run might pick up a stale token.
  */
 export async function resetBbtest(
@@ -75,7 +80,7 @@ export async function resetBbtest(
   const result: SmokeResetResult = {
     rowsAffected: 0,
     applicationsDeleted: 0,
-    publishersResetInPlace: 0,
+    publishersDeleted: 0,
     eventsDeleted: 0,
     magicTokensDeleted: 0,
   };
@@ -93,41 +98,30 @@ export async function resetBbtest(
   // Both approved publisher rows AND pending application rows live in the
   // same `publishers` table — applications are publisher rows with
   // applicationStatus='pending' and enabled=false. getByEmail returns both.
+  // We hard-delete every match regardless of applicationStatus so the next
+  // /publisher-apply/request can issue a fresh application against this
+  // email (the requestApply uniqueness gate refuses any email already
+  // attached to a publisher row).
   const rowsForEmail = await deps.registry.getByEmail(normalizedEmail);
 
   for (const row of rowsForEmail) {
     if (row.applicationStatus === 'pending' || row.applicationStatus === 'rejected') {
-      // Pending/rejected application: hard-delete. The smoke's apply
-      // step needs an unused email to issue a fresh application against.
+      // Pending/rejected application — no events to clean up (these rows
+      // were never approved + ingested). Hard-delete the row.
       await deps.registry.delete(row.id);
       result.applicationsDeleted += 1;
       result.rowsAffected += 1;
       continue;
     }
 
-    // Approved row (or legacy row with no applicationStatus): reset in
-    // place to baseline. Delete its events first.
+    // Approved row (or legacy row with no applicationStatus): delete its
+    // events first, then the publisher row itself.
     const deleted = await deps.eventStore.deleteAllForPublisher(row.id);
     result.eventsDeleted += deleted;
     result.rowsAffected += deleted;
 
-    await deps.registry.upsert({
-      ...row,
-      applicationStatus: 'approved',
-      enabled: true,
-      trustLevel: 'auto',
-      paused: false,
-      // Clear self-pause / self-disable / email-change-lock markers. We
-      // keep tokenVersion as-is because bumping it would invalidate any
-      // legitimate session (not relevant to smoke, but cheap to preserve).
-      selfPausedAt: undefined,
-      selfDisabledAt: undefined,
-      emailChangeLockedUntil: undefined,
-      pendingThresholdHalt: undefined,
-      lastFetchStatus: undefined,
-      lastFetchMessage: undefined,
-    });
-    result.publishersResetInPlace += 1;
+    await deps.registry.delete(row.id);
+    result.publishersDeleted += 1;
     result.rowsAffected += 1;
   }
 

--- a/backend/src/services/smokeReset.ts
+++ b/backend/src/services/smokeReset.ts
@@ -1,0 +1,165 @@
+// Idempotent reset of the bbtest publisher's state for the post-deploy
+// publisher-lifecycle smoke test.
+//
+// Why a dedicated reset path (instead of running the smoke against a fresh
+// publisher each time): bbtest already exists in production and survives
+// across deploys. Provisioning a fresh publisher per smoke run would add
+// real DDB rows and SES traffic for what is fundamentally a deploy
+// verification — and would force the smoke to invent a different email
+// every run. Instead, the smoke asserts that bbtest's lifecycle works
+// end-to-end starting from a known baseline.
+//
+// Baseline (after reset): bbtest publisher row exists with
+//   { enabled: true, applicationStatus: 'approved', trustLevel: 'auto',
+//     paused: false, selfPausedAt: null, selfDisabledAt: null }
+// ...and zero events for the publisher, zero application rows, zero
+// magic-token rows for the bbtest email.
+//
+// Idempotency: every step is a delete-or-no-op. Running reset twice in a
+// row (e.g. afterAll fires while beforeAll is still running on a retry) is
+// always safe — the second invocation just sees nothing to clean up.
+//
+// Why not piggy-back on PublisherAdminService.deletePublisher: that method
+// hard-deletes the row, which would break our "bbtest always exists"
+// invariant. We reset state in place instead.
+
+import {
+  ScanCommand,
+  DeleteCommand,
+  type DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import type { PublisherRegistryService } from './publisherRegistryService';
+import type { PublisherEventStore } from './publisherEventStore';
+
+export interface SmokeResetResult {
+  // Total number of DDB rows touched. Useful for log-based assertions in
+  // the smoke ("expect first reset to clean up >0 rows after a half-failed
+  // run; second reset to be 0").
+  rowsAffected: number;
+  // Per-domain counters for observability.
+  applicationsDeleted: number;
+  publishersResetInPlace: number;
+  eventsDeleted: number;
+  magicTokensDeleted: number;
+}
+
+export interface SmokeResetDeps {
+  registry: PublisherRegistryService;
+  eventStore: PublisherEventStore;
+  // Raw DDB client for ad-hoc scan-and-delete on the magic-tokens table.
+  // We don't add a deleteByEmail method to MagicTokenService because that
+  // signature would tempt non-test callers; smoke needs a sledgehammer
+  // tied to a single test email.
+  db: DynamoDBDocumentClient;
+  magicTokensTableName: string;
+}
+
+/**
+ * Resets bbtest state to baseline. See file header for the contract.
+ *
+ * Step order matters:
+ *   1. Delete events first (cheap, doesn't depend on publisher row state).
+ *   2. Reset publisher row in place (preserves the row's identity so
+ *      smoke assertions like `expect(listPublishers).toContain(bbtest)`
+ *      remain meaningful).
+ *   3. Delete pending application rows for the email (these are different
+ *      DDB rows in the publishers table — applications-as-pending-publishers
+ *      that were never approved).
+ *   4. Delete magic-token rows last — if a magic token survives a row
+ *      cleanup, the next smoke run might pick up a stale token.
+ */
+export async function resetBbtest(
+  deps: SmokeResetDeps,
+  bbtestEmail: string,
+): Promise<SmokeResetResult> {
+  const result: SmokeResetResult = {
+    rowsAffected: 0,
+    applicationsDeleted: 0,
+    publishersResetInPlace: 0,
+    eventsDeleted: 0,
+    magicTokensDeleted: 0,
+  };
+
+  const normalizedEmail = bbtestEmail.trim().toLowerCase();
+  if (!normalizedEmail) {
+    // Defensive: an empty email would scan-delete every magic-token row
+    // (FilterExpression `email = ""` matches nothing in practice, but we
+    // refuse to even attempt it).
+    throw new Error('resetBbtest: bbtestEmail must be a non-empty string');
+  }
+
+  // ─── Publishers and applications by email ────────────────────────────
+  //
+  // Both approved publisher rows AND pending application rows live in the
+  // same `publishers` table — applications are publisher rows with
+  // applicationStatus='pending' and enabled=false. getByEmail returns both.
+  const rowsForEmail = await deps.registry.getByEmail(normalizedEmail);
+
+  for (const row of rowsForEmail) {
+    if (row.applicationStatus === 'pending' || row.applicationStatus === 'rejected') {
+      // Pending/rejected application: hard-delete. The smoke's apply
+      // step needs an unused email to issue a fresh application against.
+      await deps.registry.delete(row.id);
+      result.applicationsDeleted += 1;
+      result.rowsAffected += 1;
+      continue;
+    }
+
+    // Approved row (or legacy row with no applicationStatus): reset in
+    // place to baseline. Delete its events first.
+    const deleted = await deps.eventStore.deleteAllForPublisher(row.id);
+    result.eventsDeleted += deleted;
+    result.rowsAffected += deleted;
+
+    await deps.registry.upsert({
+      ...row,
+      applicationStatus: 'approved',
+      enabled: true,
+      trustLevel: 'auto',
+      paused: false,
+      // Clear self-pause / self-disable / email-change-lock markers. We
+      // keep tokenVersion as-is because bumping it would invalidate any
+      // legitimate session (not relevant to smoke, but cheap to preserve).
+      selfPausedAt: undefined,
+      selfDisabledAt: undefined,
+      emailChangeLockedUntil: undefined,
+      pendingThresholdHalt: undefined,
+      lastFetchStatus: undefined,
+      lastFetchMessage: undefined,
+    });
+    result.publishersResetInPlace += 1;
+    result.rowsAffected += 1;
+  }
+
+  // ─── Magic tokens by email ───────────────────────────────────────────
+  //
+  // Magic-token rows are keyed by tokenHash, so we can't get-by-email — we
+  // scan with a FilterExpression. The table is small (TTL deletes rows
+  // within ~minutes of expiry, so steady-state size is bounded by
+  // unconsumed-and-unexpired tokens, typically <100).
+  let last: Record<string, unknown> | undefined;
+  const tokensToDelete: string[] = [];
+  do {
+    const r = await deps.db.send(new ScanCommand({
+      TableName: deps.magicTokensTableName,
+      FilterExpression: 'email = :e',
+      ExpressionAttributeValues: { ':e': normalizedEmail },
+      ExclusiveStartKey: last,
+    }));
+    for (const item of (r.Items ?? []) as { tokenHash?: string }[]) {
+      if (item.tokenHash) tokensToDelete.push(item.tokenHash);
+    }
+    last = r.LastEvaluatedKey;
+  } while (last);
+
+  for (const tokenHash of tokensToDelete) {
+    await deps.db.send(new DeleteCommand({
+      TableName: deps.magicTokensTableName,
+      Key: { tokenHash },
+    }));
+    result.magicTokensDeleted += 1;
+    result.rowsAffected += 1;
+  }
+
+  return result;
+}

--- a/docs/runbooks/publisher-smoke-failed.md
+++ b/docs/runbooks/publisher-smoke-failed.md
@@ -35,14 +35,17 @@ into git, or via `TF_VAR_*` env vars in your wrapper script):
 ```hcl
 admin_smoke_signing_key = "<same value as SMOKE_ADMIN_SIGNING_KEY>"
 captcha_bypass_token    = "<same value as SMOKE_CAPTCHA_BYPASS_TOKEN>"
+smoke_bbtest_email      = "<same value as SMOKE_BBTEST_EMAIL>"
 ```
 
 Then run `terraform apply` in `infrastructure/`. This wires the values
-into the admin Lambda's environment as `ADMIN_SMOKE_SIGNING_KEY` and
-`CAPTCHA_BYPASS_TOKEN` (see `aws_lambda_function.admin_handler` in
-`infrastructure/main.tf`). Both default to empty strings; while empty,
-the corresponding backend code paths are inert (smoke admin auth refuses
-all tokens, CAPTCHA bypass header is ignored).
+into the admin Lambda's environment as `ADMIN_SMOKE_SIGNING_KEY`,
+`CAPTCHA_BYPASS_TOKEN`, and `SMOKE_BBTEST_EMAIL` (see
+`aws_lambda_function.admin_handler` in `infrastructure/main.tf`). All
+default to empty strings; while empty, the corresponding backend code
+paths are inert (smoke admin auth refuses all tokens, CAPTCHA bypass
+header is ignored, the email-keyed smoke routes return 403 for every
+request).
 
 ### 3. Verify
 
@@ -143,9 +146,13 @@ publisher may be left in a non-baseline state (paused, self-disabled,
 half-processed events). To reset manually:
 
 ```bash
-# 1. Sign a short-lived smoke admin token locally.
+# 1. Sign a short-lived smoke admin token locally. The local-side env var
+#    is SMOKE_ADMIN_SIGNING_KEY (matches the GitHub repo secret name and
+#    the smoke runner under scripts/smoke/lib/adminAuth.ts). The Lambda
+#    receives the same value under ADMIN_SMOKE_SIGNING_KEY (set via
+#    terraform variable admin_smoke_signing_key).
 TOKEN=$(node -e "console.log(require('jsonwebtoken').sign(\
-  {sub:'smoke-bot',iss:'smoke'}, process.env.ADMIN_SMOKE_SIGNING_KEY, \
+  {sub:'smoke-bot',iss:'smoke'}, process.env.SMOKE_ADMIN_SIGNING_KEY, \
   {algorithm:'HS256', expiresIn:'5m'}))")
 
 # 2. Hit the reset endpoint.

--- a/docs/runbooks/publisher-smoke-failed.md
+++ b/docs/runbooks/publisher-smoke-failed.md
@@ -1,0 +1,201 @@
+# Runbook — post-deploy publisher smoke failure
+
+**Triggered by:** the "Post-deploy publisher-lifecycle smoke" step in
+`.github/workflows/deploy-production.yml` going red.
+
+**What it means:** the deploy itself succeeded (Lambda code + frontend
+artifacts shipped) but the post-deploy verification couldn't drive the
+bbtest publisher through its full lifecycle. Production may still be
+serving correctly — the smoke is an end-to-end check of the publisher
+ingest path, not a health check.
+
+---
+
+## Manual one-time setup (BEFORE the smoke can ever run green)
+
+The smoke is gated by three GitHub repo secrets and two Lambda env vars.
+Until ALL of these are populated, the smoke step exits with
+`describe.skip` (the workflow stays green but the test never executes).
+
+### 1. GitHub repo secrets
+
+Set these in **Settings → Secrets and variables → Actions**:
+
+| Secret name | Value |
+|---|---|
+| `SMOKE_BBTEST_EMAIL` | The email address of the existing `bbtest` publisher (per the cleanup-followups memo). |
+| `SMOKE_ADMIN_SIGNING_KEY` | A 256-bit random value, e.g. `openssl rand -hex 32`. MUST match the Lambda env value below. |
+| `SMOKE_CAPTCHA_BYPASS_TOKEN` | A separate 256-bit random value. MUST match the Lambda env value below. |
+
+### 2. Terraform variables → Lambda env
+
+Set these as terraform variables (e.g. via `terraform.tfvars` not checked
+into git, or via `TF_VAR_*` env vars in your wrapper script):
+
+```hcl
+admin_smoke_signing_key = "<same value as SMOKE_ADMIN_SIGNING_KEY>"
+captcha_bypass_token    = "<same value as SMOKE_CAPTCHA_BYPASS_TOKEN>"
+```
+
+Then run `terraform apply` in `infrastructure/`. This wires the values
+into the admin Lambda's environment as `ADMIN_SMOKE_SIGNING_KEY` and
+`CAPTCHA_BYPASS_TOKEN` (see `aws_lambda_function.admin_handler` in
+`infrastructure/main.tf`). Both default to empty strings; while empty,
+the corresponding backend code paths are inert (smoke admin auth refuses
+all tokens, CAPTCHA bypass header is ignored).
+
+### 3. Verify
+
+After all 5 values are in place, the next deploy will execute the smoke.
+You can also dry-run it locally against staging or a personal stack:
+
+```bash
+SMOKE_API_BASE=https://staging.chqcal.org \
+SMOKE_BBTEST_EMAIL=<the-bbtest-email> \
+SMOKE_ADMIN_SIGNING_KEY=<key> \
+SMOKE_CAPTCHA_BYPASS_TOKEN=<token> \
+npm run smoke:publisher
+```
+
+A green run prints `[smoke] reset cleaned N rows for <email>` twice
+(beforeAll + afterAll) and `walks bbtest through apply → approve → ...`
+in the test list.
+
+---
+
+## What the smoke does
+
+The single test in `scripts/smoke/publisher-lifecycle.test.ts` walks
+through:
+
+| Step | Endpoint(s) | Asserts |
+|---|---|---|
+| 1. Apply | `POST /api/publisher-apply/request` (with `X-Smoke-Bypass` header) | `{ ok: true }` |
+| 2. Consume | `POST /admin/api/smoke-magic-token-by-email` | publisher row materialized; JWT issued |
+| 3. Approve | `POST /admin/api/publisher-applications/{id}/approve` | `enabled: true` |
+| 4. Listed | `GET /admin/api/publishers` | bbtest row appears, `enabled: true` |
+| 5. Ingest + publish | `POST /admin/api/publishers/run-ingest` + poll `events/count` | count > 0 within 90s |
+| 6. Pause + ingest | `POST /api/publisher-pause` + `run-ingest` | count unchanged after 15s |
+| 7. Resume + ingest | `POST /api/publisher-resume` + `run-ingest` | count > 0 |
+| 8. Self-disable + ingest | `POST /api/publisher-disable` + `run-ingest` | count drops to 0 within 90s |
+
+`beforeAll` and `afterAll` both call `POST /admin/api/smoke-reset-bbtest`
+to ensure the journey starts and leaves bbtest in a baseline state
+regardless of failures.
+
+---
+
+## Triage by failure point
+
+### "fetch failed" / network errors
+
+The smoke runner couldn't reach `https://www.chqcal.org`. Check:
+- CloudFront distribution status (sometimes takes 5–10 min after a deploy
+  to settle).
+- Whether the deploy step itself produced a 200 from API Gateway in its
+  smoke-test step (line ~360 of `deploy-production.yml`).
+
+### Step 1 (apply) returns 400 or 401
+
+- 400 with `Email already in use` → bbtest reset didn't run cleanly.
+  Manually run reset (see "Manual reset" below) and retry.
+- 401 → `CAPTCHA_BYPASS_TOKEN` Lambda env doesn't match the
+  `SMOKE_CAPTCHA_BYPASS_TOKEN` GitHub secret. Check terraform.tfvars and
+  re-apply.
+- 403 with "Smoke route not permitted" → the route changed and isn't on
+  `SMOKE_ADMIN_ROUTE_ALLOWLIST` in `backend/src/handlers/adminHandler.ts`.
+
+### Step 2 (consume-by-email) returns 401
+
+Same root cause as 401 in step 1, but for `ADMIN_SMOKE_SIGNING_KEY` /
+`SMOKE_ADMIN_SIGNING_KEY`. The two values MUST be identical.
+
+### Step 3 (approve) returns 409 `ApplicationStateError`
+
+The publisher row is already in a non-pending state (probably approved
+from a previous run that didn't clean up). Run reset; retry.
+
+### Step 5 / 7 (publish) times out at 90s
+
+The publisher-ingest Lambda didn't run, or ran but didn't write events.
+
+- Check CloudWatch Logs for `chautauqua-calendar-publisher-ingest`. Look
+  for the run triggered around the smoke's start time (the run-ingest
+  payload includes `triggeredBy: 'smoke-bot@chqcal.invalid'` so it's
+  greppable).
+- Check the bbtest publisher's `lastFetchStatus` via the admin dashboard
+  at `/admin/publishers/`. If it's `network_error` or `parse_error`,
+  the bbtest feed source is unhealthy — fix the feed before retrying.
+
+### Step 8 (retract after self-disable) times out at 90s
+
+The reconciler isn't deleting events for self-disabled publishers, or
+the ingest run isn't reaching the reconciler. This is the symptom that
+PR #78 (`disable-publisher-retracts-events`) was meant to prevent — if
+this regression is real, file a bug and roll back.
+
+---
+
+## Manual reset (when CI was killed mid-journey)
+
+If a CI run was killed between `beforeAll` and `afterAll`, the bbtest
+publisher may be left in a non-baseline state (paused, self-disabled,
+half-processed events). To reset manually:
+
+```bash
+# 1. Sign a short-lived smoke admin token locally.
+TOKEN=$(node -e "console.log(require('jsonwebtoken').sign(\
+  {sub:'smoke-bot',iss:'smoke'}, process.env.ADMIN_SMOKE_SIGNING_KEY, \
+  {algorithm:'HS256', expiresIn:'5m'}))")
+
+# 2. Hit the reset endpoint.
+curl -fsSL -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "{\"email\":\"$SMOKE_BBTEST_EMAIL\"}" \
+  https://www.chqcal.org/admin/api/smoke-reset-bbtest
+```
+
+The response body contains `rowsAffected` — non-zero means there was
+leftover state.
+
+To find the most recent killed run:
+```bash
+gh run list --workflow=deploy-production.yml --limit 5
+```
+
+---
+
+## Disabling the smoke temporarily
+
+If the smoke is flaking and blocking deploys (rare — the polling loops
+and idempotent reset are designed to make this hard):
+
+1. Comment out the `Post-deploy publisher-lifecycle smoke` step in
+   `.github/workflows/deploy-production.yml` (don't delete; we want to
+   re-enable quickly).
+2. Open a PR with an explanation; merge.
+3. The next deploy will skip the smoke. Production behavior is
+   unaffected — the smoke is verification, not a production dependency.
+4. **File a bug** describing the flake. Don't leave the smoke disabled.
+
+---
+
+## Rotating the bypass token / signing key
+
+If either secret leaks (e.g. accidentally pasted into a public chat):
+
+1. Generate fresh values: `openssl rand -hex 32`.
+2. Update `terraform.tfvars` and `terraform apply`. The Lambda env
+   updates immediately on apply.
+3. Update the GitHub repo secrets in **Settings → Secrets**.
+4. Trigger a deploy or `workflow_dispatch` and confirm the smoke runs
+   green.
+5. Audit CloudWatch logs for any `adminSubject: 'smoke-bot'` entries
+   that occurred outside the deploy windows — those are evidence of
+   actual abuse before rotation.
+
+The bypass token only works on `/api/publisher-apply/request`; the
+signing key only admits routes on `SMOKE_ADMIN_ROUTE_ALLOWLIST`. A leak
+of either still cannot drive arbitrary admin actions, but rotation is
+the safe response.

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -81,10 +81,13 @@ variable "recaptcha_site_key" {
 # work unchanged — the corresponding backend code paths fall through to
 # their normal behavior when the env var is empty.
 #
-# Production should set both to high-entropy random values (e.g.
-# `openssl rand -hex 32`). Same values must be set as GitHub repo secrets:
+# Production should set all three to the appropriate values. The signing
+# key + bypass token should be high-entropy random (e.g. `openssl rand
+# -hex 32`); the bbtest email is the dedicated smoke mailbox. Same values
+# must be set as GitHub repo secrets:
 #   - admin_smoke_signing_key   ↔ secrets.SMOKE_ADMIN_SIGNING_KEY
 #   - captcha_bypass_token      ↔ secrets.SMOKE_CAPTCHA_BYPASS_TOKEN
+#   - smoke_bbtest_email        ↔ secrets.SMOKE_BBTEST_EMAIL
 # so deploy-production.yml can drive the smoke against the deployed stack.
 variable "admin_smoke_signing_key" {
   description = "HS256 signing key for the post-deploy publisher-lifecycle smoke. Empty disables the smoke admin auth path."
@@ -95,6 +98,13 @@ variable "admin_smoke_signing_key" {
 
 variable "captcha_bypass_token" {
   description = "Bypass token for /publisher-apply/request CAPTCHA, sent via X-Smoke-Bypass header. Empty disables the bypass entirely."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "smoke_bbtest_email" {
+  description = "Lambda-side gate for the smoke-only /smoke-reset-bbtest and /smoke-magic-token-by-email routes. Both routes refuse any request whose email body field does not match this value (defense-in-depth: a leaked admin_smoke_signing_key cannot mint actions for arbitrary emails). Empty disables both routes."
   type        = string
   sensitive   = true
   default     = ""
@@ -981,12 +991,14 @@ resource "aws_lambda_function" "admin_handler" {
       # calendar Lambda for the public feedback form. When unset, the shared
       # captchaService fails closed in prod and is permissive in dev/test.
       RECAPTCHA_SECRET_KEY = var.recaptcha_secret_key
-      # Post-deploy publisher-lifecycle smoke (scripts/smoke/...). Both vars
-      # MUST be unset (or empty) outside production — when empty, the backend
-      # code paths reject every smoke-bot token and ignore every bypass
-      # header, so the smoke surface is permanently inert.
+      # Post-deploy publisher-lifecycle smoke (scripts/smoke/...). All three
+      # vars MUST be unset (or empty) outside production — when empty, the
+      # backend code paths reject every smoke-bot token, ignore every bypass
+      # header, and 403 the email-keyed smoke routes, so the smoke surface
+      # is permanently inert.
       ADMIN_SMOKE_SIGNING_KEY = var.admin_smoke_signing_key
       CAPTCHA_BYPASS_TOKEN    = var.captcha_bypass_token
+      SMOKE_BBTEST_EMAIL      = var.smoke_bbtest_email
     }
   }
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -76,6 +76,30 @@ variable "recaptcha_site_key" {
   default     = ""
 }
 
+# Post-deploy publisher-lifecycle smoke test secrets. Both default to empty
+# so envs that don't run the smoke (local, staging, dev personal stacks)
+# work unchanged — the corresponding backend code paths fall through to
+# their normal behavior when the env var is empty.
+#
+# Production should set both to high-entropy random values (e.g.
+# `openssl rand -hex 32`). Same values must be set as GitHub repo secrets:
+#   - admin_smoke_signing_key   ↔ secrets.SMOKE_ADMIN_SIGNING_KEY
+#   - captcha_bypass_token      ↔ secrets.SMOKE_CAPTCHA_BYPASS_TOKEN
+# so deploy-production.yml can drive the smoke against the deployed stack.
+variable "admin_smoke_signing_key" {
+  description = "HS256 signing key for the post-deploy publisher-lifecycle smoke. Empty disables the smoke admin auth path."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "captcha_bypass_token" {
+  description = "Bypass token for /publisher-apply/request CAPTCHA, sent via X-Smoke-Bypass header. Empty disables the bypass entirely."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
 variable "cloudfront_cache_ttl" {
   description = "Default TTL (in seconds) for CloudFront cache behavior"
   type        = number
@@ -957,6 +981,12 @@ resource "aws_lambda_function" "admin_handler" {
       # calendar Lambda for the public feedback form. When unset, the shared
       # captchaService fails closed in prod and is permissive in dev/test.
       RECAPTCHA_SECRET_KEY = var.recaptcha_secret_key
+      # Post-deploy publisher-lifecycle smoke (scripts/smoke/...). Both vars
+      # MUST be unset (or empty) outside production — when empty, the backend
+      # code paths reject every smoke-bot token and ignore every bypass
+      # header, so the smoke surface is permanently inert.
+      ADMIN_SMOKE_SIGNING_KEY = var.admin_smoke_signing_key
+      CAPTCHA_BYPASS_TOKEN    = var.captcha_bypass_token
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "deploy:backend": "cd backend && npm run deploy",
     "deploy:frontend": "cd frontend && npm run build && npm run deploy",
     "setup": "./scripts/setup.sh",
-    "test:integration": "node integration-test.js"
+    "test:integration": "node integration-test.js",
+    "smoke:publisher": "jest --config=scripts/smoke/jest.smoke.config.js"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/scripts/smoke/jest.smoke.config.js
+++ b/scripts/smoke/jest.smoke.config.js
@@ -1,0 +1,35 @@
+// Standalone Jest config for the post-deploy smoke. Decoupled from
+// backend/jest.config.js so changes to backend's TypeScript build options
+// (target, lib, moduleResolution) cannot silently break the smoke at
+// deploy time. Inline tsconfig keeps the smoke's compile contract pinned
+// to what apiClient.ts and adminAuth.ts actually need.
+//
+// Don't add testEnvironment overrides here — node default is correct.
+// The smoke runs no DOM code; everything goes through fetch().
+
+module.exports = {
+  rootDir: __dirname,
+  testMatch: ['<rootDir>/*.test.ts'],
+  // Same Node.js 22+ localStorage workaround backend uses. The smoke
+  // doesn't touch localStorage, but jest-environment-node throws
+  // SecurityError on context-copy without this wrapper.
+  testEnvironment: '<rootDir>/../../backend/jest-environment.cjs',
+  transform: {
+    '^.+\\.ts$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          target: 'ES2022',
+          module: 'commonjs',
+          esModuleInterop: true,
+          resolveJsonModule: true,
+          strict: true,
+          skipLibCheck: true,
+        },
+      },
+    ],
+  },
+  testTimeout: 5 * 60 * 1000,
+  // Don't pull in backend/setup.ts — its console.info mock and DDB
+  // env-var defaults are wrong for the smoke (which talks to live HTTPS).
+};

--- a/scripts/smoke/lib/adminAuth.ts
+++ b/scripts/smoke/lib/adminAuth.ts
@@ -1,0 +1,34 @@
+// Smoke admin token signer. Mirrors backend/src/services/smokeAdminAuth.ts'
+// verifier — they MUST agree on signing key, algorithm, claims, and TTL
+// shape. Any drift here = the smoke fails admin auth at runtime.
+//
+// The signing key comes from env SMOKE_ADMIN_SIGNING_KEY. In CI this is a
+// GitHub repo secret; locally a developer can set it to the same value
+// provisioned to the staging admin Lambda for ad-hoc smoke runs.
+//
+// We sign per-request rather than caching one token across the test
+// because (1) tokens are 5-minute TTL by default, and (2) the smoke calls
+// admin routes interleaved with publisher routes — caching wouldn't save
+// meaningful wall-clock.
+
+import jwt from 'jsonwebtoken';
+
+const DEFAULT_TTL_SEC = 5 * 60;
+
+export function signSmokeAdminToken(opts: { ttlSec?: number } = {}): string {
+  const key = process.env.SMOKE_ADMIN_SIGNING_KEY;
+  if (!key) {
+    throw new Error(
+      'SMOKE_ADMIN_SIGNING_KEY env var is not set — cannot sign smoke admin token. ' +
+      'Set this to the same value provisioned to the admin Lambda env ADMIN_SMOKE_SIGNING_KEY.',
+    );
+  }
+  return jwt.sign(
+    { sub: 'smoke-bot', iss: 'smoke' },
+    key,
+    {
+      algorithm: 'HS256',
+      expiresIn: opts.ttlSec ?? DEFAULT_TTL_SEC,
+    },
+  );
+}

--- a/scripts/smoke/lib/apiClient.ts
+++ b/scripts/smoke/lib/apiClient.ts
@@ -1,0 +1,170 @@
+// Thin typed fetch wrappers for the post-deploy publisher-lifecycle smoke.
+//
+// The smoke runs against the real production stack (https://www.chqcal.org by
+// default), so this client uses native fetch — no SDK dependency, no in-process
+// fakes. Every call funnels through `request()` which:
+//
+//   - resolves the URL against SMOKE_API_BASE
+//   - injects per-call headers (the smoke admin Bearer token for admin
+//     routes, X-Smoke-Bypass for the apply route)
+//   - parses JSON
+//   - throws SmokeApiError on non-2xx so the test fails loudly with the
+//     status, body, and the path it tried.
+
+import { signSmokeAdminToken } from './adminAuth';
+
+export class SmokeApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string,
+    public readonly bodyText: string,
+  ) {
+    super(`SmokeApiError ${status} ${path}: ${bodyText.slice(0, 500)}`);
+    this.name = 'SmokeApiError';
+  }
+}
+
+export interface SmokeApiClientOpts {
+  baseUrl: string; // e.g. https://www.chqcal.org
+  // Optional override for tests (jest.mock fetch). Defaults to globalThis.fetch.
+  fetchImpl?: typeof fetch;
+  // CAPTCHA bypass token — same value provisioned to the admin Lambda env
+  // CAPTCHA_BYPASS_TOKEN. Sent in X-Smoke-Bypass header on the apply route.
+  captchaBypassToken: string;
+}
+
+interface RequestOpts {
+  method?: 'GET' | 'POST' | 'PATCH' | 'DELETE';
+  path: string;        // path WITHOUT base prefix, e.g. '/api/publisher-apply/request'
+  body?: unknown;      // serialized as JSON
+  headers?: Record<string, string>;
+  // When true, the smoke-admin Bearer token is auto-attached.
+  adminAuth?: boolean;
+}
+
+export class SmokeApiClient {
+  constructor(private readonly opts: SmokeApiClientOpts) {}
+
+  private async request<T>(req: RequestOpts): Promise<T> {
+    const url = `${this.opts.baseUrl}${req.path}`;
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...(req.headers ?? {}),
+    };
+    if (req.adminAuth) {
+      headers['Authorization'] = `Bearer ${signSmokeAdminToken({})}`;
+    }
+    const fetchImpl = this.opts.fetchImpl ?? globalThis.fetch;
+    const r = await fetchImpl(url, {
+      method: req.method ?? 'POST',
+      headers,
+      body: req.body !== undefined ? JSON.stringify(req.body) : undefined,
+    });
+    const text = await r.text();
+    if (!r.ok) {
+      throw new SmokeApiError(r.status, req.path, text);
+    }
+    if (!text) return {} as T;
+    try {
+      return JSON.parse(text) as T;
+    } catch {
+      throw new SmokeApiError(r.status, req.path, `non-JSON body: ${text.slice(0, 500)}`);
+    }
+  }
+
+  // ─── Public publisher portal ───────────────────────────────────────────
+
+  publisher = {
+    applyRequest: (payload: {
+      email: string;
+      name: string;
+      sourceUrl: string;
+      sourceType: 'json' | 'html';
+      organization?: string;
+      notes?: string;
+      captchaToken?: string;
+    }): Promise<{ ok: true } | { ok: false; reason: string }> =>
+      this.request({
+        path: '/api/publisher-apply/request',
+        body: { ...payload, captchaToken: payload.captchaToken ?? 'smoke-bypass' },
+        headers: { 'X-Smoke-Bypass': this.opts.captchaBypassToken },
+      }),
+
+    applyVerify: (rawToken: string): Promise<{ jwt: string; publisherId: string; email: string }> =>
+      this.request({
+        path: '/api/publisher-apply/verify',
+        body: { token: rawToken },
+      }),
+
+    pause: (jwt: string) =>
+      this.request<{ ok: true }>({
+        path: '/api/publisher-pause',
+        headers: { Authorization: `Bearer ${jwt}` },
+      }),
+
+    resume: (jwt: string) =>
+      this.request<{ ok: true }>({
+        path: '/api/publisher-resume',
+        headers: { Authorization: `Bearer ${jwt}` },
+      }),
+
+    selfDisable: (jwt: string, body: { confirmSlug: string }) =>
+      this.request<{ ok: true }>({
+        path: '/api/publisher-disable',
+        body,
+        headers: { Authorization: `Bearer ${jwt}` },
+      }),
+  };
+
+  // ─── Admin endpoints (smoke-bot Bearer token) ─────────────────────────
+
+  admin = {
+    listPublishers: () =>
+      this.request<{ publishers: Array<{ id: string; enabled: boolean; contactEmail: string; applicationStatus?: string }> }>({
+        method: 'GET',
+        path: '/admin/api/publishers',
+        adminAuth: true,
+      }),
+
+    runIngest: () =>
+      this.request<{ triggeredAt: string }>({
+        method: 'POST',
+        path: '/admin/api/publishers/run-ingest',
+        adminAuth: true,
+      }),
+
+    approveApplication: (publisherId: string) =>
+      this.request<{ publisher: { id: string; enabled: boolean } }>({
+        method: 'POST',
+        path: `/admin/api/publisher-applications/${encodeURIComponent(publisherId)}/approve`,
+        adminAuth: true,
+      }),
+
+    eventCount: (publisherId: string) =>
+      this.request<{ count: number }>({
+        method: 'POST',
+        path: `/admin/api/publishers/${encodeURIComponent(publisherId)}/events/count`,
+        adminAuth: true,
+      }),
+
+    smokeReset: (email: string) =>
+      this.request<{ rowsAffected: number }>({
+        method: 'POST',
+        path: '/admin/api/smoke-reset-bbtest',
+        body: { email },
+        adminAuth: true,
+      }),
+
+    // Materializes the publisher row from a most-recent apply magic-token
+    // row for `email` and returns the resulting publisher JWT + id. See
+    // backend/src/handlers/adminHandler.ts for the rationale (raw tokens
+    // aren't recoverable from DDB so the smoke can't replay verifyApply).
+    consumeApplyByEmail: (email: string) =>
+      this.request<{ jwt: string; publisherId: string; email: string }>({
+        method: 'POST',
+        path: '/admin/api/smoke-magic-token-by-email',
+        body: { email },
+        adminAuth: true,
+      }),
+  };
+}

--- a/scripts/smoke/lib/reset.ts
+++ b/scripts/smoke/lib/reset.ts
@@ -1,0 +1,16 @@
+// Reset helper that wraps POST /admin/api/smoke-reset-bbtest. Used as the
+// before/after teardown for the smoke journey — see publisher-lifecycle.test.ts.
+//
+// Why a wrapper (vs calling api.admin.smokeReset() inline): centralizes
+// the "log what we cleaned up" line so a CI failure shows whether the
+// previous run left state behind. If the first reset reports rowsAffected > 0
+// AND the journey was supposed to be clean, the most recent run was killed
+// mid-flight; that's a finding worth surfacing in the deploy log.
+
+import { SmokeApiClient } from './apiClient';
+
+export async function resetBbtestEmail(api: SmokeApiClient, email: string): Promise<void> {
+  const r = await api.admin.smokeReset(email);
+  // eslint-disable-next-line no-console
+  console.log(`[smoke] reset cleaned ${r.rowsAffected} rows for ${email}`);
+}

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -143,7 +143,9 @@ describeMaybe('post-deploy publisher lifecycle', () => {
 
     // 7. Self-disable + ingest. The reconciler retracts (deletes) all
     //    events for self-disabled publishers; count must drop to 0.
-    await api.publisher.selfDisable(publisherJwt, { confirmSlug: 'bbtest smoke' });
+    // confirmSlug must equal the publisher id exactly (per
+    // backend/src/handlers/publisherPortalHandler.ts handlePublisherDisable).
+    await api.publisher.selfDisable(publisherJwt, { confirmSlug: publisherId });
     await api.admin.runIngest();
     const afterDisable = await waitForEventCount(
       publisherId,

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -1,0 +1,155 @@
+// Post-deploy publisher-lifecycle smoke. Runs against the real production
+// stack (https://www.chqcal.org) after every prod deploy via
+// .github/workflows/deploy-production.yml.
+//
+// Required env vars (set in deploy-production.yml from GitHub repo secrets):
+//   SMOKE_API_BASE             — base URL, e.g. https://www.chqcal.org
+//   SMOKE_BBTEST_EMAIL         — the dedicated test email (chosen in plan task 1)
+//   SMOKE_ADMIN_SIGNING_KEY    — same value provisioned to the admin Lambda
+//   SMOKE_CAPTCHA_BYPASS_TOKEN — same value provisioned to the admin Lambda
+//
+// The journey:
+//   beforeAll  : reset bbtest to baseline (idempotent — leftover state from
+//                a killed previous run is cleaned)
+//   afterAll   : reset bbtest again (so live calendar isn't left with the
+//                bbtest test events)
+//
+//   The single `it(...)` block walks bbtest through:
+//     apply → consume-by-email (smoke shortcut for verifyApply)
+//        → admin-approve → run-ingest → assert events published
+//        → publisher-pause → run-ingest → assert event count unchanged
+//        → publisher-resume → run-ingest → assert events still published
+//        → publisher-self-disable → run-ingest → assert event count is 0
+//
+// Wall-clock ceiling: 5 minutes. Real ingest fires async on the admin
+// Lambda; the smoke uses a short polling loop after each run-ingest call.
+
+import { SmokeApiClient } from './lib/apiClient';
+import { resetBbtestEmail } from './lib/reset';
+
+const SMOKE_API_BASE = process.env.SMOKE_API_BASE ?? 'https://www.chqcal.org';
+const SMOKE_BBTEST_EMAIL = process.env.SMOKE_BBTEST_EMAIL ?? '';
+const SMOKE_CAPTCHA_BYPASS_TOKEN = process.env.SMOKE_CAPTCHA_BYPASS_TOKEN ?? '';
+
+// Skip the journey at config time when env vars are missing — running
+// `npm run smoke:publisher` locally without the secrets should print a
+// clear "skipped" line instead of erroring at the first fetch. CI will
+// always have the env, so a skipped run there indicates a config bug.
+const skipReason =
+  !SMOKE_BBTEST_EMAIL ? 'SMOKE_BBTEST_EMAIL not set' :
+  !SMOKE_CAPTCHA_BYPASS_TOKEN ? 'SMOKE_CAPTCHA_BYPASS_TOKEN not set' :
+  !process.env.SMOKE_ADMIN_SIGNING_KEY ? 'SMOKE_ADMIN_SIGNING_KEY not set' :
+  null;
+
+const describeMaybe = skipReason ? describe.skip : describe;
+
+const api = new SmokeApiClient({
+  baseUrl: SMOKE_API_BASE,
+  captchaBypassToken: SMOKE_CAPTCHA_BYPASS_TOKEN,
+});
+
+// Poll-until helper. The admin run-ingest endpoint is async-invoke, so we
+// poll the event count for up to `timeoutMs` waiting for the predicate to
+// become true. Failure prints the last observed count to make the
+// CloudWatch <-> smoke correlation easier.
+async function waitForEventCount(
+  publisherId: string,
+  predicate: (count: number) => boolean,
+  opts: { timeoutMs: number; intervalMs?: number; description: string },
+): Promise<number> {
+  const interval = opts.intervalMs ?? 5_000;
+  const deadline = Date.now() + opts.timeoutMs;
+  let lastCount = -1;
+  while (Date.now() < deadline) {
+    lastCount = (await api.admin.eventCount(publisherId)).count;
+    if (predicate(lastCount)) return lastCount;
+    await new Promise(r => setTimeout(r, interval));
+  }
+  throw new Error(
+    `[smoke] timed out waiting for event count predicate (${opts.description}) after ${opts.timeoutMs}ms; last observed count=${lastCount}`,
+  );
+}
+
+if (skipReason) {
+  // eslint-disable-next-line no-console
+  console.warn(`[smoke] skipping publisher-lifecycle: ${skipReason}`);
+}
+
+describeMaybe('post-deploy publisher lifecycle', () => {
+  beforeAll(async () => {
+    await resetBbtestEmail(api, SMOKE_BBTEST_EMAIL);
+  }, 60_000);
+  afterAll(async () => {
+    await resetBbtestEmail(api, SMOKE_BBTEST_EMAIL);
+  }, 60_000);
+
+  it('walks bbtest through apply → approve → publish → pause → resume → self-disable', async () => {
+    // 1. Apply (with CAPTCHA bypass header).
+    const apply = await api.publisher.applyRequest({
+      email: SMOKE_BBTEST_EMAIL,
+      name: 'bbtest smoke',
+      sourceUrl: 'https://example.com/bbtest.json', // overridden below
+      sourceType: 'json',
+      organization: 'CI smoke run',
+      notes: `smoke run @ ${new Date().toISOString()}`,
+    });
+    expect(apply).toMatchObject({ ok: true });
+
+    // 2. Consume the apply token by email (smoke shortcut: replays the
+    //    /publisher-apply/verify side-effects without needing the raw token,
+    //    since raw tokens are SES-only and not recoverable from DDB).
+    const consumed = await api.admin.consumeApplyByEmail(SMOKE_BBTEST_EMAIL);
+    expect(consumed.publisherId).toMatch(/^pub-/);
+    const publisherId = consumed.publisherId;
+    const publisherJwt = consumed.jwt;
+
+    // 3. Admin approves the application.
+    const approved = await api.admin.approveApplication(publisherId);
+    expect(approved.publisher.id).toBe(publisherId);
+    expect(approved.publisher.enabled).toBe(true);
+
+    const list = await api.admin.listPublishers();
+    expect(list.publishers).toContainEqual(
+      expect.objectContaining({ id: publisherId, enabled: true }),
+    );
+
+    // 4. Trigger ingest and assert events publish.
+    await api.admin.runIngest();
+    const publishedCount = await waitForEventCount(
+      publisherId,
+      (n) => n > 0,
+      { timeoutMs: 90_000, description: 'first publish' },
+    );
+    expect(publishedCount).toBeGreaterThan(0);
+
+    // 5. Pause + ingest. Event count should remain unchanged (paused
+    //    publishers are skipped in the ingest loop; existing events stay).
+    await api.publisher.pause(publisherJwt);
+    await api.admin.runIngest();
+    // Give the ingest a beat to NOT touch this publisher.
+    await new Promise(r => setTimeout(r, 15_000));
+    const afterPause = (await api.admin.eventCount(publisherId)).count;
+    expect(afterPause).toBe(publishedCount);
+
+    // 6. Resume + ingest. Events should still be published.
+    await api.publisher.resume(publisherJwt);
+    await api.admin.runIngest();
+    const afterResume = await waitForEventCount(
+      publisherId,
+      (n) => n > 0,
+      { timeoutMs: 90_000, description: 'republish after resume' },
+    );
+    expect(afterResume).toBeGreaterThan(0);
+
+    // 7. Self-disable + ingest. The reconciler retracts (deletes) all
+    //    events for self-disabled publishers; count must drop to 0.
+    await api.publisher.selfDisable(publisherJwt, { confirmSlug: 'bbtest smoke' });
+    await api.admin.runIngest();
+    const afterDisable = await waitForEventCount(
+      publisherId,
+      (n) => n === 0,
+      { timeoutMs: 90_000, description: 'retract after self-disable' },
+    );
+    expect(afterDisable).toBe(0);
+  }, 5 * 60 * 1000);
+});

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -88,7 +88,7 @@ describeMaybe('post-deploy publisher lifecycle', () => {
     const apply = await api.publisher.applyRequest({
       email: SMOKE_BBTEST_EMAIL,
       name: 'bbtest smoke',
-      sourceUrl: 'https://example.com/bbtest.json', // overridden below
+      sourceUrl: 'https://example.com/bbtest.json',
       sourceType: 'json',
       organization: 'CI smoke run',
       notes: `smoke run @ ${new Date().toISOString()}`,


### PR DESCRIPTION
## Summary
- New `scripts/smoke/publisher-lifecycle.test.ts` walks the bbtest publisher through apply → consume → approve → publish → pause → resume → self-disable → retract against the real prod stack on every deploy.
- Test-only backend hooks: CAPTCHA bypass (`X-Smoke-Bypass`), smoke-bot signing-key admin auth (separate key from Google OAuth), three smoke-only endpoints (`/smoke-reset-bbtest`, `/smoke-magic-token-by-email`, `/publishers/{id}/events/count`), all gated by an explicit allowlist so a leaked smoke token cannot drive arbitrary admin actions.
- Standalone Jest project under `scripts/smoke/` with its own inline tsconfig — backend's tsconfig changes can't silently break the smoke.

## Manual one-time setup (REQUIRED before the smoke runs green)
The smoke is gated on three GitHub repo secrets and two Lambda env vars. Until ALL are populated, the test self-skips at config time (the deploy step stays green but the test never executes).

**GitHub repo secrets (Settings → Secrets and variables → Actions):**
- `SMOKE_BBTEST_EMAIL`
- `SMOKE_ADMIN_SIGNING_KEY` — `openssl rand -hex 32`
- `SMOKE_CAPTCHA_BYPASS_TOKEN` — `openssl rand -hex 32` (separate value)

**Terraform variables (in your tfvars file or `TF_VAR_*` env):**
- `admin_smoke_signing_key` — must equal `SMOKE_ADMIN_SIGNING_KEY`
- `captcha_bypass_token` — must equal `SMOKE_CAPTCHA_BYPASS_TOKEN`

Then `terraform apply` in `infrastructure/`. Both terraform vars default to `""`, so envs that don't set them keep current behavior unchanged.

Full setup + triage instructions in `docs/runbooks/publisher-smoke-failed.md`.

## Risk
- Smoke admin token signing key is HS256 with a key separate from the Google-OAuth JWT_SECRET — a leak cannot forge a normal admin session.
- Even with a valid smoke token, the handler hard-checks the requested route against `SMOKE_ADMIN_ROUTE_ALLOWLIST` and 403s anything off-list.
- CAPTCHA bypass works only on `/api/publisher-apply/request`. Both bypass paths are no-ops when their env vars are empty.

## Test plan
- [x] All new unit tests green (`smokeAdminAuth.test.ts` 9 cases, `smokeReset.test.ts` 8 cases, captchaService bypass cases). Existing `adminHandler.{applications,publishers,redact}.test.ts` still green.
- [x] `npm run smoke:publisher` skips loudly when env vars are unset (verified locally).
- [ ] After GitHub secrets + Terraform vars are provisioned, trigger a deploy and confirm the smoke step runs end-to-end against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)