### PR TITLE
test(frontend): publisher portal integration tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "validate": "npm run type-check && npm run lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
     "test:ci": "vitest run --coverage"
   },
   "dependencies": {
@@ -26,7 +25,6 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
-    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,8 @@
     "validate": "npm run type-check && npm run lint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:ci": "vitest run --coverage"
   },
   "dependencies": {
     "preact": "^10.28.4"
@@ -25,11 +26,13 @@
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/preact": "^3.2.4",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
+    "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^9",
     "jsdom": "^28.1.0",
     "tailwindcss": "^4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "npm run validate && vite build",
+    "build": "npm run validate && npm run test:ci && vite build",
     "preview": "vite preview",
     "lint": "eslint src/",
     "type-check": "tsc --noEmit",

--- a/frontend/src/__tests__/integration/adminPublishers.test.tsx
+++ b/frontend/src/__tests__/integration/adminPublishers.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Integration tests for /admin/publishers/ — admin publisher management.
+ *
+ * Page: frontend/src/app/admin/publishers/page.tsx
+ *
+ * Covers:
+ *  - Unauth → redirect to /admin/login/ (in non-localhost contexts)
+ *  - Authed → GET /admin/api/publishers + /admin/api/publisher-applications/pending
+ *    populates table + pending list
+ *  - Approve a pending application → POST .../approve → row moves
+ *  - Reject a pending application → inline reason + POST .../reject
+ *  - Run-ingest → POST /admin/api/publishers/run-ingest → button transitions to
+ *    "Running…" and disables
+ *  - Toggle pause → PATCH /admin/api/publishers/:id with { paused: true }
+ *  - Toggle disable → PATCH /admin/api/publishers/:id with { enabled: false, paused: false }
+ *  - Last-fetch detail row renders status badge + lastFetchMessage
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/preact';
+import AdminPublishersPage from '@/app/admin/publishers/page';
+import { renderPage, installNavigationStub, type NavigationStub } from './helpers/render';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+import { loginAsAdmin, logout } from './helpers/auth';
+
+const SAMPLE_PUBLISHER = {
+  id: 'pub-1',
+  name: 'Active Publisher',
+  contactEmail: 'pub@example.test',
+  sourceUrl: 'https://example.com/feed.json',
+  sourceType: 'json' as const,
+  trustLevel: 'review' as const,
+  enabled: true,
+  paused: false,
+  applicationStatus: 'approved' as const,
+  createdAt: '2026-04-01T00:00:00.000Z',
+  lastFetchedAt: '2026-05-06T10:00:00.000Z',
+  lastFetchStatus: 'parse_error' as const,
+  lastFetchMessage: 'Sample parse error',
+};
+
+const SAMPLE_PENDING = {
+  id: 'pub-2',
+  name: 'Pending Publisher',
+  contactEmail: 'pending@example.test',
+  sourceUrl: 'https://example.com/pending.json',
+  sourceType: 'json' as const,
+  trustLevel: 'review' as const,
+  enabled: false,
+  paused: false,
+  applicationStatus: 'pending' as const,
+  createdAt: '2026-05-01T00:00:00.000Z',
+};
+
+describe('AdminPublishersPage (integration)', () => {
+  let mock: FetchMock;
+  let nav: NavigationStub;
+
+  afterEach(() => {
+    mock?.uninstall();
+    nav?.uninstall();
+    logout();
+  });
+
+  it('redirects to /admin/login/ when no admin session is present (non-localhost)', async () => {
+    nav = installNavigationStub({ hostname: 'admin.example.com' });
+    mock = installFetchMock();
+    // No loginAsAdmin — useAdminAuth should redirect.
+
+    renderPage(<AdminPublishersPage />);
+
+    await waitFor(() => {
+      expect(nav.navigations()).toContain('/admin/login/');
+    });
+    // Should NOT have called any admin API.
+    expect(mock.calls(/\/admin\/api\//)).toHaveLength(0);
+  });
+
+  it('loads and renders the publisher list and pending applications when authenticated', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [SAMPLE_PUBLISHER] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, {
+      applications: [SAMPLE_PENDING],
+    });
+
+    renderPage(<AdminPublishersPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Active Publisher')).toBeInTheDocument();
+    });
+    // Pending applications section renders the pending row separately.
+    expect(screen.getByText('Pending Publisher')).toBeInTheDocument();
+    // Last-fetch status badge + message render.
+    expect(screen.getByText('parse_error')).toBeInTheDocument();
+    expect(screen.getByText('Sample parse error')).toBeInTheDocument();
+  });
+
+  it('approves a pending application by POSTing to .../approve', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, {
+      applications: [SAMPLE_PENDING],
+    });
+    mock.on('POST', /\/admin\/api\/publisher-applications\/pub-2\/approve$/, {
+      publisher: { ...SAMPLE_PENDING, applicationStatus: 'approved' },
+    });
+
+    renderPage(<AdminPublishersPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Pending Publisher')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Approve$/i }));
+
+    await waitFor(() => {
+      const calls = mock.calls(/publisher-applications\/pub-2\/approve/);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].method).toBe('POST');
+    });
+  });
+
+  it('rejects a pending application by POSTing the reason', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, {
+      applications: [SAMPLE_PENDING],
+    });
+    mock.on('POST', /\/admin\/api\/publisher-applications\/pub-2\/reject$/, {
+      publisher: { ...SAMPLE_PENDING, applicationStatus: 'rejected' },
+    });
+
+    renderPage(<AdminPublishersPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Pending Publisher')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Reject$/i }));
+    // The Reject inline form should appear with a textarea + a confirm button.
+    const textarea = await screen.findByRole('textbox');
+    fireEvent.input(textarea, { target: { value: 'Spam application' } });
+    // Click the confirm button (the second "Reject"-labeled one).
+    const buttons = screen.getAllByRole('button', { name: /reject/i });
+    // The last "Reject" button is the inline confirm.
+    fireEvent.click(buttons[buttons.length - 1]);
+
+    await waitFor(() => {
+      const calls = mock.calls(/publisher-applications\/pub-2\/reject/);
+      expect(calls).toHaveLength(1);
+    });
+    const body = await mock.calls(/publisher-applications\/pub-2\/reject/)[0].json();
+    expect(body).toEqual({ reason: 'Spam application' });
+  });
+
+  it('triggers run-ingest and disables the button while it is running', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [SAMPLE_PUBLISHER] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, { applications: [] });
+    mock.on('POST', /\/admin\/api\/publishers\/run-ingest$/, {
+      triggeredAt: '2026-05-06T11:00:00.000Z',
+    });
+
+    renderPage(<AdminPublishersPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Active Publisher')).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole('button', { name: /Run ingest now/i });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      const calls = mock.calls(/\/publishers\/run-ingest/);
+      expect(calls).toHaveLength(1);
+      expect(calls[0].method).toBe('POST');
+    });
+    // Button transitions to "Running…" and is disabled.
+    await waitFor(() => {
+      const running = screen.getByRole('button', { name: /Running/i });
+      expect(running).toBeDisabled();
+    });
+  });
+
+  it('pauses an enabled publisher via PATCH { paused: true }', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [SAMPLE_PUBLISHER] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, { applications: [] });
+    mock.on('PATCH', /\/admin\/api\/publishers\/pub-1$/, {
+      publisher: { ...SAMPLE_PUBLISHER, paused: true },
+    });
+
+    renderPage(<AdminPublishersPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Active Publisher')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Pause Active Publisher$/i }));
+
+    await waitFor(() => {
+      const calls = mock.calls(/\/admin\/api\/publishers\/pub-1$/);
+      const patches = calls.filter(c => c.method === 'PATCH');
+      expect(patches).toHaveLength(1);
+    });
+    const patch = mock
+      .calls(/\/admin\/api\/publishers\/pub-1$/)
+      .find(c => c.method === 'PATCH')!;
+    expect(await patch.json()).toEqual({ paused: true });
+  });
+
+  it('disables an enabled publisher via PATCH { enabled: false, paused: false }', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [SAMPLE_PUBLISHER] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, { applications: [] });
+    mock.on('PATCH', /\/admin\/api\/publishers\/pub-1$/, {
+      publisher: { ...SAMPLE_PUBLISHER, enabled: false, paused: false },
+    });
+
+    renderPage(<AdminPublishersPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Active Publisher')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Disable Active Publisher$/i }));
+
+    await waitFor(() => {
+      const patches = mock
+        .calls(/\/admin\/api\/publishers\/pub-1$/)
+        .filter(c => c.method === 'PATCH');
+      expect(patches).toHaveLength(1);
+    });
+    const patch = mock
+      .calls(/\/admin\/api\/publishers\/pub-1$/)
+      .find(c => c.method === 'PATCH')!;
+    expect(await patch.json()).toEqual({ enabled: false, paused: false });
+  });
+
+  it('opens the delete confirmation modal and POSTs DELETE on confirm', async () => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+    loginAsAdmin();
+    mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [SAMPLE_PUBLISHER] });
+    mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, { applications: [] });
+    mock.on('DELETE', /\/admin\/api\/publishers\/pub-1$/, { deletedEvents: 5 });
+
+    renderPage(<AdminPublishersPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Active Publisher')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Delete Active Publisher$/i }));
+
+    // Modal renders.
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).getByText(/Delete publisher\?/i)).toBeInTheDocument();
+
+    // Confirm.
+    fireEvent.click(within(dialog).getByRole('button', { name: /^Delete$/i }));
+
+    await waitFor(() => {
+      const deletes = mock
+        .calls(/\/admin\/api\/publishers\/pub-1$/)
+        .filter(c => c.method === 'DELETE');
+      expect(deletes).toHaveLength(1);
+    });
+  });
+});

--- a/frontend/src/__tests__/integration/apply.test.tsx
+++ b/frontend/src/__tests__/integration/apply.test.tsx
@@ -68,18 +68,12 @@ describe('PublishApplyPage (integration)', () => {
   });
 
   it('renders an inline field error when the server returns one (e.g. EmailAlreadyInUse)', async () => {
+    // Use the structured `{ status, body }` shape — the fetchMock helper now
+    // honors it directly so we don't need a Response factory or a reset.
     mock.on('POST', '/api/publisher-apply/request', {
       status: 400,
       body: { error: 'Email already in use', field: 'email' },
     });
-    // The fetchMock helper accepts a function for nuanced statuses:
-    mock.reset();
-    mock.on('POST', '/api/publisher-apply/request', () =>
-      new Response(JSON.stringify({ error: 'Email already in use', field: 'email' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' },
-      }),
-    );
 
     renderPage(<PublishApplyPage />);
     fireEvent.input(screen.getByPlaceholderText(/Athenaeum Hotel/i), {

--- a/frontend/src/__tests__/integration/apply.test.tsx
+++ b/frontend/src/__tests__/integration/apply.test.tsx
@@ -159,10 +159,13 @@ describe('PublishApplyPage (integration)', () => {
   });
 
   it('disables the submit button while the request is in flight', async () => {
-    let resolveNet: (() => void) | null = null;
+    // TS's flow analyzer narrows `resolveNet` to `null` at the call site below
+    // (the closure mutation is invisible to it), so use a type variable that
+    // explicitly preserves the function-or-null union via the indirect ref.
+    const resolverRef: { current: (() => void) | null } = { current: null };
     mock.on('POST', '/api/publisher-apply/request', () => {
       return new Promise<Response>(resolve => {
-        resolveNet = () =>
+        resolverRef.current = () =>
           resolve(
             new Response(JSON.stringify({ ok: true }), {
               status: 200,
@@ -189,7 +192,7 @@ describe('PublishApplyPage (integration)', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /Sending/i })).toBeDisabled();
     });
-    resolveNet?.();
+    resolverRef.current?.();
     await waitFor(() => {
       expect(screen.getByText(/Check your email/i)).toBeInTheDocument();
     });

--- a/frontend/src/__tests__/integration/apply.test.tsx
+++ b/frontend/src/__tests__/integration/apply.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Integration tests for /publish/apply/ — the publisher application form.
+ *
+ * Page: frontend/src/app/publish/apply/page.tsx
+ * Endpoint: POST /api/publisher-apply/request
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/preact';
+import PublishApplyPage from '@/app/publish/apply/page';
+import { renderPage } from './helpers/render';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+
+describe('PublishApplyPage (integration)', () => {
+  let mock: FetchMock;
+
+  beforeEach(() => {
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+  });
+
+  // VITE_RECAPTCHA_SITE_KEY is unset in tests, so the captcha layer is
+  // skipped — see the comment block in apply/page.tsx for why submitting
+  // without a token is fine in non-prod.
+
+  it('renders all required fields and the submit button', () => {
+    renderPage(<PublishApplyPage />);
+    expect(screen.getByPlaceholderText(/Athenaeum Hotel/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/you@example.com/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/example.com\/events.json/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Send verification email/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('submits the form payload to /api/publisher-apply/request and shows success state', async () => {
+    mock.on('POST', '/api/publisher-apply/request', { ok: true });
+
+    renderPage(<PublishApplyPage />);
+    fireEvent.input(screen.getByPlaceholderText(/Athenaeum Hotel/i), {
+      target: { value: 'Test Venue' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/you@example.com/i), {
+      target: { value: 'me@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/example.com\/events.json/i), {
+      target: { value: 'https://example.com/events.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send verification email/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Check your email/i)).toBeInTheDocument();
+    });
+    const calls = mock.calls('/api/publisher-apply/request');
+    expect(calls).toHaveLength(1);
+    const body = await calls[0].json();
+    expect(body).toMatchObject({
+      name: 'Test Venue',
+      email: 'me@example.com',
+      sourceUrl: 'https://example.com/events.json',
+      sourceType: 'json',
+    });
+  });
+
+  it('renders an inline field error when the server returns one (e.g. EmailAlreadyInUse)', async () => {
+    mock.on('POST', '/api/publisher-apply/request', {
+      status: 400,
+      body: { error: 'Email already in use', field: 'email' },
+    });
+    // The fetchMock helper accepts a function for nuanced statuses:
+    mock.reset();
+    mock.on('POST', '/api/publisher-apply/request', () =>
+      new Response(JSON.stringify({ error: 'Email already in use', field: 'email' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishApplyPage />);
+    fireEvent.input(screen.getByPlaceholderText(/Athenaeum Hotel/i), {
+      target: { value: 'X' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/you@example.com/i), {
+      target: { value: 'taken@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/example.com\/events.json/i), {
+      target: { value: 'https://example.com/events.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send verification email/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Email already in use/i)).toBeInTheDocument();
+    });
+    // Error state stays editable — submit button must not be permanently disabled.
+    expect(
+      screen.getByRole('button', { name: /Send verification email/i }),
+    ).not.toBeDisabled();
+  });
+
+  it('renders a top-level error when the server returns a non-field error', async () => {
+    mock.on('POST', '/api/publisher-apply/request', () =>
+      new Response(JSON.stringify({ error: 'Validation failed' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishApplyPage />);
+    fireEvent.input(screen.getByPlaceholderText(/Athenaeum Hotel/i), {
+      target: { value: 'X' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/you@example.com/i), {
+      target: { value: 'me@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/example.com\/events.json/i), {
+      target: { value: 'https://example.com/x.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send verification email/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation failed/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders the rate-limit message on 429', async () => {
+    mock.on('POST', '/api/publisher-apply/request', () =>
+      new Response(JSON.stringify({ error: 'Too many applications, slow down.' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishApplyPage />);
+    fireEvent.input(screen.getByPlaceholderText(/Athenaeum Hotel/i), {
+      target: { value: 'X' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/you@example.com/i), {
+      target: { value: 'me@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/example.com\/events.json/i), {
+      target: { value: 'https://example.com/x.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send verification email/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Too many applications/i)).toBeInTheDocument();
+    });
+  });
+
+  it('disables the submit button while the request is in flight', async () => {
+    let resolveNet: (() => void) | null = null;
+    mock.on('POST', '/api/publisher-apply/request', () => {
+      return new Promise<Response>(resolve => {
+        resolveNet = () =>
+          resolve(
+            new Response(JSON.stringify({ ok: true }), {
+              status: 200,
+              headers: { 'Content-Type': 'application/json' },
+            }),
+          );
+      });
+    });
+
+    renderPage(<PublishApplyPage />);
+    fireEvent.input(screen.getByPlaceholderText(/Athenaeum Hotel/i), {
+      target: { value: 'X' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/you@example.com/i), {
+      target: { value: 'me@example.com' },
+    });
+    fireEvent.input(screen.getByPlaceholderText(/example.com\/events.json/i), {
+      target: { value: 'https://example.com/x.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send verification email/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Sending/i })).toBeDisabled();
+    });
+    resolveNet?.();
+    await waitFor(() => {
+      expect(screen.getByText(/Check your email/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/__tests__/integration/helpers/__tests__/fetchMock.test.ts
+++ b/frontend/src/__tests__/integration/helpers/__tests__/fetchMock.test.ts
@@ -27,12 +27,10 @@ describe('fetchMock helper', () => {
     expect((await r.json()).id).toBe(1);
   });
 
-  it('returns 404 for unhandled requests and logs an error', async () => {
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const r = await fetch('/api/missing');
-    expect(r.status).toBe(404);
-    expect(spy).toHaveBeenCalled();
-    spy.mockRestore();
+  it('throws on unhandled requests by default and records them in unhandledCalls()', async () => {
+    await expect(fetch('/api/missing')).rejects.toThrow(/no route registered for GET/);
+    expect(mock.unhandledCalls()).toHaveLength(1);
+    expect(mock.unhandledCalls()[0].url).toContain('/api/missing');
   });
 
   it('records calls() and filters by URL', async () => {
@@ -50,10 +48,9 @@ describe('fetchMock helper', () => {
     await fetch('/api/z');
     mock.reset();
     expect(mock.calls()).toHaveLength(0);
-    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    const r = await fetch('/api/z');
-    expect(r.status).toBe(404);
-    spy.mockRestore();
+    expect(mock.unhandledCalls()).toHaveLength(0);
+    // Strict mode: now that the route is gone, the next call throws.
+    await expect(fetch('/api/z')).rejects.toThrow(/no route registered/);
   });
 
   it('uninstall() restores the original fetch', () => {
@@ -73,5 +70,50 @@ describe('fetchMock helper', () => {
     const r = await fetch('/api/raw');
     expect(r.status).toBe(201);
     expect(await r.text()).toBe('plain');
+  });
+
+  it('honors a structured { status, body } response shape', async () => {
+    mock.on('POST', '/api/struct', { status: 400, body: { error: 'bad', field: 'email' } });
+    const r = await fetch('/api/struct', { method: 'POST' });
+    expect(r.status).toBe(400);
+    expect(await r.json()).toEqual({ error: 'bad', field: 'email' });
+  });
+
+  it('honors a structured response with custom headers', async () => {
+    mock.on('GET', '/api/headers', {
+      status: 200,
+      body: { ok: true },
+      headers: { 'X-Custom': 'yes' },
+    });
+    const r = await fetch('/api/headers');
+    expect(r.headers.get('X-Custom')).toBe('yes');
+  });
+
+  it('falls back to JSON-body-with-status-200 when an object lacks status/headers', async () => {
+    mock.on('GET', '/api/plain', { hello: 'world' });
+    const r = await fetch('/api/plain');
+    expect(r.status).toBe(200);
+    expect(await r.json()).toEqual({ hello: 'world' });
+  });
+});
+
+describe('fetchMock helper — permissive mode', () => {
+  let mock: FetchMock;
+
+  beforeEach(() => {
+    mock = installFetchMock({ allowUnhandled: true });
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+  });
+
+  it('returns 404 for unhandled requests when allowUnhandled is true', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const r = await fetch('/api/missing');
+    expect(r.status).toBe(404);
+    expect(spy).toHaveBeenCalled();
+    expect(mock.unhandledCalls()).toHaveLength(1);
+    spy.mockRestore();
   });
 });

--- a/frontend/src/__tests__/integration/helpers/__tests__/fetchMock.test.ts
+++ b/frontend/src/__tests__/integration/helpers/__tests__/fetchMock.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installFetchMock, type FetchMock } from '../fetchMock';
+
+describe('fetchMock helper', () => {
+  let mock: FetchMock;
+
+  beforeEach(() => {
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+  });
+
+  it('routes a GET by exact path', async () => {
+    mock.on('GET', '/api/foo', { hello: 'world' });
+    const r = await fetch('/api/foo');
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body).toEqual({ hello: 'world' });
+  });
+
+  it('routes by RegExp', async () => {
+    mock.on('GET', /\/api\/users\/\d+/, { id: 1 });
+    const r = await fetch('/api/users/42');
+    expect(r.status).toBe(200);
+    expect((await r.json()).id).toBe(1);
+  });
+
+  it('returns 404 for unhandled requests and logs an error', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const r = await fetch('/api/missing');
+    expect(r.status).toBe(404);
+    expect(spy).toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it('records calls() and filters by URL', async () => {
+    mock.on('POST', '/api/x', { ok: true });
+    mock.on('POST', '/api/y', { ok: true });
+    await fetch('/api/x', { method: 'POST', body: 'a' });
+    await fetch('/api/y', { method: 'POST', body: 'b' });
+    expect(mock.calls()).toHaveLength(2);
+    expect(mock.calls('/api/x')).toHaveLength(1);
+    expect(mock.calls('/api/y')[0].url).toContain('/api/y');
+  });
+
+  it('reset() clears routes and calls', async () => {
+    mock.on('GET', '/api/z', { ok: true });
+    await fetch('/api/z');
+    mock.reset();
+    expect(mock.calls()).toHaveLength(0);
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const r = await fetch('/api/z');
+    expect(r.status).toBe(404);
+    spy.mockRestore();
+  });
+
+  it('uninstall() restores the original fetch', () => {
+    const beforeUninstall = globalThis.fetch;
+    mock.uninstall();
+    expect(globalThis.fetch).not.toBe(beforeUninstall);
+  });
+
+  it('responder can be a function returning a status code', async () => {
+    mock.on('GET', '/api/code', () => 429);
+    const r = await fetch('/api/code');
+    expect(r.status).toBe(429);
+  });
+
+  it('responder can return a Response', async () => {
+    mock.on('GET', '/api/raw', () => new Response('plain', { status: 201 }));
+    const r = await fetch('/api/raw');
+    expect(r.status).toBe(201);
+    expect(await r.text()).toBe('plain');
+  });
+});

--- a/frontend/src/__tests__/integration/helpers/auth.ts
+++ b/frontend/src/__tests__/integration/helpers/auth.ts
@@ -1,0 +1,88 @@
+/**
+ * Auth helper for integration tests.
+ *
+ * Mirrors the localStorage shapes used by:
+ *   - frontend/src/lib/auth.ts            — admin (`chq_auth_token` + user)
+ *   - frontend/src/lib/publisherAuthClient.ts — publisher portal (`chq_publisher_*`)
+ *
+ * The publisher JWT must include a real-looking `exp` claim because
+ * isPublisherAuthenticated() decodes it and treats anything without an exp
+ * (or with an expired exp) as logged out. We synthesize a minimal HS256-shape
+ * JWT with `exp` set far in the future. The signature is gibberish; nothing
+ * in the frontend verifies it.
+ */
+
+import {
+  AUTH_TOKEN_KEY,
+  AUTH_USER_KEY,
+  type AuthUser,
+} from '@/lib/auth';
+import {
+  PUBLISHER_EMAIL_KEY,
+  PUBLISHER_ID_KEY,
+  PUBLISHER_JWT_KEY,
+} from '@/lib/publisherAuthClient';
+
+function base64url(input: object): string {
+  return btoa(JSON.stringify(input))
+    .replace(/=+$/, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_');
+}
+
+/** Build a JWT that decodes cleanly and has an `exp` far in the future. */
+function makePublisherJwt(opts: { publisherId: string; email: string; ttlSec?: number }): string {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + (opts.ttlSec ?? 3600);
+  const payload = {
+    sub: opts.publisherId,
+    email: opts.email,
+    iat: Math.floor(Date.now() / 1000),
+    exp,
+  };
+  // Signature is a constant placeholder — no client code verifies it.
+  return `${base64url(header)}.${base64url(payload)}.test-signature`;
+}
+
+export interface PublisherLoginOpts {
+  publisherId?: string;
+  email?: string;
+  jwt?: string;
+}
+
+export function loginAsPublisher(opts: PublisherLoginOpts = {}): {
+  publisherId: string;
+  email: string;
+  jwt: string;
+} {
+  const publisherId = opts.publisherId ?? 'pub-test-1';
+  const email = opts.email ?? 'pub@example.test';
+  const jwt = opts.jwt ?? makePublisherJwt({ publisherId, email });
+  localStorage.setItem(PUBLISHER_JWT_KEY, jwt);
+  localStorage.setItem(PUBLISHER_ID_KEY, publisherId);
+  localStorage.setItem(PUBLISHER_EMAIL_KEY, email);
+  return { publisherId, email, jwt };
+}
+
+export interface AdminLoginOpts {
+  email?: string;
+  name?: string;
+  jwt?: string;
+}
+
+export function loginAsAdmin(opts: AdminLoginOpts = {}): AuthUser & { jwt: string } {
+  const email = opts.email ?? 'admin@example.test';
+  const name = opts.name ?? 'Admin User';
+  const jwt = opts.jwt ?? 'test-admin-jwt';
+  localStorage.setItem(AUTH_TOKEN_KEY, jwt);
+  localStorage.setItem(AUTH_USER_KEY, JSON.stringify({ email, name }));
+  return { email, name, jwt };
+}
+
+export function logout(): void {
+  localStorage.removeItem(AUTH_TOKEN_KEY);
+  localStorage.removeItem(AUTH_USER_KEY);
+  localStorage.removeItem(PUBLISHER_JWT_KEY);
+  localStorage.removeItem(PUBLISHER_ID_KEY);
+  localStorage.removeItem(PUBLISHER_EMAIL_KEY);
+}

--- a/frontend/src/__tests__/integration/helpers/fetchMock.ts
+++ b/frontend/src/__tests__/integration/helpers/fetchMock.ts
@@ -1,0 +1,124 @@
+/**
+ * fetchMock — small route-based fetch replacement for integration tests.
+ *
+ * Each test installs the mock, registers (method, url) → response handlers,
+ * exercises the page, and asserts on `calls()`. Unhandled requests fall
+ * through to a 404 plus a console.error so missing routes fail loudly rather
+ * than silently in some success state.
+ */
+
+export type MockResponseInit = number | object | Response | ((req: Request) => Response | Promise<Response> | object | number);
+
+interface Route {
+  method: string;
+  url: string | RegExp;
+  responder: (req: Request) => Response | Promise<Response>;
+}
+
+export interface FetchMock {
+  on: (method: string, url: string | RegExp, response: MockResponseInit) => void;
+  calls: (url?: string | RegExp) => Request[];
+  reset: () => void;
+  uninstall: () => void;
+}
+
+/**
+ * Replaces globalThis.fetch with a route table. Returns a handle for the
+ * test to register routes, inspect calls, and tear down.
+ */
+export function installFetchMock(): FetchMock {
+  const original = globalThis.fetch;
+  let routes: Route[] = [];
+  const recorded: Request[] = [];
+
+  function toResponse(out: MockResponseInit, req: Request): Response | Promise<Response> {
+    if (typeof out === 'function') {
+      const v = (out as (r: Request) => Response | Promise<Response> | object | number)(req);
+      if (v instanceof Response) return v;
+      if (v instanceof Promise) {
+        return v.then(inner => {
+          if (inner instanceof Response) return inner;
+          return materialize(inner);
+        });
+      }
+      return materialize(v);
+    }
+    if (out instanceof Response) return out;
+    return materialize(out);
+  }
+
+  function materialize(value: number | object): Response {
+    if (typeof value === 'number') {
+      return new Response(JSON.stringify({}), {
+        status: value,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify(value), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  function urlMatches(pattern: string | RegExp, actual: string): boolean {
+    if (typeof pattern === 'string') {
+      // Match either an exact URL or a path ending — tests register short
+      // paths like '/api/publisher-status' and the actual fetch URL is
+      // http://localhost:3000/api/publisher-status (jsdom default origin).
+      return actual === pattern || actual.endsWith(pattern);
+    }
+    return pattern.test(actual);
+  }
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    // Normalize relative paths to absolute URLs so the Request constructor
+    // doesn't throw under jsdom/undici. Production code passes either an
+    // absolute API URL or a path-relative URL ('/api/...'); both work here.
+    let req: Request;
+    if (input instanceof Request) {
+      req = input;
+    } else {
+      const raw = typeof input === 'string' ? input : (input as URL).toString();
+      const absolute = /^https?:\/\//i.test(raw)
+        ? raw
+        : new URL(raw, globalThis.location?.origin ?? 'http://localhost').toString();
+      req = new Request(absolute, init);
+    }
+    recorded.push(req.clone());
+    const method = req.method.toUpperCase();
+    const url = req.url;
+    const route = routes.find(r => r.method.toUpperCase() === method && urlMatches(r.url, url));
+    if (!route) {
+      // Loud failure path: log and return 404 so tests notice missing routes.
+      console.error(`[fetchMock] no route for ${method} ${url}`);
+      return new Response(JSON.stringify({ error: 'no route' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return route.responder(req);
+  }) as typeof fetch;
+
+  return {
+    on(method, url, response) {
+      routes.push({
+        method: method.toUpperCase(),
+        url,
+        responder: (req) => Promise.resolve(toResponse(response, req)),
+      });
+    },
+    calls(url) {
+      if (url === undefined) return recorded.slice();
+      return recorded.filter(r => urlMatches(url, r.url));
+    },
+    reset() {
+      routes = [];
+      recorded.length = 0;
+    },
+    uninstall() {
+      globalThis.fetch = original;
+      routes = [];
+      recorded.length = 0;
+    },
+  };
+}

--- a/frontend/src/__tests__/integration/helpers/fetchMock.ts
+++ b/frontend/src/__tests__/integration/helpers/fetchMock.ts
@@ -2,12 +2,39 @@
  * fetchMock — small route-based fetch replacement for integration tests.
  *
  * Each test installs the mock, registers (method, url) → response handlers,
- * exercises the page, and asserts on `calls()`. Unhandled requests fall
- * through to a 404 plus a console.error so missing routes fail loudly rather
- * than silently in some success state.
+ * exercises the page, and asserts on `calls()`.
+ *
+ * By default, an unhandled request throws a descriptive error so missing
+ * routes fail loudly. Tests that genuinely want a 404 default can opt in via
+ * `installFetchMock({ allowUnhandled: true })`. The handle also exposes
+ * `unhandledCalls()` so a strict test can assert nothing slipped through.
+ *
+ * ## Supported response shapes (`MockResponseInit`)
+ *
+ * A registered response can be any of:
+ *
+ *  - `number` — status code with empty JSON body (e.g. `mock.on(..., 204)`)
+ *  - `Response` — used as-is
+ *  - `{ status, body, headers? }` — structured shape; `status` is required for
+ *    the structured form (presence of `status` OR `headers` triggers it). The
+ *    `body` is JSON-stringified unless it is already a string.
+ *  - any other `object` — treated as a JSON body with status 200
+ *  - `(req) => Response | object | number | Promise<...>` — function variant,
+ *    each return type follows the rules above
  */
 
-export type MockResponseInit = number | object | Response | ((req: Request) => Response | Promise<Response> | object | number);
+export interface StructuredMockResponse {
+  status: number;
+  body?: unknown;
+  headers?: Record<string, string>;
+}
+
+export type MockResponseInit =
+  | number
+  | object
+  | Response
+  | StructuredMockResponse
+  | ((req: Request) => Response | Promise<Response> | object | number | StructuredMockResponse);
 
 interface Route {
   method: string;
@@ -18,22 +45,43 @@ interface Route {
 export interface FetchMock {
   on: (method: string, url: string | RegExp, response: MockResponseInit) => void;
   calls: (url?: string | RegExp) => Request[];
+  unhandledCalls: () => Request[];
   reset: () => void;
   uninstall: () => void;
+}
+
+export interface InstallFetchMockOptions {
+  /**
+   * When true, unhandled requests return a 404 instead of throwing. Defaults
+   * to false — most tests want strict mode so missing routes fail loudly.
+   */
+  allowUnhandled?: boolean;
+}
+
+function isStructuredMockResponse(v: unknown): v is StructuredMockResponse {
+  if (v === null || typeof v !== 'object') return false;
+  if (v instanceof Response) return false;
+  if (Array.isArray(v)) return false;
+  // The structured shape is identified by the presence of `status` or
+  // `headers`. Plain `{ body: ... }` would be ambiguous with a JSON body
+  // that legitimately has a `body` field, so we don't trigger on that alone.
+  return 'status' in v || 'headers' in v;
 }
 
 /**
  * Replaces globalThis.fetch with a route table. Returns a handle for the
  * test to register routes, inspect calls, and tear down.
  */
-export function installFetchMock(): FetchMock {
+export function installFetchMock(options: InstallFetchMockOptions = {}): FetchMock {
+  const { allowUnhandled = false } = options;
   const original = globalThis.fetch;
   let routes: Route[] = [];
   const recorded: Request[] = [];
+  const unhandled: Request[] = [];
 
   function toResponse(out: MockResponseInit, req: Request): Response | Promise<Response> {
     if (typeof out === 'function') {
-      const v = (out as (r: Request) => Response | Promise<Response> | object | number)(req);
+      const v = (out as (r: Request) => Response | Promise<Response> | object | number | StructuredMockResponse)(req);
       if (v instanceof Response) return v;
       if (v instanceof Promise) {
         return v.then(inner => {
@@ -47,11 +95,25 @@ export function installFetchMock(): FetchMock {
     return materialize(out);
   }
 
-  function materialize(value: number | object): Response {
+  function materialize(value: number | object | StructuredMockResponse): Response {
     if (typeof value === 'number') {
       return new Response(JSON.stringify({}), {
         status: value,
         headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (isStructuredMockResponse(value)) {
+      const { status, body, headers } = value;
+      const hasBody = body !== undefined;
+      const serialized = hasBody
+        ? (typeof body === 'string' ? body : JSON.stringify(body))
+        : '';
+      return new Response(hasBody ? serialized : null, {
+        status,
+        headers: {
+          'Content-Type': 'application/json',
+          ...(headers ?? {}),
+        },
       });
     }
     return new Response(JSON.stringify(value), {
@@ -89,7 +151,17 @@ export function installFetchMock(): FetchMock {
     const url = req.url;
     const route = routes.find(r => r.method.toUpperCase() === method && urlMatches(r.url, url));
     if (!route) {
-      // Loud failure path: log and return 404 so tests notice missing routes.
+      unhandled.push(req.clone());
+      if (!allowUnhandled) {
+        // Strict mode: throw so tests notice missing routes rather than
+        // silently exercising error-handling paths.
+        throw new Error(
+          `[fetchMock] no route registered for ${method} ${url}. ` +
+          `Register one with mock.on('${method}', '<path>', <response>) or pass ` +
+          `installFetchMock({ allowUnhandled: true }) for permissive mode.`,
+        );
+      }
+      // Permissive mode: still log so the unhandled call is visible.
       console.error(`[fetchMock] no route for ${method} ${url}`);
       return new Response(JSON.stringify({ error: 'no route' }), {
         status: 404,
@@ -111,14 +183,19 @@ export function installFetchMock(): FetchMock {
       if (url === undefined) return recorded.slice();
       return recorded.filter(r => urlMatches(url, r.url));
     },
+    unhandledCalls() {
+      return unhandled.slice();
+    },
     reset() {
       routes = [];
       recorded.length = 0;
+      unhandled.length = 0;
     },
     uninstall() {
       globalThis.fetch = original;
       routes = [];
       recorded.length = 0;
+      unhandled.length = 0;
     },
   };
 }

--- a/frontend/src/__tests__/integration/helpers/render.tsx
+++ b/frontend/src/__tests__/integration/helpers/render.tsx
@@ -1,0 +1,102 @@
+/**
+ * Test render helper.
+ *
+ * Wraps @testing-library/preact's render so we have a single seam for any
+ * future context providers. Also exposes a navigation stub since the portal
+ * pages call `window.location.href = ...` and `window.location.replace(...)`
+ * which jsdom can't actually navigate but does record.
+ */
+
+import type { VNode } from 'preact';
+import { render as tlpRender, type RenderResult } from '@testing-library/preact';
+
+export function renderPage(node: VNode): RenderResult {
+  return tlpRender(node);
+}
+
+// Recorded URLs from `window.location.href = ...` and `.replace(...)` /
+// `.assign(...)`. installNavigationStub returns a getter and a clearer.
+export interface NavigationStub {
+  navigations: () => string[];
+  reset: () => void;
+  uninstall: () => void;
+}
+
+interface NavigatedLocation {
+  // Subset of Location we override. Other reads still go through the real
+  // jsdom window.location via the proxy.
+  href: string;
+  replace: (url: string | URL) => void;
+  assign: (url: string | URL) => void;
+}
+
+/**
+ * Replaces window.location with a Proxy that records assignments and calls.
+ * jsdom otherwise throws "Not implemented: navigation" when production code
+ * sets location.href, so we need to stub anyway.
+ *
+ * Returns a handle that exposes the recorded URLs and lets the test undo
+ * the stub.
+ */
+export function installNavigationStub(): NavigationStub {
+  const navigations: string[] = [];
+  const realLocation = window.location;
+  const realPathname = realLocation.pathname;
+  const realSearch = realLocation.search;
+
+  // Build a stand-in object. Other Location members fall through to the real
+  // location via Object.assign so reads (e.g. pathname, search, hostname)
+  // keep working.
+  const stub: NavigatedLocation = {
+    href: realLocation.href,
+    replace(url) {
+      navigations.push(String(url));
+    },
+    assign(url) {
+      navigations.push(String(url));
+    },
+  };
+
+  // Use Object.defineProperty so we can replace the (read-only) location
+  // property and restore it later.
+  const descriptor = Object.getOwnPropertyDescriptor(window, 'location');
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    enumerable: true,
+    writable: true,
+    value: new Proxy(stub, {
+      get(target, prop, receiver) {
+        if (prop === 'href') return target.href;
+        if (prop === 'replace') return target.replace;
+        if (prop === 'assign') return target.assign;
+        if (prop === 'pathname') return realPathname;
+        if (prop === 'search') return realSearch;
+        if (prop === 'hostname') return realLocation.hostname;
+        if (prop === 'origin') return realLocation.origin;
+        if (prop === 'host') return realLocation.host;
+        if (prop === 'protocol') return realLocation.protocol;
+        return Reflect.get(target, prop, receiver);
+      },
+      set(target, prop, value) {
+        if (prop === 'href') {
+          target.href = String(value);
+          navigations.push(String(value));
+          return true;
+        }
+        return Reflect.set(target, prop, value);
+      },
+    }),
+  });
+
+  return {
+    navigations: () => navigations.slice(),
+    reset: () => {
+      navigations.length = 0;
+    },
+    uninstall: () => {
+      if (descriptor) {
+        Object.defineProperty(window, 'location', descriptor);
+      }
+    },
+  };
+}

--- a/frontend/src/__tests__/integration/helpers/render.tsx
+++ b/frontend/src/__tests__/integration/helpers/render.tsx
@@ -37,8 +37,12 @@ interface NavigatedLocation {
  *
  * Returns a handle that exposes the recorded URLs and lets the test undo
  * the stub.
+ *
+ * `overrides` lets a test pin specific Location members (e.g. `hostname`) to
+ * test values that jsdom's defaults don't cover — useful for asserting code
+ * paths that gate behavior on `hostname === 'localhost'`.
  */
-export function installNavigationStub(): NavigationStub {
+export function installNavigationStub(overrides: Partial<Record<string, unknown>> = {}): NavigationStub {
   const navigations: string[] = [];
   const realLocation = window.location;
 
@@ -68,6 +72,12 @@ export function installNavigationStub(): NavigationStub {
         if (prop === 'href') return target.href;
         if (prop === 'replace') return target.replace;
         if (prop === 'assign') return target.assign;
+        // Per-test overrides take precedence so a test can pin e.g.
+        // `hostname` to a non-localhost value when exercising guards
+        // that branch on it.
+        if (typeof prop === 'string' && Object.prototype.hasOwnProperty.call(overrides, prop)) {
+          return overrides[prop];
+        }
         // Any other Location member (pathname, search, hostname, origin,
         // host, protocol, hash, ...) reads from the real jsdom location at
         // access time, so URL changes via history.replaceState are seen.

--- a/frontend/src/__tests__/integration/helpers/render.tsx
+++ b/frontend/src/__tests__/integration/helpers/render.tsx
@@ -41,12 +41,11 @@ interface NavigatedLocation {
 export function installNavigationStub(): NavigationStub {
   const navigations: string[] = [];
   const realLocation = window.location;
-  const realPathname = realLocation.pathname;
-  const realSearch = realLocation.search;
 
-  // Build a stand-in object. Other Location members fall through to the real
-  // location via Object.assign so reads (e.g. pathname, search, hostname)
-  // keep working.
+  // Build a stand-in. Reads we don't override fall through to the real
+  // jsdom location via the Proxy `get` handler so production code reading
+  // `pathname` / `search` / `hostname` keeps working as the URL evolves
+  // (e.g. via window.history.replaceState).
   const stub: NavigatedLocation = {
     href: realLocation.href,
     replace(url) {
@@ -69,13 +68,11 @@ export function installNavigationStub(): NavigationStub {
         if (prop === 'href') return target.href;
         if (prop === 'replace') return target.replace;
         if (prop === 'assign') return target.assign;
-        if (prop === 'pathname') return realPathname;
-        if (prop === 'search') return realSearch;
-        if (prop === 'hostname') return realLocation.hostname;
-        if (prop === 'origin') return realLocation.origin;
-        if (prop === 'host') return realLocation.host;
-        if (prop === 'protocol') return realLocation.protocol;
-        return Reflect.get(target, prop, receiver);
+        // Any other Location member (pathname, search, hostname, origin,
+        // host, protocol, hash, ...) reads from the real jsdom location at
+        // access time, so URL changes via history.replaceState are seen.
+        const v = Reflect.get(realLocation, prop);
+        return typeof v === 'function' ? v.bind(realLocation) : v;
       },
       set(target, prop, value) {
         if (prop === 'href') {

--- a/frontend/src/__tests__/integration/helpers/render.tsx
+++ b/frontend/src/__tests__/integration/helpers/render.tsx
@@ -68,7 +68,7 @@ export function installNavigationStub(overrides: Partial<Record<string, unknown>
     enumerable: true,
     writable: true,
     value: new Proxy(stub, {
-      get(target, prop, receiver) {
+      get(target, prop, _receiver) {
         if (prop === 'href') return target.href;
         if (prop === 'replace') return target.replace;
         if (prop === 'assign') return target.assign;

--- a/frontend/src/__tests__/integration/portal.test.tsx
+++ b/frontend/src/__tests__/integration/portal.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * Integration tests for /publish/status/ — the publisher portal.
+ *
+ * Page: frontend/src/app/publish/status/page.tsx
+ *
+ * Covers:
+ *  - Unauth redirect to /publish/login/
+ *  - Status load (GET /api/publisher-status)
+ *  - Profile name edit (PATCH /api/publisher-profile)
+ *  - Email-change request (POST /api/publisher-email-change)
+ *  - Pause/resume (POST /api/publisher-pause, /api/publisher-resume)
+ *  - Fetch-now (POST /api/publisher-fetch-now)
+ *  - Self-disable typed-confirm (POST /api/publisher-disable)
+ *  - Form-submission regression (pins react→preact/compat alias from CLAUDE.md)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor, within } from '@testing-library/preact';
+import PublishStatusPage from '@/app/publish/status/page';
+import { renderPage, installNavigationStub, type NavigationStub } from './helpers/render';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+import { loginAsPublisher, logout } from './helpers/auth';
+
+const SAMPLE_PUBLISHER = {
+  id: 'pub-test-1',
+  name: 'Test Publisher',
+  contactEmail: 'pub@example.test',
+  sourceUrl: 'https://example.com/feed.json',
+  sourceType: 'json' as const,
+  trustLevel: 'review' as const,
+  enabled: true,
+  paused: false,
+  createdAt: '2026-04-01T12:00:00.000Z',
+  applicationStatus: 'approved' as const,
+  organization: 'Acme',
+  lastFetchedAt: '2026-05-06T12:00:00.000Z',
+  lastFetchStatus: 'ok' as const,
+};
+
+describe('PublishStatusPage (integration)', () => {
+  let mock: FetchMock;
+  let nav: NavigationStub;
+
+  beforeEach(() => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+    nav.uninstall();
+    logout();
+  });
+
+  it('redirects to /publish/login/ when there is no publisher session', async () => {
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(nav.navigations()).toContain('/publish/login/');
+    });
+    // Should NOT have called the API.
+    expect(mock.calls('/api/publisher-status')).toHaveLength(0);
+  });
+
+  it('loads and renders the publisher record on mount', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', { publisher: SAMPLE_PUBLISHER });
+
+    renderPage(<PublishStatusPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Publisher details/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText('Test Publisher')).toBeInTheDocument();
+    expect(screen.getByText('pub-test-1')).toBeInTheDocument();
+    expect(screen.getByText(/Approved/)).toBeInTheDocument();
+  });
+
+  it('PATCHes /api/publisher-profile when the publisher edits the Name field', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', { publisher: SAMPLE_PUBLISHER });
+    mock.on('PATCH', '/api/publisher-profile', {
+      publisher: { ...SAMPLE_PUBLISHER, name: 'New Publisher Name' },
+    });
+
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(screen.getByText('Test Publisher')).toBeInTheDocument();
+    });
+    // Click the pencil for the Name field
+    fireEvent.click(screen.getByRole('button', { name: /Edit Name/i }));
+    // Then the input becomes labeled "Name"
+    fireEvent.input(screen.getByLabelText(/^Name$/), {
+      target: { value: 'New Publisher Name' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText('New Publisher Name')).toBeInTheDocument();
+    });
+    const calls = mock.calls('/api/publisher-profile');
+    expect(calls).toHaveLength(1);
+    expect(await calls[0].json()).toEqual({ name: 'New Publisher Name' });
+  });
+
+  it('opens the change-email modal and POSTs /api/publisher-email-change on submit', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', { publisher: SAMPLE_PUBLISHER });
+    mock.on('POST', '/api/publisher-email-change', { ok: true });
+
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Change email/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Change email/i }));
+
+    const dialog = screen.getByRole('dialog');
+    fireEvent.input(within(dialog).getByLabelText(/New email/i), {
+      target: { value: 'new-pub@example.test' },
+    });
+    // Submit the form (regression test for the react→preact/compat alias —
+    // if onChange/onInput normalisation breaks this submit silently fails).
+    fireEvent.submit(within(dialog).getByRole('button', { name: /Send confirmation link/i }).closest('form')!);
+
+    await waitFor(() => {
+      const calls = mock.calls('/api/publisher-email-change');
+      expect(calls).toHaveLength(1);
+    });
+    const body = await mock.calls('/api/publisher-email-change')[0].json();
+    expect(body).toEqual({ newEmail: 'new-pub@example.test' });
+  });
+
+  it('pauses the publisher via POST /api/publisher-pause when the user confirms', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', { publisher: SAMPLE_PUBLISHER });
+    mock.on('POST', '/api/publisher-pause', {
+      publisher: { ...SAMPLE_PUBLISHER, paused: true },
+    });
+
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Pause fetches/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Pause fetches/i }));
+    // Confirm modal
+    fireEvent.click(screen.getByRole('button', { name: /Pause anyway/i }));
+
+    await waitFor(() => {
+      expect(mock.calls('/api/publisher-pause')).toHaveLength(1);
+    });
+  });
+
+  it('triggers an immediate fetch via POST /api/publisher-fetch-now', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', { publisher: SAMPLE_PUBLISHER });
+    mock.on('POST', '/api/publisher-fetch-now', { acceptedAt: '2026-05-06T13:00:00.000Z' });
+
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^Fetch now$/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^Fetch now$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Fetch queued/i)).toBeInTheDocument();
+    });
+    expect(mock.calls('/api/publisher-fetch-now')).toHaveLength(1);
+  });
+
+  it('keeps the self-disable Confirm button disabled until the typed slug matches; then POSTs /api/publisher-disable and navigates away', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', { publisher: SAMPLE_PUBLISHER });
+    mock.on('POST', '/api/publisher-disable', {
+      ok: true,
+      emailedTo: 'pub@example.test',
+    });
+
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Disable my publisher/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Disable my publisher/i }));
+    const dialog = screen.getByRole('dialog');
+    const confirm = within(dialog).getByRole('button', { name: /Disable my publisher/i });
+    expect(confirm).toBeDisabled();
+    // Wrong slug — still disabled
+    fireEvent.input(within(dialog).getByLabelText(/Confirmation slug/i), {
+      target: { value: 'pub-wrong' },
+    });
+    expect(confirm).toBeDisabled();
+    // Right slug — enabled
+    fireEvent.input(within(dialog).getByLabelText(/Confirmation slug/i), {
+      target: { value: SAMPLE_PUBLISHER.id },
+    });
+    expect(confirm).not.toBeDisabled();
+    fireEvent.click(confirm);
+
+    await waitFor(() => {
+      expect(mock.calls('/api/publisher-disable')).toHaveLength(1);
+    });
+    await waitFor(() => {
+      expect(nav.navigations()).toContain('/publish/');
+    });
+  });
+
+  it('surfaces a top-level error when /api/publisher-status returns 500', async () => {
+    loginAsPublisher();
+    mock.on('GET', '/api/publisher-status', () =>
+      new Response(JSON.stringify({ error: 'database is on fire' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishStatusPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Could not load your status/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/database is on fire/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/integration/portalEmailChange.test.tsx
+++ b/frontend/src/__tests__/integration/portalEmailChange.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Integration tests for the email-change verify and cancel landing pages.
+ *
+ * Pages:
+ *  - frontend/src/app/publish/email-change/verify/page.tsx
+ *      GET /api/publisher-email-change/verify?token=...
+ *      kind=ok + newEmail   → window.location.replace('/publish/login/?email=&reason=email-changed')
+ *      kind=ok no newEmail  → renders "Email change verified"
+ *      kind=expired/...     → renders error
+ *  - frontend/src/app/publish/email-change/cancel/page.tsx
+ *      GET /api/publisher-email-change/cancel?token=...
+ *      kind=ok              → renders "Email change cancelled"
+ *      kind=expired/...     → renders error
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/preact';
+import PublishEmailChangeVerifyPage from '@/app/publish/email-change/verify/page';
+import PublishEmailChangeCancelPage from '@/app/publish/email-change/cancel/page';
+import { renderPage, installNavigationStub, type NavigationStub } from './helpers/render';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+
+describe('PublishEmailChangeVerifyPage (integration)', () => {
+  let mock: FetchMock;
+  let nav: NavigationStub;
+
+  beforeEach(() => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+    nav.uninstall();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('verifies a token and redirects to /publish/login/ with prefilled email', async () => {
+    window.history.replaceState({}, '', '/publish/email-change/verify/?token=tok-abc');
+    mock.on('GET', /\/api\/publisher-email-change\/verify/, {
+      kind: 'ok',
+      newEmail: 'new@example.test',
+    });
+
+    renderPage(<PublishEmailChangeVerifyPage />);
+
+    await waitFor(() => {
+      const navs = nav.navigations();
+      expect(navs.some(u => u.includes('/publish/login/'))).toBe(true);
+    });
+    const target = nav.navigations().find(u => u.includes('/publish/login/'))!;
+    expect(target).toContain('email=new%40example.test');
+    expect(target).toContain('reason=email-changed');
+
+    const calls = mock.calls(/\/api\/publisher-email-change\/verify/);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('token=tok-abc');
+  });
+
+  it('renders an error and does not navigate when the token is expired', async () => {
+    window.history.replaceState({}, '', '/publish/email-change/verify/?token=bad');
+    mock.on('GET', /\/api\/publisher-email-change\/verify/, {
+      kind: 'expired',
+    });
+
+    renderPage(<PublishEmailChangeVerifyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn.t confirm/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/expired/i)).toBeInTheDocument();
+    expect(nav.navigations()).toHaveLength(0);
+  });
+});
+
+describe('PublishEmailChangeCancelPage (integration)', () => {
+  let mock: FetchMock;
+  let nav: NavigationStub;
+
+  beforeEach(() => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+    nav.uninstall();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('cancels the pending change and renders the success page', async () => {
+    window.history.replaceState({}, '', '/publish/email-change/cancel/?token=cancel-tok');
+    mock.on('GET', /\/api\/publisher-email-change\/cancel/, {
+      kind: 'ok',
+      lockedUntil: '2026-06-01T00:00:00.000Z',
+    });
+
+    renderPage(<PublishEmailChangeCancelPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Email change cancelled/i)).toBeInTheDocument();
+    });
+    const calls = mock.calls(/\/api\/publisher-email-change\/cancel/);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('token=cancel-tok');
+  });
+});

--- a/frontend/src/__tests__/integration/portalLogin.test.tsx
+++ b/frontend/src/__tests__/integration/portalLogin.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Integration tests for /publish/login/ — publisher magic-link request.
+ * Also covers the verify landing page at /publish/verify/.
+ *
+ * Pages:
+ *  - frontend/src/app/publish/login/page.tsx — POST /api/publisher-auth/request
+ *  - frontend/src/app/publish/verify/page.tsx — POST /api/publisher-auth/verify
+ *                                              (or /api/publisher-apply/verify)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/preact';
+import PublishLoginPage from '@/app/publish/login/page';
+import PublishVerifyPage from '@/app/publish/verify/page';
+import { renderPage, installNavigationStub, type NavigationStub } from './helpers/render';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+import { logout } from './helpers/auth';
+import {
+  PUBLISHER_EMAIL_KEY,
+  PUBLISHER_ID_KEY,
+  PUBLISHER_JWT_KEY,
+} from '@/lib/publisherAuthClient';
+
+describe('PublishLoginPage (integration)', () => {
+  let mock: FetchMock;
+  let nav: NavigationStub;
+
+  beforeEach(() => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+    nav.uninstall();
+    logout();
+  });
+
+  it('submits the email and renders the "check your inbox" success state', async () => {
+    mock.on('POST', '/api/publisher-auth/request', { ok: true });
+
+    renderPage(<PublishLoginPage />);
+    fireEvent.input(screen.getByLabelText(/Email address/i), {
+      target: { value: 'me@example.test' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send sign-in link/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/sign-in link is on its way/i)).toBeInTheDocument();
+    });
+    const calls = mock.calls('/api/publisher-auth/request');
+    expect(calls).toHaveLength(1);
+    expect(await calls[0].json()).toEqual({ email: 'me@example.test' });
+  });
+
+  it('renders the rate-limit message on 429', async () => {
+    mock.on('POST', '/api/publisher-auth/request', () =>
+      new Response(JSON.stringify({ error: 'Too many sign-in requests.' }), {
+        status: 429,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishLoginPage />);
+    fireEvent.input(screen.getByLabelText(/Email address/i), {
+      target: { value: 'me@example.test' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Send sign-in link/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Too many sign-in requests/i)).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to /publish/status/ when an authenticated user lands on this page', async () => {
+    // Simulate an authenticated session: stash a JWT with a far-future exp.
+    const exp = Math.floor(Date.now() / 1000) + 3600;
+    const payload = btoa(JSON.stringify({ sub: 'pub-1', email: 'a@b.c', exp }))
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+    localStorage.setItem(PUBLISHER_JWT_KEY, `${header}.${payload}.sig`);
+    localStorage.setItem(PUBLISHER_ID_KEY, 'pub-1');
+    localStorage.setItem(PUBLISHER_EMAIL_KEY, 'a@b.c');
+
+    renderPage(<PublishLoginPage />);
+    await waitFor(() => {
+      expect(nav.navigations()).toContain('/publish/status/');
+    });
+  });
+});
+
+describe('PublishVerifyPage (integration)', () => {
+  let mock: FetchMock;
+  let nav: NavigationStub;
+  const originalSearch = window.location.search;
+
+  beforeEach(() => {
+    nav = installNavigationStub();
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+    nav.uninstall();
+    logout();
+    // Restore the URL search via history (we change it per-test to feed the
+    // page's URLSearchParams parsing).
+    window.history.replaceState({}, '', window.location.pathname + originalSearch);
+  });
+
+  it('verifies a login-purpose token and writes the publisher session', async () => {
+    window.history.replaceState({}, '', '/publish/verify/?token=abc&purpose=login');
+    mock.on('POST', '/api/publisher-auth/verify', {
+      jwt: 'jwt-here',
+      publisherId: 'pub-test-1',
+      email: 'me@example.test',
+    });
+
+    renderPage(<PublishVerifyPage />);
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Signed in/i })).toBeInTheDocument();
+    });
+    expect(localStorage.getItem(PUBLISHER_JWT_KEY)).toBe('jwt-here');
+    expect(localStorage.getItem(PUBLISHER_ID_KEY)).toBe('pub-test-1');
+    expect(localStorage.getItem(PUBLISHER_EMAIL_KEY)).toBe('me@example.test');
+  });
+
+  it('renders an error and writes no session when the token is invalid', async () => {
+    window.history.replaceState({}, '', '/publish/verify/?token=bad&purpose=login');
+    mock.on('POST', '/api/publisher-auth/verify', () =>
+      new Response(JSON.stringify({ error: 'Invalid or expired token.' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishVerifyPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn.t verify/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Invalid or expired token/i)).toBeInTheDocument();
+    expect(localStorage.getItem(PUBLISHER_JWT_KEY)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/integration/portalLogin.test.tsx
+++ b/frontend/src/__tests__/integration/portalLogin.test.tsx
@@ -14,7 +14,7 @@ import PublishLoginPage from '@/app/publish/login/page';
 import PublishVerifyPage from '@/app/publish/verify/page';
 import { renderPage, installNavigationStub, type NavigationStub } from './helpers/render';
 import { installFetchMock, type FetchMock } from './helpers/fetchMock';
-import { logout } from './helpers/auth';
+import { logout, loginAsPublisher } from './helpers/auth';
 import {
   PUBLISHER_EMAIL_KEY,
   PUBLISHER_ID_KEY,
@@ -77,19 +77,9 @@ describe('PublishLoginPage (integration)', () => {
   });
 
   it('redirects to /publish/status/ when an authenticated user lands on this page', async () => {
-    // Simulate an authenticated session: stash a JWT with a far-future exp.
-    const exp = Math.floor(Date.now() / 1000) + 3600;
-    const payload = btoa(JSON.stringify({ sub: 'pub-1', email: 'a@b.c', exp }))
-      .replace(/=+$/, '')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_');
-    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
-      .replace(/=+$/, '')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_');
-    localStorage.setItem(PUBLISHER_JWT_KEY, `${header}.${payload}.sig`);
-    localStorage.setItem(PUBLISHER_ID_KEY, 'pub-1');
-    localStorage.setItem(PUBLISHER_EMAIL_KEY, 'a@b.c');
+    // Use the shared helper rather than hand-rolling a JWT — it mirrors the
+    // app's localStorage contract and synthesizes a valid `exp` claim.
+    loginAsPublisher({ publisherId: 'pub-1', email: 'a@b.c' });
 
     renderPage(<PublishLoginPage />);
     await waitFor(() => {

--- a/frontend/src/__tests__/integration/portalLogin.test.tsx
+++ b/frontend/src/__tests__/integration/portalLogin.test.tsx
@@ -91,9 +91,10 @@ describe('PublishLoginPage (integration)', () => {
 describe('PublishVerifyPage (integration)', () => {
   let mock: FetchMock;
   let nav: NavigationStub;
-  const originalSearch = window.location.search;
+  let originalSearch: string;
 
   beforeEach(() => {
+    originalSearch = window.location.search;
     nav = installNavigationStub();
     mock = installFetchMock();
   });

--- a/frontend/src/__tests__/integration/publishTest.test.tsx
+++ b/frontend/src/__tests__/integration/publishTest.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Integration tests for /publish/test/ — the public feed validator.
+ *
+ * Page: frontend/src/app/publish/test/page.tsx
+ * Endpoint: POST /api/publisher-test
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/preact';
+import PublishTestPage from '@/app/publish/test/page';
+import { renderPage } from './helpers/render';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+
+const SAMPLE_FEED_OK = {
+  fetchStatus: 'ok',
+  feed: {
+    formatVersion: '1.0.0',
+    publisher: {
+      id: 'pub-demo',
+      name: 'Demo Publisher',
+      contactEmail: 'demo@example.com',
+    },
+    events: [
+      {
+        id: 'evt-1',
+        title: 'Sample Event',
+        startDate: '2026-07-01T18:00:00.000Z',
+        endDate: '2026-07-01T19:00:00.000Z',
+        category: 'lecture',
+        lastModified: '2026-06-15T00:00:00.000Z',
+      },
+    ],
+  },
+  report: { ok: true, errors: [], warnings: [] },
+};
+
+describe('PublishTestPage (integration)', () => {
+  let mock: FetchMock;
+
+  beforeEach(() => {
+    mock = installFetchMock();
+  });
+
+  afterEach(() => {
+    mock.uninstall();
+  });
+
+  it('rejects an empty URL with a client-side error and does not call the API', () => {
+    renderPage(<PublishTestPage />);
+    // Form has `required` so submit is blocked by the browser, but in jsdom
+    // we get an explicit click-then-error path. Click the button directly.
+    const button = screen.getByRole('button', { name: /Test feed/i });
+    fireEvent.click(button);
+    // Either the browser blocks via required, or the page surfaces "Please enter a URL".
+    // Either way, no fetch call.
+    expect(mock.calls('/api/publisher-test')).toHaveLength(0);
+  });
+
+  it('submits the URL + sourceType payload and renders the parsed event count on success', async () => {
+    mock.on('POST', '/api/publisher-test', SAMPLE_FEED_OK);
+
+    renderPage(<PublishTestPage />);
+    fireEvent.input(screen.getByLabelText(/Feed URL/i), {
+      target: { value: 'https://example.com/feed.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Test feed/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Feed OK/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/1 event parsed/i)).toBeInTheDocument();
+    expect(screen.getByText(/Sample Event/)).toBeInTheDocument();
+    const calls = mock.calls('/api/publisher-test');
+    expect(calls).toHaveLength(1);
+    const body = await calls[0].json();
+    expect(body).toMatchObject({
+      url: 'https://example.com/feed.json',
+      sourceType: 'json',
+    });
+  });
+
+  it('renders validation errors with path and message', async () => {
+    mock.on('POST', '/api/publisher-test', {
+      fetchStatus: 'validation_error',
+      feed: null,
+      report: {
+        ok: false,
+        errors: [
+          { path: 'events[0].title', message: 'must be a non-empty string' },
+        ],
+        warnings: [],
+      },
+    });
+
+    renderPage(<PublishTestPage />);
+    fireEvent.input(screen.getByLabelText(/Feed URL/i), {
+      target: { value: 'https://example.com/bad.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Test feed/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Validation error/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/events\[0\]\.title/)).toBeInTheDocument();
+    expect(screen.getByText(/must be a non-empty string/)).toBeInTheDocument();
+  });
+
+  it('renders a network/server-error banner on 500', async () => {
+    mock.on('POST', '/api/publisher-test', () =>
+      new Response(JSON.stringify({ error: 'upstream blew up' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    );
+
+    renderPage(<PublishTestPage />);
+    fireEvent.input(screen.getByLabelText(/Feed URL/i), {
+      target: { value: 'https://example.com/x.json' },
+    });
+    fireEvent.submit(
+      screen.getByRole('button', { name: /Test feed/i }).closest('form')!,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Server error/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/upstream blew up/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/integration/smoke.test.tsx
+++ b/frontend/src/__tests__/integration/smoke.test.tsx
@@ -1,0 +1,9 @@
+import { render } from '@testing-library/preact';
+import { describe, it, expect } from 'vitest';
+
+describe('vitest smoke', () => {
+  it('renders a div with preact and finds it via testing-library', () => {
+    const { getByText } = render(<div>hello</div>);
+    expect(getByText('hello')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -1,4 +1,6 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/vitest';
+import { afterEach } from 'vitest';
+import { cleanup } from '@testing-library/preact';
 
 // Mock localStorage
 const localStorageMock = (() => {
@@ -14,3 +16,9 @@ const localStorageMock = (() => {
 })();
 
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
+
+// Clean up between tests so DOM and storage don't bleed across cases.
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -16,5 +16,10 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'lcov', 'json-summary'],
+      exclude: ['out/**', 'src/**/__tests__/**', '**/*.test.{ts,tsx}'],
+    },
   },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,11 +78,13 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@typescript-eslint/eslint-plugin": "^8",
         "@typescript-eslint/parser": "^8",
+        "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^9",
         "jsdom": "^28.1.0",
         "tailwindcss": "^4",
@@ -6129,9 +6131,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
-      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7914,6 +7916,20 @@
         "preact": ">=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0"
       }
     },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
@@ -8630,32 +8646,73 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@vitest/expect": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
-      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+      "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.5",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.5",
+        "vitest": "4.1.5"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/coverage-v8/node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "chai": "^6.2.1",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
-      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.0.18",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -8664,7 +8721,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -8686,26 +8743,26 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
-      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^3.0.3"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
-      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.0.18",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -8713,13 +8770,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
-      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -8728,9 +8786,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
-      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -8738,14 +8796,15 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
-      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.0.18",
-        "tinyrainbow": "^3.0.3"
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -8981,6 +9040,35 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async": {
       "version": "3.2.6",
@@ -10484,9 +10572,9 @@
       "license": "MIT"
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -12389,9 +12477,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
-      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -14496,6 +14584,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
     "node_modules/make-dir": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -16162,9 +16262,9 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -16496,9 +16596,9 @@
       }
     },
     "node_modules/tinyrainbow": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
-      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -17540,31 +17640,31 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.0.18",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
-      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.0.18",
-        "@vitest/mocker": "4.0.18",
-        "@vitest/pretty-format": "4.0.18",
-        "@vitest/runner": "4.0.18",
-        "@vitest/snapshot": "4.0.18",
-        "@vitest/spy": "4.0.18",
-        "@vitest/utils": "4.0.18",
-        "es-module-lexer": "^1.7.0",
-        "expect-type": "^1.2.2",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
         "obug": "^2.1.1",
         "pathe": "^2.0.3",
         "picomatch": "^4.0.3",
-        "std-env": "^3.10.0",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
-        "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -17580,12 +17680,15 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.0.18",
-        "@vitest/browser-preview": "4.0.18",
-        "@vitest/browser-webdriverio": "4.0.18",
-        "@vitest/ui": "4.0.18",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
@@ -17606,6 +17709,12 @@
         "@vitest/browser-webdriverio": {
           "optional": true
         },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
         "@vitest/ui": {
           "optional": true
         },
@@ -17614,6 +17723,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/preact": "^3.2.4",
-        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -7914,20 +7913,6 @@
       },
       "peerDependencies": {
         "preact": ">=10 || ^10.0.0-alpha.0 || ^10.0.0-beta.0"
-      }
-    },
-    "node_modules/@testing-library/user-event": {
-      "version": "14.6.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
-      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tsconfig/node10": {


### PR DESCRIPTION
## Summary
- Vitest + jsdom + `@testing-library/preact` integration test suite for every publisher-portal frontend page (apply, publish/test, portal, login, email-change, admin publishers).
- Each test mocks `fetch` and drives the page state machine through user events.
- One form-submission test in `portal.test.tsx` pins the `react` → `preact/compat` alias gotcha called out in CLAUDE.md.
- Frontend `npm run build` now chains `test:ci` so the build fails on any test regression.

Implements the plan at `docs/plans/2026-05-06-frontend-portal-integration-tests-plan.md`.

## Test plan
- [x] `npm run test --workspace=frontend` passes locally (250/250)
- [x] `npm run build --workspace=frontend` runs tests and fails on a deliberately-broken assertion
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>