### PR TITLE
fix(integration): mock verifyCaptchaWithBypass for the captcha toggle

### DIFF
--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -113,14 +113,21 @@ function installSecretMock() {
 }
 
 // Mock the captcha verifier to always go through our toggle.
+// publisherPortalHandler calls verifyCaptchaWithBypass (the smoke-bypass wrapper added in PR #105),
+// so we intercept that entry point too — otherwise the wrapper's internal call to verifyCaptcha
+// uses the imported reference and bypasses jest.spyOn on the module export.
 let _captchaMockInstalled = false;
 let _captchaToggleRef: CaptchaToggle | null = null;
 function installCaptchaMock() {
   if (_captchaMockInstalled) return;
-  jest.spyOn(captchaModule, 'verifyCaptcha').mockImplementation(async (token, action) => {
+  const toggleVerify = async (token: string, action: string | undefined) => {
     if (!_captchaToggleRef) return true;
     return _captchaToggleRef.verify(token, action);
-  });
+  };
+  jest.spyOn(captchaModule, 'verifyCaptcha').mockImplementation(toggleVerify);
+  jest
+    .spyOn(captchaModule, 'verifyCaptchaWithBypass')
+    .mockImplementation(async (token, action, _headers) => toggleVerify(token, action));
   _captchaMockInstalled = true;
 }
 


### PR DESCRIPTION
## Summary
- Bug introduced by the merge interaction of #105 + #106 (each green individually).
- #105 changed `publisherPortalHandler.apply` to call `verifyCaptchaWithBypass`. #106's integration harness mocked only the inner `verifyCaptcha` via `jest.spyOn`. The wrapper's internal call to `verifyCaptcha` uses the imported reference and bypasses the spy, so `h.captcha.fail()` had no effect on the apply path.
- After both PRs merged, `integration/authAndLimits.test.ts` "apply with failing CAPTCHA returns 400" started failing on main.
- Fix: also spy on `verifyCaptchaWithBypass` and route it through the same `CaptchaToggle`.

## Test plan
- [x] `npm test --workspace=backend` green locally (49 suites, 704 tests, was failing 1 before fix)
- [ ] CI green on this PR