### PR TITLE
chore(ci): enforce frontend line coverage floor (74.3%)

### DIFF
--- a/.coverage-floor.json
+++ b/.coverage-floor.json
@@ -1,4 +1,4 @@
 {
   "backend": { "lines": 81.1 },
-  "frontend": { "lines": 0 }
+  "frontend": { "lines": 74.3 }
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vitest/config';
 import preact from '@preact/preset-vite';
 import { resolve } from 'path';
+import floor from '../.coverage-floor.json';
 
 export default defineConfig({
   plugins: [preact()],
@@ -20,6 +21,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: ['text', 'lcov', 'json-summary'],
       exclude: ['out/**', 'src/**/__tests__/**', '**/*.test.{ts,tsx}'],
+      thresholds: { lines: floor.frontend.lines },
     },
   },
 });


### PR DESCRIPTION
## Summary
- Plan 4 Task 5 follow-up — gated on PR #107 landing, which it now has.
- Sets `.coverage-floor.json` `frontend.lines` to 74.3 (measured 74.81% − 0.5%, per the same picking rule used for backend).
- Adds `coverage.thresholds: { lines: floor.frontend.lines }` to `frontend/vitest.config.ts`, sourced from the same root JSON as the backend Jest threshold.
- Verified: passes at 74.3; fails when temporarily bumped to 99.9.

## Test plan
- [x] `npm run test:ci --workspace=frontend` passes locally
- [x] `npm run build --workspace=frontend` (chained `test:ci`) green
- [ ] CI green on this PR