### PR TITLE
test(integration): publisher self-service & ingest backend integration tests

### DIFF
--- a/backend/src/__tests__/integration/adminControls.test.ts
+++ b/backend/src/__tests__/integration/adminControls.test.ts
@@ -4,6 +4,7 @@ jest.unmock('@aws-sdk/lib-dynamodb');
 jest.unmock('@aws-sdk/client-dynamodb');
 
 import { createHarness, feedOk, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
 
 async function applyApprove(
   h: Harness,
@@ -17,7 +18,7 @@ async function applyApprove(
     sourceType: 'json',
   });
   const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
-  const token = new URL(url).searchParams.get('token')!;
+  const token = tokenFromMagicLink(url);
   const v = await h.actors.publisher.verifyApplyMagicLink(token);
   await h.actors.admin.approveApplication(v.publisherId);
   if (trustLevel === 'auto') {

--- a/backend/src/__tests__/integration/adminControls.test.ts
+++ b/backend/src/__tests__/integration/adminControls.test.ts
@@ -1,0 +1,118 @@
+// Admin controls journeys (design Test plan items 12-16).
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, feedOk, type Harness } from './harness/harness';
+
+async function applyApprove(
+  h: Harness,
+  email: string,
+  trustLevel: 'auto' | 'review' = 'auto',
+): Promise<{ publisherId: string; session: string }> {
+  await h.actors.publisher.apply({
+    name: 'Admin Test',
+    email,
+    sourceUrl: 'https://example.com/feed.json',
+    sourceType: 'json',
+  });
+  const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
+  const token = new URL(url).searchParams.get('token')!;
+  const v = await h.actors.publisher.verifyApplyMagicLink(token);
+  await h.actors.admin.approveApplication(v.publisherId);
+  if (trustLevel === 'auto') {
+    await h.registry.upsert({ ...((await h.registry.get(v.publisherId))!), trustLevel: 'auto' });
+  }
+  const session = await h.signSession(v.publisherId);
+  return { publisherId: v.publisherId, session };
+}
+
+describe('admin controls', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('admin disable retracts events on next ingest', async () => {
+    const { publisherId } = await applyApprove(h, 'admindisable@example.com', 'auto');
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    await h.actors.admin.disable(publisherId);
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(0);
+  });
+
+  it('admin pause skips that publisher in next ingest', async () => {
+    const { publisherId } = await applyApprove(h, 'adminpause@example.com', 'auto');
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    await h.actors.admin.pause(publisherId);
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'e2', startDate: '2026-08-02T10:00:00Z', endDate: '2026-08-02T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    const states = await h.events.statesOf(publisherId);
+    expect(Object.keys(states)).toEqual(['e1']);
+  });
+
+  it('admin reject event preserves the event removal across re-ingest (no clobber)', async () => {
+    const { publisherId } = await applyApprove(h, 'adminreject@example.com', 'review');
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'evt-bad', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.statesOf(publisherId)).toEqual({ 'evt-bad': 'pending' });
+
+    await h.actors.admin.rejectEvent(publisherId, 'evt-bad');
+    expect(await h.events.count(publisherId)).toBe(0);
+
+    // Re-ingest with bumped lastModified — re-emerges as pending (no automatic
+    // suppression yet; reject is a delete and the next feed pull recreates it).
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'evt-bad', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-02T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    // It DOES come back as pending — but is NOT auto-published, which is the
+    // important guarantee. (A future enhancement could persist a tombstone.)
+    expect(await h.events.statesOf(publisherId)).toEqual({ 'evt-bad': 'pending' });
+  });
+
+  it('admin approve event idempotent: approving an already-published event throws 409', async () => {
+    const { publisherId } = await applyApprove(h, 'adminapprove@example.com', 'review');
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    await h.actors.admin.approveEvent(publisherId, 'e1');
+    expect(await h.events.statesOf(publisherId)).toEqual({ 'e1': 'published' });
+
+    // Second approve: store.approveEvent's ConditionExpression requires
+    // state=pending → ConditionalCheckFailed → handler maps to 409.
+    await expect(h.actors.admin.approveEvent(publisherId, 'e1'))
+      .rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  it('admin "Run ingest now" routes through the lambda invoker', async () => {
+    const { publisherId } = await applyApprove(h, 'runingest@example.com', 'auto');
+    h.feeds.set(publisherId, feedOk(publisherId, 'X', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+
+    const before = h.invoker.invocations.length;
+    await h.actors.admin.runIngest();
+    expect(h.invoker.invocations.length).toBe(before + 1);
+    // Effect of the in-process invocation: events were ingested.
+    expect(await h.events.count(publisherId)).toBe(1);
+  });
+});

--- a/backend/src/__tests__/integration/authAndLimits.test.ts
+++ b/backend/src/__tests__/integration/authAndLimits.test.ts
@@ -1,0 +1,114 @@
+// Auth and abuse-mitigation journeys (design Test plan items 22-26).
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, type Harness } from './harness/harness';
+
+describe('auth and limits', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('apply with failing CAPTCHA returns 400; no application created', async () => {
+    h.captcha.fail();
+    await expect(h.actors.publisher.apply({
+      name: 'X',
+      email: 'cap@example.com',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    })).rejects.toMatchObject({ statusCode: 400 });
+
+    // No magic-token row written.
+    expect(h.ddb.dump('magic-tokens')).toHaveLength(0);
+    // No publisher row written.
+    expect(h.ddb.dump('publishers')).toHaveLength(0);
+  });
+
+  it('apply with passing CAPTCHA succeeds', async () => {
+    h.captcha.pass();
+    await h.actors.publisher.apply({
+      name: 'X',
+      email: 'cap2@example.com',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    });
+    expect(h.ddb.dump('magic-tokens')).toHaveLength(1);
+  });
+
+  it('magic token: replay rejected; expired rejected; valid one-shot succeeds', async () => {
+    await h.actors.publisher.apply({
+      name: 'M',
+      email: 'magic@example.com',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    });
+    const url = h.mail.lastTo('magic@example.com')!.data.magicLinkUrl as string;
+    const token = new URL(url).searchParams.get('token')!;
+    // Valid one-shot succeeds.
+    await h.actors.publisher.verifyApplyMagicLink(token);
+    // Replay → 400.
+    await expect(h.actors.publisher.verifyApplyMagicLink(token))
+      .rejects.toMatchObject({ statusCode: 400 });
+
+    // Issue another, then expire.
+    await h.actors.publisher.apply({
+      name: 'E',
+      email: 'expire@example.com',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    });
+    const url2 = h.mail.lastTo('expire@example.com')!.data.magicLinkUrl as string;
+    const token2 = new URL(url2).searchParams.get('token')!;
+    h.now.advance(20 * 60 * 1000); // 20 min > 15 min TTL
+    await expect(h.actors.publisher.verifyApplyMagicLink(token2))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('per-IP rate limit on portal POST: 11th apply burst returns 429; advancing the clock unblocks', async () => {
+    // Auth-bucket cap is 10/hour. 10 successful applies (each writes a unique row),
+    // 11th hits the limiter.
+    for (let i = 0; i < 10; i++) {
+      await h.actors.publisher.apply({
+        name: `P${i}`,
+        email: `burst${i}@example.com`,
+        sourceUrl: 'https://example.com/feed.json',
+        sourceType: 'json',
+      }, { ip: '203.0.113.50' });
+    }
+    await expect(h.actors.publisher.apply({
+      name: 'P11',
+      email: 'burst11@example.com',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    }, { ip: '203.0.113.50' })).rejects.toMatchObject({ statusCode: 429 });
+
+    // Advance past the 1h window → succeeds again.
+    h.now.advance(61 * 60 * 1000);
+    await h.actors.publisher.apply({
+      name: 'P11',
+      email: 'burst11@example.com',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    }, { ip: '203.0.113.50' });
+  });
+
+  it('DNS-rebinding guard rejects loopback / private / metadata URLs at apply time (PR #85)', async () => {
+    for (const url of [
+      'http://0.0.0.0/feed.json',
+      'http://127.0.0.1/feed.json',
+      'http://169.254.169.254/feed.json',
+    ]) {
+      await expect(h.actors.publisher.apply({
+        name: 'Bad',
+        email: `bad-${Math.random()}@example.com`,
+        sourceUrl: url,
+        sourceType: 'json',
+      })).rejects.toMatchObject({ statusCode: 400 });
+    }
+  });
+});

--- a/backend/src/__tests__/integration/authAndLimits.test.ts
+++ b/backend/src/__tests__/integration/authAndLimits.test.ts
@@ -98,15 +98,16 @@ describe('auth and limits', () => {
   });
 
   it('DNS-rebinding guard rejects loopback / private / metadata URLs at apply time (PR #85)', async () => {
-    for (const url of [
+    const urls = [
       'http://0.0.0.0/feed.json',
       'http://127.0.0.1/feed.json',
       'http://169.254.169.254/feed.json',
-    ]) {
+    ];
+    for (let i = 0; i < urls.length; i++) {
       await expect(h.actors.publisher.apply({
         name: 'Bad',
-        email: `bad-${Math.random()}@example.com`,
-        sourceUrl: url,
+        email: `bad-${i}@example.com`,
+        sourceUrl: urls[i],
         sourceType: 'json',
       })).rejects.toMatchObject({ statusCode: 400 });
     }

--- a/backend/src/__tests__/integration/authAndLimits.test.ts
+++ b/backend/src/__tests__/integration/authAndLimits.test.ts
@@ -4,6 +4,7 @@ jest.unmock('@aws-sdk/lib-dynamodb');
 jest.unmock('@aws-sdk/client-dynamodb');
 
 import { createHarness, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
 
 describe('auth and limits', () => {
   let h: Harness;
@@ -48,7 +49,7 @@ describe('auth and limits', () => {
       sourceType: 'json',
     });
     const url = h.mail.lastTo('magic@example.com')!.data.magicLinkUrl as string;
-    const token = new URL(url).searchParams.get('token')!;
+    const token = tokenFromMagicLink(url);
     // Valid one-shot succeeds.
     await h.actors.publisher.verifyApplyMagicLink(token);
     // Replay → 400.
@@ -63,7 +64,7 @@ describe('auth and limits', () => {
       sourceType: 'json',
     });
     const url2 = h.mail.lastTo('expire@example.com')!.data.magicLinkUrl as string;
-    const token2 = new URL(url2).searchParams.get('token')!;
+    const token2 = tokenFromMagicLink(url2);
     h.now.advance(20 * 60 * 1000); // 20 min > 15 min TTL
     await expect(h.actors.publisher.verifyApplyMagicLink(token2))
       .rejects.toMatchObject({ statusCode: 400 });

--- a/backend/src/__tests__/integration/authAndLimits.test.ts
+++ b/backend/src/__tests__/integration/authAndLimits.test.ts
@@ -87,11 +87,15 @@ describe('auth and limits', () => {
       sourceType: 'json',
     }, { ip: '203.0.113.50' })).rejects.toMatchObject({ statusCode: 429 });
 
-    // Advance past the 1h window → succeeds again.
+    // Advance past the 1h window → succeeds again. Use a fresh email
+    // (burst12, not burst11) so the post-advance assertion only depends on
+    // the rate limiter resetting; reusing burst11 would conflate "rate-limit
+    // window expired" with "duplicate-email rejection happens after rate check"
+    // and mask handler-order regressions.
     h.now.advance(61 * 60 * 1000);
     await h.actors.publisher.apply({
-      name: 'P11',
-      email: 'burst11@example.com',
+      name: 'P12',
+      email: 'burst12@example.com',
       sourceUrl: 'https://example.com/feed.json',
       sourceType: 'json',
     }, { ip: '203.0.113.50' });

--- a/backend/src/__tests__/integration/harness/__tests__/actors.smoke.test.ts
+++ b/backend/src/__tests__/integration/harness/__tests__/actors.smoke.test.ts
@@ -8,6 +8,7 @@ jest.unmock('@aws-sdk/client-dynamodb');
 process.env.AWS_REGION = process.env.AWS_REGION ?? 'us-east-1';
 
 import { createHarness, feedOk } from '../harness';
+import { tokenFromMagicLink } from '../testHelpers';
 
 describe('actors', () => {
   it('publisher and admin methods route through handlers without throwing', async () => {
@@ -25,7 +26,7 @@ describe('actors', () => {
       const applyMail = h.mail.lastTo('x@example.com');
       expect(applyMail).toBeDefined();
       const applyUrl = applyMail!.data.magicLinkUrl as string;
-      const token = new URL(applyUrl).searchParams.get('token')!;
+      const token = tokenFromMagicLink(applyUrl);
       const verified = await h.actors.publisher.verifyApplyMagicLink(token);
       expect(verified.publisherId).toMatch(/^pub-/);
 

--- a/backend/src/__tests__/integration/harness/__tests__/actors.smoke.test.ts
+++ b/backend/src/__tests__/integration/harness/__tests__/actors.smoke.test.ts
@@ -1,0 +1,58 @@
+// Plumbing-only smoke for each actor method. Hits each method with valid
+// inputs and asserts it doesn't throw. Behavior verification lives in the
+// journey-shaped test files.
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+process.env.AWS_REGION = process.env.AWS_REGION ?? 'us-east-1';
+
+import { createHarness, feedOk } from '../harness';
+
+describe('actors', () => {
+  it('publisher and admin methods route through handlers without throwing', async () => {
+    const h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+    try {
+      // Publisher actor: apply.
+      await h.actors.publisher.apply({
+        name: 'X',
+        email: 'x@example.com',
+        sourceUrl: 'https://example.com/feed.json',
+        sourceType: 'json',
+      });
+
+      // Verify magic link.
+      const applyMail = h.mail.lastTo('x@example.com');
+      expect(applyMail).toBeDefined();
+      const applyUrl = applyMail!.data.magicLinkUrl as string;
+      const token = new URL(applyUrl).searchParams.get('token')!;
+      const verified = await h.actors.publisher.verifyApplyMagicLink(token);
+      expect(verified.publisherId).toMatch(/^pub-/);
+
+      // Admin: list publishers.
+      const list = await h.actors.admin.listPublishers();
+      expect(Array.isArray(list.publishers)).toBe(true);
+
+      // Admin: approve.
+      await h.actors.admin.approveApplication(verified.publisherId);
+
+      // Status with the freshly-issued JWT (post-approval, tokenVersion may have bumped).
+      const session = await h.signSession(verified.publisherId);
+      const st = await h.actors.publisher.status(session);
+      expect(st.publisher.id).toBe(verified.publisherId);
+
+      // Pause / resume / fetch-now.
+      await h.actors.publisher.pause(session);
+      await h.actors.publisher.resume(session);
+
+      h.feeds.set(verified.publisherId, feedOk(verified.publisherId, 'X', []));
+      // fetch-now: rate limit lets first call through.
+      await h.actors.publisher.fetchNow(session);
+
+      // Ingest.
+      await h.actors.ingest.run();
+    } finally {
+      h.dispose();
+    }
+  });
+});

--- a/backend/src/__tests__/integration/harness/__tests__/harness.smoke.test.ts
+++ b/backend/src/__tests__/integration/harness/__tests__/harness.smoke.test.ts
@@ -1,0 +1,34 @@
+// Smoke-test the harness end-to-end. Confirms wiring works at the plumbing
+// level — actual journey coverage lives in lifecycle.test.ts etc.
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+// Ensure AWS SDK has a region so adminHandler's module-load
+// DynamoDBClient/DynamoDBDocumentClient construction doesn't throw.
+process.env.AWS_REGION = process.env.AWS_REGION ?? 'us-east-1';
+
+import { createHarness } from '../harness';
+
+describe('integration harness', () => {
+  it('creates a harness, signs a session, applies, advances time', async () => {
+    const h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+    try {
+      // Apply via the publisher actor.
+      await h.actors.publisher.apply({
+        name: 'Test Publisher',
+        email: 'pub@test.example.com',
+        sourceUrl: 'https://example.com/feed.json',
+        sourceType: 'json',
+      });
+      // Verify magic link was captured.
+      const sent = h.mail.lastTo('pub@test.example.com');
+      expect(sent?.kind).toBe('apply');
+
+      h.now.advance(60_000);
+      expect(h.now.now.toISOString()).toBe('2026-06-01T00:01:00.000Z');
+    } finally {
+      h.dispose();
+    }
+  });
+});

--- a/backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
+++ b/backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
@@ -321,6 +321,30 @@ describe('InMemoryDocClient', () => {
     expect(r.LastEvaluatedKey).toBeUndefined();
   });
 
+  it("ConditionExpression '=' compares objects structurally (key order independent)", async () => {
+    // Construct two objects with the same key set but different insertion
+    // orders. With the old JSON.stringify-based deepEq these would compare
+    // unequal; structural deepEq must treat them as equal.
+    const c = makeClient();
+    const stored = { a: 1, b: 'two', c: { x: 1, y: 2 } };
+    await c.send(new PutCommand({
+      TableName: 'simple',
+      Item: { id: 'a', payload: stored },
+    }));
+    // Same keys, opposite insertion order on both the outer and nested object.
+    const compareTo: Record<string, unknown> = {};
+    compareTo.c = { y: 2, x: 1 };
+    compareTo.b = 'two';
+    compareTo.a = 1;
+    const r = await c.send(new ScanCommand({
+      TableName: 'simple',
+      FilterExpression: 'payload = :p',
+      ExpressionAttributeValues: { ':p': compareTo },
+    })) as { Items: any[] };
+    expect(r.Items).toHaveLength(1);
+    expect(r.Items[0].id).toBe('a');
+  });
+
   it('Scan with Limit + ExclusiveStartKey paginates over hash-only table', async () => {
     const c = makeClient();
     for (let i = 0; i < 4; i++) {

--- a/backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
+++ b/backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
@@ -1,0 +1,257 @@
+// Self-tests for the in-memory DynamoDBDocumentClient fake. Validate every
+// command shape used by production services in backend/src/services/
+// (see header comment in inMemoryDocClient.ts for the survey).
+
+import {
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+  QueryCommand,
+  ScanCommand,
+  BatchGetCommand,
+  BatchWriteCommand,
+  TransactWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { InMemoryDocClient } from '../inMemoryDocClient';
+
+// Override the global jest.mock('@aws-sdk/lib-dynamodb') from setup.ts so
+// `cmd instanceof PutCommand` etc. works inside the fake.
+jest.unmock('@aws-sdk/lib-dynamodb');
+
+function makeClient() {
+  return new InMemoryDocClient([
+    { name: 'simple', hashKey: 'id' },
+    { name: 'composite', hashKey: 'pk', sortKey: 'sk' },
+    {
+      name: 'events',
+      hashKey: 'publisherId',
+      sortKey: 'eventId',
+      gsis: [{ name: 'by-state', hashKey: 'state', sortKey: 'startDate' }],
+    },
+  ]);
+}
+
+describe('InMemoryDocClient', () => {
+  it('Put + Get round-trip with hash-only key', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a', n: 1 } }));
+    const r = await c.send(new GetCommand({ TableName: 'simple', Key: { id: 'a' } })) as { Item?: any };
+    expect(r.Item).toEqual({ id: 'a', n: 1 });
+  });
+
+  it('Put + Get round-trip with hash+sort key', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'composite', Item: { pk: 'p1', sk: 's1', v: 'x' } }));
+    await c.send(new PutCommand({ TableName: 'composite', Item: { pk: 'p1', sk: 's2', v: 'y' } }));
+    const r = await c.send(new GetCommand({ TableName: 'composite', Key: { pk: 'p1', sk: 's2' } })) as { Item?: any };
+    expect(r.Item).toEqual({ pk: 'p1', sk: 's2', v: 'y' });
+  });
+
+  it("Put with attribute_not_exists succeeds on empty, fails on existing", async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({
+      TableName: 'simple',
+      Item: { id: 'a' },
+      ConditionExpression: 'attribute_not_exists(id)',
+    }));
+    await expect(
+      c.send(new PutCommand({
+        TableName: 'simple',
+        Item: { id: 'a' },
+        ConditionExpression: 'attribute_not_exists(id)',
+      })),
+    ).rejects.toMatchObject({ name: 'ConditionalCheckFailedException' });
+  });
+
+  it('Update SET sets one attribute', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a', n: 1 } }));
+    await c.send(new UpdateCommand({
+      TableName: 'simple',
+      Key: { id: 'a' },
+      UpdateExpression: 'SET #x = :v',
+      ExpressionAttributeNames: { '#x': 'name' },
+      ExpressionAttributeValues: { ':v': 'hello' },
+    }));
+    const r = await c.send(new GetCommand({ TableName: 'simple', Key: { id: 'a' } })) as { Item: any };
+    expect(r.Item).toEqual({ id: 'a', n: 1, name: 'hello' });
+  });
+
+  it('Update ADD increments a number', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a', counter: 0 } }));
+    await c.send(new UpdateCommand({
+      TableName: 'simple',
+      Key: { id: 'a' },
+      UpdateExpression: 'ADD #c :one',
+      ExpressionAttributeNames: { '#c': 'counter' },
+      ExpressionAttributeValues: { ':one': 1 },
+    }));
+    await c.send(new UpdateCommand({
+      TableName: 'simple',
+      Key: { id: 'a' },
+      UpdateExpression: 'ADD #c :one',
+      ExpressionAttributeNames: { '#c': 'counter' },
+      ExpressionAttributeValues: { ':one': 1 },
+    }));
+    const r = await c.send(new GetCommand({ TableName: 'simple', Key: { id: 'a' } })) as { Item: any };
+    expect(r.Item.counter).toBe(2);
+  });
+
+  it('Update with REMOVE deletes attribute', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a', extra: 'x' } }));
+    await c.send(new UpdateCommand({
+      TableName: 'simple',
+      Key: { id: 'a' },
+      UpdateExpression: 'REMOVE extra',
+    }));
+    const r = await c.send(new GetCommand({ TableName: 'simple', Key: { id: 'a' } })) as { Item: any };
+    expect(r.Item).toEqual({ id: 'a' });
+  });
+
+  it('Update with attribute_exists guards row missing', async () => {
+    const c = makeClient();
+    await expect(
+      c.send(new UpdateCommand({
+        TableName: 'simple',
+        Key: { id: 'gone' },
+        ConditionExpression: 'attribute_exists(id)',
+        UpdateExpression: 'SET v = :v',
+        ExpressionAttributeValues: { ':v': 1 },
+      })),
+    ).rejects.toMatchObject({ name: 'ConditionalCheckFailedException' });
+  });
+
+  it('Delete with conditional returns old attributes', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a', n: 1 } }));
+    const r = await c.send(new DeleteCommand({
+      TableName: 'simple',
+      Key: { id: 'a' },
+      ConditionExpression: 'attribute_exists(id)',
+      ReturnValues: 'ALL_OLD',
+    })) as { Attributes?: any };
+    expect(r.Attributes).toEqual({ id: 'a', n: 1 });
+  });
+
+  it('Query returns matching items', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'composite', Item: { pk: 'p', sk: 's1', v: 1 } }));
+    await c.send(new PutCommand({ TableName: 'composite', Item: { pk: 'p', sk: 's2', v: 2 } }));
+    await c.send(new PutCommand({ TableName: 'composite', Item: { pk: 'q', sk: 's1', v: 3 } }));
+    const r = await c.send(new QueryCommand({
+      TableName: 'composite',
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'pk' },
+      ExpressionAttributeValues: { ':pk': 'p' },
+    })) as { Items: any[] };
+    expect(r.Items).toHaveLength(2);
+    expect(r.Items.map(i => i.sk)).toEqual(['s1', 's2']);
+  });
+
+  it('Query against a GSI returns matching items sorted by sort key', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'events', Item: { publisherId: 'p1', eventId: 'e1', state: 'published', startDate: '2026-08-01' } }));
+    await c.send(new PutCommand({ TableName: 'events', Item: { publisherId: 'p1', eventId: 'e2', state: 'published', startDate: '2026-07-01' } }));
+    await c.send(new PutCommand({ TableName: 'events', Item: { publisherId: 'p2', eventId: 'e3', state: 'pending', startDate: '2026-06-01' } }));
+    const r = await c.send(new QueryCommand({
+      TableName: 'events',
+      IndexName: 'by-state',
+      KeyConditionExpression: '#s = :s',
+      ExpressionAttributeNames: { '#s': 'state' },
+      ExpressionAttributeValues: { ':s': 'published' },
+    })) as { Items: any[] };
+    expect(r.Items).toHaveLength(2);
+    expect(r.Items.map(i => i.startDate)).toEqual(['2026-07-01', '2026-08-01']);
+  });
+
+  it('Scan with FilterExpression filters items', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a', enabled: true } }));
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'b', enabled: false } }));
+    const r = await c.send(new ScanCommand({
+      TableName: 'simple',
+      FilterExpression: 'enabled = :t',
+      ExpressionAttributeValues: { ':t': true },
+    })) as { Items: any[] };
+    expect(r.Items.map(i => i.id)).toEqual(['a']);
+  });
+
+  it('TransactWrite with three Puts atomically commits', async () => {
+    const c = makeClient();
+    await c.send(new TransactWriteCommand({
+      TransactItems: [
+        { Put: { TableName: 'simple', Item: { id: 'a', v: 1 } } },
+        { Put: { TableName: 'simple', Item: { id: 'b', v: 2 } } },
+        { Put: { TableName: 'simple', Item: { id: 'c', v: 3 } } },
+      ],
+    }));
+    expect(c.dump('simple')).toHaveLength(3);
+  });
+
+  it('TransactWrite with one failing condition rolls back all writes', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'guard' } }));
+    await expect(c.send(new TransactWriteCommand({
+      TransactItems: [
+        { Put: { TableName: 'simple', Item: { id: 'a', v: 1 } } },
+        {
+          ConditionCheck: {
+            TableName: 'simple',
+            Key: { id: 'absent' },
+            ConditionExpression: 'attribute_exists(id)',
+          },
+        },
+        { Put: { TableName: 'simple', Item: { id: 'b', v: 2 } } },
+      ],
+    }))).rejects.toMatchObject({ name: 'TransactionCanceledException' });
+    // Original guard row remains; no new rows.
+    expect(c.dump('simple').map(i => (i as any).id).sort()).toEqual(['guard']);
+  });
+
+  it('BatchWrite with both Puts and Deletes processes all', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'old' } }));
+    await c.send(new BatchWriteCommand({
+      RequestItems: {
+        simple: [
+          { PutRequest: { Item: { id: 'new1' } } },
+          { PutRequest: { Item: { id: 'new2' } } },
+          { DeleteRequest: { Key: { id: 'old' } } },
+        ],
+      },
+    }));
+    expect(c.dump('simple').map(i => (i as any).id).sort()).toEqual(['new1', 'new2']);
+  });
+
+  it('BatchGet returns all requested keys that exist', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({ TableName: 'simple', Item: { id: 'a' } }));
+    const r = await c.send(new BatchGetCommand({
+      RequestItems: { simple: { Keys: [{ id: 'a' }, { id: 'missing' }] } },
+    })) as { Responses: Record<string, any[]> };
+    expect(r.Responses.simple).toHaveLength(1);
+  });
+
+  it('throws clearly on unsupported command shapes', async () => {
+    const c = makeClient();
+    await expect(c.send({ constructor: { name: 'TransactGetItemsCommand' } } as any))
+      .rejects.toThrow(/unsupported command/);
+  });
+
+  it('Scan with dotted-path FilterExpression handles nested attrs', async () => {
+    const c = makeClient();
+    await c.send(new PutCommand({
+      TableName: 'simple',
+      Item: { id: 'a', payload: { newEmail: 'x@example.com' } },
+    }));
+    const r = await c.send(new ScanCommand({
+      TableName: 'simple',
+      FilterExpression: 'payload.newEmail = :e',
+      ExpressionAttributeValues: { ':e': 'x@example.com' },
+    })) as { Items: any[] };
+    expect(r.Items).toHaveLength(1);
+  });
+});

--- a/backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
+++ b/backend/src/__tests__/integration/harness/__tests__/inMemoryDocClient.test.ts
@@ -254,4 +254,93 @@ describe('InMemoryDocClient', () => {
     })) as { Items: any[] };
     expect(r.Items).toHaveLength(1);
   });
+
+  // ─── Pagination ─────────────────────────────────────────────────────────
+
+  it('Query with Limit < total returns LastEvaluatedKey built from hash+sort', async () => {
+    const c = makeClient();
+    for (let i = 0; i < 5; i++) {
+      await c.send(new PutCommand({
+        TableName: 'composite',
+        Item: { pk: 'p1', sk: `s${i}`, n: i },
+      }));
+    }
+    const r = await c.send(new QueryCommand({
+      TableName: 'composite',
+      KeyConditionExpression: 'pk = :p',
+      ExpressionAttributeValues: { ':p': 'p1' },
+      Limit: 2,
+    })) as { Items: any[]; Count: number; LastEvaluatedKey?: Record<string, unknown> };
+    expect(r.Items).toHaveLength(2);
+    expect(r.Items.map(i => i.sk)).toEqual(['s0', 's1']);
+    expect(r.LastEvaluatedKey).toEqual({ pk: 'p1', sk: 's1' });
+  });
+
+  it('Query resumes from ExclusiveStartKey to return remaining items', async () => {
+    const c = makeClient();
+    for (let i = 0; i < 5; i++) {
+      await c.send(new PutCommand({
+        TableName: 'composite',
+        Item: { pk: 'p1', sk: `s${i}`, n: i },
+      }));
+    }
+    // Page 1: Limit 2 → returns s0, s1; LastEvaluatedKey = { pk:'p1', sk:'s1' }
+    const r1 = await c.send(new QueryCommand({
+      TableName: 'composite',
+      KeyConditionExpression: 'pk = :p',
+      ExpressionAttributeValues: { ':p': 'p1' },
+      Limit: 2,
+    })) as { Items: any[]; LastEvaluatedKey?: Record<string, unknown> };
+    expect(r1.LastEvaluatedKey).toBeDefined();
+    // Page 2: resume → returns s2, s3, s4; no further LastEvaluatedKey.
+    const r2 = await c.send(new QueryCommand({
+      TableName: 'composite',
+      KeyConditionExpression: 'pk = :p',
+      ExpressionAttributeValues: { ':p': 'p1' },
+      ExclusiveStartKey: r1.LastEvaluatedKey,
+    })) as { Items: any[]; LastEvaluatedKey?: Record<string, unknown> };
+    expect(r2.Items.map(i => i.sk)).toEqual(['s2', 's3', 's4']);
+    expect(r2.LastEvaluatedKey).toBeUndefined();
+  });
+
+  it('Query with Limit ≥ total: no LastEvaluatedKey emitted', async () => {
+    const c = makeClient();
+    for (let i = 0; i < 3; i++) {
+      await c.send(new PutCommand({
+        TableName: 'composite',
+        Item: { pk: 'p1', sk: `s${i}`, n: i },
+      }));
+    }
+    const r = await c.send(new QueryCommand({
+      TableName: 'composite',
+      KeyConditionExpression: 'pk = :p',
+      ExpressionAttributeValues: { ':p': 'p1' },
+      Limit: 10,
+    })) as { Items: any[]; LastEvaluatedKey?: Record<string, unknown> };
+    expect(r.Items).toHaveLength(3);
+    expect(r.LastEvaluatedKey).toBeUndefined();
+  });
+
+  it('Scan with Limit + ExclusiveStartKey paginates over hash-only table', async () => {
+    const c = makeClient();
+    for (let i = 0; i < 4; i++) {
+      await c.send(new PutCommand({ TableName: 'simple', Item: { id: `id${i}`, n: i } }));
+    }
+    const r1 = await c.send(new ScanCommand({
+      TableName: 'simple',
+      Limit: 2,
+    })) as { Items: any[]; LastEvaluatedKey?: Record<string, unknown> };
+    expect(r1.Items).toHaveLength(2);
+    expect(r1.LastEvaluatedKey).toBeDefined();
+    // The LEK should only carry the hash key for a hash-only table.
+    expect(Object.keys(r1.LastEvaluatedKey!)).toEqual(['id']);
+    const r2 = await c.send(new ScanCommand({
+      TableName: 'simple',
+      ExclusiveStartKey: r1.LastEvaluatedKey,
+    })) as { Items: any[]; LastEvaluatedKey?: Record<string, unknown> };
+    // The two pages combined should cover all 4 items.
+    const seen = [...r1.Items, ...r2.Items].map(i => i.id).sort();
+    expect(seen).toEqual(['id0', 'id1', 'id2', 'id3']);
+    expect(r2.LastEvaluatedKey).toBeUndefined();
+  });
 });

--- a/backend/src/__tests__/integration/harness/actors.ts
+++ b/backend/src/__tests__/integration/harness/actors.ts
@@ -134,15 +134,27 @@ export interface Actors {
 }
 
 // To make admin handler routes pass auth, we mint an admin JWT each call.
-// adminHandler.ts captures JWT_SECRET at module load (line ~89), so once
-// it's loaded our setting `process.env.JWT_SECRET` here has no effect.
-// We sniff the captured value via the same default ('your-secret-key')
-// adminHandler uses. The whitelist is read on every call, so setting it
-// here works.
+// adminHandler.ts captures JWT_SECRET at module load. integrationSetup.ts
+// (which every integration test imports as its first import) sets
+// process.env.JWT_SECRET *before* any production module loads, so that
+// captured value is whatever integrationSetup wrote. We re-read it here
+// at the same point in time so signatures verify.
+//
+// We deliberately do NOT fall back to a different literal — if the env
+// var is unset, the captured adminHandler value would be 'your-secret-key'
+// (its production fallback), which would silently break verification.
+// Instead we throw, which will surface as a fast, obvious test failure.
 const ADMIN_EMAIL = 'admin@test.chqcal.local';
-// Match harness.ts's pre-import env. Both agree on the same value so the
-// adminHandler-captured constant matches what we sign with.
-const ADMIN_JWT_SECRET = process.env.JWT_SECRET ?? 'test-admin-jwt-secret';
+const ADMIN_JWT_SECRET = (() => {
+  const v = process.env.JWT_SECRET;
+  if (!v) {
+    throw new Error(
+      "actors.ts: process.env.JWT_SECRET is not set. " +
+      "Make sure integrationSetup.ts ran (every integration test imports it via harness.ts)."
+    );
+  }
+  return v;
+})();
 
 import jwt from 'jsonwebtoken';
 

--- a/backend/src/__tests__/integration/harness/actors.ts
+++ b/backend/src/__tests__/integration/harness/actors.ts
@@ -1,0 +1,337 @@
+// Actor API: typed wrappers around APIGatewayProxyEvent that drive each
+// production handler in the same routing path it would take in real
+// API Gateway.
+//
+// Each method:
+//   1. Builds an APIGatewayProxyEvent with realistic shape.
+//   2. Calls the appropriate statically-imported handler.
+//   3. Parses the JSON response body.
+//   4. On non-2xx, throws HandlerError so tests can use rejects.toThrow.
+
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  handlePublisherApplyRequest,
+  handlePublisherApplyVerify,
+  handlePublisherAuthRequest,
+  handlePublisherAuthVerify,
+  handlePublisherStatus,
+  handlePublisherProfilePatch,
+  handlePublisherEmailChangeRequest,
+  handlePublisherEmailChangeCancelSelf,
+  handlePublisherEmailChangeVerify,
+  handlePublisherEmailChangeCancelByOld,
+  handlePublisherFetchNow,
+  handlePublisherPause,
+  handlePublisherResume,
+  handlePublisherDisable,
+} from '../../../handlers/publisherPortalHandler';
+import { handler as adminHandler } from '../../../handlers/adminHandler';
+import type { ApplyFormPayload } from '../../../types/publisher';
+import type { Harness } from './harness';
+
+export class HandlerError extends Error {
+  constructor(public readonly statusCode: number, public readonly body: any) {
+    super(typeof body?.error === 'string' ? body.error : `Handler returned ${statusCode}`);
+    this.name = 'HandlerError';
+  }
+}
+
+interface BuildEventOpts {
+  method?: string;
+  path?: string;
+  body?: Record<string, unknown> | null;
+  headers?: Record<string, string>;
+  query?: Record<string, string>;
+  ip?: string;
+}
+
+function buildEvent(opts: BuildEventOpts = {}): APIGatewayProxyEvent {
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    ...(opts.headers ?? {}),
+  };
+  return {
+    httpMethod: opts.method ?? 'POST',
+    path: opts.path ?? '/',
+    headers,
+    multiValueHeaders: {},
+    body: opts.body ? JSON.stringify(opts.body) : null,
+    isBase64Encoded: false,
+    pathParameters: null,
+    queryStringParameters: opts.query ?? null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {
+      identity: {
+        sourceIp: opts.ip ?? '127.0.0.1',
+      },
+    } as any,
+    resource: '',
+  } as unknown as APIGatewayProxyEvent;
+}
+
+function parseResult(r: APIGatewayProxyResult): { statusCode: number; body: any } {
+  let body: any = {};
+  if (typeof r.body === 'string' && r.body.length > 0) {
+    try { body = JSON.parse(r.body); }
+    catch { body = { _raw: r.body }; }
+  }
+  return { statusCode: r.statusCode, body };
+}
+
+function unwrap<T = any>(r: APIGatewayProxyResult): T {
+  const p = parseResult(r);
+  if (p.statusCode < 200 || p.statusCode >= 300) {
+    throw new HandlerError(p.statusCode, p.body);
+  }
+  return p.body as T;
+}
+
+// ─── Publisher actor ────────────────────────────────────────────────────
+
+export interface PublisherActor {
+  apply(payload: Partial<ApplyFormPayload> & { captchaToken?: string }, opts?: { ip?: string }): Promise<{ ok: true }>;
+  verifyApplyMagicLink(token: string): Promise<{ jwt: string; publisherId: string; email: string }>;
+  loginRequest(email: string, opts?: { ip?: string }): Promise<{ ok: true }>;
+  verifyLoginMagicLink(token: string): Promise<{ jwt: string; publisherId: string; email: string }>;
+  status(jwtToken: string): Promise<{ publisher: any }>;
+  updateProfile(jwtToken: string, patch: Record<string, unknown>): Promise<{ publisher: any }>;
+  requestEmailChange(jwtToken: string, newEmail: string): Promise<{ ok: true }>;
+  confirmEmailChange(rawToken: string): Promise<any>;
+  cancelEmailChangeByOld(rawToken: string): Promise<any>;
+  cancelEmailChangeBySelf(jwtToken: string): Promise<any>;
+  pause(jwtToken: string): Promise<{ publisher: any }>;
+  resume(jwtToken: string): Promise<{ publisher: any }>;
+  fetchNow(jwtToken: string): Promise<{ acceptedAt: string }>;
+  selfDisable(jwtToken: string, confirmSlug: string): Promise<{ ok: true; emailedTo: string }>;
+}
+
+// ─── Admin actor (routed through adminHandler with bypass) ─────────────
+
+export interface AdminActor {
+  approveApplication(publisherId: string, reviewerEmail?: string): Promise<{ publisher: any }>;
+  rejectApplication(publisherId: string, reason?: string, reviewerEmail?: string): Promise<{ publisher: any }>;
+  listPublishers(): Promise<{ publishers: any[] }>;
+  pause(publisherId: string): Promise<{ publisher: any }>;
+  resume(publisherId: string): Promise<{ publisher: any }>;
+  disable(publisherId: string): Promise<{ publisher: any }>;
+  approveEvent(publisherId: string, eventId: string): Promise<void>;
+  rejectEvent(publisherId: string, eventId: string): Promise<void>;
+  runIngest(reviewerEmail?: string): Promise<{ triggeredAt: string }>;
+}
+
+// ─── Ingest actor ───────────────────────────────────────────────────────
+
+export interface IngestActor {
+  run(singlePublisherId?: string): Promise<void>;
+}
+
+// Combined.
+export interface Actors {
+  publisher: PublisherActor;
+  admin: AdminActor;
+  ingest: IngestActor;
+}
+
+// To make admin handler routes pass auth, we mint an admin JWT each call.
+// adminHandler.ts captures JWT_SECRET at module load (line ~89), so once
+// it's loaded our setting `process.env.JWT_SECRET` here has no effect.
+// We sniff the captured value via the same default ('your-secret-key')
+// adminHandler uses. The whitelist is read on every call, so setting it
+// here works.
+const ADMIN_EMAIL = 'admin@test.chqcal.local';
+// Match harness.ts's pre-import env. Both agree on the same value so the
+// adminHandler-captured constant matches what we sign with.
+const ADMIN_JWT_SECRET = process.env.JWT_SECRET ?? 'test-admin-jwt-secret';
+
+import jwt from 'jsonwebtoken';
+
+function mintAdminJwt(email = ADMIN_EMAIL): string {
+  return jwt.sign({ email, name: 'Test Admin' }, ADMIN_JWT_SECRET, { expiresIn: '7d' });
+}
+
+async function callAdmin(opts: BuildEventOpts & { reviewerEmail?: string }): Promise<APIGatewayProxyResult> {
+  const headers = {
+    Authorization: `Bearer ${mintAdminJwt(opts.reviewerEmail)}`,
+    ...(opts.headers ?? {}),
+  };
+  const event = buildEvent({ ...opts, headers });
+  return adminHandler(event, {} as any);
+}
+
+export function buildActors(h: Harness): Actors {
+  const publisher: PublisherActor = {
+    async apply(payload, opts = {}) {
+      const r = await handlePublisherApplyRequest(
+        buildEvent({ ip: opts.ip }),
+        { ...payload, captchaToken: payload.captchaToken ?? 'test-token' } as any,
+      );
+      return unwrap(r);
+    },
+    async verifyApplyMagicLink(token) {
+      const r = await handlePublisherApplyVerify(buildEvent(), { token });
+      return unwrap(r);
+    },
+    async loginRequest(email, opts = {}) {
+      const r = await handlePublisherAuthRequest(buildEvent({ ip: opts.ip }), { email });
+      return unwrap(r);
+    },
+    async verifyLoginMagicLink(token) {
+      const r = await handlePublisherAuthVerify(buildEvent(), { token });
+      return unwrap(r);
+    },
+    async status(jwtToken) {
+      const r = await handlePublisherStatus(
+        buildEvent({ method: 'GET', headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async updateProfile(jwtToken, patch) {
+      const r = await handlePublisherProfilePatch(
+        buildEvent({
+          method: 'PATCH',
+          headers: { Authorization: `Bearer ${jwtToken}` },
+          body: patch,
+        }),
+        patch,
+      );
+      return unwrap(r);
+    },
+    async requestEmailChange(jwtToken, newEmail) {
+      const r = await handlePublisherEmailChangeRequest(
+        buildEvent({ headers: { Authorization: `Bearer ${jwtToken}` }, body: { newEmail } }),
+        { newEmail },
+      );
+      return unwrap(r);
+    },
+    async confirmEmailChange(rawToken) {
+      const r = await handlePublisherEmailChangeVerify(
+        buildEvent({ method: 'GET', query: { token: rawToken } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async cancelEmailChangeByOld(rawToken) {
+      const r = await handlePublisherEmailChangeCancelByOld(
+        buildEvent({ method: 'GET', query: { token: rawToken } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async cancelEmailChangeBySelf(jwtToken) {
+      const r = await handlePublisherEmailChangeCancelSelf(
+        buildEvent({ method: 'DELETE', headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async pause(jwtToken) {
+      const r = await handlePublisherPause(
+        buildEvent({ headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async resume(jwtToken) {
+      const r = await handlePublisherResume(
+        buildEvent({ headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async fetchNow(jwtToken) {
+      const r = await handlePublisherFetchNow(
+        buildEvent({ headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async selfDisable(jwtToken, confirmSlug) {
+      const r = await handlePublisherDisable(
+        buildEvent({ headers: { Authorization: `Bearer ${jwtToken}` }, body: { confirmSlug } }),
+        { confirmSlug },
+      );
+      return unwrap(r);
+    },
+  };
+
+  const admin: AdminActor = {
+    async approveApplication(publisherId, reviewerEmail) {
+      const r = await callAdmin({
+        method: 'POST',
+        path: `/publisher-applications/${encodeURIComponent(publisherId)}/approve`,
+        reviewerEmail,
+        body: {},
+      });
+      return unwrap(r);
+    },
+    async rejectApplication(publisherId, reason, reviewerEmail) {
+      const r = await callAdmin({
+        method: 'POST',
+        path: `/publisher-applications/${encodeURIComponent(publisherId)}/reject`,
+        reviewerEmail,
+        body: { reason },
+      });
+      return unwrap(r);
+    },
+    async listPublishers() {
+      const r = await callAdmin({ method: 'GET', path: '/publishers' });
+      return unwrap(r);
+    },
+    async pause(publisherId) {
+      const r = await callAdmin({
+        method: 'PATCH',
+        path: `/publishers/${encodeURIComponent(publisherId)}`,
+        body: { paused: true },
+      });
+      return unwrap(r);
+    },
+    async resume(publisherId) {
+      const r = await callAdmin({
+        method: 'PATCH',
+        path: `/publishers/${encodeURIComponent(publisherId)}`,
+        body: { paused: false },
+      });
+      return unwrap(r);
+    },
+    async disable(publisherId) {
+      const r = await callAdmin({
+        method: 'PATCH',
+        path: `/publishers/${encodeURIComponent(publisherId)}`,
+        body: { enabled: false },
+      });
+      return unwrap(r);
+    },
+    async approveEvent(publisherId, eventId) {
+      const r = await callAdmin({
+        method: 'POST',
+        path: `/publisher-events/${encodeURIComponent(publisherId)}/${encodeURIComponent(eventId)}/approve`,
+      });
+      if (r.statusCode !== 204) unwrap(r);
+    },
+    async rejectEvent(publisherId, eventId) {
+      const r = await callAdmin({
+        method: 'POST',
+        path: `/publisher-events/${encodeURIComponent(publisherId)}/${encodeURIComponent(eventId)}/reject`,
+      });
+      if (r.statusCode !== 204) unwrap(r);
+    },
+    async runIngest(reviewerEmail) {
+      const r = await callAdmin({
+        method: 'POST',
+        path: '/publishers/run-ingest',
+        reviewerEmail,
+      });
+      return unwrap(r);
+    },
+  };
+
+  const ingest: IngestActor = {
+    async run(singlePublisherId) {
+      await h.ingest.run(singlePublisherId);
+    },
+  };
+
+  return { publisher, admin, ingest };
+}

--- a/backend/src/__tests__/integration/harness/fakes.ts
+++ b/backend/src/__tests__/integration/harness/fakes.ts
@@ -1,0 +1,256 @@
+// Fake collaborators used by the integration harness:
+//   - ClockController: deterministic clock the harness can advance
+//   - MailCapture: in-memory `MailService` implementation that records sends
+//   - FakeFeedFetcher: matches `fetchAndParseFeed` signature; per-publisher results
+//   - FakeLambdaInvoker: in-process Lambda invoker that calls runIngest()
+//   - FakeRateLimiter: an in-memory limiter that uses the harness clock
+//
+// These are pure objects — no module mocking happens here. The harness wires
+// them into the real services via constructor injection or via the
+// `_setXxxForTests` hooks the production handlers expose.
+
+import type {
+  MailService,
+  ApprovalEmailOpts,
+  RejectionEmailOpts,
+  EmailChangeVerifyOpts,
+  EmailChangeWarningOpts,
+  EmailChangeCommittedOpts,
+  EmailChangeCancelledOpts,
+  SelfDisabledConfirmationOpts,
+} from '../../../services/mailService';
+import type {
+  RateLimiter,
+  RateLimitOptions,
+  RateLimitDecision,
+} from '../../../services/rateLimitService';
+import type {
+  FetchFeedInput,
+  FetchFeedOutput,
+} from '../../../services/publisherFeedFetcher';
+import type { PublisherRecord } from '../../../types/publisher';
+
+// ─── Clock ──────────────────────────────────────────────────────────────
+
+export class ClockController {
+  private current: Date;
+  constructor(now: Date | string) {
+    this.current = typeof now === 'string' ? new Date(now) : now;
+  }
+  get now(): Date { return new Date(this.current); }
+  /** Returns ms since epoch, suitable for `() => Date.now()` callers. */
+  nowMs(): number { return this.current.getTime(); }
+  advance(ms: number): void {
+    this.current = new Date(this.current.getTime() + ms);
+  }
+  set(date: Date | string): void {
+    this.current = typeof date === 'string' ? new Date(date) : date;
+  }
+}
+
+// ─── Mail capture ───────────────────────────────────────────────────────
+
+export type SentMailKind =
+  | 'apply'
+  | 'login'
+  | 'approval'
+  | 'rejection'
+  | 'email_change_verify'
+  | 'email_change_warning'
+  | 'email_change_committed'
+  | 'email_change_cancelled'
+  | 'self_disabled_confirmation';
+
+export interface SentMail {
+  kind: SentMailKind;
+  to: string;
+  data: Record<string, unknown>;
+}
+
+export class MailCapture implements MailService {
+  private readonly sent: SentMail[] = [];
+
+  async sendApplyMagicLink(toEmail: string, applicantName: string, magicLinkUrl: string) {
+    this.sent.push({ kind: 'apply', to: toEmail, data: { applicantName, magicLinkUrl } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendLoginMagicLink(toEmail: string, magicLinkUrl: string) {
+    this.sent.push({ kind: 'login', to: toEmail, data: { magicLinkUrl } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendApprovalEmail(opts: ApprovalEmailOpts) {
+    this.sent.push({ kind: 'approval', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendRejectionEmail(opts: RejectionEmailOpts) {
+    this.sent.push({ kind: 'rejection', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendEmailChangeVerify(opts: EmailChangeVerifyOpts) {
+    this.sent.push({ kind: 'email_change_verify', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendEmailChangeWarning(opts: EmailChangeWarningOpts) {
+    this.sent.push({ kind: 'email_change_warning', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendEmailChangeCommitted(opts: EmailChangeCommittedOpts) {
+    this.sent.push({ kind: 'email_change_committed', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendEmailChangeCancelled(opts: EmailChangeCancelledOpts) {
+    this.sent.push({ kind: 'email_change_cancelled', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendSelfDisabledConfirmation(opts: SelfDisabledConfirmationOpts) {
+    this.sent.push({ kind: 'self_disabled_confirmation', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+
+  all(): SentMail[] { return [...this.sent]; }
+  byKind(kind: SentMailKind): SentMail[] { return this.sent.filter(m => m.kind === kind); }
+  lastTo(email: string): SentMail | undefined {
+    const lower = email.trim().toLowerCase();
+    for (let i = this.sent.length - 1; i >= 0; i--) {
+      if (this.sent[i].to.trim().toLowerCase() === lower) return this.sent[i];
+    }
+    return undefined;
+  }
+  clear(): void { this.sent.length = 0; }
+}
+
+// ─── Fake feed fetcher ──────────────────────────────────────────────────
+
+export class FakeFeedFetcher {
+  private readonly responses = new Map<string, FetchFeedOutput>();
+
+  set(publisherId: string, result: FetchFeedOutput): void {
+    this.responses.set(publisherId, result);
+  }
+
+  /** Matches `fetchAndParseFeed` signature so we can be passed as `deps.fetcher`. */
+  fetchFn = async (input: FetchFeedInput): Promise<FetchFeedOutput> => {
+    const r = this.responses.get(input.registeredPublisherId);
+    if (!r) {
+      // Default: a clean network_error so ingest's outcome path runs.
+      return {
+        fetchStatus: 'network_error',
+        feed: null,
+        report: {
+          ok: false,
+          errors: [{ path: '/', message: 'no fake response set' }],
+          warnings: [],
+        },
+      };
+    }
+    return r;
+  };
+}
+
+// Helper: build a successful FetchFeedOutput from a list of feed events.
+export function feedOk(
+  publisherId: string,
+  publisherName: string,
+  events: Array<{
+    id: string;
+    title?: string;
+    description?: string;
+    startDate: string;
+    endDate: string;
+    lastModified: string;
+    [k: string]: unknown;
+  }>,
+): FetchFeedOutput {
+  const safeEvents = events.map(e => ({
+    title: e.title ?? `Event ${e.id}`,
+    description: e.description ?? '',
+    ...e,
+  }));
+  return {
+    fetchStatus: 'ok',
+    // Cast through unknown — the FeedDocument type from publisher-format
+    // requires more fields, but reconcile only reads a subset.
+    feed: {
+      version: '1.0',
+      publisher: { id: publisherId, name: publisherName },
+      events: safeEvents,
+    } as unknown as FetchFeedOutput['feed'],
+    report: { ok: true, errors: [], warnings: [] },
+  };
+}
+
+// ─── Fake Lambda invoker ────────────────────────────────────────────────
+//
+// The /publisher-fetch-now and /publishers/run-ingest paths call
+// `lambdaClient().send(new InvokeCommand(...))`. In tests we route those
+// invocations to an in-process callback so the fake ingest happens
+// synchronously.
+
+export class FakeLambdaInvoker {
+  public readonly invocations: Array<{ functionName: string; payload: unknown }> = [];
+  constructor(private readonly run: (payload: { singlePublisherId?: string }) => Promise<void>) {}
+
+  async send(cmd: any): Promise<{ StatusCode: number }> {
+    const input = cmd?.input ?? cmd;
+    const fnName = input?.FunctionName ?? 'unknown';
+    let payload: { singlePublisherId?: string } = {};
+    try {
+      const buf = input?.Payload;
+      if (buf) {
+        const text = typeof buf === 'string' ? buf : Buffer.from(buf).toString('utf8');
+        payload = JSON.parse(text);
+      }
+    } catch {
+      // ignore — leave payload empty
+    }
+    this.invocations.push({ functionName: fnName, payload });
+    await this.run(payload);
+    return { StatusCode: 202 };
+  }
+}
+
+// ─── Captcha toggle ─────────────────────────────────────────────────────
+
+export class CaptchaToggle {
+  private result = true;
+  pass(): void { this.result = true; }
+  fail(): void { this.result = false; }
+  /** Module-mock target — matches verifyCaptcha(token, action) → Promise<boolean>. */
+  verify = async (_token: string, _action?: string): Promise<boolean> => this.result;
+}
+
+// ─── In-memory rate limiter (clock-driven) ─────────────────────────────
+//
+// The production InMemoryRateLimiter uses Date.now(), which we don't want
+// in tests because we can't advance the harness clock through it. This
+// variant takes the clock controller and is otherwise identical.
+
+export class FakeRateLimiter implements RateLimiter {
+  private readonly state = new Map<string, number[]>();
+  constructor(private readonly clock: ClockController) {}
+
+  async checkAndConsume(opts: RateLimitOptions): Promise<RateLimitDecision> {
+    const now = this.clock.nowMs();
+    const windowStart = now - opts.windowMs;
+    const existing = this.state.get(opts.key) ?? [];
+    const recent = existing.filter(t => t > windowStart);
+    if (recent.length >= opts.max) {
+      const oldest = recent[0];
+      this.state.set(opts.key, recent);
+      return {
+        ok: false,
+        retryAfterSeconds: Math.max(1, Math.ceil((oldest + opts.windowMs - now) / 1000)),
+      };
+    }
+    recent.push(now);
+    this.state.set(opts.key, recent);
+    return { ok: true };
+  }
+  reset(key?: string): void {
+    if (key === undefined) this.state.clear();
+    else this.state.delete(key);
+  }
+}
+
+// ─── Re-export PublisherRecord for actor signatures ─────────────────────
+export type { PublisherRecord };

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -1,0 +1,289 @@
+// Integration test harness.
+//
+// Each test file constructs a harness with `await createHarness({ now })` in
+// `beforeEach`, runs a journey via the actor API, and discards the harness in
+// `afterEach` (`harness.dispose()`).
+//
+// The harness owns:
+//   - the in-memory DDB fake (shared across all services)
+//   - real services constructed against the fake
+//   - a clock controller, mail capture, fake feed fetcher, fake lambda invoker
+//   - an in-memory rate limiter
+//   - a per-harness JWT signing secret
+//
+// It calls the production handlers' `_setXxxForTests` injection points so the
+// handlers route through our fakes instead of building their own clients.
+
+import { InMemoryDocClient, type TableSpec } from './inMemoryDocClient';
+import {
+  ClockController,
+  MailCapture,
+  FakeFeedFetcher,
+  FakeLambdaInvoker,
+  CaptchaToggle,
+  FakeRateLimiter,
+} from './fakes';
+import { PublisherRegistryService } from '../../../services/publisherRegistryService';
+import { PublisherEventStore } from '../../../services/publisherEventStore';
+import { PublisherSidecarPublisher } from '../../../services/publisherSidecarPublisher';
+import { PublisherApplicationService } from '../../../services/publisherApplicationService';
+import { PublisherEmailChangeService } from '../../../services/publisherEmailChangeService';
+import { PublisherAdminService } from '../../../services/publisherAdminService';
+import { MagicTokenService } from '../../../services/magicTokenService';
+import { runIngest, type IngestDeps } from '../../../handlers/publisherIngestHandler';
+import { selfDisable } from '../../../services/publisherSelfActionService';
+import * as portal from '../../../handlers/publisherPortalHandler';
+import * as admin from '../../../handlers/adminHandler';
+import * as captchaModule from '../../../services/captchaService';
+import * as secretCache from '../../../services/publisherSecretCache';
+
+import jwt from 'jsonwebtoken';
+import type { Actors } from './actors';
+
+// Re-exports for tests.
+export type { ClockController, MailCapture, FakeFeedFetcher } from './fakes';
+export { feedOk } from './fakes';
+
+const PUBLISHERS_TABLE = 'publishers';
+const PUBLISHER_EVENTS_TABLE = 'publisher-events';
+const MAGIC_TOKENS_TABLE = 'magic-tokens';
+const RATE_LIMIT_TABLE = 'rate-limit';
+
+const TABLE_SPECS: TableSpec[] = [
+  { name: PUBLISHERS_TABLE, hashKey: 'id' },
+  {
+    name: PUBLISHER_EVENTS_TABLE,
+    hashKey: 'publisherId',
+    sortKey: 'eventId',
+    gsis: [{ name: 'by-state', hashKey: 'state', sortKey: 'startDate' }],
+  },
+  { name: MAGIC_TOKENS_TABLE, hashKey: 'tokenHash' },
+  { name: RATE_LIMIT_TABLE, hashKey: 'id' },
+];
+
+export interface Harness {
+  ddb: InMemoryDocClient;
+  now: ClockController;
+  feeds: FakeFeedFetcher;
+  mail: MailCapture;
+  invoker: FakeLambdaInvoker;
+  captcha: CaptchaToggle;
+  rateLimiter: FakeRateLimiter;
+  registry: PublisherRegistryService;
+  store: PublisherEventStore;
+  appService: PublisherApplicationService;
+  emailChangeService: PublisherEmailChangeService;
+  adminService: PublisherAdminService;
+  magicTokens: MagicTokenService;
+  /** Ingest a feed cycle in-process. */
+  ingest: { run: (singlePublisherId?: string) => Promise<void> };
+  /** Sign a publisher session JWT for a given record. */
+  signSession: (publisherId: string, opts?: { tokenVersion?: number; email?: string }) => Promise<string>;
+  /** Returns event states for a publisher: { [eventId]: state }. */
+  events: {
+    statesOf: (publisherId: string) => Promise<Record<string, 'published' | 'pending'>>;
+    count: (publisherId: string) => Promise<number>;
+  };
+  /** Lazily-imported actor wrappers. Set after createHarness completes. */
+  actors: Actors;
+  jwtSecret: string;
+  dispose: () => void;
+}
+
+export interface CreateHarnessOpts {
+  now?: Date | string;
+}
+
+// Module-level singletons (so harness can reset across tests).
+let _harnessSingleton: Harness | null = null;
+const TEST_JWT_SECRET = 'test-publisher-jwt-secret-do-not-use-in-prod';
+
+// Mock the publisher secret cache so signPublisherJwt / verifyPublisherJwt use
+// our deterministic secret. This needs to happen before any test module that
+// imports auth. We do it once on first import of harness.ts.
+let _secretMockInstalled = false;
+function installSecretMock() {
+  if (_secretMockInstalled) return;
+  jest.spyOn(secretCache, 'getPublisherJwtSecret').mockResolvedValue(TEST_JWT_SECRET);
+  _secretMockInstalled = true;
+}
+
+// Mock the captcha verifier to always go through our toggle.
+let _captchaMockInstalled = false;
+let _captchaToggleRef: CaptchaToggle | null = null;
+function installCaptchaMock() {
+  if (_captchaMockInstalled) return;
+  jest.spyOn(captchaModule, 'verifyCaptcha').mockImplementation(async (token, action) => {
+    if (!_captchaToggleRef) return true;
+    return _captchaToggleRef.verify(token, action);
+  });
+  _captchaMockInstalled = true;
+}
+
+export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harness> {
+  installSecretMock();
+  installCaptchaMock();
+
+  const now = new ClockController(opts.now ?? new Date());
+  const ddb = new InMemoryDocClient(TABLE_SPECS);
+  // The DDB fake has a `.send(cmd)` shape but isn't a real DocumentClient.
+  // Services accept the type as `DynamoDBDocumentClient` — we cast through
+  // unknown.
+  const docClient = ddb as unknown as import('@aws-sdk/lib-dynamodb').DynamoDBDocumentClient;
+
+  const mail = new MailCapture();
+  const captcha = new CaptchaToggle();
+  _captchaToggleRef = captcha;
+  const feeds = new FakeFeedFetcher();
+  const rateLimiter = new FakeRateLimiter(now);
+
+  const nowFn = () => now.now;
+
+  const registry = new PublisherRegistryService(docClient, PUBLISHERS_TABLE);
+  const store = new PublisherEventStore(docClient, PUBLISHER_EVENTS_TABLE);
+  const magicTokens = new MagicTokenService(docClient, MAGIC_TOKENS_TABLE, nowFn);
+
+  // The sidecar publisher needs an S3 client; we don't actually exercise S3
+  // in integration tests so we stub the publish() method.
+  const sidecar = {
+    publish: async () => undefined,
+  } as unknown as PublisherSidecarPublisher;
+
+  const appService = new PublisherApplicationService({
+    registry,
+    tokens: magicTokens,
+    mail,
+    siteBaseUrl: 'https://test.chqcal.local',
+    now: nowFn,
+  });
+  const emailChangeService = new PublisherEmailChangeService({
+    registry,
+    tokens: magicTokens,
+    mail,
+    siteBaseUrl: 'https://test.chqcal.local',
+    now: nowFn,
+  });
+  const adminService = new PublisherAdminService(registry, store, {
+    mail,
+    siteBaseUrl: 'https://test.chqcal.local',
+  });
+
+  // Set up ingest. The Lambda invoker (used by both /publisher-fetch-now and
+  // /publishers/run-ingest) routes back to runIngest in-process so a single
+  // harness run can drive both the API call and the resulting ingest.
+  const ingestDeps: IngestDeps = {
+    registry,
+    store,
+    sidecar,
+    fetcher: feeds.fetchFn,
+    now: nowFn(),
+    publishersTableName: PUBLISHERS_TABLE,
+  };
+  const runIngestInProcess = async (payload: { singlePublisherId?: string } = {}) => {
+    // Refresh deps.now to reflect the current clock.
+    const deps: IngestDeps = { ...ingestDeps, now: now.now };
+    await runIngest(deps, { singlePublisherId: payload.singlePublisherId });
+  };
+  const invoker = new FakeLambdaInvoker(runIngestInProcess);
+
+  // Wire handler-level injection points. Each call captures the prior value
+  // so dispose() can restore.
+  portal._setStatusRegistryForTests(registry);
+  portal._setAppServiceForTests(appService);
+  portal._setEmailChangeServiceForTests(emailChangeService);
+  portal._setSelfDisableDepsForTests({
+    registry,
+    magicTokens,
+    mail,
+  });
+  portal._setRateLimiterForTests(rateLimiter);
+  admin._setPublisherAdminForTests(adminService);
+  admin._setLambdaClientForTests(invoker as unknown as import('@aws-sdk/client-lambda').LambdaClient);
+
+  // Set the publisher-ingest function name so the invoker's lookup doesn't
+  // throw. The fake invoker ignores the value.
+  process.env.PUBLISHER_INGEST_FUNCTION_NAME = 'test-publisher-ingest';
+  process.env.SES_FROM_ADDRESS = 'test@chqcal.local';
+  process.env.SITE_BASE_URL = 'https://test.chqcal.local';
+
+  // Lazy-import actors to avoid circular imports.
+  const { buildActors } = await import('./actors');
+
+  const events = {
+    statesOf: async (publisherId: string) => {
+      const all = await store.listForPublisher(publisherId);
+      const out: Record<string, 'published' | 'pending'> = {};
+      for (const e of all) out[e.eventId] = e.state;
+      return out;
+    },
+    count: async (publisherId: string) => {
+      const all = await store.listForPublisher(publisherId);
+      return all.length;
+    },
+  };
+
+  const signSession = async (publisherId: string, sopts: { tokenVersion?: number; email?: string } = {}) => {
+    const rec = await registry.get(publisherId);
+    const tv = sopts.tokenVersion ?? rec?.tokenVersion ?? 0;
+    const email = sopts.email ?? rec?.contactEmail ?? 'test@example.com';
+    return jwt.sign(
+      {
+        sub: publisherId,
+        role: 'publisher',
+        email,
+        tokenVersion: tv,
+      },
+      TEST_JWT_SECRET,
+      { expiresIn: '7d' },
+    );
+  };
+
+  const harness: Harness = {
+    ddb,
+    now,
+    feeds,
+    mail,
+    invoker,
+    captcha,
+    rateLimiter,
+    registry,
+    store,
+    appService,
+    emailChangeService,
+    adminService,
+    magicTokens,
+    ingest: {
+      run: async (singlePublisherId?: string) => {
+        await runIngestInProcess(singlePublisherId ? { singlePublisherId } : {});
+      },
+    },
+    signSession,
+    events,
+    actors: undefined as unknown as Actors,
+    jwtSecret: TEST_JWT_SECRET,
+    dispose: () => {
+      portal._setStatusRegistryForTests(null);
+      portal._setAppServiceForTests(null);
+      portal._setEmailChangeServiceForTests(null);
+      portal._setSelfDisableDepsForTests(null);
+      portal._setRateLimiterForTests(null);
+      admin._setPublisherAdminForTests(null);
+      admin._setLambdaClientForTests(null);
+      _captchaToggleRef = null;
+      _harnessSingleton = null;
+    },
+  };
+  harness.actors = buildActors(harness);
+  _harnessSingleton = harness;
+
+  // Re-export for selfDisable callers — the handler picks deps from
+  // `_setSelfDisableDepsForTests`, but the `selfDisable` action import is
+  // a free function so just import-and-use is fine.
+  void selfDisable;
+
+  return harness;
+}
+
+export function currentHarness(): Harness | null {
+  return _harnessSingleton;
+}

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -191,8 +191,12 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
   };
   const invoker = new FakeLambdaInvoker(runIngestInProcess);
 
-  // Wire handler-level injection points. Each call captures the prior value
-  // so dispose() can restore.
+  // Wire handler-level injection points. The setters simply overwrite the
+  // module-level singletons in each handler; dispose() passes `null` to
+  // each one, which causes those handlers to fall back to lazily
+  // constructing fresh defaults on the next call (rather than restoring a
+  // previously-captured value). This is safe because every test file
+  // builds a new harness in beforeEach and tears it down in afterEach.
   portal._setStatusRegistryForTests(registry);
   portal._setAppServiceForTests(appService);
   portal._setEmailChangeServiceForTests(emailChangeService);

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -14,6 +14,11 @@
 // It calls the production handlers' `_setXxxForTests` injection points so the
 // handlers route through our fakes instead of building their own clients.
 
+// Side-effect import: sets env vars and unmocks the AWS SDK BEFORE any
+// production module loads. adminHandler.ts captures JWT_SECRET / whitelist
+// at module load, so this must be the first import in this file.
+import './integrationSetup';
+
 import { InMemoryDocClient, type TableSpec } from './inMemoryDocClient';
 import {
   ClockController,

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -36,7 +36,6 @@ import { PublisherEmailChangeService } from '../../../services/publisherEmailCha
 import { PublisherAdminService } from '../../../services/publisherAdminService';
 import { MagicTokenService } from '../../../services/magicTokenService';
 import { runIngest, type IngestDeps } from '../../../handlers/publisherIngestHandler';
-import { selfDisable } from '../../../services/publisherSelfActionService';
 import * as portal from '../../../handlers/publisherPortalHandler';
 import * as admin from '../../../handlers/adminHandler';
 import * as captchaModule from '../../../services/captchaService';
@@ -284,11 +283,6 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
   };
   harness.actors = buildActors(harness);
   _harnessSingleton = harness;
-
-  // Re-export for selfDisable callers — the handler picks deps from
-  // `_setSelfDisableDepsForTests`, but the `selfDisable` action import is
-  // a free function so just import-and-use is fine.
-  void selfDisable;
 
   return harness;
 }

--- a/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
+++ b/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
@@ -283,14 +283,38 @@ function compare(a: unknown, b: unknown, op: string): boolean {
   throw new Error(`Unsupported comparison ${op} between ${typeof a} and ${typeof b}`);
 }
 
+// Structural deep-equality. Key order independent (an earlier JSON.stringify
+// version was order-dependent which made attribute_exists/`=` ConditionExpression
+// comparisons false-negative whenever two objects had the same keys in
+// different insertion orders).
 function deepEq(a: unknown, b: unknown): boolean {
   if (a === b) return true;
-  if (typeof a !== typeof b) return false;
+  // Handle NaN === NaN (Number.isNaN true on both sides).
+  if (typeof a === 'number' && typeof b === 'number'
+    && Number.isNaN(a) && Number.isNaN(b)) return true;
   if (a === null || b === null) return false;
-  if (typeof a === 'object') {
-    return JSON.stringify(a) === JSON.stringify(b);
+  if (a === undefined || b === undefined) return false;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return false; // primitives already handled by ===
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false;
+    if (a.length !== (b as unknown[]).length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEq(a[i], (b as unknown[])[i])) return false;
+    }
+    return true;
   }
-  return false;
+  if (Array.isArray(b)) return false;
+  const ao = a as Record<string, unknown>;
+  const bo = b as Record<string, unknown>;
+  const aKeys = Object.keys(ao);
+  const bKeys = Object.keys(bo);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(bo, k)) return false;
+    if (!deepEq(ao[k], bo[k])) return false;
+  }
+  return true;
 }
 
 function evalCondition(expr: string, ctx: ExprCtx): boolean {

--- a/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
+++ b/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
@@ -621,12 +621,10 @@ export class InMemoryDocClient {
   private doQuery(input: any): { Items?: Item[]; Count?: number; LastEvaluatedKey?: Record<string, unknown> } {
     this.commandLog.push({ type: 'Query', input });
     const t = this.requireTable(input.TableName);
-    let hashKey = t.spec.hashKey;
     let sortKey = t.spec.sortKey;
     if (input.IndexName) {
       const gsi = (t.spec.gsis ?? []).find(g => g.name === input.IndexName);
       if (!gsi) throw new Error(`Unknown index '${input.IndexName}' on table '${t.spec.name}'`);
-      hashKey = gsi.hashKey;
       sortKey = gsi.sortKey;
     }
     const all = Array.from(t.items.values());
@@ -648,7 +646,9 @@ export class InMemoryDocClient {
         }),
       );
     }
-    // Sort by sort key ascending (or by hashKey if no sortKey).
+    // Sort by sort key ascending (when present). DDB makes no ordering
+    // promise without a sort key; we leave hash-only results in insertion
+    // order to match what production code would actually rely on.
     if (sortKey) {
       candidates.sort((a, b) => {
         const av = a[sortKey!] as string | number | undefined;
@@ -659,10 +659,7 @@ export class InMemoryDocClient {
         return 0;
       });
     }
-    return {
-      Items: candidates.map(i => JSON.parse(JSON.stringify(i))),
-      Count: candidates.length,
-    };
+    return this.applyPagination(candidates, t.spec, input);
   }
 
   // ─── ScanCommand ───────────────────────────────────────────────────────
@@ -679,10 +676,49 @@ export class InMemoryDocClient {
         }),
       );
     }
-    return {
-      Items: candidates.map(i => JSON.parse(JSON.stringify(i))),
-      Count: candidates.length,
+    return this.applyPagination(candidates, t.spec, input);
+  }
+
+  // Apply ExclusiveStartKey + Limit semantics:
+  //   - resume: drop items up to and including the one whose hash+sort match
+  //     ExclusiveStartKey (matches DDB behaviour where the start key is the
+  //     last *returned* item from the previous page).
+  //   - Limit is applied AFTER filtering, mirroring DDB's contract for
+  //     filtered queries — we don't model the page-before-filter behaviour
+  //     because production code paginates with `while (LastEvaluatedKey)` loops
+  //     that drain all pages, and what matters there is total convergence.
+  //   - LastEvaluatedKey is built from the table's hash+sort attributes of the
+  //     last returned item, but only when there are more items beyond it.
+  private applyPagination(
+    candidates: Item[],
+    spec: TableSpec,
+    input: { Limit?: number; ExclusiveStartKey?: Record<string, unknown> },
+  ): { Items: Item[]; Count: number; LastEvaluatedKey?: Record<string, unknown> } {
+    let working = candidates;
+    if (input.ExclusiveStartKey) {
+      const startJson = keyJsonFromKey(spec, input.ExclusiveStartKey);
+      const idx = working.findIndex(i => keyJsonFromItem(spec, i) === startJson);
+      if (idx >= 0) working = working.slice(idx + 1);
+      // If the start key is no longer present (e.g. deleted between pages),
+      // we conservatively return the full remaining slice — DDB's actual
+      // behaviour is undefined here and production code does not rely on it.
+    }
+    const limit = typeof input.Limit === 'number' && input.Limit > 0 ? input.Limit : undefined;
+    let returned = working;
+    let lastEvaluatedKey: Record<string, unknown> | undefined;
+    if (limit !== undefined && working.length > limit) {
+      returned = working.slice(0, limit);
+      const last = returned[returned.length - 1];
+      const lek: Record<string, unknown> = { [spec.hashKey]: last[spec.hashKey] };
+      if (spec.sortKey !== undefined) lek[spec.sortKey] = last[spec.sortKey];
+      lastEvaluatedKey = lek;
+    }
+    const out: { Items: Item[]; Count: number; LastEvaluatedKey?: Record<string, unknown> } = {
+      Items: returned.map(i => JSON.parse(JSON.stringify(i))),
+      Count: returned.length,
     };
+    if (lastEvaluatedKey) out.LastEvaluatedKey = lastEvaluatedKey;
+    return out;
   }
 
   // ─── BatchGetCommand ───────────────────────────────────────────────────

--- a/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
+++ b/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
@@ -1,0 +1,854 @@
+/**
+ * In-memory DynamoDBDocumentClient fake.
+ *
+ * Implements `.send(cmd)` for the subset of commands used by production
+ * services in `backend/src/services/`. As of Task 1 (survey from
+ * grep -rE '(Get|Put|Update|Delete|Query|Scan|BatchGet|BatchWrite|TransactWrite)Command'),
+ * production code uses ALL of:
+ *   BatchGetCommand, BatchWriteCommand, DeleteCommand, GetCommand,
+ *   PutCommand, QueryCommand, ScanCommand, TransactWriteCommand,
+ *   UpdateCommand
+ *
+ * The fake fails loudly on any unsupported command shape — better a missing
+ * case break a test than silently produce wrong data.
+ *
+ * Storage shape: Map<tableName, Map<keyJson, item>> where keyJson is
+ * JSON.stringify({ [hashKey]: ..., [sortKey]?: ... }).
+ *
+ * Condition / filter / key-condition expression support:
+ *   - functions: attribute_exists(name), attribute_not_exists(name),
+ *                begins_with(name, value)
+ *   - binary ops: =, <>, <, >, <=, >=
+ *   - boolean ops: AND, OR (left-assoc, AND tighter than OR), parentheses
+ *   - dotted attribute paths: emailChangePayload.newEmail
+ *   - ExpressionAttributeNames substitution (#name → real name)
+ *   - ExpressionAttributeValues substitution (:val → real value)
+ *
+ * Conditional failures throw an error whose `name === 'ConditionalCheckFailedException'`
+ * so production code that catches by name keeps working.
+ *
+ * TransactWrite atomicity: validate ALL conditions on a snapshot of the
+ * tables, then if every condition passes, apply ALL writes; otherwise apply
+ * nothing and throw a TransactionCanceledException with CancellationReasons.
+ */
+
+import {
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  DeleteCommand,
+  QueryCommand,
+  ScanCommand,
+  BatchGetCommand,
+  BatchWriteCommand,
+  TransactWriteCommand,
+} from '@aws-sdk/lib-dynamodb';
+
+export interface GsiSpec {
+  name: string;
+  hashKey: string;
+  sortKey?: string;
+}
+export interface TableSpec {
+  name: string;
+  hashKey: string;
+  sortKey?: string;
+  gsis?: GsiSpec[];
+}
+
+type Item = Record<string, unknown>;
+
+class ConditionalCheckFailedException extends Error {
+  constructor(message = 'The conditional request failed') {
+    super(message);
+    this.name = 'ConditionalCheckFailedException';
+  }
+}
+
+class TransactionCanceledException extends Error {
+  public CancellationReasons: Array<{ Code: string; Message?: string }>;
+  constructor(reasons: Array<{ Code: string; Message?: string }>) {
+    super('Transaction cancelled, please refer cancellation reasons for specific reasons');
+    this.name = 'TransactionCanceledException';
+    this.CancellationReasons = reasons;
+  }
+}
+
+// ─── Expression evaluation ──────────────────────────────────────────────
+
+type AttrNames = Record<string, string> | undefined;
+type AttrValues = Record<string, unknown> | undefined;
+
+function resolveName(token: string, names: AttrNames): string {
+  if (token.startsWith('#')) {
+    if (!names || !(token in names)) {
+      throw new Error(`ExpressionAttributeName ${token} not found`);
+    }
+    return names[token];
+  }
+  return token;
+}
+
+function resolveValue(token: string, values: AttrValues): unknown {
+  if (!token.startsWith(':')) {
+    throw new Error(`Expected expression value placeholder, got ${token}`);
+  }
+  if (!values || !(token in values)) {
+    throw new Error(`ExpressionAttributeValue ${token} not found`);
+  }
+  return values[token];
+}
+
+function getPath(item: Item, path: string, names: AttrNames): unknown {
+  // Resolve dotted path with possible #-prefixed segments.
+  const parts = path.split('.').map(p => resolveName(p, names));
+  let cur: unknown = item;
+  for (const p of parts) {
+    if (cur === undefined || cur === null) return undefined;
+    cur = (cur as Item)[p];
+  }
+  return cur;
+}
+
+function pathExists(item: Item, path: string, names: AttrNames): boolean {
+  const parts = path.split('.').map(p => resolveName(p, names));
+  let cur: unknown = item;
+  for (const p of parts) {
+    if (cur === undefined || cur === null) return false;
+    if (typeof cur !== 'object') return false;
+    if (!Object.prototype.hasOwnProperty.call(cur, p)) return false;
+    cur = (cur as Item)[p];
+  }
+  return true;
+}
+
+// Tokenize a condition / filter / keyCondition expression.
+function tokenize(expr: string): string[] {
+  const toks: string[] = [];
+  let i = 0;
+  while (i < expr.length) {
+    const c = expr[i];
+    if (/\s/.test(c)) { i++; continue; }
+    if (c === '(' || c === ')' || c === ',') {
+      toks.push(c);
+      i++;
+      continue;
+    }
+    // Two-char ops.
+    if (i + 1 < expr.length) {
+      const two = expr.slice(i, i + 2);
+      if (two === '<>' || two === '<=' || two === '>=') {
+        toks.push(two);
+        i += 2;
+        continue;
+      }
+    }
+    if (c === '=' || c === '<' || c === '>') {
+      toks.push(c);
+      i++;
+      continue;
+    }
+    // Identifier / placeholder / dotted path / number.
+    let j = i;
+    while (j < expr.length && /[A-Za-z0-9_#:.]/.test(expr[j])) j++;
+    if (j === i) throw new Error(`Unexpected character '${c}' at ${i} in '${expr}'`);
+    toks.push(expr.slice(i, j));
+    i = j;
+  }
+  return toks;
+}
+
+interface ExprCtx {
+  item: Item;
+  names: AttrNames;
+  values: AttrValues;
+}
+
+// Recursive-descent parser/evaluator. Grammar:
+//   expr   := orExpr
+//   orExpr := andExpr ( 'OR' andExpr )*
+//   andExpr:= notExpr ( 'AND' notExpr )*
+//   notExpr:= primary
+//   primary:= '(' expr ')' | func '(' args ')' | comparison
+//   comparison := operand op operand
+//   operand := IDENT | :value
+class ExprParser {
+  private idx = 0;
+  constructor(private readonly toks: string[]) {}
+
+  evalExpr(ctx: ExprCtx): boolean {
+    const r = this.parseOr(ctx);
+    if (this.idx !== this.toks.length) {
+      throw new Error(`Unexpected trailing tokens in expression: ${this.toks.slice(this.idx).join(' ')}`);
+    }
+    return r;
+  }
+  private parseOr(ctx: ExprCtx): boolean {
+    let left = this.parseAnd(ctx);
+    while (this.peek()?.toUpperCase() === 'OR') {
+      this.idx++;
+      const right = this.parseAnd(ctx);
+      left = left || right;
+    }
+    return left;
+  }
+  private parseAnd(ctx: ExprCtx): boolean {
+    let left = this.parsePrimary(ctx);
+    while (this.peek()?.toUpperCase() === 'AND') {
+      this.idx++;
+      const right = this.parsePrimary(ctx);
+      left = left && right;
+    }
+    return left;
+  }
+  private parsePrimary(ctx: ExprCtx): boolean {
+    const tok = this.peek();
+    if (tok === '(') {
+      this.idx++;
+      const r = this.parseOr(ctx);
+      if (this.peek() !== ')') throw new Error(`Expected ')'`);
+      this.idx++;
+      return r;
+    }
+    // function call?
+    const next = this.toks[this.idx + 1];
+    if (next === '(' && tok && /^[A-Za-z_]/.test(tok)) {
+      const fn = tok.toLowerCase();
+      this.idx += 2; // consume name + '('
+      const args: string[] = [];
+      while (this.peek() !== ')') {
+        args.push(this.toks[this.idx++]);
+        if (this.peek() === ',') this.idx++;
+      }
+      this.idx++; // consume ')'
+      return this.evalFunc(fn, args, ctx);
+    }
+    // comparison.
+    const left = this.toks[this.idx++];
+    const op = this.toks[this.idx++];
+    const right = this.toks[this.idx++];
+    return this.evalComparison(left, op, right, ctx);
+  }
+
+  private peek(): string | undefined { return this.toks[this.idx]; }
+
+  private evalFunc(fn: string, args: string[], ctx: ExprCtx): boolean {
+    switch (fn) {
+      case 'attribute_exists': {
+        return pathExists(ctx.item, args[0], ctx.names);
+      }
+      case 'attribute_not_exists': {
+        return !pathExists(ctx.item, args[0], ctx.names);
+      }
+      case 'begins_with': {
+        const v = getPath(ctx.item, args[0], ctx.names);
+        const prefix = resolveValue(args[1], ctx.values);
+        if (typeof v !== 'string' || typeof prefix !== 'string') return false;
+        return v.startsWith(prefix);
+      }
+      default:
+        throw new Error(`Unsupported function: ${fn}`);
+    }
+  }
+
+  private evalComparison(leftTok: string, op: string, rightTok: string, ctx: ExprCtx): boolean {
+    const lv = leftTok.startsWith(':')
+      ? resolveValue(leftTok, ctx.values)
+      : getPath(ctx.item, leftTok, ctx.names);
+    const rv = rightTok.startsWith(':')
+      ? resolveValue(rightTok, ctx.values)
+      : getPath(ctx.item, rightTok, ctx.names);
+    return compare(lv, rv, op);
+  }
+}
+
+function compare(a: unknown, b: unknown, op: string): boolean {
+  if (op === '=') return deepEq(a, b);
+  if (op === '<>') return !deepEq(a, b);
+  if (a === undefined || b === undefined) return false;
+  if (a === null || b === null) return false;
+  // Numeric / string comparison.
+  if (typeof a === 'number' && typeof b === 'number') {
+    if (op === '<') return a < b;
+    if (op === '>') return a > b;
+    if (op === '<=') return a <= b;
+    if (op === '>=') return a >= b;
+  }
+  if (typeof a === 'string' && typeof b === 'string') {
+    if (op === '<') return a < b;
+    if (op === '>') return a > b;
+    if (op === '<=') return a <= b;
+    if (op === '>=') return a >= b;
+  }
+  throw new Error(`Unsupported comparison ${op} between ${typeof a} and ${typeof b}`);
+}
+
+function deepEq(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return false;
+  if (typeof a === 'object') {
+    return JSON.stringify(a) === JSON.stringify(b);
+  }
+  return false;
+}
+
+function evalCondition(expr: string, ctx: ExprCtx): boolean {
+  const parser = new ExprParser(tokenize(expr));
+  return parser.evalExpr(ctx);
+}
+
+// ─── Update expression ──────────────────────────────────────────────────
+//
+// Supports:
+//   SET path = :v, path = path + :v, path = path - :v
+//   ADD path :n
+//   REMOVE path
+// Multiple clauses comma-separated. Clause keywords (SET/ADD/REMOVE) split
+// the expression. Sufficient for production usage in this repo.
+
+function applyUpdateExpression(
+  item: Item,
+  expr: string,
+  names: AttrNames,
+  values: AttrValues,
+): Item {
+  const out: Item = JSON.parse(JSON.stringify(item));
+  // Tokenize by capturing keyword regions.
+  const re = /(SET|ADD|REMOVE|DELETE)\s+/gi;
+  const matches = [...expr.matchAll(re)];
+  for (let i = 0; i < matches.length; i++) {
+    const kw = matches[i][1].toUpperCase();
+    const start = matches[i].index! + matches[i][0].length;
+    const end = i + 1 < matches.length ? matches[i + 1].index! : expr.length;
+    const body = expr.slice(start, end).trim();
+    const clauses = splitTopLevelCommas(body);
+    for (const clause of clauses) {
+      applyUpdateClause(out, kw, clause.trim(), names, values);
+    }
+  }
+  return out;
+}
+
+function splitTopLevelCommas(s: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let cur = '';
+  for (const c of s) {
+    if (c === '(') depth++;
+    else if (c === ')') depth--;
+    if (c === ',' && depth === 0) {
+      if (cur.trim()) out.push(cur);
+      cur = '';
+    } else cur += c;
+  }
+  if (cur.trim()) out.push(cur);
+  return out;
+}
+
+function applyUpdateClause(
+  item: Item,
+  keyword: string,
+  clause: string,
+  names: AttrNames,
+  values: AttrValues,
+): void {
+  if (keyword === 'SET') {
+    // path = expr
+    const eqIdx = clause.indexOf('=');
+    if (eqIdx === -1) throw new Error(`SET clause missing '=': ${clause}`);
+    const path = clause.slice(0, eqIdx).trim();
+    const rhs = clause.slice(eqIdx + 1).trim();
+    setPath(item, path, evalRhs(item, rhs, names, values), names);
+    return;
+  }
+  if (keyword === 'ADD') {
+    // path :n
+    const m = clause.match(/^(\S+)\s+(:\S+)$/);
+    if (!m) throw new Error(`ADD clause invalid: ${clause}`);
+    const path = m[1];
+    const incr = resolveValue(m[2], values);
+    const cur = getPath(item, path, names);
+    if (cur === undefined) {
+      setPath(item, path, incr, names);
+    } else {
+      if (typeof cur !== 'number' || typeof incr !== 'number') {
+        throw new Error(`ADD requires numeric on both sides: ${clause}`);
+      }
+      setPath(item, path, cur + incr, names);
+    }
+    return;
+  }
+  if (keyword === 'REMOVE') {
+    removePath(item, clause.trim(), names);
+    return;
+  }
+  if (keyword === 'DELETE') {
+    throw new Error(`DELETE update keyword not supported in fake`);
+  }
+}
+
+function evalRhs(item: Item, rhs: string, names: AttrNames, values: AttrValues): unknown {
+  // Support `:v`, `path`, `path + :v`, `path - :v`, `:v + :v2` (rare).
+  const plusM = rhs.match(/^(\S+)\s*([+-])\s*(\S+)$/);
+  if (plusM) {
+    const lv = plusM[1].startsWith(':')
+      ? resolveValue(plusM[1], values)
+      : getPath(item, plusM[1], names);
+    const rv = plusM[3].startsWith(':')
+      ? resolveValue(plusM[3], values)
+      : getPath(item, plusM[3], names);
+    if (typeof lv !== 'number' || typeof rv !== 'number') {
+      throw new Error(`+/- requires numbers in update expr: ${rhs}`);
+    }
+    return plusM[2] === '+' ? lv + rv : lv - rv;
+  }
+  if (rhs.startsWith(':')) return resolveValue(rhs, values);
+  return getPath(item, rhs, names);
+}
+
+function setPath(item: Item, path: string, value: unknown, names: AttrNames): void {
+  const parts = path.split('.').map(p => resolveName(p, names));
+  let cur: Item = item;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const k = parts[i];
+    if (cur[k] === undefined || cur[k] === null || typeof cur[k] !== 'object') {
+      cur[k] = {};
+    }
+    cur = cur[k] as Item;
+  }
+  cur[parts[parts.length - 1]] = value;
+}
+
+function removePath(item: Item, path: string, names: AttrNames): void {
+  const parts = path.split('.').map(p => resolveName(p, names));
+  let cur: Item = item;
+  for (let i = 0; i < parts.length - 1; i++) {
+    const k = parts[i];
+    if (cur[k] === undefined || typeof cur[k] !== 'object') return;
+    cur = cur[k] as Item;
+  }
+  delete cur[parts[parts.length - 1]];
+}
+
+// ─── Main client ────────────────────────────────────────────────────────
+
+interface TableState {
+  spec: TableSpec;
+  items: Map<string, Item>;
+}
+
+function keyJsonFromItem(spec: TableSpec, item: Item): string {
+  const k: Record<string, unknown> = { [spec.hashKey]: item[spec.hashKey] };
+  if (spec.sortKey !== undefined) k[spec.sortKey] = item[spec.sortKey];
+  return JSON.stringify(k);
+}
+function keyJsonFromKey(spec: TableSpec, key: Record<string, unknown>): string {
+  const k: Record<string, unknown> = { [spec.hashKey]: key[spec.hashKey] };
+  if (spec.sortKey !== undefined) k[spec.sortKey] = key[spec.sortKey];
+  return JSON.stringify(k);
+}
+
+export class InMemoryDocClient {
+  private readonly tables = new Map<string, TableState>();
+  // Hooks for tests that want to assert specific commands were sent.
+  public readonly commandLog: Array<{ type: string; input: unknown }> = [];
+
+  constructor(specs: TableSpec[]) {
+    for (const spec of specs) {
+      this.tables.set(spec.name, { spec, items: new Map() });
+    }
+  }
+
+  /** Register additional table specs after construction (e.g. on-the-fly tests). */
+  addTable(spec: TableSpec): void {
+    if (!this.tables.has(spec.name)) {
+      this.tables.set(spec.name, { spec, items: new Map() });
+    }
+  }
+
+  dump(table: string): Item[] {
+    const t = this.requireTable(table);
+    return Array.from(t.items.values()).map(i => JSON.parse(JSON.stringify(i)));
+  }
+
+  seed(table: string, items: Item[]): void {
+    const t = this.requireTable(table);
+    for (const it of items) {
+      t.items.set(keyJsonFromItem(t.spec, it), JSON.parse(JSON.stringify(it)));
+    }
+  }
+
+  clear(): void {
+    for (const t of this.tables.values()) t.items.clear();
+    this.commandLog.length = 0;
+  }
+
+  private requireTable(name: string): TableState {
+    const t = this.tables.get(name);
+    if (!t) throw new Error(`InMemoryDocClient: unknown table '${name}'`);
+    return t;
+  }
+
+  async send(cmd: unknown): Promise<unknown> {
+    if (cmd instanceof GetCommand) {
+      return this.doGet((cmd as GetCommand).input);
+    }
+    if (cmd instanceof PutCommand) {
+      return this.doPut((cmd as PutCommand).input);
+    }
+    if (cmd instanceof UpdateCommand) {
+      return this.doUpdate((cmd as UpdateCommand).input);
+    }
+    if (cmd instanceof DeleteCommand) {
+      return this.doDelete((cmd as DeleteCommand).input);
+    }
+    if (cmd instanceof QueryCommand) {
+      return this.doQuery((cmd as QueryCommand).input);
+    }
+    if (cmd instanceof ScanCommand) {
+      return this.doScan((cmd as ScanCommand).input);
+    }
+    if (cmd instanceof BatchGetCommand) {
+      return this.doBatchGet((cmd as BatchGetCommand).input);
+    }
+    if (cmd instanceof BatchWriteCommand) {
+      return this.doBatchWrite((cmd as BatchWriteCommand).input);
+    }
+    if (cmd instanceof TransactWriteCommand) {
+      return this.doTransactWrite((cmd as TransactWriteCommand).input);
+    }
+    const ctorName = (cmd as { constructor?: { name?: string } })?.constructor?.name ?? 'unknown';
+    throw new Error(
+      `InMemoryDocClient: unsupported command shape '${ctorName}'. ` +
+      `Add a handler in inMemoryDocClient.ts or switch the test to use a supported command.`,
+    );
+  }
+
+  // ─── GetCommand ────────────────────────────────────────────────────────
+  private doGet(input: any): { Item?: Item } {
+    this.commandLog.push({ type: 'Get', input });
+    const t = this.requireTable(input.TableName);
+    const key = input.Key as Record<string, unknown>;
+    const stored = t.items.get(keyJsonFromKey(t.spec, key));
+    return stored ? { Item: JSON.parse(JSON.stringify(stored)) } : {};
+  }
+
+  // ─── PutCommand ────────────────────────────────────────────────────────
+  private doPut(input: any): { Attributes?: Item } {
+    this.commandLog.push({ type: 'Put', input });
+    const t = this.requireTable(input.TableName);
+    const item = input.Item as Item;
+    const keyJson = keyJsonFromItem(t.spec, item);
+    if (input.ConditionExpression) {
+      const existing = t.items.get(keyJson) ?? {};
+      const ok = evalCondition(input.ConditionExpression, {
+        item: existing,
+        names: input.ExpressionAttributeNames,
+        values: input.ExpressionAttributeValues,
+      });
+      if (!ok) throw new ConditionalCheckFailedException();
+    }
+    t.items.set(keyJson, JSON.parse(JSON.stringify(item)));
+    return {};
+  }
+
+  // ─── UpdateCommand ─────────────────────────────────────────────────────
+  private doUpdate(input: any): { Attributes?: Item } {
+    this.commandLog.push({ type: 'Update', input });
+    const t = this.requireTable(input.TableName);
+    const key = input.Key as Record<string, unknown>;
+    const keyJson = keyJsonFromKey(t.spec, key);
+    const isCreate = !t.items.has(keyJson);
+    const existing: Item = t.items.get(keyJson) ?? { ...key };
+    if (input.ConditionExpression) {
+      // For an upsert (UpdateItem on a missing row), conditions evaluate
+      // against an EMPTY item — DDB's contract is "attribute_exists(id)
+      // returns false on a missing row" regardless of the Key fields.
+      const ctx: ExprCtx = {
+        item: isCreate ? {} : existing,
+        names: input.ExpressionAttributeNames,
+        values: input.ExpressionAttributeValues,
+      };
+      const ok = evalCondition(input.ConditionExpression, ctx);
+      if (!ok) throw new ConditionalCheckFailedException();
+    }
+    let updated = existing;
+    if (input.UpdateExpression) {
+      // For a create-via-update (no row yet) seed with the key fields.
+      if (isCreate) updated = { ...key };
+      updated = applyUpdateExpression(
+        updated,
+        input.UpdateExpression,
+        input.ExpressionAttributeNames,
+        input.ExpressionAttributeValues,
+      );
+    }
+    t.items.set(keyJson, JSON.parse(JSON.stringify(updated)));
+    if (input.ReturnValues === 'ALL_OLD') {
+      return { Attributes: existing && !isCreate ? JSON.parse(JSON.stringify(existing)) : undefined };
+    }
+    if (input.ReturnValues === 'ALL_NEW') {
+      return { Attributes: JSON.parse(JSON.stringify(updated)) };
+    }
+    return {};
+  }
+
+  // ─── DeleteCommand ─────────────────────────────────────────────────────
+  private doDelete(input: any): { Attributes?: Item } {
+    this.commandLog.push({ type: 'Delete', input });
+    const t = this.requireTable(input.TableName);
+    const key = input.Key as Record<string, unknown>;
+    const keyJson = keyJsonFromKey(t.spec, key);
+    const existing = t.items.get(keyJson);
+    if (input.ConditionExpression) {
+      const ctx: ExprCtx = {
+        item: existing ?? {},
+        names: input.ExpressionAttributeNames,
+        values: input.ExpressionAttributeValues,
+      };
+      const ok = evalCondition(input.ConditionExpression, ctx);
+      if (!ok) throw new ConditionalCheckFailedException();
+    }
+    if (existing) t.items.delete(keyJson);
+    if (input.ReturnValues === 'ALL_OLD' && existing) {
+      return { Attributes: JSON.parse(JSON.stringify(existing)) };
+    }
+    return {};
+  }
+
+  // ─── QueryCommand ──────────────────────────────────────────────────────
+  private doQuery(input: any): { Items?: Item[]; Count?: number; LastEvaluatedKey?: Record<string, unknown> } {
+    this.commandLog.push({ type: 'Query', input });
+    const t = this.requireTable(input.TableName);
+    let hashKey = t.spec.hashKey;
+    let sortKey = t.spec.sortKey;
+    if (input.IndexName) {
+      const gsi = (t.spec.gsis ?? []).find(g => g.name === input.IndexName);
+      if (!gsi) throw new Error(`Unknown index '${input.IndexName}' on table '${t.spec.name}'`);
+      hashKey = gsi.hashKey;
+      sortKey = gsi.sortKey;
+    }
+    const all = Array.from(t.items.values());
+    // Evaluate KeyConditionExpression against each item (treating it as a
+    // filter; it's a simple AND of comparisons in production usage).
+    let candidates = all.filter(item =>
+      evalCondition(input.KeyConditionExpression, {
+        item,
+        names: input.ExpressionAttributeNames,
+        values: input.ExpressionAttributeValues,
+      }),
+    );
+    if (input.FilterExpression) {
+      candidates = candidates.filter(item =>
+        evalCondition(input.FilterExpression, {
+          item,
+          names: input.ExpressionAttributeNames,
+          values: input.ExpressionAttributeValues,
+        }),
+      );
+    }
+    // Sort by sort key ascending (or by hashKey if no sortKey).
+    if (sortKey) {
+      candidates.sort((a, b) => {
+        const av = a[sortKey!] as string | number | undefined;
+        const bv = b[sortKey!] as string | number | undefined;
+        if (av === undefined || bv === undefined) return 0;
+        if (av < bv) return input.ScanIndexForward === false ? 1 : -1;
+        if (av > bv) return input.ScanIndexForward === false ? -1 : 1;
+        return 0;
+      });
+    }
+    return {
+      Items: candidates.map(i => JSON.parse(JSON.stringify(i))),
+      Count: candidates.length,
+    };
+  }
+
+  // ─── ScanCommand ───────────────────────────────────────────────────────
+  private doScan(input: any): { Items?: Item[]; Count?: number; LastEvaluatedKey?: Record<string, unknown> } {
+    this.commandLog.push({ type: 'Scan', input });
+    const t = this.requireTable(input.TableName);
+    let candidates = Array.from(t.items.values());
+    if (input.FilterExpression) {
+      candidates = candidates.filter(item =>
+        evalCondition(input.FilterExpression, {
+          item,
+          names: input.ExpressionAttributeNames,
+          values: input.ExpressionAttributeValues,
+        }),
+      );
+    }
+    return {
+      Items: candidates.map(i => JSON.parse(JSON.stringify(i))),
+      Count: candidates.length,
+    };
+  }
+
+  // ─── BatchGetCommand ───────────────────────────────────────────────────
+  private doBatchGet(input: any): { Responses?: Record<string, Item[]> } {
+    this.commandLog.push({ type: 'BatchGet', input });
+    const responses: Record<string, Item[]> = {};
+    for (const [tableName, req] of Object.entries(input.RequestItems as Record<string, { Keys: Array<Record<string, unknown>> }>)) {
+      const t = this.requireTable(tableName);
+      const out: Item[] = [];
+      for (const key of req.Keys) {
+        const stored = t.items.get(keyJsonFromKey(t.spec, key));
+        if (stored) out.push(JSON.parse(JSON.stringify(stored)));
+      }
+      responses[tableName] = out;
+    }
+    return { Responses: responses };
+  }
+
+  // ─── BatchWriteCommand ─────────────────────────────────────────────────
+  private doBatchWrite(input: any): Record<string, never> {
+    this.commandLog.push({ type: 'BatchWrite', input });
+    for (const [tableName, ops] of Object.entries(input.RequestItems as Record<string, Array<any>>)) {
+      const t = this.requireTable(tableName);
+      for (const op of ops) {
+        if (op.PutRequest) {
+          const item = op.PutRequest.Item as Item;
+          t.items.set(keyJsonFromItem(t.spec, item), JSON.parse(JSON.stringify(item)));
+        } else if (op.DeleteRequest) {
+          const key = op.DeleteRequest.Key as Record<string, unknown>;
+          t.items.delete(keyJsonFromKey(t.spec, key));
+        }
+      }
+    }
+    return {};
+  }
+
+  // ─── TransactWriteCommand ─────────────────────────────────────────────
+  private doTransactWrite(input: any): Record<string, never> {
+    this.commandLog.push({ type: 'TransactWrite', input });
+    const items = (input.TransactItems as Array<any>) ?? [];
+    // Snapshot all involved tables for atomicity.
+    const snapshots = new Map<string, Map<string, Item>>();
+    const snapshotTable = (name: string) => {
+      if (!snapshots.has(name)) {
+        const t = this.requireTable(name);
+        const copy = new Map<string, Item>();
+        for (const [k, v] of t.items) copy.set(k, JSON.parse(JSON.stringify(v)));
+        snapshots.set(name, copy);
+      }
+    };
+    for (const it of items) {
+      const which = it.Put ?? it.Update ?? it.Delete ?? it.ConditionCheck;
+      snapshotTable(which.TableName);
+    }
+
+    // Validate every item against snapshot. If any fails, throw with
+    // CancellationReasons for each item — succeeds get { Code: 'None' };
+    // failures get the appropriate code.
+    const reasons: Array<{ Code: string; Message?: string }> = [];
+    let anyFailed = false;
+    // We also build the would-be effects in a parallel snapshot so that
+    // sequential ops within the txn see each other's pending effects (for
+    // condition checks against fresh state — DDB doesn't actually do this,
+    // but it's close enough for our test usage).
+    const pending = new Map<string, Map<string, Item | null /* deleted */>>();
+    const pendingTable = (name: string) => {
+      if (!pending.has(name)) pending.set(name, new Map());
+      return pending.get(name)!;
+    };
+    const lookup = (tableName: string, keyJson: string): Item | undefined => {
+      const ptbl = pending.get(tableName);
+      if (ptbl?.has(keyJson)) {
+        const v = ptbl.get(keyJson);
+        return v === null ? undefined : (v as Item);
+      }
+      return snapshots.get(tableName)?.get(keyJson);
+    };
+
+    for (const it of items) {
+      try {
+        if (it.ConditionCheck) {
+          const cc = it.ConditionCheck;
+          const t = this.requireTable(cc.TableName);
+          const keyJson = keyJsonFromKey(t.spec, cc.Key);
+          const existing = lookup(cc.TableName, keyJson) ?? {};
+          const ok = evalCondition(cc.ConditionExpression, {
+            item: existing,
+            names: cc.ExpressionAttributeNames,
+            values: cc.ExpressionAttributeValues,
+          });
+          if (!ok) throw new ConditionalCheckFailedException();
+          reasons.push({ Code: 'None' });
+        } else if (it.Put) {
+          const op = it.Put;
+          const t = this.requireTable(op.TableName);
+          const keyJson = keyJsonFromItem(t.spec, op.Item);
+          if (op.ConditionExpression) {
+            const existing = lookup(op.TableName, keyJson) ?? {};
+            const ok = evalCondition(op.ConditionExpression, {
+              item: existing,
+              names: op.ExpressionAttributeNames,
+              values: op.ExpressionAttributeValues,
+            });
+            if (!ok) throw new ConditionalCheckFailedException();
+          }
+          pendingTable(op.TableName).set(keyJson, JSON.parse(JSON.stringify(op.Item)));
+          reasons.push({ Code: 'None' });
+        } else if (it.Update) {
+          const op = it.Update;
+          const t = this.requireTable(op.TableName);
+          const keyJson = keyJsonFromKey(t.spec, op.Key);
+          const existed = lookup(op.TableName, keyJson) !== undefined;
+          const existing = lookup(op.TableName, keyJson) ?? { ...op.Key };
+          if (op.ConditionExpression) {
+            const ok = evalCondition(op.ConditionExpression, {
+              item: existed ? existing : {},
+              names: op.ExpressionAttributeNames,
+              values: op.ExpressionAttributeValues,
+            });
+            if (!ok) throw new ConditionalCheckFailedException();
+          }
+          const updated = applyUpdateExpression(
+            existing,
+            op.UpdateExpression,
+            op.ExpressionAttributeNames,
+            op.ExpressionAttributeValues,
+          );
+          pendingTable(op.TableName).set(keyJson, JSON.parse(JSON.stringify(updated)));
+          reasons.push({ Code: 'None' });
+        } else if (it.Delete) {
+          const op = it.Delete;
+          const t = this.requireTable(op.TableName);
+          const keyJson = keyJsonFromKey(t.spec, op.Key);
+          const existing = lookup(op.TableName, keyJson);
+          if (op.ConditionExpression) {
+            const ok = evalCondition(op.ConditionExpression, {
+              item: existing ?? {},
+              names: op.ExpressionAttributeNames,
+              values: op.ExpressionAttributeValues,
+            });
+            if (!ok) throw new ConditionalCheckFailedException();
+          }
+          pendingTable(op.TableName).set(keyJson, null);
+          reasons.push({ Code: 'None' });
+        }
+      } catch (err) {
+        anyFailed = true;
+        const name = (err as { name?: string } | null)?.name;
+        if (name === 'ConditionalCheckFailedException') {
+          reasons.push({ Code: 'ConditionalCheckFailed' });
+        } else {
+          reasons.push({ Code: 'TransactionConflict', Message: (err as Error).message });
+        }
+      }
+    }
+    if (anyFailed) {
+      throw new TransactionCanceledException(reasons);
+    }
+    // Commit all pending effects.
+    for (const [tableName, ptbl] of pending) {
+      const t = this.requireTable(tableName);
+      for (const [keyJson, value] of ptbl) {
+        if (value === null) t.items.delete(keyJson);
+        else t.items.set(keyJson, value);
+      }
+    }
+    return {};
+  }
+}

--- a/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
+++ b/backend/src/__tests__/integration/harness/inMemoryDocClient.ts
@@ -711,8 +711,15 @@ export class InMemoryDocClient {
   //     filtered queries — we don't model the page-before-filter behaviour
   //     because production code paginates with `while (LastEvaluatedKey)` loops
   //     that drain all pages, and what matters there is total convergence.
-  //   - LastEvaluatedKey is built from the table's hash+sort attributes of the
-  //     last returned item, but only when there are more items beyond it.
+  //   - LastEvaluatedKey is built from the BASE TABLE's hash+sort attributes
+  //     of the last returned item, but only when there are more items beyond
+  //     it. NOTE: real DDB also includes the GSI's hash+sort key attributes
+  //     in LEK when paginating a Query against a GSI; we do not. That's safe
+  //     for this harness because no production query path paginates over a
+  //     GSI — every `while (LastEvaluatedKey)` loop in `backend/src/services/`
+  //     and `backend/src/handlers/` runs against the base table. If a future
+  //     code path starts paginating GSI queries, extend this to merge the
+  //     index's keys into LEK.
   private applyPagination(
     candidates: Item[],
     spec: TableSpec,

--- a/backend/src/__tests__/integration/harness/integrationSetup.ts
+++ b/backend/src/__tests__/integration/harness/integrationSetup.ts
@@ -1,0 +1,20 @@
+// Test-environment shim: every integration test file imports this BEFORE any
+// production module to guarantee env vars are set in time. Production
+// adminHandler.ts captures JWT_SECRET / ADMIN_EMAIL_WHITELIST / etc. at
+// module load, so the env must be in place before that load.
+//
+// This file also unmocks @aws-sdk/lib-dynamodb / client-dynamodb (overriding
+// setup.ts's global mock) so our InMemoryDocClient works at all and so
+// production services can construct the SDK class hierarchy without
+// crashing on undefined config.
+
+process.env.AWS_REGION = process.env.AWS_REGION ?? 'us-east-1';
+process.env.JWT_SECRET = 'test-admin-jwt-secret';
+process.env.ADMIN_EMAIL_WHITELIST = 'admin@test.chqcal.local';
+process.env.SES_FROM_ADDRESS = 'test@chqcal.local';
+process.env.SITE_BASE_URL = 'https://test.chqcal.local';
+process.env.PUBLISHER_INGEST_FUNCTION_NAME = 'test-publisher-ingest';
+delete process.env.PUBLISHER_RATE_LIMIT_TABLE_NAME;
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');

--- a/backend/src/__tests__/integration/harness/testHelpers.ts
+++ b/backend/src/__tests__/integration/harness/testHelpers.ts
@@ -1,0 +1,15 @@
+// Shared helpers for integration tests. Keep these dependency-light so any
+// test file can import them without pulling the harness in.
+
+/**
+ * Extract the `token` query parameter from a magic-link URL. Throws a clear
+ * error (rather than returning `null` or relying on a `!` non-null assertion)
+ * when the URL is missing the parameter — this catches handler-shape
+ * regressions where the email payload no longer carries the expected token
+ * field, instead of failing later as a confusing TypeError.
+ */
+export function tokenFromMagicLink(url: string): string {
+  const t = new URL(url).searchParams.get('token');
+  if (!t) throw new Error(`Expected 'token' query param in URL: ${url}`);
+  return t;
+}

--- a/backend/src/__tests__/integration/ingestEdgeCases.test.ts
+++ b/backend/src/__tests__/integration/ingestEdgeCases.test.ts
@@ -4,6 +4,7 @@ jest.unmock('@aws-sdk/lib-dynamodb');
 jest.unmock('@aws-sdk/client-dynamodb');
 
 import { createHarness, feedOk, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
 
 async function applyApprove(h: Harness, email: string): Promise<{ publisherId: string }> {
   await h.actors.publisher.apply({
@@ -13,7 +14,7 @@ async function applyApprove(h: Harness, email: string): Promise<{ publisherId: s
     sourceType: 'json',
   });
   const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
-  const token = new URL(url).searchParams.get('token')!;
+  const token = tokenFromMagicLink(url);
   const v = await h.actors.publisher.verifyApplyMagicLink(token);
   await h.actors.admin.approveApplication(v.publisherId);
   await h.registry.upsert({ ...((await h.registry.get(v.publisherId))!), trustLevel: 'auto' });

--- a/backend/src/__tests__/integration/ingestEdgeCases.test.ts
+++ b/backend/src/__tests__/integration/ingestEdgeCases.test.ts
@@ -67,7 +67,7 @@ describe('ingest edge cases', () => {
     expect(await h.events.count(publisherId)).toBe(1);
   });
 
-  it('unchanged feed (same lastModified): no state changes; updates timestamps', async () => {
+  it('unchanged feed (same lastModified): event row is not rewritten (updatedAt preserved)', async () => {
     const { publisherId } = await applyApprove(h, 'unchanged@example.com');
     const evt = { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' };
     h.feeds.set(publisherId, feedOk(publisherId, 'U', [evt]));

--- a/backend/src/__tests__/integration/ingestEdgeCases.test.ts
+++ b/backend/src/__tests__/integration/ingestEdgeCases.test.ts
@@ -1,0 +1,117 @@
+// Ingest edge cases (design Test plan items 17-21).
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, feedOk, type Harness } from './harness/harness';
+
+async function applyApprove(h: Harness, email: string): Promise<{ publisherId: string }> {
+  await h.actors.publisher.apply({
+    name: 'Edge',
+    email,
+    sourceUrl: 'https://example.com/feed.json',
+    sourceType: 'json',
+  });
+  const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
+  const token = new URL(url).searchParams.get('token')!;
+  const v = await h.actors.publisher.verifyApplyMagicLink(token);
+  await h.actors.admin.approveApplication(v.publisherId);
+  await h.registry.upsert({ ...((await h.registry.get(v.publisherId))!), trustLevel: 'auto' });
+  return { publisherId: v.publisherId };
+}
+
+describe('ingest edge cases', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('records network_error when fetcher reports network failure; preserves prior events', async () => {
+    const { publisherId } = await applyApprove(h, 'neterr@example.com');
+    h.feeds.set(publisherId, feedOk(publisherId, 'N', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    h.feeds.set(publisherId, {
+      fetchStatus: 'network_error',
+      feed: null,
+      report: { ok: false, errors: [{ path: '/', message: 'ECONNREFUSED' }], warnings: [] },
+    });
+    await h.actors.ingest.run();
+    const pub = await h.registry.get(publisherId);
+    expect(pub?.lastFetchStatus).toBe('network_error');
+    expect(await h.events.count(publisherId)).toBe(1);
+  });
+
+  it('records validation_error when fetcher reports schema-invalid; no diff', async () => {
+    const { publisherId } = await applyApprove(h, 'validerr@example.com');
+    h.feeds.set(publisherId, feedOk(publisherId, 'V', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    h.feeds.set(publisherId, {
+      fetchStatus: 'validation_error',
+      feed: null,
+      report: { ok: false, errors: [{ path: '/events/0/title', message: 'required' }], warnings: [] },
+    });
+    await h.actors.ingest.run();
+    const pub = await h.registry.get(publisherId);
+    expect(pub?.lastFetchStatus).toBe('validation_error');
+    expect(await h.events.count(publisherId)).toBe(1);
+  });
+
+  it('unchanged feed (same lastModified): no state changes; updates timestamps', async () => {
+    const { publisherId } = await applyApprove(h, 'unchanged@example.com');
+    const evt = { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' };
+    h.feeds.set(publisherId, feedOk(publisherId, 'U', [evt]));
+    await h.actors.ingest.run();
+    const before = (await h.store.listForPublisher(publisherId))[0];
+
+    // Re-ingest same event with same lastModified → no diff applied to it.
+    await h.actors.ingest.run();
+    const after = (await h.store.listForPublisher(publisherId))[0];
+    expect(after.updatedAt).toBe(before.updatedAt); // unchanged → no write
+  });
+
+  it('threshold halt: feed shrinks below threshold → setThresholdHalt called; events untouched', async () => {
+    const { publisherId } = await applyApprove(h, 'halt@example.com');
+    // Seed 10 future events.
+    const events = Array.from({ length: 10 }, (_, i) => ({
+      id: `e${i}`,
+      startDate: `2026-08-${String(i + 1).padStart(2, '0')}T10:00:00Z`,
+      endDate: `2026-08-${String(i + 1).padStart(2, '0')}T11:00:00Z`,
+      lastModified: '2026-06-01T00:00:00Z',
+    }));
+    h.feeds.set(publisherId, feedOk(publisherId, 'H', events));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(10);
+
+    // Shrink to 1 event — removes 9 of 10 future events, well over the 50% threshold.
+    h.feeds.set(publisherId, feedOk(publisherId, 'H', [events[0]]));
+    await h.actors.ingest.run();
+    const pub = await h.registry.get(publisherId);
+    expect(pub?.pendingThresholdHalt).toBeDefined();
+    expect(pub?.lastFetchStatus).toBe('threshold_halt');
+    expect(await h.events.count(publisherId)).toBe(10);
+  });
+
+  it('disabled publisher: ingest retracts (skipping reconcile entirely)', async () => {
+    const { publisherId } = await applyApprove(h, 'disabled@example.com');
+    h.feeds.set(publisherId, feedOk(publisherId, 'D', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    await h.actors.admin.disable(publisherId);
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(0);
+  });
+});

--- a/backend/src/__tests__/integration/lifecycle.test.ts
+++ b/backend/src/__tests__/integration/lifecycle.test.ts
@@ -7,12 +7,13 @@ jest.unmock('@aws-sdk/lib-dynamodb');
 jest.unmock('@aws-sdk/client-dynamodb');
 
 import { createHarness, feedOk, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
 
 function getApplyToken(h: Harness, email: string): string {
   const sent = h.mail.lastTo(email);
   if (!sent) throw new Error(`no mail captured to ${email}`);
   const url = sent.data.magicLinkUrl as string;
-  return new URL(url).searchParams.get('token')!;
+  return tokenFromMagicLink(url);
 }
 
 describe('publisher lifecycle', () => {

--- a/backend/src/__tests__/integration/lifecycle.test.ts
+++ b/backend/src/__tests__/integration/lifecycle.test.ts
@@ -1,0 +1,138 @@
+// Lifecycle journeys: apply → admin approve / reject → portal access.
+//
+// Includes the PR #100 regression test: admin-approved events stay
+// `published` across re-ingest with bumped lastModified.
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, feedOk, type Harness } from './harness/harness';
+
+function getApplyToken(h: Harness, email: string): string {
+  const sent = h.mail.lastTo(email);
+  if (!sent) throw new Error(`no mail captured to ${email}`);
+  const url = sent.data.magicLinkUrl as string;
+  return new URL(url).searchParams.get('token')!;
+}
+
+describe('publisher lifecycle', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('walks an auto-trust publisher: apply → verify → approve → ingest publishes events as published', async () => {
+    const email = 'auto@example.com';
+    await h.actors.publisher.apply({
+      name: 'Auto Trust',
+      email,
+      sourceUrl: 'https://example.com/auto.json',
+      sourceType: 'json',
+    });
+    const token = getApplyToken(h, email);
+    const verified = await h.actors.publisher.verifyApplyMagicLink(token);
+    expect(verified.publisherId).toMatch(/^pub-/);
+
+    await h.actors.admin.approveApplication(verified.publisherId);
+
+    // Promote to auto-trust manually (admin patches the row to bypass review).
+    await h.registry.upsert({
+      ...((await h.registry.get(verified.publisherId))!),
+      trustLevel: 'auto',
+    });
+
+    // Configure feed for this publisher.
+    h.feeds.set(verified.publisherId, feedOk(verified.publisherId, 'Auto Trust', [
+      { id: 'evt-1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    const states = await h.events.statesOf(verified.publisherId);
+    expect(states).toEqual({ 'evt-1': 'published' });
+  });
+
+  it('walks a review-trust publisher and preserves admin-approved state across re-ingest with bumped lastModified', async () => {
+    const email = 'review@example.com';
+    await h.actors.publisher.apply({
+      name: 'Review Trust',
+      email,
+      sourceUrl: 'https://example.com/review.json',
+      sourceType: 'json',
+    });
+    const token = getApplyToken(h, email);
+    const verified = await h.actors.publisher.verifyApplyMagicLink(token);
+    await h.actors.admin.approveApplication(verified.publisherId);
+
+    // First ingest with one event → state pending.
+    h.feeds.set(verified.publisherId, feedOk(verified.publisherId, 'Review Trust', [
+      { id: 'evt-1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.statesOf(verified.publisherId)).toEqual({ 'evt-1': 'pending' });
+
+    // Admin approves the event.
+    await h.actors.admin.approveEvent(verified.publisherId, 'evt-1');
+    expect(await h.events.statesOf(verified.publisherId)).toEqual({ 'evt-1': 'published' });
+
+    // Re-ingest with bumped lastModified — PR #100 regression: state must
+    // remain 'published'.
+    h.feeds.set(verified.publisherId, feedOk(verified.publisherId, 'Review Trust', [
+      { id: 'evt-1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-02T00:00:00Z' },
+    ]));
+    h.now.advance(60 * 60 * 1000);
+    await h.actors.ingest.run();
+    expect(await h.events.statesOf(verified.publisherId)).toEqual({ 'evt-1': 'published' });
+  });
+
+  it('rejects an application: applicant gets rejection email; portal login attempt cannot create JWT', async () => {
+    const email = 'rejected@example.com';
+    await h.actors.publisher.apply({
+      name: 'Rejected',
+      email,
+      sourceUrl: 'https://example.com/rejected.json',
+      sourceType: 'json',
+    });
+    const token = getApplyToken(h, email);
+    const verified = await h.actors.publisher.verifyApplyMagicLink(token);
+
+    h.mail.clear();
+    await h.actors.admin.rejectApplication(verified.publisherId, 'Not relevant');
+
+    const rejectMail = h.mail.byKind('rejection');
+    expect(rejectMail).toHaveLength(1);
+    expect(rejectMail[0].to).toBe(email);
+
+    // Pending → rejected: portal-status calls succeed but applicationStatus = 'rejected'.
+    const session = await h.signSession(verified.publisherId);
+    const status = await h.actors.publisher.status(session);
+    expect(status.publisher.applicationStatus).toBe('rejected');
+
+    // Authenticated mutations are gated to approved publishers — pause is 403.
+    await expect(h.actors.publisher.pause(session)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+
+  it('refuses a duplicate-email apply: second apply with the same email is rejected', async () => {
+    const email = 'dup@example.com';
+    await h.actors.publisher.apply({
+      name: 'First',
+      email,
+      sourceUrl: 'https://example.com/first.json',
+      sourceType: 'json',
+    });
+    const token = getApplyToken(h, email);
+    await h.actors.publisher.verifyApplyMagicLink(token);
+
+    // Second apply with the same email → 400.
+    await expect(h.actors.publisher.apply({
+      name: 'Second',
+      email,
+      sourceUrl: 'https://example.com/second.json',
+      sourceType: 'json',
+    })).rejects.toMatchObject({ statusCode: 400 });
+  });
+});

--- a/backend/src/__tests__/integration/selfService.test.ts
+++ b/backend/src/__tests__/integration/selfService.test.ts
@@ -1,0 +1,148 @@
+// Self-service portal journeys (design Test plan items 5-11).
+//
+// Includes the PR #78 regression test: self-disable retracts events on next
+// ingest run.
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, feedOk, type Harness } from './harness/harness';
+
+async function applyApproveAndSession(
+  h: Harness,
+  email: string,
+  name = 'Test',
+  sourceUrl = 'https://example.com/feed.json',
+): Promise<{ publisherId: string; session: string }> {
+  await h.actors.publisher.apply({ name, email, sourceUrl, sourceType: 'json' });
+  const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
+  const token = new URL(url).searchParams.get('token')!;
+  const v = await h.actors.publisher.verifyApplyMagicLink(token);
+  await h.actors.admin.approveApplication(v.publisherId);
+  const session = await h.signSession(v.publisherId);
+  return { publisherId: v.publisherId, session };
+}
+
+describe('publisher self-service portal', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('pause skips that publisher in next ingest; resume re-enables', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'pause@example.com');
+    // Promote to auto-trust so events publish without admin intervention.
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'auto' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    // Pause via portal. Subsequent ingest should leave events untouched but
+    // also not pull from the feed (we change the feed to verify).
+    await h.actors.publisher.pause(session);
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e2', startDate: '2026-08-02T10:00:00Z', endDate: '2026-08-02T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    const states = await h.events.statesOf(publisherId);
+    expect(Object.keys(states)).toEqual(['e1']);
+
+    // Resume → ingest pulls feed (now containing both e1 and e2).
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+      { id: 'e2', startDate: '2026-08-02T10:00:00Z', endDate: '2026-08-02T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.publisher.resume(session);
+    await h.actors.ingest.run();
+    const after = await h.events.statesOf(publisherId);
+    expect(Object.keys(after).sort()).toEqual(['e1', 'e2']);
+  });
+
+  it('updates profile name; rejects malformed input', async () => {
+    const { session } = await applyApproveAndSession(h, 'profile@example.com');
+    const r = await h.actors.publisher.updateProfile(session, { name: 'New Name' });
+    expect(r.publisher.name).toBe('New Name');
+
+    // Empty name is rejected.
+    await expect(h.actors.publisher.updateProfile(session, { name: '' }))
+      .rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it('walks email change: request → confirm with magic link → re-using the link fails', async () => {
+    const { session } = await applyApproveAndSession(h, 'old@example.com');
+    h.mail.clear();
+    await h.actors.publisher.requestEmailChange(session, 'new@example.com');
+
+    const verifyMail = h.mail.lastTo('new@example.com');
+    expect(verifyMail?.kind).toBe('email_change_verify');
+    const verifyUrl = verifyMail!.data.verifyUrl as string;
+    const verifyToken = new URL(verifyUrl).searchParams.get('token')!;
+
+    const result = await h.actors.publisher.confirmEmailChange(verifyToken);
+    expect(result.kind).toBe('ok');
+    expect(result.newEmail).toBe('new@example.com');
+
+    // Replay the same token → already_used.
+    const replay = await h.actors.publisher.confirmEmailChange(verifyToken);
+    expect(replay.kind).toBe('already_used');
+  });
+
+  it('cancels email change via the old-address link; later confirm with the same verify token fails', async () => {
+    const { session } = await applyApproveAndSession(h, 'old@example.com');
+    h.mail.clear();
+    await h.actors.publisher.requestEmailChange(session, 'new@example.com');
+    const verifyToken = new URL((h.mail.lastTo('new@example.com')!.data.verifyUrl as string)).searchParams.get('token')!;
+    const cancelToken = new URL((h.mail.lastTo('old@example.com')!.data.cancelUrl as string)).searchParams.get('token')!;
+
+    const cancelResult = await h.actors.publisher.cancelEmailChangeByOld(cancelToken);
+    expect(cancelResult.kind).toBe('ok');
+
+    const result = await h.actors.publisher.confirmEmailChange(verifyToken);
+    expect(result.kind).toBe('already_used');
+  });
+
+  it('self-disable retracts events on next ingest (PR #78)', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'disable@example.com');
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'auto' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'D', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(1);
+
+    // Self-disable.
+    await h.actors.publisher.selfDisable(session, publisherId);
+
+    // Next ingest retracts events.
+    await h.actors.ingest.run();
+    expect(await h.events.count(publisherId)).toBe(0);
+  });
+
+  it('self-disable typed-slug mismatch returns 400; publisher remains enabled', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'mismatch@example.com');
+
+    await expect(h.actors.publisher.selfDisable(session, 'wrong-slug'))
+      .rejects.toMatchObject({ statusCode: 400 });
+
+    const pub = await h.registry.get(publisherId);
+    expect(pub?.enabled).toBe(true);
+  });
+
+  it('fetch-now invokes ingest in-process via FakeLambdaInvoker', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'fetch@example.com');
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'auto' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'F', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.publisher.fetchNow(session);
+    // The fake invoker triggers runIngest in-process; the event should be there.
+    expect(await h.events.count(publisherId)).toBe(1);
+    expect(h.invoker.invocations).toHaveLength(1);
+    expect(h.invoker.invocations[0].payload).toMatchObject({ singlePublisherId: publisherId });
+  });
+});

--- a/backend/src/__tests__/integration/selfService.test.ts
+++ b/backend/src/__tests__/integration/selfService.test.ts
@@ -7,6 +7,7 @@ jest.unmock('@aws-sdk/lib-dynamodb');
 jest.unmock('@aws-sdk/client-dynamodb');
 
 import { createHarness, feedOk, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
 
 async function applyApproveAndSession(
   h: Harness,
@@ -16,7 +17,7 @@ async function applyApproveAndSession(
 ): Promise<{ publisherId: string; session: string }> {
   await h.actors.publisher.apply({ name, email, sourceUrl, sourceType: 'json' });
   const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
-  const token = new URL(url).searchParams.get('token')!;
+  const token = tokenFromMagicLink(url);
   const v = await h.actors.publisher.verifyApplyMagicLink(token);
   await h.actors.admin.approveApplication(v.publisherId);
   const session = await h.signSession(v.publisherId);
@@ -81,7 +82,7 @@ describe('publisher self-service portal', () => {
     const verifyMail = h.mail.lastTo('new@example.com');
     expect(verifyMail?.kind).toBe('email_change_verify');
     const verifyUrl = verifyMail!.data.verifyUrl as string;
-    const verifyToken = new URL(verifyUrl).searchParams.get('token')!;
+    const verifyToken = tokenFromMagicLink(verifyUrl);
 
     const result = await h.actors.publisher.confirmEmailChange(verifyToken);
     expect(result.kind).toBe('ok');
@@ -96,8 +97,8 @@ describe('publisher self-service portal', () => {
     const { session } = await applyApproveAndSession(h, 'old@example.com');
     h.mail.clear();
     await h.actors.publisher.requestEmailChange(session, 'new@example.com');
-    const verifyToken = new URL((h.mail.lastTo('new@example.com')!.data.verifyUrl as string)).searchParams.get('token')!;
-    const cancelToken = new URL((h.mail.lastTo('old@example.com')!.data.cancelUrl as string)).searchParams.get('token')!;
+    const verifyToken = tokenFromMagicLink(h.mail.lastTo('new@example.com')!.data.verifyUrl as string);
+    const cancelToken = tokenFromMagicLink(h.mail.lastTo('old@example.com')!.data.cancelUrl as string);
 
     const cancelResult = await h.actors.publisher.cancelEmailChangeByOld(cancelToken);
     expect(cancelResult.kind).toBe('ok');

--- a/docs/plans/2026-05-06-publisher-integration-tests-plan.md
+++ b/docs/plans/2026-05-06-publisher-integration-tests-plan.md
@@ -453,3 +453,17 @@ EOF
   ```
 
 - [ ] **Step 2: Wait for CI to pass and request review**
+
+---
+
+## Post-merge
+
+After this PR merges, the repo owner must update branch protection on `main`:
+
+- Settings → Branches → Branch protection rules → `main` → Edit
+- Under "Require status checks to pass before merging", add: `test-backend (24)`, `test-backend (25)`, `test-frontend (24)`, `test-frontend (25)`.
+- Save.
+
+This cannot be done from a workflow file — it requires repo-settings access in the GitHub UI.
+
+The CI `push:` trigger broadening (Task 10) is achieved automatically by PR #103 (`chore/ci-concurrency-dedupe`), which adds `push: { branches: ['**'] }` plus `concurrency:`. No workflow file changes are made in this PR.


### PR DESCRIPTION
## Summary
- New `backend/src/__tests__/integration/` suite covers publisher lifecycle, self-service portal, admin controls, ingest edge cases, and auth/limits — all journey-shaped, all running against an in-memory DDB fake (no docker, no DynamoDB Local).
- Pins the PR #100 (sticky `published`) and PR #78 (self-disable retracts) regressions so they can't recur.
- 45 new tests, all green, ~14s wall-clock.

## CI
This PR does NOT modify `.github/workflows/build-and-test.yml`. The `push:` trigger that gates merges on this suite is added by PR #103 (`chore/ci-concurrency-dedupe`), which is already open and mergeable. Once #103 lands, every push to a branch will run the integration suite as part of `test-backend`.

## Manual follow-up after merge
Add `test-backend (24)`, `test-backend (25)`, `test-frontend (24)`, `test-frontend (25)` to required status checks under main's branch protection (Settings → Branches → main → Edit). This requires GitHub UI access; cannot be set from a workflow file.

## Test plan
- [x] \`npx jest integration/ --coverage=false\` (8 suites, 45 tests, all green)
- [x] \`npm run test:ci\` (full backend suite, 46 suites, 664 tests, all green)
- [ ] CI green on this PR
- [ ] CI red if PR #100's reconciler fix is reverted (regression catches it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)