### PR TITLE
Publisher observability: ingest history, per-event status, notifications

### DIFF
--- a/backend/src/__tests__/adminHandler.publishers.test.ts
+++ b/backend/src/__tests__/adminHandler.publishers.test.ts
@@ -263,3 +263,131 @@ describe('POST /publishers/run-ingest', () => {
     errSpy.mockRestore();
   });
 });
+
+describe('POST /publisher-events/:pid/:eid/reject', () => {
+  it('passes reason from body to rejectEvent and returns 204', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockResolvedValue(undefined);
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({
+        path: '/publisher-events/pub-1/evt-1/reject',
+        httpMethod: 'POST',
+        body: JSON.stringify({ reason: 'duplicate' }),
+      }),
+      ctx,
+    );
+
+    expect(r.statusCode).toBe(204);
+    expect(stub.rejectEvent).toHaveBeenCalledWith('pub-1', 'evt-1', 'duplicate');
+  });
+
+  it('passes reason=undefined when body is empty', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockResolvedValue(undefined);
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({ path: '/publisher-events/pub-1/evt-1/reject', httpMethod: 'POST', body: null }),
+      ctx,
+    );
+
+    expect(r.statusCode).toBe(204);
+    expect(stub.rejectEvent).toHaveBeenCalledWith('pub-1', 'evt-1', undefined);
+  });
+
+  it('normalizes whitespace-only reason to undefined', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockResolvedValue(undefined);
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({
+        path: '/publisher-events/pub-1/evt-1/reject',
+        httpMethod: 'POST',
+        body: JSON.stringify({ reason: '   ' }),
+      }),
+      ctx,
+    );
+
+    expect(r.statusCode).toBe(204);
+    expect(stub.rejectEvent).toHaveBeenCalledWith('pub-1', 'evt-1', undefined);
+  });
+
+  it('slices reason longer than 500 chars to 500', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockResolvedValue(undefined);
+    _setPublisherAdminForTests(stub as any);
+
+    const longReason = 'x'.repeat(600);
+    const r = await handler(
+      evt({
+        path: '/publisher-events/pub-1/evt-1/reject',
+        httpMethod: 'POST',
+        body: JSON.stringify({ reason: longReason }),
+      }),
+      ctx,
+    );
+
+    expect(r.statusCode).toBe(204);
+    const calledWith = stub.rejectEvent.mock.calls[0][2] as string;
+    expect(calledWith.length).toBe(500);
+  });
+
+  it('returns 400 when body is present but malformed JSON (global early-exit before route handler)', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockResolvedValue(undefined);
+    _setPublisherAdminForTests(stub as any);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const r = await handler(
+      evt({
+        path: '/publisher-events/pub-1/evt-1/reject',
+        httpMethod: 'POST',
+        body: 'not-json{{{',
+      }),
+      ctx,
+    );
+
+    // The adminHandler parses the body at the top level and short-circuits
+    // with 400 before reaching the reject route logic.
+    expect(r.statusCode).toBe(400);
+    expect(stub.rejectEvent).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('decodes URL-encoded ids before passing them to rejectEvent', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockResolvedValue(undefined);
+    _setPublisherAdminForTests(stub as any);
+
+    const r = await handler(
+      evt({
+        path: '/publisher-events/pub%2F1/evt%201/reject',
+        httpMethod: 'POST',
+        body: null,
+      }),
+      ctx,
+    );
+
+    expect(r.statusCode).toBe(204);
+    expect(stub.rejectEvent).toHaveBeenCalledWith('pub/1', 'evt 1', undefined);
+  });
+
+  it('returns 500 when rejectEvent throws', async () => {
+    const stub = mkAdmin();
+    stub.rejectEvent.mockRejectedValue(new Error('DDB exploded'));
+    _setPublisherAdminForTests(stub as any);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    const r = await handler(
+      evt({ path: '/publisher-events/pub-1/evt-1/reject', httpMethod: 'POST', body: null }),
+      ctx,
+    );
+
+    expect(r.statusCode).toBe(500);
+    expect(JSON.parse(r.body).error).toMatch(/Failed to reject event/);
+    errSpy.mockRestore();
+  });
+});

--- a/backend/src/__tests__/integration/adminControls.test.ts
+++ b/backend/src/__tests__/integration/adminControls.test.ts
@@ -76,17 +76,18 @@ describe('admin controls', () => {
     expect(await h.events.statesOf(publisherId)).toEqual({ 'evt-bad': 'pending' });
 
     await h.actors.admin.rejectEvent(publisherId, 'evt-bad');
-    expect(await h.events.count(publisherId)).toBe(0);
+    // Soft-delete: event is now marked state='rejected' (not hard-deleted).
+    expect(await h.events.statesOf(publisherId)).toEqual({ 'evt-bad': 'rejected' });
 
-    // Re-ingest with bumped lastModified — re-emerges as pending (no automatic
-    // suppression yet; reject is a delete and the next feed pull recreates it).
+    // Re-ingest with bumped lastModified — rejected state is preserved (no clobber).
+    // The event stays rejected even when the feed is refreshed.
     h.feeds.set(publisherId, feedOk(publisherId, 'X', [
       { id: 'evt-bad', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-02T00:00:00Z' },
     ]));
     await h.actors.ingest.run();
-    // It DOES come back as pending — but is NOT auto-published, which is the
-    // important guarantee. (A future enhancement could persist a tombstone.)
-    expect(await h.events.statesOf(publisherId)).toEqual({ 'evt-bad': 'pending' });
+    // Rejected state is sticky — re-ingest preserves it, which is the important
+    // guarantee: once an event is rejected, re-ingestion will not resurrect it.
+    expect(await h.events.statesOf(publisherId)).toEqual({ 'evt-bad': 'rejected' });
   });
 
   it('admin approve event idempotent: approving an already-published event throws 409', async () => {

--- a/backend/src/__tests__/integration/harness/actors.ts
+++ b/backend/src/__tests__/integration/harness/actors.ts
@@ -24,6 +24,8 @@ import {
   handlePublisherPause,
   handlePublisherResume,
   handlePublisherDisable,
+  handlePublisherRuns,
+  handlePublisherEvents,
 } from '../../../handlers/publisherPortalHandler';
 import { handler as adminHandler } from '../../../handlers/adminHandler';
 import type { ApplyFormPayload } from '../../../types/publisher';
@@ -104,6 +106,8 @@ export interface PublisherActor {
   resume(jwtToken: string): Promise<{ publisher: any }>;
   fetchNow(jwtToken: string): Promise<{ acceptedAt: string }>;
   selfDisable(jwtToken: string, confirmSlug: string): Promise<{ ok: true; emailedTo: string }>;
+  runs(jwtToken: string): Promise<{ runs: Array<any> }>;
+  events(jwtToken: string): Promise<{ events: Array<any> }>;
 }
 
 // ─── Admin actor (routed through adminHandler with bypass) ─────────────
@@ -116,7 +120,7 @@ export interface AdminActor {
   resume(publisherId: string): Promise<{ publisher: any }>;
   disable(publisherId: string): Promise<{ publisher: any }>;
   approveEvent(publisherId: string, eventId: string): Promise<void>;
-  rejectEvent(publisherId: string, eventId: string): Promise<void>;
+  rejectEvent(publisherId: string, eventId: string, reason?: string): Promise<void>;
   runIngest(reviewerEmail?: string): Promise<{ triggeredAt: string }>;
 }
 
@@ -266,6 +270,20 @@ export function buildActors(h: Harness): Actors {
       );
       return unwrap(r);
     },
+    async runs(jwtToken) {
+      const r = await handlePublisherRuns(
+        buildEvent({ method: 'GET', path: '/publisher-runs', headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
+    async events(jwtToken) {
+      const r = await handlePublisherEvents(
+        buildEvent({ method: 'GET', path: '/publisher-events', headers: { Authorization: `Bearer ${jwtToken}` } }),
+        {},
+      );
+      return unwrap(r);
+    },
   };
 
   const admin: AdminActor = {
@@ -322,10 +340,11 @@ export function buildActors(h: Harness): Actors {
       });
       if (r.statusCode !== 204) unwrap(r);
     },
-    async rejectEvent(publisherId, eventId) {
+    async rejectEvent(publisherId, eventId, reason) {
       const r = await callAdmin({
         method: 'POST',
         path: `/publisher-events/${encodeURIComponent(publisherId)}/${encodeURIComponent(eventId)}/reject`,
+        body: reason !== undefined ? { reason } : {},
       });
       if (r.statusCode !== 204) unwrap(r);
     },

--- a/backend/src/__tests__/integration/harness/fakes.ts
+++ b/backend/src/__tests__/integration/harness/fakes.ts
@@ -18,6 +18,9 @@ import type {
   EmailChangeCommittedOpts,
   EmailChangeCancelledOpts,
   SelfDisabledConfirmationOpts,
+  IngestFailureEmailOpts,
+  IngestRecoveryEmailOpts,
+  EventRejectedEmailOpts,
 } from '../../../services/mailService';
 import type {
   RateLimiter,
@@ -59,7 +62,10 @@ export type SentMailKind =
   | 'email_change_warning'
   | 'email_change_committed'
   | 'email_change_cancelled'
-  | 'self_disabled_confirmation';
+  | 'self_disabled_confirmation'
+  | 'ingest_failure'
+  | 'ingest_recovery'
+  | 'event_rejected';
 
 export interface SentMail {
   kind: SentMailKind;
@@ -104,6 +110,18 @@ export class MailCapture implements MailService {
   }
   async sendSelfDisabledConfirmation(opts: SelfDisabledConfirmationOpts) {
     this.sent.push({ kind: 'self_disabled_confirmation', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendIngestFailureEmail(opts: IngestFailureEmailOpts) {
+    this.sent.push({ kind: 'ingest_failure', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendIngestRecoveryEmail(opts: IngestRecoveryEmailOpts) {
+    this.sent.push({ kind: 'ingest_recovery', to: opts.to, data: { ...opts } });
+    return { messageId: `mid-${this.sent.length}` };
+  }
+  async sendEventRejectedEmail(opts: EventRejectedEmailOpts) {
+    this.sent.push({ kind: 'event_rejected', to: opts.to, data: { ...opts } });
     return { messageId: `mid-${this.sent.length}` };
   }
 

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -35,6 +35,7 @@ import { PublisherApplicationService } from '../../../services/publisherApplicat
 import { PublisherEmailChangeService } from '../../../services/publisherEmailChangeService';
 import { PublisherAdminService } from '../../../services/publisherAdminService';
 import { MagicTokenService } from '../../../services/magicTokenService';
+import type { StoredPublisherEvent } from '../../../types/publisher';
 import { runIngest, type IngestDeps } from '../../../handlers/publisherIngestHandler';
 import * as portal from '../../../handlers/publisherPortalHandler';
 import * as admin from '../../../handlers/adminHandler';
@@ -85,7 +86,7 @@ export interface Harness {
   signSession: (publisherId: string, opts?: { tokenVersion?: number; email?: string }) => Promise<string>;
   /** Returns event states for a publisher: { [eventId]: state }. */
   events: {
-    statesOf: (publisherId: string) => Promise<Record<string, 'published' | 'pending'>>;
+    statesOf: (publisherId: string) => Promise<Record<string, StoredPublisherEvent['state']>>;
     count: (publisherId: string) => Promise<number>;
   };
   /** Lazily-imported actor wrappers. Set after createHarness completes. */
@@ -227,7 +228,7 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
   const events = {
     statesOf: async (publisherId: string) => {
       const all = await store.listForPublisher(publisherId);
-      const out: Record<string, 'published' | 'pending'> = {};
+      const out: Record<string, StoredPublisherEvent['state']> = {};
       for (const e of all) out[e.eventId] = e.state;
       return out;
     },

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -35,6 +35,8 @@ import { PublisherApplicationService } from '../../../services/publisherApplicat
 import { PublisherEmailChangeService } from '../../../services/publisherEmailChangeService';
 import { PublisherAdminService } from '../../../services/publisherAdminService';
 import { MagicTokenService } from '../../../services/magicTokenService';
+import { PublisherIngestRunStore } from '../../../services/publisherIngestRunStore';
+import { PublisherNotificationService } from '../../../services/publisherNotificationService';
 import type { StoredPublisherEvent } from '../../../types/publisher';
 import { runIngest, type IngestDeps } from '../../../handlers/publisherIngestHandler';
 import * as portal from '../../../handlers/publisherPortalHandler';
@@ -53,6 +55,7 @@ const PUBLISHERS_TABLE = 'publishers';
 const PUBLISHER_EVENTS_TABLE = 'publisher-events';
 const MAGIC_TOKENS_TABLE = 'magic-tokens';
 const RATE_LIMIT_TABLE = 'rate-limit';
+const PUBLISHER_INGEST_RUNS_TABLE = 'publisher-ingest-runs';
 
 const TABLE_SPECS: TableSpec[] = [
   { name: PUBLISHERS_TABLE, hashKey: 'id' },
@@ -64,6 +67,7 @@ const TABLE_SPECS: TableSpec[] = [
   },
   { name: MAGIC_TOKENS_TABLE, hashKey: 'tokenHash' },
   { name: RATE_LIMIT_TABLE, hashKey: 'id' },
+  { name: PUBLISHER_INGEST_RUNS_TABLE, hashKey: 'publisherId', sortKey: 'runAt' },
 ];
 
 export interface Harness {
@@ -183,6 +187,11 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
   // Set up ingest. The Lambda invoker (used by both /publisher-fetch-now and
   // /publishers/run-ingest) routes back to runIngest in-process so a single
   // harness run can drive both the API call and the resulting ingest.
+  const runStore = new PublisherIngestRunStore(docClient, PUBLISHER_INGEST_RUNS_TABLE);
+  const notifier = new PublisherNotificationService({
+    mail,
+    portalUrl: 'https://test.chqcal.local/publish/status/',
+  });
   const ingestDeps: IngestDeps = {
     registry,
     store,
@@ -190,6 +199,8 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
     fetcher: feeds.fetchFn,
     now: nowFn(),
     publishersTableName: PUBLISHERS_TABLE,
+    runStore,
+    notifier,
   };
   const runIngestInProcess = async (payload: { singlePublisherId?: string } = {}) => {
     // Refresh deps.now to reflect the current clock.

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -179,11 +179,6 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
     siteBaseUrl: 'https://test.chqcal.local',
     now: nowFn,
   });
-  const adminService = new PublisherAdminService(registry, store, {
-    mail,
-    siteBaseUrl: 'https://test.chqcal.local',
-  });
-
   // Set up ingest. The Lambda invoker (used by both /publisher-fetch-now and
   // /publishers/run-ingest) routes back to runIngest in-process so a single
   // harness run can drive both the API call and the resulting ingest.
@@ -191,6 +186,12 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
   const notifier = new PublisherNotificationService({
     mail,
     portalUrl: 'https://test.chqcal.local/publish/status/',
+  });
+
+  const adminService = new PublisherAdminService(registry, store, {
+    mail,
+    siteBaseUrl: 'https://test.chqcal.local',
+    notifier,
   });
   const ingestDeps: IngestDeps = {
     registry,
@@ -216,6 +217,8 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
   // previously-captured value). This is safe because every test file
   // builds a new harness in beforeEach and tears it down in afterEach.
   portal._setStatusRegistryForTests(registry);
+  portal._setRunStoreForTests(runStore);
+  portal._setEventStoreForTests(store);
   portal._setAppServiceForTests(appService);
   portal._setEmailChangeServiceForTests(emailChangeService);
   portal._setSelfDisableDepsForTests({
@@ -290,6 +293,8 @@ export async function createHarness(opts: CreateHarnessOpts = {}): Promise<Harne
     jwtSecret: TEST_JWT_SECRET,
     dispose: () => {
       portal._setStatusRegistryForTests(null);
+      portal._setRunStoreForTests(null);
+      portal._setEventStoreForTests(null);
       portal._setAppServiceForTests(null);
       portal._setEmailChangeServiceForTests(null);
       portal._setSelfDisableDepsForTests(null);

--- a/backend/src/__tests__/integration/publisherRunsAndEvents.test.ts
+++ b/backend/src/__tests__/integration/publisherRunsAndEvents.test.ts
@@ -1,0 +1,196 @@
+// Integration coverage for publisher observability endpoints (Task 20):
+//   GET /publisher-runs   — last N ingest run rows for the calling publisher
+//   GET /publisher-events — the calling publisher's events (all states)
+// Plus the admin-reject-with-reason → notification email path, end-to-end.
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, feedOk, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
+
+async function applyApproveAndSession(
+  h: Harness,
+  email: string,
+  name = 'Test',
+  sourceUrl = 'https://example.com/feed.json',
+): Promise<{ publisherId: string; session: string }> {
+  await h.actors.publisher.apply({ name, email, sourceUrl, sourceType: 'json' });
+  const url = h.mail.lastTo(email)!.data.magicLinkUrl as string;
+  const token = tokenFromMagicLink(url);
+  const v = await h.actors.publisher.verifyApplyMagicLink(token);
+  await h.actors.admin.approveApplication(v.publisherId);
+  const session = await h.signSession(v.publisherId);
+  return { publisherId: v.publisherId, session };
+}
+
+describe('publisher observability — /publisher-runs and /publisher-events', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('returns runs and events scoped to the JWT publisher', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'obs1@example.com');
+    // Auto-trust so events publish without admin approval.
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'auto' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+      { id: 'e2', startDate: '2026-08-02T10:00:00Z', endDate: '2026-08-02T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    const runsResp = await h.actors.publisher.runs(session);
+    expect(runsResp.runs.length).toBe(1);
+    expect(runsResp.runs[0].publisherId).toBe(publisherId);
+    expect(runsResp.runs[0].status).toBe('ok');
+    expect(runsResp.runs[0].counts).toEqual({ added: 2, updated: 0, retracted: 0, unchanged: 0 });
+
+    const eventsResp = await h.actors.publisher.events(session);
+    expect(eventsResp.events.length).toBe(2);
+    for (const e of eventsResp.events) {
+      expect(e.state).toBe('published');
+      expect(typeof e.title).toBe('string');
+      // The full feed payload should NOT leak into the response.
+      expect((e as any).payload).toBeUndefined();
+    }
+  });
+
+  it('cross-publisher isolation: pub-A JWT cannot see pub-B events or runs', async () => {
+    const a = await applyApproveAndSession(h, 'a@example.com', 'A');
+    const b = await applyApproveAndSession(h, 'b@example.com', 'B');
+    await h.registry.upsert({ ...((await h.registry.get(a.publisherId))!), trustLevel: 'auto' });
+    await h.registry.upsert({ ...((await h.registry.get(b.publisherId))!), trustLevel: 'auto' });
+    h.feeds.set(a.publisherId, feedOk(a.publisherId, 'A', [
+      { id: 'a1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    h.feeds.set(b.publisherId, feedOk(b.publisherId, 'B', [
+      { id: 'b1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+      { id: 'b2', startDate: '2026-08-02T10:00:00Z', endDate: '2026-08-02T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    const aEvents = await h.actors.publisher.events(a.session);
+    expect(aEvents.events.map((e: any) => e.eventId).sort()).toEqual(['a1']);
+
+    const bEvents = await h.actors.publisher.events(b.session);
+    expect(bEvents.events.map((e: any) => e.eventId).sort()).toEqual(['b1', 'b2']);
+
+    const aRuns = await h.actors.publisher.runs(a.session);
+    expect(aRuns.runs.every((r: any) => r.publisherId === a.publisherId)).toBe(true);
+
+    const bRuns = await h.actors.publisher.runs(b.session);
+    expect(bRuns.runs.every((r: any) => r.publisherId === b.publisherId)).toBe(true);
+  });
+
+  it('runs reflect streak transitions: ok → fail → ok', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'streak@example.com');
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'auto' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    // Advance clock so the second run gets a distinct runAt sort key.
+    h.now.advance(60_000);
+
+    // Simulate a fetch failure by overwriting the feed fixture with a
+    // network_error response. The harness FakeFeedFetcher returns whatever
+    // was last set for a given publisherId.
+    h.feeds.set(publisherId, {
+      fetchStatus: 'network_error',
+      feed: null,
+      report: { ok: false, errors: [{ path: '/', message: 'simulated failure' }], warnings: [] },
+    });
+    await h.actors.ingest.run();
+
+    // Advance clock again and restore the working feed.
+    h.now.advance(60_000);
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    const runs = await h.actors.publisher.runs(session);
+    expect(runs.runs.length).toBe(3);
+    // listRecentRuns returns newest-first (ScanIndexForward: false).
+    expect(runs.runs[0].status).toBe('ok');
+    expect(runs.runs[1].status).not.toBe('ok');
+    expect(runs.runs[2].status).toBe('ok');
+  });
+
+  it('admin reject with reason: event becomes state=rejected with reason; notification email captured', async () => {
+    const { publisherId } = await applyApproveAndSession(h, 'reject@example.com');
+    // Use review trustLevel so events stay state='pending' awaiting admin action.
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'review' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    h.mail.clear();
+
+    await h.actors.admin.rejectEvent(publisherId, 'e1', 'duplicate of upstream feed');
+
+    // The stored row should now be state='rejected' with the reason preserved.
+    const states = await h.events.statesOf(publisherId);
+    expect(states['e1']).toBe('rejected');
+
+    // The publisher contactEmail should have received an event_rejected mail.
+    const sent = h.mail.lastTo('reject@example.com');
+    expect(sent).toBeTruthy();
+    expect(sent!.kind).toBe('event_rejected');
+    expect(sent!.data.reason).toBe('duplicate of upstream feed');
+  });
+
+  it('admin reject without reason: event becomes state=rejected; notification email sent with no reason', async () => {
+    const { publisherId } = await applyApproveAndSession(h, 'reject2@example.com');
+    await h.registry.upsert({ ...((await h.registry.get(publisherId))!), trustLevel: 'review' });
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    h.mail.clear();
+    await h.actors.admin.rejectEvent(publisherId, 'e1');
+
+    const states = await h.events.statesOf(publisherId);
+    expect(states['e1']).toBe('rejected');
+
+    // Notification still sent (notificationsEnabled defaults to true).
+    const sent = h.mail.lastTo('reject2@example.com');
+    expect(sent).toBeTruthy();
+    expect(sent!.kind).toBe('event_rejected');
+    // reason field should be absent or undefined when no reason provided.
+    expect(sent!.data.reason).toBeUndefined();
+  });
+
+  it('notificationsEnabled=false suppresses emails on admin reject', async () => {
+    const { publisherId } = await applyApproveAndSession(h, 'silent@example.com');
+    await h.registry.upsert({
+      ...((await h.registry.get(publisherId))!),
+      trustLevel: 'review',
+      notificationsEnabled: false,
+    });
+    h.feeds.set(publisherId, feedOk(publisherId, 'P', [
+      { id: 'e1', startDate: '2026-08-01T10:00:00Z', endDate: '2026-08-01T11:00:00Z', lastModified: '2026-06-01T00:00:00Z' },
+    ]));
+    await h.actors.ingest.run();
+
+    h.mail.clear();
+    await h.actors.admin.rejectEvent(publisherId, 'e1', 'reason');
+
+    expect(h.mail.lastTo('silent@example.com')).toBeUndefined();
+  });
+
+  it('PATCH /publisher-profile { notificationsEnabled: false } persists', async () => {
+    const { publisherId, session } = await applyApproveAndSession(h, 'toggle@example.com');
+    const updated = await h.actors.publisher.updateProfile(session, { notificationsEnabled: false });
+    expect(updated.publisher.notificationsEnabled).toBe(false);
+    const fresh = (await h.registry.get(publisherId))!;
+    expect(fresh.notificationsEnabled).toBe(false);
+  });
+});

--- a/backend/src/__tests__/mailService.test.ts
+++ b/backend/src/__tests__/mailService.test.ts
@@ -217,6 +217,140 @@ describe('SesMailService', () => {
     expect(mockSend).not.toHaveBeenCalled();
   });
 
+  // ─── Observability emails (Task 6) ───────────────────────────────────
+
+  it('sendIngestFailureEmail subject mentions the feed broke; body includes publisher name, status, error, and portal link', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-fail-1' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    const out = await svc.sendIngestFailureEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme Concerts',
+      status: 'parse_error',
+      message: 'Unexpected token } at position 142',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    expect(out.messageId).toBe('mid-fail-1');
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Destination.ToAddresses).toEqual(['pub@example.com']);
+    expect(cmd.input.Content.Simple.Subject.Data).toMatch(/feed.*(broke|broken)/i);
+    const text = cmd.input.Content.Simple.Body.Text.Data;
+    expect(text).toContain('Acme Concerts');
+    expect(text).toContain('Unexpected token');
+    expect(text).toContain('https://x.test/publish/status/');
+    const html = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).toContain('Acme Concerts');
+    expect(html).toContain('Unexpected token');
+    expect(html).toContain('<pre');
+    expect(html).toContain('https://x.test/publish/status/');
+  });
+
+  it('sendIngestFailureEmail HTML-escapes publisher name and error message', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-fail-2' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendIngestFailureEmail({
+      to: 'p@x.com',
+      publisherName: '<script>x</script>',
+      status: 'validation_error',
+      message: '<img src=y onerror=z>',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    const html: string = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).not.toContain('<img src=y');
+    expect(html).toContain('&lt;img');
+  });
+
+  it('sendIngestRecoveryEmail subject signals success; body shows counts and portal link', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-rec-1' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    const out = await svc.sendIngestRecoveryEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme',
+      counts: { added: 12, updated: 3, retracted: 1, unchanged: 5 },
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    expect(out.messageId).toBe('mid-rec-1');
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Content.Simple.Subject.Data).toMatch(/working again|recovered|back/i);
+    const text = cmd.input.Content.Simple.Body.Text.Data;
+    expect(text).toContain('Acme');
+    expect(text).toMatch(/12/);
+    expect(text).toMatch(/3/);
+    expect(text).toContain('https://x.test/publish/status/');
+  });
+
+  it('sendEventRejectedEmail with reason includes the reason verbatim and event details', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-evrej-1' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    const out = await svc.sendEventRejectedEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme',
+      eventTitle: 'Symphony Gala',
+      eventStartDate: '2026-07-01T18:00:00.000Z',
+      reason: 'Duplicate of upstream feed event',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    expect(out.messageId).toBe('mid-evrej-1');
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Content.Simple.Subject.Data).toMatch(/removed|rejected/i);
+    expect(cmd.input.Content.Simple.Subject.Data).toContain('Symphony Gala');
+    const text = cmd.input.Content.Simple.Body.Text.Data;
+    expect(text).toContain('Symphony Gala');
+    expect(text).toContain('Duplicate of upstream feed event');
+    expect(text).toContain('https://x.test/publish/status/');
+  });
+
+  it('sendEventRejectedEmail without reason shows a generic line', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-evrej-2' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendEventRejectedEmail({
+      to: 'pub@example.com',
+      publisherName: 'Acme',
+      eventTitle: 'Lecture',
+      eventStartDate: '2026-07-01T18:00:00.000Z',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    const text = cmd.input.Content.Simple.Body.Text.Data;
+    // No "Reason:" header line when reason is omitted; instead a generic admin line.
+    expect(text).not.toMatch(/^Reason:/m);
+    expect(text).toMatch(/admin removed|removed by/i);
+  });
+
+  it('sendEventRejectedEmail HTML-escapes the event title and reason', async () => {
+    mockSend.mockResolvedValue({ MessageId: 'mid-evrej-3' });
+    const svc = new SesMailService(mockClient, 'no-reply@chqcal.org');
+    await svc.sendEventRejectedEmail({
+      to: 'p@x.com',
+      publisherName: 'Acme',
+      eventTitle: '<b>Concert</b>',
+      eventStartDate: '2026-07-01T18:00:00.000Z',
+      reason: '<img src=y>',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    const html: string = cmd.input.Content.Simple.Body.Html.Data;
+    expect(html).not.toContain('<b>Concert</b>');
+    expect(html).toContain('&lt;b&gt;Concert&lt;/b&gt;');
+    expect(html).not.toContain('<img src=y');
+  });
+
+  it('observability emails throw if SES_FROM_ADDRESS is empty', async () => {
+    const svc = new SesMailService(mockClient, '');
+    await expect(svc.sendIngestFailureEmail({
+      to: 'a@b', publisherName: 'X', status: 'network_error', message: 'm', portalUrl: 'u',
+    })).rejects.toThrow(/SES_FROM_ADDRESS/);
+    await expect(svc.sendIngestRecoveryEmail({
+      to: 'a@b', publisherName: 'X', counts: { added: 0, updated: 0, retracted: 0, unchanged: 0 }, portalUrl: 'u',
+    })).rejects.toThrow(/SES_FROM_ADDRESS/);
+    await expect(svc.sendEventRejectedEmail({
+      to: 'a@b', publisherName: 'X', eventTitle: 't', eventStartDate: '2026-07-01T18:00:00Z', portalUrl: 'u',
+    })).rejects.toThrow(/SES_FROM_ADDRESS/);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it('approval/rejection emails throw if SES_FROM_ADDRESS is empty', async () => {
     const svc = new SesMailService(mockClient, '');
     await expect(

--- a/backend/src/__tests__/publisherAdminService.test.ts
+++ b/backend/src/__tests__/publisherAdminService.test.ts
@@ -317,7 +317,7 @@ describe('PublisherAdminService', () => {
 
     it('calls notifier.notifyEventRejected with publisher, event, and reason when event is found', async () => {
       (store as any).getEvent.mockResolvedValue(event);
-      store.rejectEvent.mockResolvedValue(undefined);
+      store.rejectEvent.mockResolvedValue(true);
       registry.get.mockResolvedValue(publisher);
 
       await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'duplicate');
@@ -330,7 +330,7 @@ describe('PublisherAdminService', () => {
 
     it('does NOT call notifier when getEvent returns undefined (event already gone)', async () => {
       (store as any).getEvent.mockResolvedValue(undefined);
-      store.rejectEvent.mockResolvedValue(undefined);
+      store.rejectEvent.mockResolvedValue(true);
 
       await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'reason');
 
@@ -340,7 +340,7 @@ describe('PublisherAdminService', () => {
 
     it('does NOT call notifier when publisher registry returns null', async () => {
       (store as any).getEvent.mockResolvedValue(event);
-      store.rejectEvent.mockResolvedValue(undefined);
+      store.rejectEvent.mockResolvedValue(true);
       registry.get.mockResolvedValue(null);
 
       await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'reason');
@@ -350,12 +350,27 @@ describe('PublisherAdminService', () => {
 
     it('forwards undefined reason to the notifier when no reason given', async () => {
       (store as any).getEvent.mockResolvedValue(event);
-      store.rejectEvent.mockResolvedValue(undefined);
+      store.rejectEvent.mockResolvedValue(true);
       registry.get.mockResolvedValue(publisher);
 
       await svcWithNotifier.rejectEvent('pub-1', 'evt-1');
 
       expect(notifier.notifyEventRejected).toHaveBeenCalledWith({ publisher, event, reason: undefined });
+    });
+
+    it('does NOT call notifier when store.rejectEvent returns false (no-op transition)', async () => {
+      // Already non-pending row (rejected/published/deleted): store swallows
+      // the ConditionalCheckFailedException and returns false. No state change
+      // happened, so no email should be sent — even though getEvent succeeded
+      // pre-check.
+      (store as any).getEvent.mockResolvedValue(event);
+      store.rejectEvent.mockResolvedValue(false);
+      registry.get.mockResolvedValue(publisher);
+
+      await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'reason');
+
+      expect(notifier.notifyEventRejected).not.toHaveBeenCalled();
+      expect(registry.get).not.toHaveBeenCalled();
     });
   });
 

--- a/backend/src/__tests__/publisherAdminService.test.ts
+++ b/backend/src/__tests__/publisherAdminService.test.ts
@@ -1,6 +1,7 @@
 import { ApplicationStateError, PublisherAdminService } from '../services/publisherAdminService';
 import { ConcurrentApplicationUpdateError } from '../services/publisherRegistryService';
 import type { PublisherRecord, StoredPublisherEvent } from '../types/publisher';
+import type { PublisherNotificationService } from '../services/publisherNotificationService';
 
 function makeRecord(overrides: Partial<PublisherRecord> = {}): PublisherRecord {
   return {
@@ -68,6 +69,7 @@ describe('PublisherAdminService', () => {
     } as any;
     store = {
       listPending: jest.fn(),
+      getEvent: jest.fn(),
       approveEvent: jest.fn(),
       rejectEvent: jest.fn(),
       deleteAllForPublisher: jest.fn(),
@@ -288,12 +290,73 @@ describe('PublisherAdminService', () => {
     expect(store.approveEvent).toHaveBeenCalledWith('pub-1', 'evt-1');
   });
 
-  it('rejectEvent delegates to store.rejectEvent with same args', async () => {
+  it('rejectEvent delegates to store.rejectEvent with same args (no reason, no notifier)', async () => {
+    (store as any).getEvent.mockResolvedValue(undefined);
     store.rejectEvent.mockResolvedValue(undefined);
 
     await svc.rejectEvent('pub-1', 'evt-1');
 
-    expect(store.rejectEvent).toHaveBeenCalledWith('pub-1', 'evt-1');
+    expect((store as any).getEvent).toHaveBeenCalledWith('pub-1', 'evt-1');
+    expect(store.rejectEvent).toHaveBeenCalledWith('pub-1', 'evt-1', undefined);
+  });
+
+  describe('rejectEvent with notifier', () => {
+    let notifier: { notifyEventRejected: jest.Mock };
+    let svcWithNotifier: PublisherAdminService;
+    const event = makePendingEvent();
+    const publisher = makeRecord();
+
+    beforeEach(() => {
+      notifier = { notifyEventRejected: jest.fn().mockResolvedValue(undefined) };
+      svcWithNotifier = new PublisherAdminService(
+        registry as any,
+        store as any,
+        { notifier: notifier as unknown as PublisherNotificationService },
+      );
+    });
+
+    it('calls notifier.notifyEventRejected with publisher, event, and reason when event is found', async () => {
+      (store as any).getEvent.mockResolvedValue(event);
+      store.rejectEvent.mockResolvedValue(undefined);
+      registry.get.mockResolvedValue(publisher);
+
+      await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'duplicate');
+
+      expect((store as any).getEvent).toHaveBeenCalledWith('pub-1', 'evt-1');
+      expect(store.rejectEvent).toHaveBeenCalledWith('pub-1', 'evt-1', 'duplicate');
+      expect(registry.get).toHaveBeenCalledWith('pub-1');
+      expect(notifier.notifyEventRejected).toHaveBeenCalledWith({ publisher, event, reason: 'duplicate' });
+    });
+
+    it('does NOT call notifier when getEvent returns undefined (event already gone)', async () => {
+      (store as any).getEvent.mockResolvedValue(undefined);
+      store.rejectEvent.mockResolvedValue(undefined);
+
+      await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'reason');
+
+      expect(notifier.notifyEventRejected).not.toHaveBeenCalled();
+      expect(registry.get).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call notifier when publisher registry returns null', async () => {
+      (store as any).getEvent.mockResolvedValue(event);
+      store.rejectEvent.mockResolvedValue(undefined);
+      registry.get.mockResolvedValue(null);
+
+      await svcWithNotifier.rejectEvent('pub-1', 'evt-1', 'reason');
+
+      expect(notifier.notifyEventRejected).not.toHaveBeenCalled();
+    });
+
+    it('forwards undefined reason to the notifier when no reason given', async () => {
+      (store as any).getEvent.mockResolvedValue(event);
+      store.rejectEvent.mockResolvedValue(undefined);
+      registry.get.mockResolvedValue(publisher);
+
+      await svcWithNotifier.rejectEvent('pub-1', 'evt-1');
+
+      expect(notifier.notifyEventRejected).toHaveBeenCalledWith({ publisher, event, reason: undefined });
+    });
   });
 
   // ── listThresholdHalts ─────────────────────────────────────────────────────

--- a/backend/src/__tests__/publisherEventStore.adminOps.test.ts
+++ b/backend/src/__tests__/publisherEventStore.adminOps.test.ts
@@ -57,9 +57,10 @@ describe('PublisherEventStore admin ops', () => {
     await expect(store.approveEvent('p', 'e')).rejects.toThrow('boom');
   });
 
-  it('rejectEvent updates state to rejected with reason and rejectedAt', async () => {
+  it('rejectEvent updates state to rejected with reason and rejectedAt and returns true', async () => {
     mockClient.send.mockResolvedValue({});
-    await store.rejectEvent('p', 'e', 'duplicate of upstream feed');
+    const transitioned = await store.rejectEvent('p', 'e', 'duplicate of upstream feed');
+    expect(transitioned).toBe(true);
     const cmd: any = mockClient.send.mock.calls[0][0];
     expect(cmd.constructor.name).toBe('UpdateCommand');
     expect(cmd.input.UpdateExpression).toContain('#s = :rejected');
@@ -94,10 +95,10 @@ describe('PublisherEventStore admin ops', () => {
     expect((cmd.input.ExpressionAttributeValues[':reason'] as string).length).toBe(500);
   });
 
-  it('rejectEvent treats ConditionalCheckFailedException as a no-op success (state !== pending)', async () => {
+  it('rejectEvent treats ConditionalCheckFailedException as a no-op and returns false (state !== pending)', async () => {
     const err = Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' });
     mockClient.send.mockRejectedValue(err);
-    await expect(store.rejectEvent('p', 'e', 'r')).resolves.toBeUndefined();
+    await expect(store.rejectEvent('p', 'e', 'r')).resolves.toBe(false);
   });
 
   it('rejectEvent re-throws other errors', async () => {

--- a/backend/src/__tests__/publisherEventStore.adminOps.test.ts
+++ b/backend/src/__tests__/publisherEventStore.adminOps.test.ts
@@ -40,24 +40,57 @@ describe('PublisherEventStore admin ops', () => {
     await expect(store.approveEvent('p', 'e')).rejects.toThrow('boom');
   });
 
-  it('rejectEvent deletes the row guarded by state=pending', async () => {
+  it('rejectEvent updates state to rejected with reason and rejectedAt', async () => {
+    mockClient.send.mockResolvedValue({});
+    await store.rejectEvent('p', 'e', 'duplicate of upstream feed');
+    const cmd: any = mockClient.send.mock.calls[0][0];
+    expect(cmd.constructor.name).toBe('UpdateCommand');
+    expect(cmd.input.UpdateExpression).toContain('#s = :rejected');
+    expect(cmd.input.UpdateExpression).toContain('rejectedAt = :now');
+    expect(cmd.input.UpdateExpression).toContain('rejectionReason = :reason');
+    expect(cmd.input.ExpressionAttributeValues[':reason']).toBe('duplicate of upstream feed');
+    expect(cmd.input.ExpressionAttributeValues[':rejected']).toBe('rejected');
+    expect(cmd.input.ExpressionAttributeValues[':pending']).toBe('pending');
+    expect(cmd.input.ConditionExpression).toBe('attribute_exists(publisherId) AND #s = :pending');
+    expect(cmd.input.ExpressionAttributeNames['#s']).toBe('state');
+  });
+
+  it('rejectEvent omits rejectionReason when reason is undefined', async () => {
     mockClient.send.mockResolvedValue({});
     await store.rejectEvent('p', 'e');
     const cmd: any = mockClient.send.mock.calls[0][0];
-    expect(cmd.constructor.name).toBe('DeleteCommand');
-    expect(cmd.input.ConditionExpression).toBe('#s = :pending');
-    expect(cmd.input.ExpressionAttributeNames['#s']).toBe('state');
-    expect(cmd.input.ExpressionAttributeValues[':pending']).toBe('pending');
+    expect(cmd.input.UpdateExpression).not.toContain('rejectionReason');
+    expect(cmd.input.ExpressionAttributeValues[':reason']).toBeUndefined();
   });
 
-  it('rejectEvent treats ConditionalCheckFailedException as a no-op success', async () => {
+  it('rejectEvent omits rejectionReason when reason is whitespace-only', async () => {
+    mockClient.send.mockResolvedValue({});
+    await store.rejectEvent('p', 'e', '   ');
+    const cmd: any = mockClient.send.mock.calls[0][0];
+    expect(cmd.input.UpdateExpression).not.toContain('rejectionReason');
+  });
+
+  it('rejectEvent caps reason at 500 chars defensively', async () => {
+    mockClient.send.mockResolvedValue({});
+    await store.rejectEvent('p', 'e', 'x'.repeat(600));
+    const cmd: any = mockClient.send.mock.calls[0][0];
+    expect((cmd.input.ExpressionAttributeValues[':reason'] as string).length).toBe(500);
+  });
+
+  it('rejectEvent treats ConditionalCheckFailedException as a no-op success (state !== pending)', async () => {
     const err = Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' });
     mockClient.send.mockRejectedValue(err);
-    await expect(store.rejectEvent('p', 'e')).resolves.toBeUndefined();
+    await expect(store.rejectEvent('p', 'e', 'r')).resolves.toBeUndefined();
   });
 
   it('rejectEvent re-throws other errors', async () => {
     mockClient.send.mockRejectedValue(new Error('boom'));
-    await expect(store.rejectEvent('p', 'e')).rejects.toThrow('boom');
+    await expect(store.rejectEvent('p', 'e', 'r')).rejects.toThrow('boom');
+  });
+
+  it('approve-after-reject still fails (existing approve ConditionExpression rejects state=rejected)', async () => {
+    const err = Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' });
+    mockClient.send.mockRejectedValue(err);
+    await expect(store.approveEvent('p', 'e')).rejects.toThrow(/cannot approve/);
   });
 });

--- a/backend/src/__tests__/publisherEventStore.adminOps.test.ts
+++ b/backend/src/__tests__/publisherEventStore.adminOps.test.ts
@@ -11,6 +11,23 @@ describe('PublisherEventStore admin ops', () => {
     store = new PublisherEventStore(mockClient as any, 'chq-publisher-events');
   });
 
+  it('getEvent issues a GetCommand with the correct table, publisherId, and eventId', async () => {
+    const item = { publisherId: 'p', eventId: 'e', state: 'pending' };
+    mockClient.send.mockResolvedValue({ Item: item });
+    const result = await store.getEvent('p', 'e');
+    const cmd: any = mockClient.send.mock.calls[0][0];
+    expect(cmd.constructor.name).toBe('GetCommand');
+    expect(cmd.input.TableName).toBe('chq-publisher-events');
+    expect(cmd.input.Key).toEqual({ publisherId: 'p', eventId: 'e' });
+    expect(result).toEqual(item);
+  });
+
+  it('getEvent returns undefined when the item does not exist', async () => {
+    mockClient.send.mockResolvedValue({ Item: undefined });
+    const result = await store.getEvent('p', 'missing');
+    expect(result).toBeUndefined();
+  });
+
   it('listPending uses the by-state GSI with state=pending', async () => {
     mockClient.send.mockResolvedValue({ Items: [] });
     await store.listPending();

--- a/backend/src/__tests__/publisherIngestHandler.integration.test.ts
+++ b/backend/src/__tests__/publisherIngestHandler.integration.test.ts
@@ -1,5 +1,20 @@
 import { runIngest } from '../handlers/publisherIngestHandler';
 
+function makeFakeRunStore() {
+  return {
+    recordRun: jest.fn().mockResolvedValue(undefined),
+    getMostRecentRun: jest.fn().mockResolvedValue(undefined),
+    listRecentRuns: jest.fn().mockResolvedValue([]),
+  };
+}
+
+function makeFakeNotifier() {
+  return {
+    notifyIngestRunRecorded: jest.fn().mockResolvedValue(undefined),
+    notifyEventRejected: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe('runIngest (integration)', () => {
   it('processes one auto publisher end to end', async () => {
     const testPub = {
@@ -57,6 +72,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(store.applyDiff).toHaveBeenCalledTimes(1);
@@ -93,6 +110,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(store.listForPublisher).not.toHaveBeenCalled();
@@ -142,6 +161,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(registry.setThresholdHalt).toHaveBeenCalledWith('p1', undefined);
@@ -181,6 +202,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(registry.setThresholdHalt).not.toHaveBeenCalled();
@@ -234,6 +257,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(store.applyDiff).not.toHaveBeenCalled();
@@ -287,6 +312,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(registry.setThresholdHalt).toHaveBeenCalledTimes(1);
@@ -342,6 +369,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(store.applyDiff).toHaveBeenCalledTimes(2);
@@ -378,6 +407,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(sidecar.publish).toHaveBeenCalledTimes(1);
@@ -409,6 +440,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(fetcher).not.toHaveBeenCalled();
@@ -446,6 +479,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(store.deleteAllForPublisher).toHaveBeenCalledTimes(2);
@@ -507,6 +542,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(callOrder).toEqual([
@@ -543,6 +580,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     // Paused publishers are intentionally invisible to the active and
@@ -602,6 +641,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     // The fetch went out (it's already in flight before we know about the
@@ -663,6 +704,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     // The transaction was attempted but rolled back atomically — no events
@@ -704,6 +747,8 @@ describe('runIngest (integration)', () => {
       fetcher: fetcher as any,
       now: new Date('2026-06-01T00:00:00Z'),
       publishersTableName: 'chq-publishers',
+      runStore: makeFakeRunStore() as any,
+      notifier: makeFakeNotifier() as any,
     });
 
     expect(fetcher).not.toHaveBeenCalled();
@@ -758,6 +803,8 @@ describe('runIngest (integration)', () => {
           fetcher: fetcher as any,
           now: new Date('2026-06-01T00:00:00Z'),
           publishersTableName: 'chq-publishers',
+          runStore: makeFakeRunStore() as any,
+          notifier: makeFakeNotifier() as any,
         },
         { singlePublisherId: 'target' },
       );
@@ -807,6 +854,8 @@ describe('runIngest (integration)', () => {
           fetcher: fetcher as any,
           now: new Date('2026-06-01T00:00:00Z'),
           publishersTableName: 'chq-publishers',
+          runStore: makeFakeRunStore() as any,
+          notifier: makeFakeNotifier() as any,
         },
         { singlePublisherId: 'paused-pub' },
       );
@@ -845,6 +894,8 @@ describe('runIngest (integration)', () => {
           fetcher: fetcher as any,
           now: new Date('2026-06-01T00:00:00Z'),
           publishersTableName: 'chq-publishers',
+          runStore: makeFakeRunStore() as any,
+          notifier: makeFakeNotifier() as any,
         },
         { singlePublisherId: 'disabled-pub' },
       );
@@ -880,6 +931,8 @@ describe('runIngest (integration)', () => {
             fetcher: fetcher as any,
             now: new Date('2026-06-01T00:00:00Z'),
             publishersTableName: 'chq-publishers',
+            runStore: makeFakeRunStore() as any,
+            notifier: makeFakeNotifier() as any,
           },
           { singlePublisherId: 'no-such-pub' },
         );
@@ -892,5 +945,144 @@ describe('runIngest (integration)', () => {
       expect(store.deleteAllForPublisher).not.toHaveBeenCalled();
       expect(sidecar.publish).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('runIngest records run rows and triggers notifications', () => {
+  it('records an OK run row with counts', async () => {
+    const p = { id: 'p1', name: 'X', contactEmail: 'a@b', sourceUrl: 'https://x', sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't' };
+    const registry = {
+      listAll: jest.fn().mockResolvedValue([p]),
+      get: jest.fn().mockResolvedValue(p),
+      recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
+      setThresholdHalt: jest.fn().mockResolvedValue(undefined),
+    };
+    const fetcher = jest.fn().mockResolvedValue({
+      fetchStatus: 'ok',
+      report: { ok: true, errors: [], warnings: [] },
+      feed: { formatVersion: '1.0', publisher: { id: 'p1', name: 'X', contactEmail: 'a@b' }, events: [{
+        id: 'e1', title: 'E', startDate: '2026-07-04T18:00:00-04:00', endDate: '2026-07-04T19:00:00-04:00', category: 'Lecture', lastModified: '2026-05-01T00:00:00-04:00',
+      }] },
+    });
+    const store = {
+      listForPublisher: jest.fn().mockResolvedValue([]),
+      applyDiff: jest.fn().mockResolvedValue(undefined),
+      listAllPublished: jest.fn().mockResolvedValue([]),
+      deleteAllForPublisher: jest.fn().mockResolvedValue(0),
+    };
+    const sidecar = { publish: jest.fn().mockResolvedValue(undefined) };
+    const runStore = makeFakeRunStore();
+    const notifier = makeFakeNotifier();
+
+    await runIngest({
+      registry: registry as any, store: store as any, sidecar: sidecar as any,
+      fetcher: fetcher as any, now: new Date('2026-06-01T00:00:00Z'),
+      publishersTableName: 'chq-publishers',
+      runStore: runStore as any, notifier: notifier as any,
+    });
+
+    expect(runStore.recordRun).toHaveBeenCalledTimes(1);
+    const row = runStore.recordRun.mock.calls[0][0];
+    expect(row.status).toBe('ok');
+    expect(row.counts).toEqual({ added: 1, updated: 0, retracted: 0, unchanged: 0 });
+    expect(row.triggeredBy).toBe('schedule');
+    expect(notifier.notifyIngestRunRecorded).toHaveBeenCalledTimes(1);
+  });
+
+  it('records a fetch-failure run row and routes through notifier', async () => {
+    const p = { id: 'p1', name: 'X', contactEmail: 'a@b', sourceUrl: 'https://x', sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't' };
+    const registry = {
+      listAll: jest.fn().mockResolvedValue([p]),
+      recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
+      setThresholdHalt: jest.fn().mockResolvedValue(undefined),
+    };
+    const fetcher = jest.fn().mockResolvedValue({
+      fetchStatus: 'parse_error', feed: null,
+      report: { ok: false, errors: [{ path: '/events/0/title', message: 'must be string' }], warnings: [] },
+    });
+    const store = {
+      listForPublisher: jest.fn(), applyDiff: jest.fn(),
+      listAllPublished: jest.fn().mockResolvedValue([]),
+      deleteAllForPublisher: jest.fn().mockResolvedValue(0),
+    };
+    const sidecar = { publish: jest.fn().mockResolvedValue(undefined) };
+    const runStore = makeFakeRunStore();
+    const notifier = makeFakeNotifier();
+
+    await runIngest({
+      registry: registry as any, store: store as any, sidecar: sidecar as any,
+      fetcher: fetcher as any, now: new Date(), publishersTableName: 'chq-publishers',
+      runStore: runStore as any, notifier: notifier as any,
+    });
+
+    expect(runStore.recordRun).toHaveBeenCalledWith(expect.objectContaining({
+      publisherId: 'p1', status: 'parse_error',
+    }));
+    expect(notifier.notifyIngestRunRecorded).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes opts.trigger through to the run row', async () => {
+    const p = { id: 'p1', name: 'X', contactEmail: 'a@b', sourceUrl: 'https://x', sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't' };
+    const registry = {
+      listAll: jest.fn().mockResolvedValue([p]),
+      get: jest.fn().mockResolvedValue(p),
+      recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
+      setThresholdHalt: jest.fn().mockResolvedValue(undefined),
+    };
+    const fetcher = jest.fn().mockResolvedValue({
+      fetchStatus: 'ok', report: { ok: true, errors: [], warnings: [] },
+      feed: { formatVersion: '1.0', publisher: { id: 'p1', name: 'X', contactEmail: 'a@b' }, events: [] },
+    });
+    const store = {
+      listForPublisher: jest.fn().mockResolvedValue([]),
+      applyDiff: jest.fn().mockResolvedValue(undefined),
+      listAllPublished: jest.fn().mockResolvedValue([]),
+      deleteAllForPublisher: jest.fn().mockResolvedValue(0),
+    };
+    const sidecar = { publish: jest.fn().mockResolvedValue(undefined) };
+    const runStore = makeFakeRunStore();
+    const notifier = makeFakeNotifier();
+
+    await runIngest({
+      registry: registry as any, store: store as any, sidecar: sidecar as any,
+      fetcher: fetcher as any, now: new Date(), publishersTableName: 'chq-publishers',
+      runStore: runStore as any, notifier: notifier as any,
+    }, { trigger: 'publisher-fetch-now' });
+
+    expect(runStore.recordRun.mock.calls[0][0].triggeredBy).toBe('publisher-fetch-now');
+  });
+
+  it('runStore.recordRun failure does not break ingest', async () => {
+    const p = { id: 'p1', name: 'X', contactEmail: 'a@b', sourceUrl: 'https://x', sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't' };
+    const registry = {
+      listAll: jest.fn().mockResolvedValue([p]),
+      get: jest.fn().mockResolvedValue(p),
+      recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
+      setThresholdHalt: jest.fn().mockResolvedValue(undefined),
+    };
+    const fetcher = jest.fn().mockResolvedValue({
+      fetchStatus: 'ok', report: { ok: true, errors: [], warnings: [] },
+      feed: { formatVersion: '1.0', publisher: { id: 'p1', name: 'X', contactEmail: 'a@b' }, events: [] },
+    });
+    const store = {
+      listForPublisher: jest.fn().mockResolvedValue([]),
+      applyDiff: jest.fn().mockResolvedValue(undefined),
+      listAllPublished: jest.fn().mockResolvedValue([]),
+      deleteAllForPublisher: jest.fn().mockResolvedValue(0),
+    };
+    const sidecar = { publish: jest.fn().mockResolvedValue(undefined) };
+    const runStore = makeFakeRunStore();
+    runStore.recordRun.mockRejectedValueOnce(new Error('DDB down'));
+    const notifier = makeFakeNotifier();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(runIngest({
+      registry: registry as any, store: store as any, sidecar: sidecar as any,
+      fetcher: fetcher as any, now: new Date(), publishersTableName: 'chq-publishers',
+      runStore: runStore as any, notifier: notifier as any,
+    })).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    expect(notifier.notifyIngestRunRecorded).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
   });
 });

--- a/backend/src/__tests__/publisherIngestHandler.integration.test.ts
+++ b/backend/src/__tests__/publisherIngestHandler.integration.test.ts
@@ -1052,6 +1052,41 @@ describe('runIngest records run rows and triggers notifications', () => {
     expect(runStore.recordRun.mock.calls[0][0].triggeredBy).toBe('publisher-fetch-now');
   });
 
+  it('runStore.getMostRecentRun failure skips notifier (prevents spurious failure email on flaky DDB)', async () => {
+    const p = { id: 'p1', name: 'X', contactEmail: 'a@b', sourceUrl: 'https://x', sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't' };
+    const registry = {
+      listAll: jest.fn().mockResolvedValue([p]),
+      get: jest.fn().mockResolvedValue(p),
+      recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
+      setThresholdHalt: jest.fn().mockResolvedValue(undefined),
+    };
+    const fetcher = jest.fn().mockResolvedValue({
+      fetchStatus: 'parse_error', feed: null,
+      report: { ok: false, errors: [{ path: '/', message: 'boom' }], warnings: [] },
+    });
+    const store = {
+      listForPublisher: jest.fn(), applyDiff: jest.fn(),
+      listAllPublished: jest.fn().mockResolvedValue([]),
+      deleteAllForPublisher: jest.fn().mockResolvedValue(0),
+    };
+    const sidecar = { publish: jest.fn().mockResolvedValue(undefined) };
+    const runStore = makeFakeRunStore();
+    runStore.getMostRecentRun.mockRejectedValueOnce(new Error('DDB read failed'));
+    const notifier = makeFakeNotifier();
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(runIngest({
+      registry: registry as any, store: store as any, sidecar: sidecar as any,
+      fetcher: fetcher as any, now: new Date(), publishersTableName: 'chq-publishers',
+      runStore: runStore as any, notifier: notifier as any,
+    })).resolves.toBeUndefined();
+    // The run row is still recorded (best-effort audit) but the notification
+    // is skipped — the streak signal is unknowable without prevRun.
+    expect(runStore.recordRun).toHaveBeenCalledTimes(1);
+    expect(notifier.notifyIngestRunRecorded).not.toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
   it('runStore.recordRun failure does not break ingest', async () => {
     const p = { id: 'p1', name: 'X', contactEmail: 'a@b', sourceUrl: 'https://x', sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't' };
     const registry = {

--- a/backend/src/__tests__/publisherIngestRunStore.test.ts
+++ b/backend/src/__tests__/publisherIngestRunStore.test.ts
@@ -1,0 +1,95 @@
+jest.unmock('@aws-sdk/lib-dynamodb');
+
+import { PublisherIngestRunStore } from '../services/publisherIngestRunStore';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+const mockSend = jest.fn();
+const mockClient: any = { send: mockSend };
+const TABLE = 'test-runs-table';
+
+function row(overrides: Partial<IngestRunRow> = {}): IngestRunRow {
+  return {
+    publisherId: 'pub-1',
+    runAt: '2026-05-06T12:00:00.000Z',
+    status: 'ok',
+    triggeredBy: 'schedule',
+    counts: { added: 1, updated: 0, retracted: 0, unchanged: 5 },
+    ...overrides,
+  };
+}
+
+describe('PublisherIngestRunStore', () => {
+  let store: PublisherIngestRunStore;
+  beforeEach(() => {
+    jest.resetAllMocks();
+    store = new PublisherIngestRunStore(mockClient, TABLE);
+  });
+
+  test('recordRun writes the row with a 90-day TTL', async () => {
+    mockSend.mockResolvedValue({});
+    const r = row();
+    await store.recordRun(r);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.TableName).toBe(TABLE);
+    const item: IngestRunRow = cmd.input.Item;
+    expect(item.publisherId).toBe('pub-1');
+    expect(item.runAt).toBe(r.runAt);
+    const expectedTtlBase = Math.floor(Date.parse(r.runAt) / 1000);
+    expect(item.ttl).toBeGreaterThanOrEqual(expectedTtlBase + 7_776_000 - 60);
+    expect(item.ttl).toBeLessThanOrEqual(expectedTtlBase + 7_776_000 + 60);
+  });
+
+  test('recordRun preserves caller-supplied ttl if present (defense in depth)', async () => {
+    mockSend.mockResolvedValue({});
+    await store.recordRun(row({ ttl: 1234567890 }));
+    const item: IngestRunRow = (mockSend.mock.calls[0][0] as any).input.Item;
+    // Implementation choice: overwrite caller-supplied ttl with the computed one.
+    // Either behaviour is acceptable; pin the actual behaviour. Adjust the
+    // expected value below to match what the implementation does.
+    expect(typeof item.ttl).toBe('number');
+  });
+
+  test('getMostRecentRun queries with Limit=1, ScanIndexForward=false', async () => {
+    mockSend.mockResolvedValue({ Items: [row()] });
+    const got = await store.getMostRecentRun('pub-1');
+    expect(got?.publisherId).toBe('pub-1');
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.TableName).toBe(TABLE);
+    expect(cmd.input.Limit).toBe(1);
+    expect(cmd.input.ScanIndexForward).toBe(false);
+    expect(cmd.input.KeyConditionExpression).toContain('publisherId');
+    expect(cmd.input.ExpressionAttributeValues[':p']).toBe('pub-1');
+  });
+
+  test('getMostRecentRun returns undefined when table empty', async () => {
+    mockSend.mockResolvedValue({ Items: [] });
+    expect(await store.getMostRecentRun('pub-1')).toBeUndefined();
+  });
+
+  test('getMostRecentRun returns undefined when Items is missing', async () => {
+    mockSend.mockResolvedValue({});
+    expect(await store.getMostRecentRun('pub-1')).toBeUndefined();
+  });
+
+  test('listRecentRuns returns rows newest-first up to limit', async () => {
+    mockSend.mockResolvedValue({ Items: [row({ runAt: '2026-05-06T12:00:00.000Z' })] });
+    const out = await store.listRecentRuns('pub-1', 30);
+    expect(out).toHaveLength(1);
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Limit).toBe(30);
+    expect(cmd.input.ScanIndexForward).toBe(false);
+  });
+
+  test('listRecentRuns defaults limit to 30', async () => {
+    mockSend.mockResolvedValue({ Items: [] });
+    await store.listRecentRuns('pub-1');
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Limit).toBe(30);
+  });
+
+  test('listRecentRuns returns [] when Items is missing', async () => {
+    mockSend.mockResolvedValue({});
+    expect(await store.listRecentRuns('pub-1')).toEqual([]);
+  });
+});

--- a/backend/src/__tests__/publisherIngestRunStore.test.ts
+++ b/backend/src/__tests__/publisherIngestRunStore.test.ts
@@ -40,14 +40,15 @@ describe('PublisherIngestRunStore', () => {
     expect(item.ttl).toBeLessThanOrEqual(expectedTtlBase + 7_776_000 + 60);
   });
 
-  test('recordRun preserves caller-supplied ttl if present (defense in depth)', async () => {
+  test('recordRun overwrites caller-supplied ttl with the computed 90-day value', async () => {
     mockSend.mockResolvedValue({});
-    await store.recordRun(row({ ttl: 1234567890 }));
+    const r = row({ ttl: 1234567890 });
+    await store.recordRun(r);
     const item: IngestRunRow = (mockSend.mock.calls[0][0] as any).input.Item;
-    // Implementation choice: overwrite caller-supplied ttl with the computed one.
-    // Either behaviour is acceptable; pin the actual behaviour. Adjust the
-    // expected value below to match what the implementation does.
-    expect(typeof item.ttl).toBe('number');
+    expect(item.ttl).not.toBe(1234567890);
+    const expectedBase = Math.floor(Date.parse(r.runAt) / 1000) + 7_776_000;
+    expect(item.ttl).toBeGreaterThanOrEqual(expectedBase - 60);
+    expect(item.ttl).toBeLessThanOrEqual(expectedBase + 60);
   });
 
   test('getMostRecentRun queries with Limit=1, ScanIndexForward=false', async () => {

--- a/backend/src/__tests__/publisherNotificationService.test.ts
+++ b/backend/src/__tests__/publisherNotificationService.test.ts
@@ -1,0 +1,237 @@
+import { PublisherNotificationService } from '../services/publisherNotificationService';
+import type { PublisherRecord } from '../types/publisher';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+function publisher(overrides: Partial<PublisherRecord> = {}): PublisherRecord {
+  return {
+    id: 'pub-1',
+    name: 'Test Pub',
+    contactEmail: 'pub@example.com',
+    sourceUrl: 'https://example.com/feed.json',
+    sourceType: 'json',
+    trustLevel: 'review',
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<IngestRunRow> = {}): IngestRunRow {
+  return {
+    publisherId: 'pub-1',
+    runAt: '2026-05-06T12:00:00.000Z',
+    status: 'ok',
+    triggeredBy: 'schedule',
+    counts: { added: 1, updated: 0, retracted: 0, unchanged: 5 },
+    ...overrides,
+  };
+}
+
+function makeMail() {
+  return {
+    sendApplyMagicLink: jest.fn(),
+    sendLoginMagicLink: jest.fn(),
+    sendApprovalEmail: jest.fn(),
+    sendRejectionEmail: jest.fn(),
+    sendEmailChangeVerify: jest.fn(),
+    sendEmailChangeWarning: jest.fn(),
+    sendEmailChangeCommitted: jest.fn(),
+    sendEmailChangeCancelled: jest.fn(),
+    sendSelfDisabledConfirmation: jest.fn(),
+    sendIngestFailureEmail: jest.fn().mockResolvedValue({ messageId: 'm1' }),
+    sendIngestRecoveryEmail: jest.fn().mockResolvedValue({ messageId: 'm2' }),
+    sendEventRejectedEmail: jest.fn().mockResolvedValue({ messageId: 'm3' }),
+  };
+}
+
+describe('PublisherNotificationService.notifyIngestRunRecorded', () => {
+  test('first failure after OK streak sends failure email with correct opts', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test/publish/status/' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error', message: 'boom', counts: undefined }),
+    });
+    expect(mail.sendIngestFailureEmail).toHaveBeenCalledTimes(1);
+    expect(mail.sendIngestFailureEmail).toHaveBeenCalledWith({
+      to: 'pub@example.com',
+      publisherName: 'Test Pub',
+      status: 'parse_error',
+      message: 'boom',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('first OK after failure streak sends recovery email with correct opts', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test/publish/status/' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'network_error', message: 'timeout', counts: undefined }),
+      newRun: run({ status: 'ok', counts: { added: 5, updated: 1, retracted: 0, unchanged: 10 } }),
+    });
+    expect(mail.sendIngestRecoveryEmail).toHaveBeenCalledTimes(1);
+    expect(mail.sendIngestRecoveryEmail).toHaveBeenCalledWith({
+      to: 'pub@example.com',
+      publisherName: 'Test Pub',
+      counts: { added: 5, updated: 1, retracted: 0, unchanged: 10 },
+      portalUrl: 'https://x.test/publish/status/',
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+  });
+
+  test('OK→OK is silent', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'ok' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('failure→failure is silent (consecutive failures suppress repeat)', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'parse_error' }),
+      newRun: run({ status: 'network_error' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('first ever run that fails sends failure email (prevRun undefined treated as OK)', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: undefined,
+      newRun: run({ status: 'parse_error', message: 'boom' }),
+    });
+    expect(mail.sendIngestFailureEmail).toHaveBeenCalledTimes(1);
+  });
+
+  test('first ever run that succeeds is silent', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: undefined,
+      newRun: run({ status: 'ok' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('notificationsEnabled === false short-circuits', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher({ notificationsEnabled: false }),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+  });
+
+  test('mail throw is swallowed and logged (does not propagate)', async () => {
+    const mail = makeMail();
+    mail.sendIngestFailureEmail.mockRejectedValueOnce(new Error('SES down'));
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error' }),
+    })).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test('mail timeout (>2s) is swallowed', async () => {
+    const mail = makeMail();
+    mail.sendIngestFailureEmail.mockImplementation(() => new Promise(() => {})); // never resolves
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.useFakeTimers();
+    const promise = svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error' }),
+    });
+    jest.advanceTimersByTime(2_001);
+    await expect(promise).resolves.toBeUndefined();
+    jest.useRealTimers();
+    errSpy.mockRestore();
+  });
+});
+
+describe('PublisherNotificationService.notifyEventRejected', () => {
+  test('sends rejection email with reason verbatim', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test/publish/status/' });
+    await svc.notifyEventRejected({
+      publisher: publisher(),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'Symphony' } } as any,
+      reason: 'duplicate',
+    });
+    expect(mail.sendEventRejectedEmail).toHaveBeenCalledWith({
+      to: 'pub@example.com',
+      publisherName: 'Test Pub',
+      eventTitle: 'Symphony',
+      eventStartDate: '2026-07-01T18:00:00Z',
+      reason: 'duplicate',
+      portalUrl: 'https://x.test/publish/status/',
+    });
+  });
+
+  test('reason undefined still sends but with reason: undefined', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyEventRejected({
+      publisher: publisher(),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'X' } } as any,
+      reason: undefined,
+    });
+    expect(mail.sendEventRejectedEmail).toHaveBeenCalledWith(expect.objectContaining({ reason: undefined }));
+  });
+
+  test('whitespace-only reason becomes undefined', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyEventRejected({
+      publisher: publisher(),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'X' } } as any,
+      reason: '   ',
+    });
+    expect(mail.sendEventRejectedEmail).toHaveBeenCalledWith(expect.objectContaining({ reason: undefined }));
+  });
+
+  test('event title falls back to "(untitled)" when payload.title missing', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyEventRejected({
+      publisher: publisher(),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: {} } as any,
+      reason: 'r',
+    });
+    expect(mail.sendEventRejectedEmail).toHaveBeenCalledWith(expect.objectContaining({ eventTitle: '(untitled)' }));
+  });
+
+  test('notificationsEnabled === false short-circuits', async () => {
+    const mail = makeMail();
+    const svc = new PublisherNotificationService({ mail: mail as any, portalUrl: 'https://x.test' });
+    await svc.notifyEventRejected({
+      publisher: publisher({ notificationsEnabled: false }),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'X' } } as any,
+      reason: 'r',
+    });
+    expect(mail.sendEventRejectedEmail).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/__tests__/publisherPortalHandler.events.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.events.test.ts
@@ -1,0 +1,255 @@
+// Tests for GET /publisher-events (Task 11).
+// Uses the same mock pattern as publisherPortalHandler.status.test.ts:
+// publisherAuthService is mocked at module level so we don't need Secrets Manager.
+// The registry and eventStore are replaced via the _set*ForTests helpers.
+
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import {
+  handlePublisherEvents,
+  _setStatusRegistryForTests,
+  _setEventStoreForTests,
+} from '../handlers/publisherPortalHandler';
+import type { StoredPublisherEvent } from '../types/publisher';
+
+jest.mock('../services/publisherAuthService', () => ({
+  verifyPublisherJwt: jest.fn(),
+}));
+import { verifyPublisherJwt } from '../services/publisherAuthService';
+
+const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
+  httpMethod: 'GET',
+  path: '/publisher-events',
+  resource: '/publisher-events',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  headers: {},
+  multiValueHeaders: {},
+  body: null,
+  isBase64Encoded: false,
+  stageVariables: null,
+  requestContext: { identity: { sourceIp: '203.0.113.1' } } as any,
+  ...overrides,
+});
+
+function fakeRegistry(rec: Record<string, unknown> | null) {
+  return {
+    get: jest.fn().mockResolvedValue(rec),
+  };
+}
+
+function makeStoredEvent(overrides: Partial<StoredPublisherEvent> = {}): StoredPublisherEvent {
+  return {
+    publisherId: 'p1',
+    eventId: 'e1',
+    startDate: '2026-07-01T18:00:00Z',
+    endDate: '2026-07-01T19:00:00Z',
+    lastModified: 't',
+    state: 'published',
+    updatedAt: '2026-05-01T00:00:00Z',
+    payload: { id: 'e1', title: 'Concert' } as any,
+    ...overrides,
+  };
+}
+
+describe('handlePublisherEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    _setStatusRegistryForTests(null);
+    _setEventStoreForTests(null);
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    _setStatusRegistryForTests(fakeRegistry({ id: 'p1', applicationStatus: 'approved' }) as any);
+    _setEventStoreForTests({ listForPublisher: jest.fn().mockResolvedValue([]) } as any);
+    const r = await handlePublisherEvents(evt(), {});
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns 401 when JWT verification fails', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue(null);
+    _setStatusRegistryForTests(fakeRegistry({ id: 'p1', applicationStatus: 'approved' }) as any);
+    _setEventStoreForTests({ listForPublisher: jest.fn().mockResolvedValue([]) } as any);
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer bad.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns event summaries for the JWT publisher', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const events: StoredPublisherEvent[] = [
+      makeStoredEvent({ eventId: 'e1', state: 'published', payload: { id: 'e1', title: 'Concert' } as any }),
+      makeStoredEvent({ eventId: 'e2', state: 'pending', startDate: '2026-07-02T18:00:00Z', endDate: '2026-07-02T19:00:00Z', payload: { id: 'e2', title: 'Lecture' } as any }),
+      makeStoredEvent({
+        eventId: 'e3',
+        state: 'rejected',
+        startDate: '2026-07-03T18:00:00Z',
+        endDate: '2026-07-03T19:00:00Z',
+        rejectionReason: 'duplicate',
+        rejectedAt: '2026-05-05T10:00:00Z',
+        payload: { id: 'e3', title: 'Panel' } as any,
+      }),
+    ];
+    const store = { listForPublisher: jest.fn().mockResolvedValue(events) };
+    _setEventStoreForTests(store as any);
+
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.events).toHaveLength(3);
+
+    // First event: published, no optional fields
+    expect(body.events[0]).toEqual({
+      eventId: 'e1',
+      title: 'Concert',
+      startDate: '2026-07-01T18:00:00Z',
+      endDate: '2026-07-01T19:00:00Z',
+      state: 'published',
+      updatedAt: '2026-05-01T00:00:00Z',
+    });
+
+    // Full payload must NOT leak into the response
+    expect((body.events[0] as any).payload).toBeUndefined();
+
+    // Rejected event carries rejectionReason + rejectedAt
+    const rejected = body.events.find((e: any) => e.state === 'rejected');
+    expect(rejected).toBeDefined();
+    expect(rejected.rejectionReason).toBe('duplicate');
+    expect(rejected.rejectedAt).toBe('2026-05-05T10:00:00Z');
+
+    // store called with JWT's publisher id
+    expect(store.listForPublisher).toHaveBeenCalledWith('p1');
+  });
+
+  it('returns empty array when no events exist', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    _setEventStoreForTests({ listForPublisher: jest.fn().mockResolvedValue([]) } as any);
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body)).toEqual({ events: [] });
+  });
+
+  it('cross-publisher isolation: always uses JWT publisherId, not query param', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const store = { listForPublisher: jest.fn().mockResolvedValue([]) };
+    _setEventStoreForTests(store as any);
+    await handlePublisherEvents(
+      evt({
+        headers: { Authorization: 'Bearer good.jwt' },
+        queryStringParameters: { publisherId: 'p2' },
+      }),
+      {},
+    );
+    expect(store.listForPublisher).toHaveBeenCalledWith('p1');
+    expect(store.listForPublisher).not.toHaveBeenCalledWith('p2');
+  });
+
+  it('returns 404 when publisher row does not exist', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-deleted', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(fakeRegistry(null) as any);
+    _setEventStoreForTests({ listForPublisher: jest.fn().mockResolvedValue([]) } as any);
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('rejected events include rejectionReason and rejectedAt when present', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const events: StoredPublisherEvent[] = [
+      makeStoredEvent({
+        eventId: 'e-rejected',
+        state: 'rejected',
+        rejectionReason: 'too long',
+        rejectedAt: '2026-05-06T09:00:00Z',
+        payload: { id: 'e-rejected', title: 'Old Event' } as any,
+      }),
+    ];
+    _setEventStoreForTests({ listForPublisher: jest.fn().mockResolvedValue(events) } as any);
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    const body = JSON.parse(r.body);
+    const e = body.events[0];
+    expect(e.rejectionReason).toBe('too long');
+    expect(e.rejectedAt).toBe('2026-05-06T09:00:00Z');
+    // Fields that should NOT be present on non-rejected events
+    expect(e.payload).toBeUndefined();
+  });
+
+  it('approved event does not include rejectionReason or rejectedAt', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const events: StoredPublisherEvent[] = [
+      makeStoredEvent({ state: 'published' }),
+    ];
+    _setEventStoreForTests({ listForPublisher: jest.fn().mockResolvedValue(events) } as any);
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    const body = JSON.parse(r.body);
+    const e = body.events[0];
+    expect(e.state).toBe('published');
+    expect(e.rejectionReason).toBeUndefined();
+    expect(e.rejectedAt).toBeUndefined();
+  });
+
+  it('returns 500 when eventStore throws', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    _setEventStoreForTests({
+      listForPublisher: jest.fn().mockRejectedValue(new Error('DDB error')),
+    } as any);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const r = await handlePublisherEvents(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(500);
+    errSpy.mockRestore();
+  });
+});

--- a/backend/src/__tests__/publisherPortalHandler.profile.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.profile.test.ts
@@ -339,4 +339,56 @@ describe('handlePublisherProfilePatch', () => {
     expect(r.statusCode).toBe(500);
     errSpy.mockRestore();
   });
+
+  it('PATCH /publisher-profile { notificationsEnabled: false } persists and returns updated record', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    registry.get
+      .mockResolvedValueOnce(makeRecord()) // session check
+      .mockResolvedValueOnce(makeRecord({ notificationsEnabled: false })); // post-write read
+    registry.updateProfile.mockResolvedValue(undefined);
+    const r = await handlePublisherProfilePatch(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      { notificationsEnabled: false },
+    );
+    expect(r.statusCode).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.publisher.notificationsEnabled).toBe(false);
+    expect(registry.updateProfile).toHaveBeenCalledWith('pub-1', { notificationsEnabled: false });
+    expect(testPublisherFeed).not.toHaveBeenCalled();
+  });
+
+  it('PATCH /publisher-profile { notificationsEnabled: true } persists and returns updated record', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    registry.get
+      .mockResolvedValueOnce(makeRecord({ notificationsEnabled: false })) // session check
+      .mockResolvedValueOnce(makeRecord({ notificationsEnabled: true })); // post-write read
+    registry.updateProfile.mockResolvedValue(undefined);
+    const r = await handlePublisherProfilePatch(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      { notificationsEnabled: true },
+    );
+    expect(r.statusCode).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.publisher.notificationsEnabled).toBe(true);
+    expect(registry.updateProfile).toHaveBeenCalledWith('pub-1', { notificationsEnabled: true });
+    expect(testPublisherFeed).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 with code=invalid_notifications_enabled for non-boolean notificationsEnabled', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    registry.get.mockResolvedValueOnce(makeRecord());
+    const r = await handlePublisherProfilePatch(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      { notificationsEnabled: 'yes' as any },
+    );
+    expect(r.statusCode).toBe(400);
+    expect(JSON.parse(r.body).code).toBe('invalid_notifications_enabled');
+    expect(registry.updateProfile).not.toHaveBeenCalled();
+  });
 });

--- a/backend/src/__tests__/publisherPortalHandler.runs.test.ts
+++ b/backend/src/__tests__/publisherPortalHandler.runs.test.ts
@@ -1,0 +1,172 @@
+// Tests for GET /publisher-runs (Task 10).
+// Uses the same mock pattern as publisherPortalHandler.status.test.ts:
+// publisherAuthService is mocked at module level so we don't need Secrets Manager.
+// The registry and runStore are replaced via the _set*ForTests helpers.
+
+import type { APIGatewayProxyEvent } from 'aws-lambda';
+import {
+  handlePublisherRuns,
+  _setStatusRegistryForTests,
+  _setRunStoreForTests,
+} from '../handlers/publisherPortalHandler';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+jest.mock('../services/publisherAuthService', () => ({
+  verifyPublisherJwt: jest.fn(),
+}));
+import { verifyPublisherJwt } from '../services/publisherAuthService';
+
+const evt = (overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent => ({
+  httpMethod: 'GET',
+  path: '/publisher-runs',
+  resource: '/publisher-runs',
+  pathParameters: null,
+  queryStringParameters: null,
+  multiValueQueryStringParameters: null,
+  headers: {},
+  multiValueHeaders: {},
+  body: null,
+  isBase64Encoded: false,
+  stageVariables: null,
+  requestContext: { identity: { sourceIp: '203.0.113.1' } } as any,
+  ...overrides,
+});
+
+function fakeRegistry(rec: Record<string, unknown> | null) {
+  return {
+    get: jest.fn().mockResolvedValue(rec),
+  };
+}
+
+function fakeRunStore(runs: IngestRunRow[]) {
+  return {
+    listRecentRuns: jest.fn().mockResolvedValue(runs),
+    getMostRecentRun: jest.fn().mockResolvedValue(runs[0]),
+    recordRun: jest.fn(),
+  };
+}
+
+describe('handlePublisherRuns', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    _setStatusRegistryForTests(null);
+    _setRunStoreForTests(null);
+  });
+
+  it('returns 401 when Authorization header is missing', async () => {
+    _setStatusRegistryForTests(fakeRegistry({ id: 'p1', applicationStatus: 'approved' }) as any);
+    _setRunStoreForTests(fakeRunStore([]) as any);
+    const r = await handlePublisherRuns(evt(), {});
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns 401 when JWT verification fails', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue(null);
+    _setStatusRegistryForTests(fakeRegistry({ id: 'p1', applicationStatus: 'approved' }) as any);
+    _setRunStoreForTests(fakeRunStore([]) as any);
+    const r = await handlePublisherRuns(
+      evt({ headers: { Authorization: 'Bearer bad.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(401);
+  });
+
+  it('returns the publisher\'s runs when authenticated', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const runs: IngestRunRow[] = [
+      {
+        publisherId: 'p1',
+        runAt: '2026-05-06T12:00:00Z',
+        status: 'ok',
+        triggeredBy: 'schedule',
+        counts: { added: 1, updated: 0, retracted: 0, unchanged: 5 },
+      },
+    ];
+    const store = fakeRunStore(runs);
+    _setRunStoreForTests(store as any);
+    const r = await handlePublisherRuns(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(200);
+    const body = JSON.parse(r.body);
+    expect(body.runs).toHaveLength(1);
+    expect(store.listRecentRuns).toHaveBeenCalledWith('p1', 30);
+  });
+
+  it('returns empty array when no runs exist', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    _setRunStoreForTests(fakeRunStore([]) as any);
+    const r = await handlePublisherRuns(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(200);
+    expect(JSON.parse(r.body)).toEqual({ runs: [] });
+  });
+
+  it('always uses JWT publisherId (ignores queryStringParameters.publisherId)', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const store = fakeRunStore([]);
+    _setRunStoreForTests(store as any);
+    await handlePublisherRuns(
+      evt({
+        headers: { Authorization: 'Bearer good.jwt' },
+        queryStringParameters: { publisherId: 'p2' },
+      }),
+      {},
+    );
+    expect(store.listRecentRuns).toHaveBeenCalledWith('p1', 30);
+  });
+
+  it('returns 404 when publisher row does not exist', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'pub-deleted', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(fakeRegistry(null) as any);
+    _setRunStoreForTests(fakeRunStore([]) as any);
+    const r = await handlePublisherRuns(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(404);
+  });
+
+  it('returns 500 when runStore throws', async () => {
+    (verifyPublisherJwt as jest.Mock).mockResolvedValue({
+      sub: 'p1', role: 'publisher', email: 'p@x.com', tokenVersion: 0,
+    });
+    _setStatusRegistryForTests(
+      fakeRegistry({ id: 'p1', applicationStatus: 'approved', tokenVersion: 0 }) as any,
+    );
+    const store = {
+      listRecentRuns: jest.fn().mockRejectedValue(new Error('DDB throttled')),
+    };
+    _setRunStoreForTests(store as any);
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+    const r = await handlePublisherRuns(
+      evt({ headers: { Authorization: 'Bearer good.jwt' } }),
+      {},
+    );
+    expect(r.statusCode).toBe(500);
+    errSpy.mockRestore();
+  });
+});

--- a/backend/src/__tests__/publisherProfileService.test.ts
+++ b/backend/src/__tests__/publisherProfileService.test.ts
@@ -221,4 +221,35 @@ describe('updatePublisherProfile', () => {
       sourceUrl: 'https://other.example/feed.json',
     });
   });
+
+  it('accepts notificationsEnabled: true and persists it', async () => {
+    const registry = { updateProfile: jest.fn().mockResolvedValue(undefined) };
+    const runFeedTest = jest.fn();
+    await updatePublisherProfile('p1', { notificationsEnabled: true }, { registry: registry as any, runFeedTest });
+    expect(registry.updateProfile).toHaveBeenCalledWith('p1', { notificationsEnabled: true });
+    expect(runFeedTest).not.toHaveBeenCalled();
+  });
+
+  it('accepts notificationsEnabled: false', async () => {
+    const registry = { updateProfile: jest.fn().mockResolvedValue(undefined) };
+    await updatePublisherProfile('p1', { notificationsEnabled: false }, { registry: registry as any, runFeedTest: jest.fn() });
+    expect(registry.updateProfile).toHaveBeenCalledWith('p1', { notificationsEnabled: false });
+  });
+
+  it('rejects non-boolean notificationsEnabled with validation error', async () => {
+    const registry = { updateProfile: jest.fn() };
+    await expect(updatePublisherProfile('p1', { notificationsEnabled: 'yes' as any }, { registry: registry as any, runFeedTest: jest.fn() }))
+      .rejects.toThrow(/notificationsEnabled.*boolean/);
+    expect(registry.updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('combines notificationsEnabled with other patch fields', async () => {
+    const registry = { updateProfile: jest.fn().mockResolvedValue(undefined) };
+    await updatePublisherProfile(
+      'p1',
+      { name: 'New Name', notificationsEnabled: false },
+      { registry: registry as any, runFeedTest: jest.fn() },
+    );
+    expect(registry.updateProfile).toHaveBeenCalledWith('p1', { name: 'New Name', notificationsEnabled: false });
+  });
 });

--- a/backend/src/__tests__/publisherReconciler.test.ts
+++ b/backend/src/__tests__/publisherReconciler.test.ts
@@ -4,8 +4,15 @@ import type { FeedDocument } from '@chq-calendar/publisher-format';
 
 const NOW = new Date('2026-06-01T00:00:00Z');
 
-function ev(id: string, start: string, lastMod: string, state: 'published' | 'pending' = 'published'): StoredPublisherEvent {
-  return {
+function ev(
+  id: string,
+  start: string,
+  lastMod: string,
+  state: 'published' | 'pending' | 'rejected' = 'published',
+  rejectionReason?: string,
+  rejectedAt?: string,
+): StoredPublisherEvent {
+  const result: StoredPublisherEvent = {
     publisherId: 'p',
     eventId: id,
     startDate: start,
@@ -24,6 +31,9 @@ function ev(id: string, start: string, lastMod: string, state: 'published' | 'pe
     state,
     updatedAt: lastMod,
   };
+  if (rejectionReason) result.rejectionReason = rejectionReason;
+  if (rejectedAt) result.rejectedAt = rejectedAt;
+  return result;
 }
 
 function feed(events: any[]): FeedDocument {
@@ -198,5 +208,66 @@ describe('reconcile', () => {
     });
     expect(r.diff.inserts[0].payload.sourcePublisherId).toBe('p');
     expect(r.diff.inserts[0].payload.sourcePublisherName).toBe('P');
+  });
+
+  it('preserves admin-rejected state across re-ingest with newer lastModified (review trust)', () => {
+    const stored = [
+      ev(
+        'a',
+        '2026-07-01T00:00:00-04:00',
+        '2026-04-01T00:00:00-04:00',
+        'rejected',
+        'duplicate of city-hall keynote',
+        '2026-05-02T10:00:00.000Z',
+      ),
+    ];
+    const r = reconcile({
+      stored,
+      feed: feed([{ id: 'a', title: 'A', startDate: '2026-07-01T00:00:00-04:00', endDate: '2026-07-01T01:00:00-04:00', category: 'Lecture', lastModified: '2026-05-01T00:00:00-04:00' }]),
+      now: NOW,
+      trustLevel: 'review',
+    });
+    expect(r.applied).toBe(true);
+    expect(r.diff.updates).toHaveLength(1);
+    const updated = r.diff.updates[0]!;
+    expect(updated.state).toBe('rejected');
+    expect(updated.rejectionReason).toBe('duplicate of city-hall keynote');
+    expect(updated.rejectedAt).toBe('2026-05-02T10:00:00.000Z');
+  });
+
+  it('preserves admin-rejected state when trustLevel is auto (rejection sticks regardless)', () => {
+    const stored = [
+      ev(
+        'a',
+        '2026-07-01T00:00:00-04:00',
+        '2026-04-01T00:00:00-04:00',
+        'rejected',
+        'off-topic content',
+        '2026-05-01T14:30:00.000Z',
+      ),
+    ];
+    const r = reconcile({
+      stored,
+      feed: feed([{ id: 'a', title: 'A', startDate: '2026-07-01T00:00:00-04:00', endDate: '2026-07-01T01:00:00-04:00', category: 'Lecture', lastModified: '2026-05-05T00:00:00-04:00' }]),
+      now: NOW,
+      trustLevel: 'auto',
+    });
+    expect(r.applied).toBe(true);
+    expect(r.diff.updates).toHaveLength(1);
+    const updated = r.diff.updates[0]!;
+    expect(updated.state).toBe('rejected');
+    expect(updated.rejectionReason).toBe('off-topic content');
+    expect(updated.rejectedAt).toBe('2026-05-01T14:30:00.000Z');
+  });
+
+  it('publisher dropping a rejected event from feed produces a normal removal', () => {
+    const stored = [
+      ev('a', '2026-08-01T00:00:00-04:00', '2026-04-01T00:00:00-04:00', 'rejected', 'spam', '2026-05-01T10:00:00.000Z'),
+    ];
+    const r = reconcile({ stored, feed: feed([]), now: NOW, trustLevel: 'review' });
+    expect(r.applied).toBe(true);
+    expect(r.diff.removals).toHaveLength(1);
+    expect(r.diff.removals[0]!.eventId).toBe('a');
+    expect(r.diff.removals[0]!.state).toBe('rejected');
   });
 });

--- a/backend/src/__tests__/publisherRegistryService.test.ts
+++ b/backend/src/__tests__/publisherRegistryService.test.ts
@@ -409,5 +409,15 @@ describe('PublisherRegistryService', () => {
       mockSend.mockRejectedValue(condErr);
       await expect(svc.updateProfile('deleted', { name: 'X' })).rejects.toBeInstanceOf(PublisherNotFoundError);
     });
+
+    it('updateProfile accepts notificationsEnabled boolean', async () => {
+      mockSend.mockResolvedValue({});
+      await svc.updateProfile('p1', { notificationsEnabled: false });
+      const cmd: any = mockSend.mock.calls[0][0];
+      // The field name lives in ExpressionAttributeNames (placeholder like #k0 → 'notificationsEnabled')
+      const fieldNames = Object.values(cmd.input.ExpressionAttributeNames as Record<string, string>);
+      expect(fieldNames).toContain('notificationsEnabled');
+      expect(Object.values(cmd.input.ExpressionAttributeValues as Record<string, unknown>)).toContain(false);
+    });
   });
 });

--- a/backend/src/__tests__/publisherSidecarPublisher.test.ts
+++ b/backend/src/__tests__/publisherSidecarPublisher.test.ts
@@ -19,7 +19,7 @@ function mockListReturns(...years: number[]): void {
   });
 }
 
-const ev = (id: string, year = 2026, state: 'published' | 'pending' = 'published'): StoredPublisherEvent => ({
+const ev = (id: string, year = 2026, state: 'published' | 'pending' | 'rejected' = 'published'): StoredPublisherEvent => ({
   publisherId: 'p',
   eventId: id,
   startDate: `${year}-07-04T18:00:00-04:00`,
@@ -89,6 +89,21 @@ describe('PublisherSidecarPublisher', () => {
     mockListReturns();
     const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache');
     await pub.publish([ev('a', 2026, 'published'), ev('b', 2026, 'pending')]);
+    const putCall = mockSend.mock.calls.find(c => c[0] instanceof PutObjectCommand);
+    const cmd: any = putCall![0];
+    const body = JSON.parse(cmd.input.Body as string);
+    expect(body.data).toHaveLength(1);
+    expect(body.data[0].id).toBe('a');
+  });
+
+  it('excludes both pending and rejected events, keeping only published', async () => {
+    mockListReturns();
+    const pub = new PublisherSidecarPublisher(mockS3, 'bucket', 'cache/calendar-cache');
+    await pub.publish([
+      ev('a', 2026, 'published'),
+      ev('b', 2026, 'pending'),
+      ev('c', 2026, 'rejected'),
+    ]);
     const putCall = mockSend.mock.calls.find(c => c[0] instanceof PutObjectCommand);
     const cmd: any = putCall![0];
     const body = JSON.parse(cmd.input.Body as string);

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -15,6 +15,7 @@ import { ApplicationStateError, PublisherAdminService } from '../services/publis
 import { PublisherRegistryService } from '../services/publisherRegistryService';
 import { PublisherEventStore } from '../services/publisherEventStore';
 import { SesMailService } from '../services/mailService';
+import { PublisherNotificationService } from '../services/publisherNotificationService';
 import { signPublisherJwt } from '../services/publisherAuthService';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -59,12 +60,15 @@ export const _setLambdaClientForTests = _setIngestLambdaClientForTests;
 let _publisherAdmin: PublisherAdminService | null = null;
 function publisherAdmin(): PublisherAdminService {
   if (!_publisherAdmin) {
+    const mail = new SesMailService();
+    const portalUrl = `${(process.env.SITE_BASE_URL ?? 'https://www.chqcal.org').replace(/\/$/, '')}/publish/status/`;
     _publisherAdmin = new PublisherAdminService(
       new PublisherRegistryService(docClient, process.env.PUBLISHERS_TABLE_NAME ?? 'chautauqua-calendar-publishers'),
       new PublisherEventStore(docClient, process.env.PUBLISHER_EVENTS_TABLE_NAME ?? 'chautauqua-calendar-publisher-events'),
       {
-        mail: new SesMailService(),
+        mail,
         siteBaseUrl: process.env.SITE_BASE_URL ?? 'https://www.chqcal.org',
+        notifier: new PublisherNotificationService({ mail, portalUrl }),
       },
     );
   }
@@ -765,7 +769,14 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
     const matchReject = path.match(/^\/publisher-events\/([^/]+)\/([^/]+)\/reject$/);
     if (matchReject && httpMethod === 'POST') {
       try {
-        await publisherAdmin().rejectEvent(decodeURIComponent(matchReject[1]), decodeURIComponent(matchReject[2]));
+        const publisherId = decodeURIComponent(matchReject[1]);
+        const eventId = decodeURIComponent(matchReject[2]);
+        // requestBody is already parsed by the global parser above; any
+        // malformed JSON was rejected with 400 before we got here.
+        const rawReason = typeof requestBody?.reason === 'string' ? requestBody.reason : undefined;
+        const trimmed = rawReason?.trim();
+        const reason = trimmed && trimmed.length > 0 ? trimmed.slice(0, 500) : undefined;
+        await publisherAdmin().rejectEvent(publisherId, eventId, reason);
         return createResponse(204, {});
       } catch (error) {
         console.error('Error rejecting publisher event:', error);

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -34,6 +34,8 @@ import {
   handlePublisherPause,
   handlePublisherResume,
   handlePublisherDisable,
+  handlePublisherRuns,
+  handlePublisherEvents,
 } from './publisherPortalHandler';
 
 // DynamoDB client
@@ -554,6 +556,21 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
     // sits BEFORE the admin auth gate.
     if (path === '/publisher-disable' && httpMethod === 'POST') {
       return await handlePublisherDisable(event, requestBody);
+    }
+
+    // Task 10 (publisher observability): publisher sees their own ingest-run
+    // history. Publisher-JWT-auth'd; handler enforces auth itself, so it sits
+    // BEFORE the admin auth gate. Exact match avoids shadowing admin sub-routes.
+    if (path === '/publisher-runs' && httpMethod === 'GET') {
+      return await handlePublisherRuns(event, requestBody);
+    }
+
+    // Task 11 (publisher observability): publisher sees their own event
+    // summaries (all states). Publisher-JWT-auth'd. Exact match on
+    // '/publisher-events' so the admin-only '/publisher-events/pending' and
+    // approve/reject sub-routes below are unaffected.
+    if (path === '/publisher-events' && httpMethod === 'GET') {
+      return await handlePublisherEvents(event, requestBody);
     }
 
     // All remaining endpoints require authentication, except in local development

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -275,7 +275,10 @@ export async function scheduledHandler(
       runStore: new PublisherIngestRunStore(ddb, process.env.PUBLISHER_INGEST_RUNS_TABLE_NAME!),
       notifier: new PublisherNotificationService({
         mail: new SesMailService(),
-        portalUrl: `${process.env.SITE_BASE_URL ?? 'https://www.chqcal.org'}/publish/status/`,
+        // Strip a trailing slash from SITE_BASE_URL before joining so the
+        // resulting URL doesn't double-slash if the env var is set with a
+        // trailing slash. Matches the pattern in publisherAdminService.ts.
+        portalUrl: `${(process.env.SITE_BASE_URL ?? 'https://www.chqcal.org').replace(/\/$/, '')}/publish/status/`,
       }),
     },
     { singlePublisherId: evt?.singlePublisherId },

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -7,6 +7,11 @@ import { PublisherEventStore, PublisherDeletedDuringApplyError } from '../servic
 import { PublisherSidecarPublisher } from '../services/publisherSidecarPublisher';
 import { fetchAndParseFeed } from '../services/publisherFeedFetcher';
 import { reconcile } from '../services/publisherReconciler';
+import { PublisherIngestRunStore } from '../services/publisherIngestRunStore';
+import { PublisherNotificationService } from '../services/publisherNotificationService';
+import { SesMailService } from '../services/mailService';
+import type { PublisherRecord } from '../types/publisher';
+import type { IngestRunRow, IngestRunCounts, IngestRunTrigger } from '../types/publisherIngestRun';
 
 export interface IngestDeps {
   registry: PublisherRegistryService;
@@ -18,6 +23,12 @@ export interface IngestDeps {
   // ConditionCheck to atomically refuse the diff if the publisher row was
   // deleted between snapshot and commit.
   publishersTableName: string;
+  // Persists per-iteration run rows. Used for the publisher-portal history
+  // panel and for streak-detection feeding the notifier.
+  runStore: PublisherIngestRunStore;
+  // Sends ingest-failure / ingest-recovery / event-rejected emails.
+  // Internally bounded by a 2s mail timeout; never propagates failures.
+  notifier: PublisherNotificationService;
 }
 
 export interface RunIngestOpts {
@@ -28,6 +39,30 @@ export interface RunIngestOpts {
   // disabled publishers in single-publisher mode behave the same as in a
   // full scan (paused → skipped, disabled → retracted).
   singlePublisherId?: string;
+  // Defaults to 'schedule' on the EventBridge cron path. /publisher-fetch-now
+  // passes 'publisher-fetch-now'; the admin "Run ingest now" button passes
+  // 'admin'. Recorded onto each run row.
+  trigger?: IngestRunTrigger;
+}
+
+async function recordRunAndNotify(
+  deps: IngestDeps,
+  p: PublisherRecord,
+  opts: RunIngestOpts,
+  newRun: IngestRunRow,
+): Promise<void> {
+  let prevRun: IngestRunRow | undefined;
+  try {
+    prevRun = await deps.runStore.getMostRecentRun(p.id);
+  } catch (err) {
+    console.error(`[publisher-ingest] failed to read most-recent run for ${p.id}:`, err);
+  }
+  try {
+    await deps.runStore.recordRun(newRun);
+  } catch (err) {
+    console.error(`[publisher-ingest] failed to record run for ${p.id}:`, err);
+  }
+  await deps.notifier.notifyIngestRunRecorded({ publisher: p, prevRun, newRun });
 }
 
 export async function runIngest(deps: IngestDeps, opts: RunIngestOpts = {}): Promise<void> {
@@ -78,6 +113,13 @@ export async function runIngest(deps: IngestDeps, opts: RunIngestOpts = {}): Pro
           .join('; ')
           .slice(0, 500);
         await deps.registry.recordFetchOutcome(p.id, { status: f.fetchStatus, message });
+        await recordRunAndNotify(deps, p, opts, {
+          publisherId: p.id,
+          runAt: deps.now.toISOString(),
+          status: f.fetchStatus,
+          message,
+          triggeredBy: opts.trigger ?? 'schedule',
+        });
         continue;
       }
       const stored = await deps.store.listForPublisher(p.id);
@@ -93,6 +135,13 @@ export async function runIngest(deps: IngestDeps, opts: RunIngestOpts = {}): Pro
         await deps.registry.recordFetchOutcome(p.id, {
           status: 'threshold_halt',
           message: result.haltedByThreshold!.reason,
+        });
+        await recordRunAndNotify(deps, p, opts, {
+          publisherId: p.id,
+          runAt: deps.now.toISOString(),
+          status: 'threshold_halt',
+          message: result.haltedByThreshold!.reason.slice(0, 500),
+          triggeredBy: opts.trigger ?? 'schedule',
         });
         continue;
       }
@@ -128,8 +177,22 @@ export async function runIngest(deps: IngestDeps, opts: RunIngestOpts = {}): Pro
         await deps.registry.setThresholdHalt(p.id, undefined);
       }
       await deps.registry.recordFetchOutcome(p.id, { status: 'ok' });
+      const counts: IngestRunCounts = {
+        added: result.diff.inserts.length,
+        updated: result.diff.updates.length,
+        retracted: result.diff.removals.length,
+        unchanged: result.diff.unchanged,
+      };
+      await recordRunAndNotify(deps, p, opts, {
+        publisherId: p.id,
+        runAt: deps.now.toISOString(),
+        status: 'ok',
+        counts,
+        triggeredBy: opts.trigger ?? 'schedule',
+      });
     } catch (err) {
       console.error(`[publisher-ingest] publisher ${p.id} failed:`, err);
+      const message = `unhandled error: ${(err as Error).message ?? String(err)}`.slice(0, 500);
       try {
         // This catch fires for unhandled throws from the loop body — DDB
         // errors, reconcile assertion failures, etc. fetchAndParseFeed
@@ -138,11 +201,18 @@ export async function runIngest(deps: IngestDeps, opts: RunIngestOpts = {}): Pro
         // raw error message.
         await deps.registry.recordFetchOutcome(p.id, {
           status: 'network_error',
-          message: `unhandled error: ${(err as Error).message ?? String(err)}`.slice(0, 500),
+          message,
         });
       } catch (recordErr) {
         console.error(`[publisher-ingest] failed to record outcome for ${p.id}:`, recordErr);
       }
+      await recordRunAndNotify(deps, p, opts, {
+        publisherId: p.id,
+        runAt: deps.now.toISOString(),
+        status: 'network_error',
+        message,
+        triggeredBy: opts.trigger ?? 'schedule',
+      });
     }
   }
   // Retract events for disabled publishers. Disabling a publisher (enabled=false)
@@ -192,6 +262,11 @@ export async function scheduledHandler(
       fetcher: fetchAndParseFeed,
       now: new Date(),
       publishersTableName: process.env.PUBLISHERS_TABLE_NAME!,
+      runStore: new PublisherIngestRunStore(ddb, process.env.PUBLISHER_INGEST_RUNS_TABLE_NAME!),
+      notifier: new PublisherNotificationService({
+        mail: new SesMailService(),
+        portalUrl: `${process.env.SITE_BASE_URL ?? 'https://www.chqcal.org'}/publish/status/`,
+      }),
     },
     { singlePublisherId: evt?.singlePublisherId },
   );

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -51,18 +51,28 @@ async function recordRunAndNotify(
   opts: RunIngestOpts,
   newRun: IngestRunRow,
 ): Promise<void> {
+  // We need prevRun to detect streak transitions. If the read throws, we
+  // can't tell whether this run is a transition — and a fall-through to
+  // `prevRun=undefined` would be interpreted as "first ever run" by the
+  // notifier (treats prevRun=undefined as OK), producing a spurious
+  // "feed broke" email on every flaky-DDB ingest. Skip the notification
+  // entirely on read failure; the run row is still recorded for history.
   let prevRun: IngestRunRow | undefined;
+  let prevRunReadOk = true;
   try {
     prevRun = await deps.runStore.getMostRecentRun(p.id);
   } catch (err) {
-    console.error(`[publisher-ingest] failed to read most-recent run for ${p.id}:`, err);
+    console.error(`[publisher-ingest] failed to read most-recent run for ${p.id}; skipping notification:`, err);
+    prevRunReadOk = false;
   }
   try {
     await deps.runStore.recordRun(newRun);
   } catch (err) {
     console.error(`[publisher-ingest] failed to record run for ${p.id}:`, err);
   }
-  await deps.notifier.notifyIngestRunRecorded({ publisher: p, prevRun, newRun });
+  if (prevRunReadOk) {
+    await deps.notifier.notifyIngestRunRecorded({ publisher: p, prevRun, newRun });
+  }
 }
 
 export async function runIngest(deps: IngestDeps, opts: RunIngestOpts = {}): Promise<void> {

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -50,7 +50,9 @@ import {
   InMemoryRateLimiter,
   type RateLimiter,
 } from '../services/rateLimitService';
-import type { ApplyFormPayload, PublisherRecord, SourceType } from '../types/publisher';
+import type { ApplyFormPayload, PublisherRecord, StoredPublisherEvent, SourceType } from '../types/publisher';
+import { PublisherIngestRunStore } from '../services/publisherIngestRunStore';
+import { PublisherEventStore } from '../services/publisherEventStore';
 
 // ─── Doc-client helper ───────────────────────────────────────────────────
 //
@@ -499,6 +501,48 @@ export function _setStatusRegistryForTests(r: PublisherRegistryService | null): 
   _statusRegistry = r;
 }
 
+// ─── PublisherIngestRunStore singleton ───────────────────────────────────
+//
+// Used by /publisher-runs to fetch a publisher's own ingest-run history.
+// Lazy factory mirrors the statusRegistry() pattern above.
+
+let _runStore: PublisherIngestRunStore | null = null;
+
+function runStore(): PublisherIngestRunStore {
+  if (!_runStore) {
+    _runStore = new PublisherIngestRunStore(
+      buildDocClient(),
+      process.env.PUBLISHER_INGEST_RUNS_TABLE_NAME ?? 'chautauqua-calendar-publisher-ingest-runs',
+    );
+  }
+  return _runStore;
+}
+
+export function _setRunStoreForTests(s: PublisherIngestRunStore | null): void {
+  _runStore = s;
+}
+
+// ─── PublisherEventStore singleton ────────────────────────────────────────
+//
+// Used by /publisher-events to fetch a publisher's own event summaries.
+// Lazy factory mirrors the statusRegistry() pattern above.
+
+let _eventStore: PublisherEventStore | null = null;
+
+function eventStore(): PublisherEventStore {
+  if (!_eventStore) {
+    _eventStore = new PublisherEventStore(
+      buildDocClient(),
+      process.env.PUBLISHER_EVENTS_TABLE_NAME ?? 'chautauqua-calendar-publisher-events',
+    );
+  }
+  return _eventStore;
+}
+
+export function _setEventStoreForTests(s: PublisherEventStore | null): void {
+  _eventStore = s;
+}
+
 // ─── /publisher-status (publisher JWT only) ──────────────────────────────
 //
 // Returns the caller's own publisher record, sanitized:
@@ -531,6 +575,76 @@ export async function handlePublisherStatus(
     });
   } catch (err) {
     console.error('Error in /publisher-status:', err);
+    return json(500, { error: 'Internal server error' });
+  }
+}
+
+// ─── GET /publisher-runs (publisher JWT only) ────────────────────────────
+//
+// Returns the caller's own ingest-run history (last 30, newest-first). Used
+// by the IngestHistoryPanel on /publish/status/. Pending/rejected applicants
+// fall through the same auth path as /publisher-status (auth is checked but
+// applicationStatus is NOT gated — any publisher can view their run history).
+export async function handlePublisherRuns(
+  event: APIGatewayProxyEvent,
+  _requestBody: Record<string, unknown>,
+): Promise<APIGatewayProxyResult> {
+  try {
+    const sess = await requirePublisherSession(event, statusRegistry());
+    if (sess.kind === 'unauthorized') return json(401, { error: sess.message });
+    if (sess.kind === 'publisher_missing') return json(404, { error: 'Publisher not found' });
+    const runs = await runStore().listRecentRuns(sess.publisher.id, 30);
+    return json(200, { runs });
+  } catch (err) {
+    console.error('Error in /publisher-runs:', err);
+    return json(500, { error: 'Internal server error' });
+  }
+}
+
+// ─── GET /publisher-events (publisher JWT only) ──────────────────────────
+//
+// Returns the caller's own events (all states — published, pending, rejected),
+// projected to a small summary shape that omits the full feed payload. Used
+// by the PublisherEventsPanel on /publish/status/. Exact path match (no
+// startsWith) so the admin-only /publisher-events/pending route is unaffected.
+
+export interface PublisherEventSummary {
+  eventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  state: 'published' | 'pending' | 'rejected';
+  rejectionReason?: string;
+  rejectedAt?: string;
+  updatedAt: string;
+}
+
+function toSummary(e: StoredPublisherEvent): PublisherEventSummary {
+  const out: PublisherEventSummary = {
+    eventId: e.eventId,
+    title: (e.payload as { title?: string }).title ?? '(untitled)',
+    startDate: e.startDate,
+    endDate: e.endDate,
+    state: e.state,
+    updatedAt: e.updatedAt,
+  };
+  if (e.rejectionReason) out.rejectionReason = e.rejectionReason;
+  if (e.rejectedAt) out.rejectedAt = e.rejectedAt;
+  return out;
+}
+
+export async function handlePublisherEvents(
+  event: APIGatewayProxyEvent,
+  _requestBody: Record<string, unknown>,
+): Promise<APIGatewayProxyResult> {
+  try {
+    const sess = await requirePublisherSession(event, statusRegistry());
+    if (sess.kind === 'unauthorized') return json(401, { error: sess.message });
+    if (sess.kind === 'publisher_missing') return json(404, { error: 'Publisher not found' });
+    const rows = await eventStore().listForPublisher(sess.publisher.id);
+    return json(200, { events: rows.map(toSummary) });
+  } catch (err) {
+    console.error('Error in /publisher-events:', err);
     return json(500, { error: 'Internal server error' });
   }
 }

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -181,7 +181,7 @@ export function _resetPublisherAuthRateLimitForTests(): void {
 const corsHeaders = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': process.env.SITE_BASE_URL ?? 'https://www.chqcal.org',
-  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, POST, PATCH, DELETE, OPTIONS',
   // Authorization is included for Phase C authenticated publisher endpoints
   // (status page, feed management). The Phase A/B routes here don't read it,
   // but the header is shared and CORS preflight is per-resource — better to

--- a/backend/src/services/mailService.ts
+++ b/backend/src/services/mailService.ts
@@ -30,6 +30,10 @@ export interface MailService {
   // after a successful self-disable confirmation. Records the slug so the
   // publisher has a written reference for re-enable conversations.
   sendSelfDisabledConfirmation(opts: SelfDisabledConfirmationOpts): Promise<{ messageId: string }>;
+  // Task 6 (publisher observability).
+  sendIngestFailureEmail(opts: IngestFailureEmailOpts): Promise<{ messageId: string }>;
+  sendIngestRecoveryEmail(opts: IngestRecoveryEmailOpts): Promise<{ messageId: string }>;
+  sendEventRejectedEmail(opts: EventRejectedEmailOpts): Promise<{ messageId: string }>;
 }
 
 export interface EmailChangeVerifyOpts {
@@ -80,6 +84,30 @@ export interface RejectionEmailOpts {
   publisherName: string;
   reason?: string;
   applyAgainUrl: string;
+}
+
+export interface IngestFailureEmailOpts {
+  to: string;
+  publisherName: string;
+  status: 'parse_error' | 'validation_error' | 'network_error' | 'threshold_halt';
+  message: string;
+  portalUrl: string; // absolute URL to /publish/status/
+}
+
+export interface IngestRecoveryEmailOpts {
+  to: string;
+  publisherName: string;
+  counts: { added: number; updated: number; retracted: number; unchanged: number };
+  portalUrl: string;
+}
+
+export interface EventRejectedEmailOpts {
+  to: string;
+  publisherName: string;
+  eventTitle: string;
+  eventStartDate: string; // ISO 8601
+  reason?: string;        // undefined/empty → generic line
+  portalUrl: string;
 }
 
 export class SesMailService implements MailService {
@@ -175,6 +203,39 @@ export class SesMailService implements MailService {
     const subject = 'Your Chautauqua Calendar publisher is disabled';
     const text = selfDisabledConfirmationText(opts);
     const html = selfDisabledConfirmationHtml(opts);
+    return this._send(opts.to, subject, text, html);
+  }
+
+  async sendIngestFailureEmail(opts: IngestFailureEmailOpts) {
+    if (!this.fromAddress) {
+      throw new Error('SES_FROM_ADDRESS env var not set');
+    }
+    const subject = 'Your Chautauqua Calendar feed broke';
+    const text = ingestFailureText(opts);
+    const html = ingestFailureHtml(opts);
+    return this._send(opts.to, subject, text, html);
+  }
+
+  async sendIngestRecoveryEmail(opts: IngestRecoveryEmailOpts) {
+    if (!this.fromAddress) {
+      throw new Error('SES_FROM_ADDRESS env var not set');
+    }
+    const subject = 'Your Chautauqua Calendar feed is working again';
+    const text = ingestRecoveryText(opts);
+    const html = ingestRecoveryHtml(opts);
+    return this._send(opts.to, subject, text, html);
+  }
+
+  async sendEventRejectedEmail(opts: EventRejectedEmailOpts) {
+    if (!this.fromAddress) {
+      throw new Error('SES_FROM_ADDRESS env var not set');
+    }
+    const truncatedTitle = opts.eventTitle.length > 80
+      ? opts.eventTitle.slice(0, 80) + '…'
+      : opts.eventTitle;
+    const subject = `Event removed: ${truncatedTitle}`;
+    const text = eventRejectedText(opts);
+    const html = eventRejectedHtml(opts);
     return this._send(opts.to, subject, text, html);
   }
 
@@ -524,6 +585,164 @@ function selfDisabledConfirmationHtml(o: SelfDisabledConfirmationOpts): string {
     `<pre style="margin:0.5em 0 0.5em 1em;font-size:1.05em">${safeSlug}</pre>`,
     '<p>Re-enabling a disabled publisher is an admin action — reply to this email or contact us at <a href="mailto:hello@chqcal.org">hello@chqcal.org</a> if you change your mind. Your previously-published events will need to be re-fetched from your feed, so make sure the feed is still serving them when you ask to re-enable.</p>',
     '<p>If you did <strong>not</strong> request this, contact us right away.</p>',
+    '<p>— Chautauqua Calendar</p>',
+    '</body></html>',
+  ].join('');
+}
+
+// ─── Observability email templates (Task 6) ──────────────────────────────
+
+const OBSERVABILITY_FOOTER = "If you don't want these notifications, sign in and turn off email alerts.";
+
+function humanizeStatus(status: IngestFailureEmailOpts['status']): string {
+  switch (status) {
+    case 'parse_error': return 'Parse error';
+    case 'validation_error': return 'Validation error';
+    case 'network_error': return 'Network error';
+    case 'threshold_halt': return 'Threshold halt';
+  }
+}
+
+function ingestFailureText(o: IngestFailureEmailOpts): string {
+  return [
+    `Hi ${o.publisherName || 'there'},`,
+    '',
+    'The last ingest run for your Chautauqua Calendar feed encountered an error.',
+    '',
+    `Status: ${humanizeStatus(o.status)}`,
+    'Error:',
+    `    ${o.message}`,
+    '',
+    `View details: ${o.portalUrl}`,
+    '',
+    OBSERVABILITY_FOOTER,
+    '',
+    '— Chautauqua Calendar',
+  ].join('\n');
+}
+
+function ingestFailureHtml(o: IngestFailureEmailOpts): string {
+  const safeName = escapeHtml(o.publisherName || 'there');
+  const safeStatus = escapeHtml(humanizeStatus(o.status));
+  const safeMessage = escapeHtml(o.message);
+  const safeUrl = encodeURI(o.portalUrl);
+  return [
+    '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
+    `<p>Hi ${safeName},</p>`,
+    '<p>The last ingest run for your Chautauqua Calendar feed encountered an error.</p>',
+    `<p><strong>Status:</strong> ${safeStatus}</p>`,
+    '<p><strong>Error:</strong></p>',
+    `<pre style="margin:0.5em 0 0.5em 1em;font-size:1.05em">${safeMessage}</pre>`,
+    `<p>View details: <a href="${safeUrl}">${escapeHtml(safeUrl)}</a></p>`,
+    `<p><em>${escapeHtml(OBSERVABILITY_FOOTER)}</em></p>`,
+    '<p>— Chautauqua Calendar</p>',
+    '</body></html>',
+  ].join('');
+}
+
+function ingestRecoveryText(o: IngestRecoveryEmailOpts): string {
+  const { added, updated, retracted, unchanged } = o.counts;
+  return [
+    `Hi ${o.publisherName || 'there'},`,
+    '',
+    'Good news — your Chautauqua Calendar feed is working again.',
+    '',
+    'Latest ingest counts:',
+    `  +${added} added   ~${updated} updated   -${retracted} retracted   ${unchanged} unchanged`,
+    '',
+    `View details: ${o.portalUrl}`,
+    '',
+    OBSERVABILITY_FOOTER,
+    '',
+    '— Chautauqua Calendar',
+  ].join('\n');
+}
+
+function ingestRecoveryHtml(o: IngestRecoveryEmailOpts): string {
+  const safeName = escapeHtml(o.publisherName || 'there');
+  const safeUrl = encodeURI(o.portalUrl);
+  const { added, updated, retracted, unchanged } = o.counts;
+  return [
+    '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
+    `<p>Hi ${safeName},</p>`,
+    '<p>Good news — your Chautauqua Calendar feed is <strong>working again</strong>.</p>',
+    '<p><strong>Latest ingest counts:</strong></p>',
+    `<pre style="margin:0.5em 0 0.5em 1em;font-size:1.05em">+${added} added   ~${updated} updated   -${retracted} retracted   ${unchanged} unchanged</pre>`,
+    `<p>View details: <a href="${safeUrl}">${escapeHtml(safeUrl)}</a></p>`,
+    `<p><em>${escapeHtml(OBSERVABILITY_FOOTER)}</em></p>`,
+    '<p>— Chautauqua Calendar</p>',
+    '</body></html>',
+  ].join('');
+}
+
+function eventRejectedText(o: EventRejectedEmailOpts): string {
+  const startDisplay = (() => {
+    try {
+      return new Date(o.eventStartDate).toLocaleString('en-US', {
+        timeZone: 'UTC',
+        month: 'long', day: 'numeric', year: 'numeric',
+        hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+      });
+    } catch {
+      return o.eventStartDate;
+    }
+  })();
+
+  const lines = [
+    `Hi ${o.publisherName || 'there'},`,
+    '',
+    `An event from your Chautauqua Calendar feed has been removed:`,
+    '',
+    `  Title:  ${o.eventTitle}`,
+    `  Starts: ${startDisplay}`,
+  ];
+
+  if (o.reason && o.reason.trim().length > 0) {
+    lines.push('', `Reason: ${o.reason.trim()}`);
+  } else {
+    lines.push('', 'An admin removed this event from the calendar.');
+  }
+
+  lines.push(
+    '',
+    `View your feed status: ${o.portalUrl}`,
+    '',
+    OBSERVABILITY_FOOTER,
+    '',
+    '— Chautauqua Calendar',
+  );
+  return lines.join('\n');
+}
+
+function eventRejectedHtml(o: EventRejectedEmailOpts): string {
+  const safeName = escapeHtml(o.publisherName || 'there');
+  const safeTitle = escapeHtml(o.eventTitle);
+  const safeUrl = encodeURI(o.portalUrl);
+
+  const startDisplay = (() => {
+    try {
+      return new Date(o.eventStartDate).toLocaleString('en-US', {
+        timeZone: 'UTC',
+        month: 'long', day: 'numeric', year: 'numeric',
+        hour: 'numeric', minute: '2-digit', timeZoneName: 'short',
+      });
+    } catch {
+      return escapeHtml(o.eventStartDate);
+    }
+  })();
+
+  const reasonBlock = o.reason && o.reason.trim().length > 0
+    ? `<p><strong>Reason:</strong></p><blockquote style="margin:0 0 0 1em;padding-left:1em;border-left:3px solid #ccc;color:#444">${escapeHtml(o.reason.trim())}</blockquote>`
+    : '<p>An admin removed this event from the calendar.</p>';
+
+  return [
+    '<!doctype html><html><body style="font-family:system-ui,sans-serif;line-height:1.5">',
+    `<p>Hi ${safeName},</p>`,
+    '<p>An event from your Chautauqua Calendar feed has been removed:</p>',
+    `<p><strong>${safeTitle}</strong><br/>${escapeHtml(startDisplay)}</p>`,
+    reasonBlock,
+    `<p>View your feed status: <a href="${safeUrl}">${escapeHtml(safeUrl)}</a></p>`,
+    `<p><em>${escapeHtml(OBSERVABILITY_FOOTER)}</em></p>`,
     '<p>— Chautauqua Calendar</p>',
     '</body></html>',
   ].join('');

--- a/backend/src/services/publisherAdminService.ts
+++ b/backend/src/services/publisherAdminService.ts
@@ -131,11 +131,15 @@ export class PublisherAdminService {
     reason?: string,
   ): Promise<void> {
     // Read the event BEFORE rejecting so we have its title/startDate for the
-    // notification email. If the row is gone (never existed or already deleted),
-    // store.rejectEvent's ConditionExpression will be a no-op — don't notify.
+    // notification email. store.rejectEvent returns a transitioned boolean —
+    // false when the row was already non-pending (already-rejected, already-
+    // published, gone). We notify ONLY when the row actually transitioned to
+    // 'rejected', so admin double-clicks or races against approve don't
+    // produce a misleading "your event was rejected" email for an event that
+    // is in fact still published.
     const event = await this.store.getEvent(publisherId, eventId);
-    await this.store.rejectEvent(publisherId, eventId, reason);
-    if (event && this.reviewDeps.notifier) {
+    const transitioned = await this.store.rejectEvent(publisherId, eventId, reason);
+    if (transitioned && event && this.reviewDeps.notifier) {
       const publisher = await this.registry.get(publisherId);
       if (publisher) {
         await this.reviewDeps.notifier.notifyEventRejected({ publisher, event, reason });

--- a/backend/src/services/publisherAdminService.ts
+++ b/backend/src/services/publisherAdminService.ts
@@ -3,6 +3,7 @@ import { ConcurrentApplicationUpdateError } from './publisherRegistryService';
 import type { PublisherRegistryService } from './publisherRegistryService';
 import type { PublisherEventStore } from './publisherEventStore';
 import type { MailService } from './mailService';
+import type { PublisherNotificationService } from './publisherNotificationService';
 
 export interface CreatePublisherInput {
   id: string;
@@ -33,6 +34,10 @@ export interface ApplicationReviewDeps {
   // Used to build the magic-link login URL embedded in the approval email.
   // Falls back to https://www.chqcal.org if not set.
   siteBaseUrl?: string;
+  // Optional so callers (smoke harness, tests) that don't need event-rejection
+  // emails don't have to wire the notifier. The admin reject path will skip
+  // the notification step if this is missing.
+  notifier?: PublisherNotificationService;
 }
 
 const MAX_REJECTION_REASON_LEN = 500;
@@ -120,8 +125,22 @@ export class PublisherAdminService {
     return this.store.approveEvent(publisherId, eventId);
   }
 
-  rejectEvent(publisherId: string, eventId: string): Promise<void> {
-    return this.store.rejectEvent(publisherId, eventId);
+  async rejectEvent(
+    publisherId: string,
+    eventId: string,
+    reason?: string,
+  ): Promise<void> {
+    // Read the event BEFORE rejecting so we have its title/startDate for the
+    // notification email. If the row is gone (never existed or already deleted),
+    // store.rejectEvent's ConditionExpression will be a no-op — don't notify.
+    const event = await this.store.getEvent(publisherId, eventId);
+    await this.store.rejectEvent(publisherId, eventId, reason);
+    if (event && this.reviewDeps.notifier) {
+      const publisher = await this.registry.get(publisherId);
+      if (publisher) {
+        await this.reviewDeps.notifier.notifyEventRejected({ publisher, event, reason });
+      }
+    }
   }
 
   async listThresholdHalts(): Promise<PublisherRecord[]> {

--- a/backend/src/services/publisherEventStore.ts
+++ b/backend/src/services/publisherEventStore.ts
@@ -1,5 +1,4 @@
 import {
-  DeleteCommand,
   QueryCommand,
   TransactWriteCommand,
   UpdateCommand,
@@ -118,17 +117,37 @@ export class PublisherEventStore {
     }
   }
 
-  async rejectEvent(publisherId: string, eventId: string): Promise<void> {
-    // Guard against deleting an already-published event if /reject races a
-    // /approve or arrives after publication. ConditionalCheckFailedException
-    // is treated as a no-op — the row exists in a state we cannot reject from.
+  async rejectEvent(
+    publisherId: string,
+    eventId: string,
+    reason?: string,
+  ): Promise<void> {
+    // Soft-delete: rows transition to state='rejected' (terminal) instead of
+    // being deleted. Re-ingest preserves them via publisherReconciler.toStored.
+    // The condition `#s = :pending` keeps approve/reject races atomic — same
+    // semantics as the previous DeleteCommand. ConditionalCheckFailedException
+    // is treated as a no-op (the row is in a state we can't reject from, e.g.
+    // already-rejected, already-published, or already-deleted).
+    const trimmed = reason?.trim();
+    const setParts = ['#s = :rejected', 'rejectedAt = :now', 'updatedAt = :now'];
+    const exprValues: Record<string, unknown> = {
+      ':rejected': 'rejected',
+      ':pending': 'pending',
+      ':now': new Date().toISOString(),
+    };
+    if (trimmed && trimmed.length > 0) {
+      setParts.push('rejectionReason = :reason');
+      // Caller is responsible for the 500-char cap; defense in depth here.
+      exprValues[':reason'] = trimmed.slice(0, 500);
+    }
     try {
-      await this.db.send(new DeleteCommand({
+      await this.db.send(new UpdateCommand({
         TableName: this.tableName,
         Key: { publisherId, eventId },
-        ConditionExpression: '#s = :pending',
+        UpdateExpression: `SET ${setParts.join(', ')}`,
+        ConditionExpression: 'attribute_exists(publisherId) AND #s = :pending',
         ExpressionAttributeNames: { '#s': 'state' },
-        ExpressionAttributeValues: { ':pending': 'pending' },
+        ExpressionAttributeValues: exprValues,
       }));
     } catch (err) {
       if ((err as { name?: string })?.name === 'ConditionalCheckFailedException') return;

--- a/backend/src/services/publisherEventStore.ts
+++ b/backend/src/services/publisherEventStore.ts
@@ -129,11 +129,15 @@ export class PublisherEventStore {
     }
   }
 
+  // Returns true iff the row transitioned from 'pending' to 'rejected' on this
+  // call. Returns false on the conditional-no-op path (row already non-pending
+  // or already deleted) so callers can decide whether to fire side-effects
+  // like notification emails.
   async rejectEvent(
     publisherId: string,
     eventId: string,
     reason?: string,
-  ): Promise<void> {
+  ): Promise<boolean> {
     // Soft-delete: rows transition to state='rejected' (terminal) instead of
     // being deleted. Re-ingest preserves them via publisherReconciler.toStored.
     // The condition `#s = :pending` keeps approve/reject races atomic — same
@@ -161,8 +165,9 @@ export class PublisherEventStore {
         ExpressionAttributeNames: { '#s': 'state' },
         ExpressionAttributeValues: exprValues,
       }));
+      return true;
     } catch (err) {
-      if ((err as { name?: string })?.name === 'ConditionalCheckFailedException') return;
+      if ((err as { name?: string })?.name === 'ConditionalCheckFailedException') return false;
       throw err;
     }
   }

--- a/backend/src/services/publisherEventStore.ts
+++ b/backend/src/services/publisherEventStore.ts
@@ -1,4 +1,5 @@
 import {
+  GetCommand,
   QueryCommand,
   TransactWriteCommand,
   UpdateCommand,
@@ -52,6 +53,17 @@ export class PublisherEventStore {
       last = r.LastEvaluatedKey;
     } while (last);
     return total;
+  }
+
+  async getEvent(
+    publisherId: string,
+    eventId: string,
+  ): Promise<StoredPublisherEvent | undefined> {
+    const r = await this.db.send(new GetCommand({
+      TableName: this.tableName,
+      Key: { publisherId, eventId },
+    }));
+    return r.Item as StoredPublisherEvent | undefined;
   }
 
   async listAllPublished(): Promise<StoredPublisherEvent[]> {

--- a/backend/src/services/publisherIngestRunStore.ts
+++ b/backend/src/services/publisherIngestRunStore.ts
@@ -1,0 +1,51 @@
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+const NINETY_DAYS_S = 90 * 24 * 60 * 60;
+
+export class PublisherIngestRunStore {
+  constructor(
+    private readonly db: DynamoDBDocumentClient,
+    private readonly tableName: string,
+  ) {}
+
+  async recordRun(row: IngestRunRow): Promise<void> {
+    const ttl = Math.floor(Date.parse(row.runAt) / 1000) + NINETY_DAYS_S;
+    await this.db.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: { ...row, ttl },
+      }),
+    );
+  }
+
+  async getMostRecentRun(publisherId: string): Promise<IngestRunRow | undefined> {
+    const out = await this.db.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'publisherId = :p',
+        ExpressionAttributeValues: { ':p': publisherId },
+        ScanIndexForward: false,
+        Limit: 1,
+      }),
+    );
+    return (out.Items?.[0] as IngestRunRow | undefined) ?? undefined;
+  }
+
+  async listRecentRuns(publisherId: string, limit = 30): Promise<IngestRunRow[]> {
+    const out = await this.db.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'publisherId = :p',
+        ExpressionAttributeValues: { ':p': publisherId },
+        ScanIndexForward: false,
+        Limit: limit,
+      }),
+    );
+    return (out.Items ?? []) as IngestRunRow[];
+  }
+}

--- a/backend/src/services/publisherNotificationService.ts
+++ b/backend/src/services/publisherNotificationService.ts
@@ -80,18 +80,26 @@ export class PublisherNotificationService {
   // Bounded swallow-on-failure wrapper. Email is best-effort; a failed/late
   // mail call must NOT cause the caller (ingest loop, admin handler) to fail.
   // Errors and 2s+ timeouts are logged and swallowed.
+  //
+  // Important: when the timeout wins Promise.race, fn() keeps running as a
+  // floating promise. If it rejects later (AWS SDK retry-then-fail), Node 15+
+  // raises an unhandledRejection that defaults to crashing the Lambda.
+  // Attach a no-op .catch BEFORE racing so a late rejection is logged and
+  // swallowed instead.
   private async guarded(fn: () => Promise<unknown>): Promise<void> {
     let timer: ReturnType<typeof setTimeout> | undefined;
+    const inner = fn().catch(err => {
+      console.error('[notification] mail send failed (late):', err);
+      return '__failed__' as const;
+    });
     try {
       const timeout = new Promise<'__timeout__'>(resolve => {
         timer = setTimeout(() => resolve('__timeout__'), MAIL_TIMEOUT_MS);
       });
-      const result = await Promise.race([fn(), timeout]);
+      const result = await Promise.race([inner, timeout]);
       if (result === '__timeout__') {
         console.error('[notification] mail send timed out after 2s');
       }
-    } catch (err) {
-      console.error('[notification] mail send failed:', err);
     } finally {
       if (timer) clearTimeout(timer);
     }

--- a/backend/src/services/publisherNotificationService.ts
+++ b/backend/src/services/publisherNotificationService.ts
@@ -1,0 +1,99 @@
+import type { MailService } from './mailService';
+import type { PublisherRecord, StoredPublisherEvent } from '../types/publisher';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+const MAIL_TIMEOUT_MS = 2_000;
+
+export interface NotifyIngestRunArgs {
+  publisher: PublisherRecord;
+  prevRun: IngestRunRow | undefined;
+  newRun: IngestRunRow;
+}
+
+export interface NotifyEventRejectedArgs {
+  publisher: PublisherRecord;
+  event: StoredPublisherEvent;
+  reason: string | undefined;
+}
+
+export interface PublisherNotificationServiceDeps {
+  mail: MailService;
+  // Absolute URL to the publisher portal status page; embedded in email bodies.
+  portalUrl: string;
+}
+
+export class PublisherNotificationService {
+  constructor(private readonly deps: PublisherNotificationServiceDeps) {}
+
+  async notifyIngestRunRecorded(args: NotifyIngestRunArgs): Promise<void> {
+    if (args.publisher.notificationsEnabled === false) return;
+
+    // prevRun undefined is treated as OK so the first-ever run only emails
+    // on failure. This avoids a "your feed is broken" email on the first
+    // schedule fire after deployment for a publisher that has never run.
+    const prevOk = args.prevRun === undefined || args.prevRun.status === 'ok';
+    const newOk = args.newRun.status === 'ok';
+
+    if (prevOk && !newOk) {
+      await this.guarded(() =>
+        this.deps.mail.sendIngestFailureEmail({
+          to: args.publisher.contactEmail,
+          publisherName: args.publisher.name,
+          status: args.newRun.status as Exclude<IngestRunRow['status'], 'ok'>,
+          message: args.newRun.message ?? '(no message)',
+          portalUrl: this.deps.portalUrl,
+        }),
+      );
+      return;
+    }
+    if (!prevOk && newOk) {
+      await this.guarded(() =>
+        this.deps.mail.sendIngestRecoveryEmail({
+          to: args.publisher.contactEmail,
+          publisherName: args.publisher.name,
+          counts: args.newRun.counts ?? { added: 0, updated: 0, retracted: 0, unchanged: 0 },
+          portalUrl: this.deps.portalUrl,
+        }),
+      );
+      return;
+    }
+    // ok→ok or fail→fail: silent.
+  }
+
+  async notifyEventRejected(args: NotifyEventRejectedArgs): Promise<void> {
+    if (args.publisher.notificationsEnabled === false) return;
+    const title = (args.event.payload as { title?: string } | undefined)?.title ?? '(untitled)';
+    const trimmed = args.reason?.trim();
+    const reason = trimmed && trimmed.length > 0 ? trimmed : undefined;
+    await this.guarded(() =>
+      this.deps.mail.sendEventRejectedEmail({
+        to: args.publisher.contactEmail,
+        publisherName: args.publisher.name,
+        eventTitle: title,
+        eventStartDate: args.event.startDate,
+        reason,
+        portalUrl: this.deps.portalUrl,
+      }),
+    );
+  }
+
+  // Bounded swallow-on-failure wrapper. Email is best-effort; a failed/late
+  // mail call must NOT cause the caller (ingest loop, admin handler) to fail.
+  // Errors and 2s+ timeouts are logged and swallowed.
+  private async guarded(fn: () => Promise<unknown>): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const timeout = new Promise<'__timeout__'>(resolve => {
+        timer = setTimeout(() => resolve('__timeout__'), MAIL_TIMEOUT_MS);
+      });
+      const result = await Promise.race([fn(), timeout]);
+      if (result === '__timeout__') {
+        console.error('[notification] mail send timed out after 2s');
+      }
+    } catch (err) {
+      console.error('[notification] mail send failed:', err);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}

--- a/backend/src/services/publisherProfileService.ts
+++ b/backend/src/services/publisherProfileService.ts
@@ -29,6 +29,7 @@ export interface ProfilePatch {
   organization?: string;
   sourceUrl?: string;
   sourceType?: SourceType;
+  notificationsEnabled?: boolean;
 }
 
 const ALLOWED_FIELDS = new Set<keyof ProfilePatch>([
@@ -36,6 +37,7 @@ const ALLOWED_FIELDS = new Set<keyof ProfilePatch>([
   'organization',
   'sourceUrl',
   'sourceType',
+  'notificationsEnabled',
 ]);
 // SourceType is 'json' | 'html' in this codebase (see types/publisher.ts);
 // the values that match the existing /publisher-test endpoint.
@@ -124,6 +126,17 @@ export async function updatePublisherProfile(
       );
     }
     patch.sourceType = v as SourceType;
+  }
+
+  if ('notificationsEnabled' in rawPatch) {
+    const v = rawPatch.notificationsEnabled;
+    if (typeof v !== 'boolean') {
+      throw new ProfileValidationError(
+        'invalid_notifications_enabled',
+        '"notificationsEnabled" must be a boolean.',
+      );
+    }
+    patch.notificationsEnabled = v;
   }
 
   if (Object.keys(patch).length === 0) {

--- a/backend/src/services/publisherReconciler.ts
+++ b/backend/src/services/publisherReconciler.ts
@@ -23,18 +23,20 @@ function toStored(
   nowIso: string,
   existing?: StoredPublisherEvent,
 ): StoredPublisherEvent {
-  // Once an event reaches state='published' it is terminal. Re-ingest never
-  // demotes — admin approvals (state='published' under trustLevel='review')
-  // and trust-level changes never push a published row back to pending.
-  // The only ways out of 'published' are admin reject (delete) or removal
-  // due to feed-absence, both handled outside toStored.
-  const state: 'published' | 'pending' =
+  // Once an event reaches state='published' or state='rejected' it is terminal.
+  // Re-ingest never demotes — admin approvals (state='published' under
+  // trustLevel='review') and admin rejections (state='rejected') are sticky.
+  // The only ways out are removal due to feed-absence, both handled outside toStored.
+  // When preserving 'rejected', also preserve rejectionReason and rejectedAt.
+  const state: 'published' | 'pending' | 'rejected' =
     existing?.state === 'published'
       ? 'published'
-      : trustLevel === 'auto'
-        ? 'published'
-        : 'pending';
-  return {
+      : existing?.state === 'rejected'
+        ? 'rejected'
+        : trustLevel === 'auto'
+          ? 'published'
+          : 'pending';
+  const result: StoredPublisherEvent = {
     publisherId: publisher.id,
     eventId: ev.id,
     startDate: ev.startDate,
@@ -44,6 +46,12 @@ function toStored(
     state,
     updatedAt: nowIso,
   };
+  // Preserve rejection metadata (reason and timestamp) when persisting rejected state.
+  if (state === 'rejected' && existing) {
+    if (existing.rejectionReason) result.rejectionReason = existing.rejectionReason;
+    if (existing.rejectedAt) result.rejectedAt = existing.rejectedAt;
+  }
+  return result;
 }
 
 export function reconcile(input: ReconcileInput): ReconcileResult {

--- a/backend/src/services/publisherRegistryService.ts
+++ b/backend/src/services/publisherRegistryService.ts
@@ -404,7 +404,7 @@ export class PublisherRegistryService {
   // contactEmail here would let a caller skip that flow with a single typo.
   async updateProfile(
     id: string,
-    patch: Partial<Pick<PublisherRecord, 'name' | 'organization' | 'sourceUrl' | 'sourceType'>>,
+    patch: Partial<Pick<PublisherRecord, 'name' | 'organization' | 'sourceUrl' | 'sourceType' | 'notificationsEnabled'>>,
   ): Promise<void> {
     if (Object.keys(patch).length === 0) return;
     const setParts: string[] = [];

--- a/backend/src/types/publisher.ts
+++ b/backend/src/types/publisher.ts
@@ -18,6 +18,11 @@ export interface PublisherRecord {
   // from `enabled = false`, which retracts (hard-deletes) all events on the
   // next ingest run. Optional/defaulted-undefined; absence means "not paused".
   paused?: boolean;
+  // Single opt-out switch for the publisher-observability email notifications
+  // (ingest-failure, ingest-recovery, event-rejected). Operational emails
+  // (magic link, email-change verify, self-disable confirmation) are unaffected.
+  // Absent → treated as true (default-on for legacy rows).
+  notificationsEnabled?: boolean;
   // Identity-version counter. Bumped on email change verify and self-disable.
   // Issued JWTs include this; mismatch with the row's current value → 401.
   // Defaults to 0 for legacy rows that were created before this field existed.
@@ -74,7 +79,13 @@ export interface StoredPublisherEvent {
   endDate: string;
   lastModified: string;
   payload: FeedEvent & { sourcePublisherId: string; sourcePublisherName: string };
-  state: 'published' | 'pending';
+  state: 'published' | 'pending' | 'rejected';
+  // Set when admin rejects. Optional so blank reasons are simply absent.
+  // Cap at 500 chars in the handler that sets it.
+  rejectionReason?: string;
+  // ISO 8601 timestamp at which admin rejected. Sidecar/UI uses this to
+  // sort rejected items and to show "Rejected on …" in the publisher portal.
+  rejectedAt?: string;
   updatedAt: string;
 }
 

--- a/backend/src/types/publisherIngestRun.ts
+++ b/backend/src/types/publisherIngestRun.ts
@@ -1,0 +1,24 @@
+import type { FetchStatus } from './publisher';
+
+export type IngestRunTrigger = 'schedule' | 'admin' | 'publisher-fetch-now';
+
+export interface IngestRunCounts {
+  added: number;
+  updated: number;
+  retracted: number;
+  unchanged: number;
+}
+
+export interface IngestRunRow {
+  publisherId: string;
+  // ISO 8601. Sort key.
+  runAt: string;
+  status: FetchStatus;
+  // Capped at 500 chars by the writer. Optional so OK runs omit it.
+  message?: string;
+  // Only populated when status === 'ok'.
+  counts?: IngestRunCounts;
+  triggeredBy: IngestRunTrigger;
+  // Unix seconds. ~90 days from runAt. Auto-expires the row.
+  ttl?: number;
+}

--- a/docs/superpowers/plans/2026-05-06-publisher-observability-plan.md
+++ b/docs/superpowers/plans/2026-05-06-publisher-observability-plan.md
@@ -1,0 +1,2314 @@
+# Publisher Observability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle three publisher-experience features — ingest history timeline, per-event status grid, and email notifications — so a publisher can self-diagnose feed problems and learn about admin actions without contacting an admin.
+
+**Architecture:** New DDB table for ingest-run history (last 30 per publisher, 90-day TTL); soft-delete reject (`state='rejected'`) preserved across re-ingest; inline `notificationService` with 2s SES timeout that swallows email failures. Two new collapsible panels on `/publish/status/`. One new opt-out flag on the publisher row.
+
+**Tech Stack:** TypeScript, AWS Lambda + DynamoDB + SES, Vite + Preact, Terraform, Jest (backend), Vitest + @testing-library/preact (frontend).
+
+**Spec:** [docs/superpowers/specs/2026-05-06-publisher-observability-design.md](../specs/2026-05-06-publisher-observability-design.md)
+
+**Branch:** Work on `spec/publisher-observability` (the spec lives there). Each task commits to that branch. Open one PR after the full plan completes.
+
+---
+
+## File map
+
+### Backend — new files
+- `backend/src/types/publisherIngestRun.ts` — `IngestRunRow`, `IngestRunCounts`, `IngestRunTrigger`
+- `backend/src/services/publisherIngestRunStore.ts` — DDB wrapper for the new table
+- `backend/src/services/publisherNotificationService.ts` — streak detection + dispatch to mailService
+- `backend/src/__tests__/publisherIngestRunStore.test.ts`
+- `backend/src/__tests__/publisherNotificationService.test.ts`
+- `backend/src/__tests__/integration/publisherRunsAndEvents.test.ts`
+
+### Backend — modified files
+- `backend/src/types/publisher.ts` — extend `StoredPublisherEvent.state`; add `rejectionReason`, `rejectedAt`; add `notificationsEnabled` to `PublisherRecord`
+- `backend/src/services/publisherEventStore.ts` — `rejectEvent` becomes soft-delete; `listForPublisher` already returns all (no change)
+- `backend/src/services/publisherReconciler.ts` — `toStored` preserves rejected state + reason + rejectedAt
+- `backend/src/services/publisherSidecarPublisher.ts` — sidecar filters out `state === 'rejected'`
+- `backend/src/services/mailService.ts` — three new methods (failure, recovery, eventRejected) + bodies
+- `backend/src/services/publisherProfileService.ts` — accept `notificationsEnabled` in update patch
+- `backend/src/services/publisherRegistryService.ts` — `updateProfile` allow-list adds `notificationsEnabled`
+- `backend/src/handlers/publisherIngestHandler.ts` — wire run-store + notifier
+- `backend/src/handlers/publisherPortalHandler.ts` — `GET /publisher-runs`, `GET /publisher-events`; profile patch passes through `notificationsEnabled`
+- `backend/src/handlers/adminHandler.ts` — accept reason on reject; call notifier
+- `backend/src/__tests__/publisherEventStore.test.ts` — soft-delete reject pins
+- `backend/src/__tests__/publisherReconciler.test.ts` — preserve rejected pins
+- `backend/src/__tests__/publisherIngestHandler.integration.test.ts` — runs recorded + notifier fires on transitions
+- `backend/src/__tests__/publisherSidecarPublisher.test.ts` — rejected filter pin
+- `backend/src/__tests__/mailService.test.ts` — three new bodies
+- `backend/src/__tests__/publisherProfileService.test.ts` — notificationsEnabled patch
+- `backend/src/__tests__/adminHandler.publishers.test.ts` (or new `adminHandler.publisherEvents.test.ts`) — reason parsing
+
+### Frontend — new files
+- `frontend/src/app/publish/status/IngestHistoryPanel.tsx`
+- `frontend/src/app/publish/status/PublisherEventsPanel.tsx`
+- `frontend/src/app/publish/status/__tests__/IngestHistoryPanel.test.tsx`
+- `frontend/src/app/publish/status/__tests__/PublisherEventsPanel.test.tsx`
+
+### Frontend — modified files
+- `frontend/src/lib/publisherStatusApi.ts` — `getPublisherRuns`, `getPublisherEvents`; `patchPublisherProfile` types extended
+- `frontend/src/app/publish/status/page.tsx` — mount panels + notifications checkbox
+- `frontend/src/app/publish/status/__tests__/page.test.tsx` — extend for new panels + toggle
+- `frontend/src/app/admin/publisher-events/page.tsx` — reason textarea on reject
+
+### Infrastructure — modified files
+- `infrastructure/publisher-ingest.tf` — new DDB table + IAM grants
+
+### Smoke / scripts — modified files
+- `scripts/post-deploy-publisher-smoke.ts` (or wherever the existing smoke harness lives) — assert `GET /publisher-runs` + `GET /publisher-events` for bbtest; assert at least one run row appears after invoke
+
+---
+
+## Phase 1 — Foundation: types, ingest-run store, soft-delete reject
+
+### Task 1: Type additions
+
+**Files:**
+- Modify: `backend/src/types/publisher.ts`
+- Create: `backend/src/types/publisherIngestRun.ts`
+
+- [ ] **Step 1: Extend `StoredPublisherEvent` and `PublisherRecord` in `backend/src/types/publisher.ts`**
+
+Edit the `StoredPublisherEvent` interface so `state` accepts `'rejected'`, and add the two new optional fields. Edit `PublisherRecord` to add `notificationsEnabled?: boolean`.
+
+```ts
+// in PublisherRecord (insert near `paused?: boolean;`):
+  // Single opt-out switch for the publisher-observability email notifications
+  // (ingest-failure, ingest-recovery, event-rejected). Operational emails
+  // (magic link, email-change verify, self-disable confirmation) are unaffected.
+  // Absent → treated as true (default-on for legacy rows).
+  notificationsEnabled?: boolean;
+```
+
+```ts
+// replace the existing StoredPublisherEvent.state line and append two fields:
+export interface StoredPublisherEvent {
+  publisherId: string;
+  eventId: string;
+  startDate: string;
+  endDate: string;
+  lastModified: string;
+  payload: FeedEvent & { sourcePublisherId: string; sourcePublisherName: string };
+  state: 'published' | 'pending' | 'rejected';
+  // Set when admin rejects. Optional so blank reasons are simply absent.
+  // Cap at 500 chars in the handler that sets it.
+  rejectionReason?: string;
+  // ISO 8601 timestamp at which admin rejected. Sidecar/UI uses this to
+  // sort rejected items and to show "Rejected on …" in the publisher portal.
+  rejectedAt?: string;
+  updatedAt: string;
+}
+```
+
+- [ ] **Step 2: Create `backend/src/types/publisherIngestRun.ts`**
+
+```ts
+import type { FetchStatus } from './publisher';
+
+export type IngestRunTrigger = 'schedule' | 'admin' | 'publisher-fetch-now';
+
+export interface IngestRunCounts {
+  added: number;
+  updated: number;
+  retracted: number;
+  unchanged: number;
+}
+
+export interface IngestRunRow {
+  publisherId: string;
+  // ISO 8601. Sort key.
+  runAt: string;
+  status: FetchStatus;
+  // Capped at 500 chars by the writer. Optional so OK runs omit it.
+  message?: string;
+  // Only populated when status === 'ok'.
+  counts?: IngestRunCounts;
+  triggeredBy: IngestRunTrigger;
+  // Unix seconds. ~90 days from runAt. Auto-expires the row.
+  ttl?: number;
+}
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd backend && npm run typecheck`
+Expected: PASS (no source consumers of the new fields yet)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/types/publisher.ts backend/src/types/publisherIngestRun.ts
+git commit -m "feat(publisher): add IngestRunRow type, extend StoredPublisherEvent with rejected state"
+```
+
+---
+
+### Task 2: PublisherIngestRunStore service
+
+**Files:**
+- Create: `backend/src/services/publisherIngestRunStore.ts`
+- Test: `backend/src/__tests__/publisherIngestRunStore.test.ts`
+
+Pattern: mirror `publisherRegistryService.ts` (DDB DocumentClient wrapper). Look at it for the `import { DynamoDBDocumentClient, … }` set.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `backend/src/__tests__/publisherIngestRunStore.test.ts`:
+
+```ts
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, PutCommand, QueryCommand } from '@aws-sdk/lib-dynamodb';
+import { PublisherIngestRunStore } from '../services/publisherIngestRunStore';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+const TABLE = 'test-runs-table';
+
+function row(overrides: Partial<IngestRunRow> = {}): IngestRunRow {
+  return {
+    publisherId: 'pub-1',
+    runAt: '2026-05-06T12:00:00.000Z',
+    status: 'ok',
+    triggeredBy: 'schedule',
+    counts: { added: 1, updated: 0, retracted: 0, unchanged: 5 },
+    ...overrides,
+  };
+}
+
+describe('PublisherIngestRunStore', () => {
+  const ddbMock = mockClient(DynamoDBDocumentClient);
+  const docClient = DynamoDBDocumentClient.from({} as never);
+  const store = new PublisherIngestRunStore(docClient, TABLE);
+
+  beforeEach(() => ddbMock.reset());
+
+  test('recordRun writes the row with a 90-day TTL', async () => {
+    ddbMock.on(PutCommand).resolves({});
+    const r = row();
+    await store.recordRun(r);
+    const call = ddbMock.commandCalls(PutCommand)[0]!;
+    expect(call.args[0].input.TableName).toBe(TABLE);
+    const item = call.args[0].input.Item as IngestRunRow;
+    expect(item.publisherId).toBe('pub-1');
+    expect(item.runAt).toBe(r.runAt);
+    expect(item.ttl).toBeGreaterThan(Math.floor(Date.parse(r.runAt) / 1000));
+    // ~90 days = 7,776,000s
+    expect(item.ttl! - Math.floor(Date.parse(r.runAt) / 1000)).toBeGreaterThanOrEqual(7_776_000 - 60);
+  });
+
+  test('getMostRecentRun queries with Limit=1, ScanIndexForward=false', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [row()] });
+    const got = await store.getMostRecentRun('pub-1');
+    expect(got?.publisherId).toBe('pub-1');
+    const call = ddbMock.commandCalls(QueryCommand)[0]!;
+    expect(call.args[0].input.Limit).toBe(1);
+    expect(call.args[0].input.ScanIndexForward).toBe(false);
+    expect(call.args[0].input.KeyConditionExpression).toContain('publisherId');
+  });
+
+  test('getMostRecentRun returns undefined when table empty', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+    expect(await store.getMostRecentRun('pub-1')).toBeUndefined();
+  });
+
+  test('listRecentRuns returns at most `limit` rows newest-first', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [row({ runAt: '2026-05-06T12:00:00.000Z' })] });
+    const out = await store.listRecentRuns('pub-1', 30);
+    expect(out).toHaveLength(1);
+    const call = ddbMock.commandCalls(QueryCommand)[0]!;
+    expect(call.args[0].input.Limit).toBe(30);
+    expect(call.args[0].input.ScanIndexForward).toBe(false);
+  });
+
+  test('listRecentRuns defaults limit to 30', async () => {
+    ddbMock.on(QueryCommand).resolves({ Items: [] });
+    await store.listRecentRuns('pub-1');
+    expect(ddbMock.commandCalls(QueryCommand)[0]!.args[0].input.Limit).toBe(30);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `cd backend && npx jest publisherIngestRunStore -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the service**
+
+Create `backend/src/services/publisherIngestRunStore.ts`:
+
+```ts
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+const NINETY_DAYS_S = 90 * 24 * 60 * 60;
+
+export class PublisherIngestRunStore {
+  constructor(
+    private readonly db: DynamoDBDocumentClient,
+    private readonly tableName: string,
+  ) {}
+
+  async recordRun(row: IngestRunRow): Promise<void> {
+    const ttl = Math.floor(Date.parse(row.runAt) / 1000) + NINETY_DAYS_S;
+    await this.db.send(
+      new PutCommand({
+        TableName: this.tableName,
+        Item: { ...row, ttl },
+      }),
+    );
+  }
+
+  async getMostRecentRun(publisherId: string): Promise<IngestRunRow | undefined> {
+    const out = await this.db.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'publisherId = :p',
+        ExpressionAttributeValues: { ':p': publisherId },
+        ScanIndexForward: false,
+        Limit: 1,
+      }),
+    );
+    return (out.Items?.[0] as IngestRunRow | undefined) ?? undefined;
+  }
+
+  async listRecentRuns(publisherId: string, limit = 30): Promise<IngestRunRow[]> {
+    const out = await this.db.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: 'publisherId = :p',
+        ExpressionAttributeValues: { ':p': publisherId },
+        ScanIndexForward: false,
+        Limit: limit,
+      }),
+    );
+    return (out.Items ?? []) as IngestRunRow[];
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && npx jest publisherIngestRunStore -v`
+Expected: PASS — 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/publisherIngestRunStore.ts backend/src/__tests__/publisherIngestRunStore.test.ts
+git commit -m "feat(publisher): PublisherIngestRunStore — record/list ingest runs with 90-day TTL"
+```
+
+---
+
+### Task 3: Soft-delete reject in PublisherEventStore
+
+**Files:**
+- Modify: `backend/src/services/publisherEventStore.ts:121-137`
+- Modify (extend tests): `backend/src/__tests__/publisherEventStore.test.ts`
+
+- [ ] **Step 1: Add failing tests for soft-delete reject**
+
+Open `backend/src/__tests__/publisherEventStore.test.ts` and copy the mock setup from the existing `rejectEvent` test (likely uses `aws-sdk-client-mock` against `DynamoDBDocumentClient`). Replace the existing `rejectEvent` test block with:
+
+```ts
+describe('PublisherEventStore.rejectEvent (soft-delete)', () => {
+  // Reuse the file's existing `mockClient`, `docClient`, `store`, and `TABLE` constants
+  // from the harness above.
+  beforeEach(() => ddbMock.reset());
+
+  test('updates state to rejected with reason and rejectedAt', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.rejectEvent('pub-1', 'ev-1', 'duplicate of upstream feed');
+    const call = ddbMock.commandCalls(UpdateCommand)[0]!;
+    const input = call.args[0].input;
+    expect(input.UpdateExpression).toContain('SET #s = :rejected');
+    expect(input.UpdateExpression).toContain('rejectedAt = :now');
+    expect(input.UpdateExpression).toContain('rejectionReason = :reason');
+    expect(input.ExpressionAttributeValues![':reason']).toBe('duplicate of upstream feed');
+    expect(input.ConditionExpression).toContain('#s = :pending');
+  });
+
+  test('omits rejectionReason when reason is undefined', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.rejectEvent('pub-1', 'ev-1');
+    const input = ddbMock.commandCalls(UpdateCommand)[0]!.args[0].input;
+    expect(input.UpdateExpression).not.toContain('rejectionReason');
+    expect(input.ExpressionAttributeValues![':reason']).toBeUndefined();
+  });
+
+  test('omits rejectionReason when reason is whitespace-only', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.rejectEvent('pub-1', 'ev-1', '   ');
+    const input = ddbMock.commandCalls(UpdateCommand)[0]!.args[0].input;
+    expect(input.UpdateExpression).not.toContain('rejectionReason');
+  });
+
+  test('caps reason at 500 chars defensively', async () => {
+    ddbMock.on(UpdateCommand).resolves({});
+    await store.rejectEvent('pub-1', 'ev-1', 'x'.repeat(600));
+    const input = ddbMock.commandCalls(UpdateCommand)[0]!.args[0].input;
+    expect((input.ExpressionAttributeValues![':reason'] as string).length).toBe(500);
+  });
+
+  test('swallows ConditionalCheckFailedException (state !== pending)', async () => {
+    const err = Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' });
+    ddbMock.on(UpdateCommand).rejects(err);
+    await expect(store.rejectEvent('pub-1', 'ev-1', 'r')).resolves.toBeUndefined();
+  });
+
+  test('rethrows other DDB errors', async () => {
+    ddbMock.on(UpdateCommand).rejects(new Error('throttle'));
+    await expect(store.rejectEvent('pub-1', 'ev-1', 'r')).rejects.toThrow('throttle');
+  });
+
+  test('approve-after-reject still fails (existing approve condition rejects state=rejected)', async () => {
+    const err = Object.assign(new Error('cond'), { name: 'ConditionalCheckFailedException' });
+    ddbMock.on(UpdateCommand).rejects(err);
+    await expect(store.approveEvent('pub-1', 'ev-1')).rejects.toThrow(/cannot approve/);
+  });
+});
+```
+
+If the existing test file uses an in-memory DDB harness instead of `aws-sdk-client-mock`, mirror that pattern: seed a row, call the method, read the row back, assert fields.
+
+- [ ] **Step 2: Run tests to confirm failure**
+
+Run: `cd backend && npx jest publisherEventStore.test -v`
+Expected: FAIL — soft-delete tests fail because the current implementation deletes.
+
+- [ ] **Step 3: Replace `rejectEvent` with soft-delete**
+
+In `backend/src/services/publisherEventStore.ts`, replace the existing `rejectEvent` method (lines 121–137) with:
+
+```ts
+async rejectEvent(
+  publisherId: string,
+  eventId: string,
+  reason?: string,
+): Promise<void> {
+  // Soft-delete: rows transition to state='rejected' (terminal) instead of
+  // being deleted. Re-ingest preserves them via publisherReconciler.toStored.
+  // The condition `#s = :pending` keeps approve/reject races atomic — same
+  // semantics as the previous DeleteCommand. ConditionalCheckFailedException
+  // is treated as a no-op (the row is in a state we can't reject from, e.g.
+  // already-rejected, already-published, or already-deleted).
+  const trimmed = reason?.trim();
+  const setParts = ['#s = :rejected', 'rejectedAt = :now', 'updatedAt = :now'];
+  const exprValues: Record<string, unknown> = {
+    ':rejected': 'rejected',
+    ':pending': 'pending',
+    ':now': new Date().toISOString(),
+  };
+  if (trimmed && trimmed.length > 0) {
+    setParts.push('rejectionReason = :reason');
+    // Caller (adminHandler) is responsible for the 500-char cap; defense in
+    // depth here keeps a misbehaving caller from writing huge values.
+    exprValues[':reason'] = trimmed.slice(0, 500);
+  }
+  try {
+    await this.db.send(new UpdateCommand({
+      TableName: this.tableName,
+      Key: { publisherId, eventId },
+      UpdateExpression: `SET ${setParts.join(', ')}`,
+      ConditionExpression: 'attribute_exists(publisherId) AND #s = :pending',
+      ExpressionAttributeNames: { '#s': 'state' },
+      ExpressionAttributeValues: exprValues,
+    }));
+  } catch (err) {
+    if ((err as { name?: string })?.name === 'ConditionalCheckFailedException') return;
+    throw err;
+  }
+}
+```
+
+You'll need `UpdateCommand` imported at the top of the file (it's likely already there; if not, add it to the existing `@aws-sdk/lib-dynamodb` import).
+
+- [ ] **Step 4: Run all event-store tests**
+
+Run: `cd backend && npx jest publisherEventStore -v`
+Expected: PASS — all soft-delete tests + existing approve tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/publisherEventStore.ts backend/src/__tests__/publisherEventStore.test.ts
+git commit -m "feat(publisher): rejectEvent now soft-deletes (state='rejected' + optional reason)"
+```
+
+---
+
+### Task 4: Reconciler preserves rejected state across re-ingest
+
+**Files:**
+- Modify: `backend/src/services/publisherReconciler.ts:19-47`
+- Modify: `backend/src/__tests__/publisherReconciler.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `backend/src/__tests__/publisherReconciler.test.ts`:
+
+```ts
+describe('reconcile preserves admin-rejected state', () => {
+  const fixedNow = new Date('2026-05-06T12:00:00.000Z');
+
+  test('a rejected stored row stays rejected when feed event is unchanged', () => {
+    const existing: StoredPublisherEvent = {
+      publisherId: 'pub-1',
+      eventId: 'ev-1',
+      startDate: '2026-07-01T18:00:00.000Z',
+      endDate: '2026-07-01T20:00:00.000Z',
+      lastModified: '2026-05-01T09:00:00.000Z',
+      payload: { /* … */ } as never,
+      state: 'rejected',
+      rejectionReason: 'duplicate of city-hall keynote',
+      rejectedAt: '2026-05-02T10:00:00.000Z',
+      updatedAt: '2026-05-02T10:00:00.000Z',
+    };
+    const feedEvent = {
+      id: 'ev-1',
+      title: 'Test',
+      startDate: existing.startDate,
+      endDate: existing.endDate,
+      lastModified: '2026-05-05T09:00:00.000Z', // newer
+    } as never;
+    const feed = { publisher: { id: 'pub-1', name: 'Pub' }, events: [feedEvent] } as never;
+
+    const result = reconcile({ stored: [existing], feed, now: fixedNow, trustLevel: 'review' });
+    expect(result.applied).toBe(true);
+    // The reconciler's update path triggers because lastModified is newer; we expect
+    // the rebuilt row to retain `state='rejected'` AND the reason+rejectedAt fields.
+    const updated = result.diff.updates[0]!;
+    expect(updated.state).toBe('rejected');
+    expect(updated.rejectionReason).toBe('duplicate of city-hall keynote');
+    expect(updated.rejectedAt).toBe('2026-05-02T10:00:00.000Z');
+  });
+
+  test('publisher dropping a rejected event from feed deletes the row (normal removal)', () => {
+    const existing: StoredPublisherEvent = {
+      publisherId: 'pub-1',
+      eventId: 'ev-1',
+      startDate: '2026-07-01T18:00:00.000Z',
+      endDate: '2026-07-01T20:00:00.000Z',
+      lastModified: '2026-05-01T09:00:00.000Z',
+      payload: {} as never,
+      state: 'rejected',
+      updatedAt: '2026-05-02T10:00:00.000Z',
+    };
+    const feed = { publisher: { id: 'pub-1', name: 'Pub' }, events: [] } as never;
+
+    const result = reconcile({ stored: [existing], feed, now: fixedNow, trustLevel: 'review' });
+    expect(result.applied).toBe(true);
+    expect(result.diff.removals).toHaveLength(1);
+    expect(result.diff.removals[0]!.eventId).toBe('ev-1');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd backend && npx jest publisherReconciler -v -t "preserves admin-rejected"`
+Expected: FAIL — `state` comes back as `'pending'` because `toStored` only checks for `'published'`.
+
+- [ ] **Step 3: Update `toStored` in `publisherReconciler.ts`**
+
+Replace the existing `toStored` function (lines 19–47):
+
+```ts
+function toStored(
+  ev: FeedEvent,
+  publisher: FeedDocument['publisher'],
+  trustLevel: TrustLevel,
+  nowIso: string,
+  existing?: StoredPublisherEvent,
+): StoredPublisherEvent {
+  // Terminal admin-set states are preserved across re-ingest:
+  //  - 'published': admin explicitly approved (or trustLevel='auto' set it)
+  //  - 'rejected':  admin explicitly rejected; preserved with reason+rejectedAt
+  // The only ways out of these states are admin reset (not implemented) or
+  // removal due to feed-absence (handled outside toStored as a normal removal).
+  const preserveExisting =
+    existing?.state === 'published' || existing?.state === 'rejected';
+  const state: StoredPublisherEvent['state'] = preserveExisting
+    ? existing!.state
+    : trustLevel === 'auto'
+      ? 'published'
+      : 'pending';
+
+  const out: StoredPublisherEvent = {
+    publisherId: publisher.id,
+    eventId: ev.id,
+    startDate: ev.startDate,
+    endDate: ev.endDate,
+    lastModified: ev.lastModified,
+    payload: { ...ev, sourcePublisherId: publisher.id, sourcePublisherName: publisher.name },
+    state,
+    updatedAt: nowIso,
+  };
+  if (existing?.state === 'rejected') {
+    if (existing.rejectionReason !== undefined) out.rejectionReason = existing.rejectionReason;
+    if (existing.rejectedAt !== undefined) out.rejectedAt = existing.rejectedAt;
+  }
+  return out;
+}
+```
+
+- [ ] **Step 4: Run all reconciler tests**
+
+Run: `cd backend && npx jest publisherReconciler -v`
+Expected: PASS — all existing tests plus the two new ones.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/publisherReconciler.ts backend/src/__tests__/publisherReconciler.test.ts
+git commit -m "feat(publisher): reconciler preserves rejected state + reason across re-ingest"
+```
+
+---
+
+### Task 5: Sidecar publisher filters out rejected events
+
+**Files:**
+- Modify: `backend/src/services/publisherSidecarPublisher.ts`
+- Modify: `backend/src/__tests__/publisherSidecarPublisher.test.ts`
+
+- [ ] **Step 1: Find the existing pending-state filter**
+
+Run: `grep -n "state" backend/src/services/publisherSidecarPublisher.ts`
+
+You're looking for a line that filters or skips events whose `state !== 'published'` (or `state === 'pending'`). The change is to ensure rejected events are also excluded from the public sidecar payload.
+
+- [ ] **Step 2: Add a failing test**
+
+Append to `backend/src/__tests__/publisherSidecarPublisher.test.ts` a test that puts a `state='rejected'` row in the input set and asserts it's excluded from the sidecar output. Mirror the existing pending-state exclusion test.
+
+```ts
+test('rejected events are excluded from sidecar payload', () => {
+  const rows: StoredPublisherEvent[] = [
+    { /* …published row… */, state: 'published' },
+    { /* …same shape… */, state: 'rejected' },
+  ];
+  // Call the sidecar publish function (look at existing tests for the signature)
+  const out = buildSidecar(rows /* or whatever the existing test calls */);
+  expect(out.events).toHaveLength(1);
+  expect(out.events[0].state).toBe('published');
+});
+```
+
+- [ ] **Step 3: Run failing test**
+
+Run: `cd backend && npx jest publisherSidecarPublisher -v -t "rejected"`
+Expected: FAIL — current filter keeps `state !== 'pending'` rows, which lets `'rejected'` through.
+
+- [ ] **Step 4: Tighten the filter**
+
+In `backend/src/services/publisherSidecarPublisher.ts`, change the filter from `state !== 'pending'` (or equivalent) to `state === 'published'`. The exact line depends on the implementation; a positive include is clearer than chasing additional negatives if the union grows again.
+
+```ts
+// Before: e.state !== 'pending'
+// After:
+e.state === 'published'
+```
+
+- [ ] **Step 5: Run all sidecar tests**
+
+Run: `cd backend && npx jest publisherSidecarPublisher -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/publisherSidecarPublisher.ts backend/src/__tests__/publisherSidecarPublisher.test.ts
+git commit -m "fix(publisher): sidecar excludes rejected events (positive published-only filter)"
+```
+
+---
+
+## Phase 2 — Notifications: mail templates and notification service
+
+### Task 6: Three new mail templates
+
+**Files:**
+- Modify: `backend/src/services/mailService.ts`
+- Modify: `backend/src/__tests__/mailService.test.ts`
+
+- [ ] **Step 1: Define the three new option interfaces and method signatures**
+
+In `backend/src/services/mailService.ts`, after the existing `RejectionEmailOpts` interface, add:
+
+```ts
+export interface IngestFailureEmailOpts {
+  toEmail: string;
+  publisherName: string;
+  status: 'parse_error' | 'validation_error' | 'network_error' | 'threshold_halt';
+  message: string;
+  portalUrl: string; // absolute URL to /publish/status/
+}
+
+export interface IngestRecoveryEmailOpts {
+  toEmail: string;
+  publisherName: string;
+  counts: { added: number; updated: number; retracted: number; unchanged: number };
+  portalUrl: string;
+}
+
+export interface EventRejectedEmailOpts {
+  toEmail: string;
+  publisherName: string;
+  eventTitle: string;
+  eventStartDate: string; // ISO 8601
+  reason?: string;        // undefined/empty → generic line
+  portalUrl: string;
+}
+```
+
+Add to the `MailService` interface:
+
+```ts
+sendIngestFailureEmail(opts: IngestFailureEmailOpts): Promise<{ messageId: string }>;
+sendIngestRecoveryEmail(opts: IngestRecoveryEmailOpts): Promise<{ messageId: string }>;
+sendEventRejectedEmail(opts: EventRejectedEmailOpts): Promise<{ messageId: string }>;
+```
+
+Add corresponding methods to `SesMailService` that delegate to private body-builder functions (mirror the existing `sendApprovalEmail` shape).
+
+- [ ] **Step 2: Add tests for the bodies**
+
+Append to `backend/src/__tests__/mailService.test.ts`:
+
+```ts
+describe('SesMailService — observability emails', () => {
+  // Reuse the existing SES-mock harness from this file. Each test should
+  // capture the SendEmailCommand input and assert on Subject + Body.
+
+  test('sendIngestFailureEmail subject and body include publisher name and error', async () => {
+    // Capture call. Assert subject contains 'feed' and 'broke' (or "broken"),
+    // contains publisherName and the message string, and contains portalUrl.
+    // Body uses <pre> for monospace error blocks (Outlook compat — see PR #88).
+  });
+
+  test('sendIngestRecoveryEmail subject signals success and body shows counts', async () => {
+    // counts.added etc. should appear in body.
+  });
+
+  test('sendEventRejectedEmail with reason includes the reason verbatim', async () => {});
+
+  test('sendEventRejectedEmail without reason shows the generic line', async () => {
+    // body should NOT include "Reason:" header line; should include something
+    // like "An admin removed this event from the calendar."
+  });
+});
+```
+
+Pattern: look at the existing `sendApprovalEmail` test in the same file for the exact mock + assertion pattern.
+
+- [ ] **Step 3: Run tests to confirm failure**
+
+Run: `cd backend && npx jest mailService -v -t "observability"`
+Expected: FAIL — methods not defined yet.
+
+- [ ] **Step 4: Implement bodies**
+
+Add three private body-builder functions and wire each `send…` method through `this.sendEmail(...)` like the existing approval/rejection methods. Use `<pre>` blocks for monospace error messages (per PR #88 and the existing approval template). Subject line guidelines:
+
+- Failure: `[Chautauqua Calendar] Your feed broke`
+- Recovery: `[Chautauqua Calendar] Your feed is working again`
+- Event rejected: `[Chautauqua Calendar] Event removed: <event title>` (truncate title to 80 chars to keep subject reasonable)
+
+Body shape (text + HTML; mirror existing patterns). Footer link must point to `opts.portalUrl`. The email body must include a one-line "If you don't want these notifications, sign in and turn off email alerts." pointer to the toggle.
+
+- [ ] **Step 5: Run all mail tests**
+
+Run: `cd backend && npx jest mailService -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/services/mailService.ts backend/src/__tests__/mailService.test.ts
+git commit -m "feat(mail): three new templates — ingest-failure, ingest-recovery, event-rejected"
+```
+
+---
+
+### Task 7: PublisherNotificationService
+
+**Files:**
+- Create: `backend/src/services/publisherNotificationService.ts`
+- Test: `backend/src/__tests__/publisherNotificationService.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `backend/src/__tests__/publisherNotificationService.test.ts`:
+
+```ts
+import { PublisherNotificationService } from '../services/publisherNotificationService';
+import type { PublisherRecord } from '../types/publisher';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+
+function publisher(overrides: Partial<PublisherRecord> = {}): PublisherRecord {
+  return {
+    id: 'pub-1',
+    name: 'Test Pub',
+    contactEmail: 'pub@example.com',
+    sourceUrl: 'https://example.com/feed.json',
+    sourceType: 'json',
+    trustLevel: 'review',
+    enabled: true,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function run(overrides: Partial<IngestRunRow> = {}): IngestRunRow {
+  return {
+    publisherId: 'pub-1',
+    runAt: '2026-05-06T12:00:00.000Z',
+    status: 'ok',
+    triggeredBy: 'schedule',
+    counts: { added: 1, updated: 0, retracted: 0, unchanged: 5 },
+    ...overrides,
+  };
+}
+
+describe('PublisherNotificationService.notifyIngestRunRecorded', () => {
+  let mail: { sendIngestFailureEmail: jest.Mock; sendIngestRecoveryEmail: jest.Mock; sendEventRejectedEmail: jest.Mock };
+  let svc: PublisherNotificationService;
+  beforeEach(() => {
+    mail = {
+      sendIngestFailureEmail: jest.fn().mockResolvedValue({ messageId: 'm1' }),
+      sendIngestRecoveryEmail: jest.fn().mockResolvedValue({ messageId: 'm2' }),
+      sendEventRejectedEmail: jest.fn().mockResolvedValue({ messageId: 'm3' }),
+    };
+    svc = new PublisherNotificationService({ mail: mail as never, portalUrl: 'https://chqcal.org/publish/status/' });
+  });
+
+  test('first failure after OK streak sends failure email', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error', message: 'expected }', counts: undefined }),
+    });
+    expect(mail.sendIngestFailureEmail).toHaveBeenCalledTimes(1);
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('first OK after failure streak sends recovery email', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'network_error', message: 'timeout', counts: undefined }),
+      newRun: run({ status: 'ok' }),
+    });
+    expect(mail.sendIngestRecoveryEmail).toHaveBeenCalledTimes(1);
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+  });
+
+  test('OK→OK is silent', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'ok' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('failure→failure is silent (consecutive failures suppress repeat email)', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'parse_error' }),
+      newRun: run({ status: 'network_error' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+  });
+
+  test('first ever run that fails sends failure email (prevRun undefined treated as OK)', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: undefined,
+      newRun: run({ status: 'parse_error' }),
+    });
+    expect(mail.sendIngestFailureEmail).toHaveBeenCalledTimes(1);
+  });
+
+  test('first ever run that succeeds is silent', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: undefined,
+      newRun: run({ status: 'ok' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+    expect(mail.sendIngestRecoveryEmail).not.toHaveBeenCalled();
+  });
+
+  test('notificationsEnabled === false short-circuits', async () => {
+    await svc.notifyIngestRunRecorded({
+      publisher: publisher({ notificationsEnabled: false }),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error' }),
+    });
+    expect(mail.sendIngestFailureEmail).not.toHaveBeenCalled();
+  });
+
+  test('mail throw is swallowed and logged (does not propagate)', async () => {
+    mail.sendIngestFailureEmail.mockRejectedValueOnce(new Error('SES down'));
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    await expect(svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error' }),
+    })).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  test('mail timeout (>2s) is swallowed', async () => {
+    mail.sendIngestFailureEmail.mockImplementation(() => new Promise(() => {})); // never resolves
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.useFakeTimers();
+    const promise = svc.notifyIngestRunRecorded({
+      publisher: publisher(),
+      prevRun: run({ status: 'ok' }),
+      newRun: run({ status: 'parse_error' }),
+    });
+    jest.advanceTimersByTime(2_001);
+    await expect(promise).resolves.toBeUndefined();
+    jest.useRealTimers();
+    errSpy.mockRestore();
+  });
+});
+
+describe('PublisherNotificationService.notifyEventRejected', () => {
+  test('sends rejection email with reason verbatim', async () => {
+    const mail = { sendEventRejectedEmail: jest.fn().mockResolvedValue({ messageId: 'x' }) };
+    const svc = new PublisherNotificationService({ mail: mail as never, portalUrl: 'https://chqcal.org/publish/status/' });
+    await svc.notifyEventRejected({
+      publisher: publisher(),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'Symphony' } } as never,
+      reason: 'duplicate',
+    });
+    expect(mail.sendEventRejectedEmail).toHaveBeenCalledWith(expect.objectContaining({
+      eventTitle: 'Symphony',
+      reason: 'duplicate',
+    }));
+  });
+
+  test('reason undefined still sends email (body shows generic line)', async () => {
+    const mail = { sendEventRejectedEmail: jest.fn().mockResolvedValue({ messageId: 'x' }) };
+    const svc = new PublisherNotificationService({ mail: mail as never, portalUrl: 'https://chqcal.org/publish/status/' });
+    await svc.notifyEventRejected({
+      publisher: publisher(),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'Symphony' } } as never,
+      reason: undefined,
+    });
+    expect(mail.sendEventRejectedEmail).toHaveBeenCalledWith(expect.objectContaining({
+      reason: undefined,
+    }));
+  });
+
+  test('notificationsEnabled === false short-circuits', async () => {
+    const mail = { sendEventRejectedEmail: jest.fn() };
+    const svc = new PublisherNotificationService({ mail: mail as never, portalUrl: 'https://chqcal.org/publish/status/' });
+    await svc.notifyEventRejected({
+      publisher: publisher({ notificationsEnabled: false }),
+      event: { eventId: 'ev-1', startDate: '2026-07-01T18:00:00Z', payload: { title: 'X' } } as never,
+      reason: 'r',
+    });
+    expect(mail.sendEventRejectedEmail).not.toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd backend && npx jest publisherNotificationService -v`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the service**
+
+Create `backend/src/services/publisherNotificationService.ts`:
+
+```ts
+import type { MailService } from './mailService';
+import type { PublisherRecord } from '../types/publisher';
+import type { IngestRunRow } from '../types/publisherIngestRun';
+import type { StoredPublisherEvent } from '../types/publisher';
+
+const MAIL_TIMEOUT_MS = 2_000;
+
+export interface NotifyIngestRunArgs {
+  publisher: PublisherRecord;
+  prevRun: IngestRunRow | undefined;
+  newRun: IngestRunRow;
+}
+
+export interface NotifyEventRejectedArgs {
+  publisher: PublisherRecord;
+  event: StoredPublisherEvent;
+  reason: string | undefined;
+}
+
+export interface PublisherNotificationServiceDeps {
+  mail: MailService;
+  // Absolute URL to the publisher portal status page; used in email bodies.
+  portalUrl: string;
+}
+
+export class PublisherNotificationService {
+  constructor(private readonly deps: PublisherNotificationServiceDeps) {}
+
+  async notifyIngestRunRecorded(args: NotifyIngestRunArgs): Promise<void> {
+    if (args.publisher.notificationsEnabled === false) return;
+
+    const prevOk = args.prevRun === undefined || args.prevRun.status === 'ok';
+    const newOk = args.newRun.status === 'ok';
+
+    if (prevOk && !newOk) {
+      await this.guarded(() =>
+        this.deps.mail.sendIngestFailureEmail({
+          toEmail: args.publisher.contactEmail,
+          publisherName: args.publisher.name,
+          status: args.newRun.status as Exclude<IngestRunRow['status'], 'ok'>,
+          message: args.newRun.message ?? '(no message)',
+          portalUrl: this.deps.portalUrl,
+        }),
+      );
+      return;
+    }
+    if (!prevOk && newOk) {
+      await this.guarded(() =>
+        this.deps.mail.sendIngestRecoveryEmail({
+          toEmail: args.publisher.contactEmail,
+          publisherName: args.publisher.name,
+          counts: args.newRun.counts ?? { added: 0, updated: 0, retracted: 0, unchanged: 0 },
+          portalUrl: this.deps.portalUrl,
+        }),
+      );
+      return;
+    }
+    // ok→ok or fail→fail: silent.
+  }
+
+  async notifyEventRejected(args: NotifyEventRejectedArgs): Promise<void> {
+    if (args.publisher.notificationsEnabled === false) return;
+    const title = (args.event.payload as { title?: string } | undefined)?.title ?? '(untitled)';
+    await this.guarded(() =>
+      this.deps.mail.sendEventRejectedEmail({
+        toEmail: args.publisher.contactEmail,
+        publisherName: args.publisher.name,
+        eventTitle: title,
+        eventStartDate: args.event.startDate,
+        reason: args.reason && args.reason.trim().length > 0 ? args.reason.trim() : undefined,
+        portalUrl: this.deps.portalUrl,
+      }),
+    );
+  }
+
+  // Bound failure-mode wrapper. Email is best-effort; a failed/late mail call
+  // must NOT cause the caller (ingest loop, admin handler) to fail. Errors and
+  // timeouts are logged and swallowed.
+  private async guarded(fn: () => Promise<unknown>): Promise<void> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const timeout = new Promise<'__timeout__'>(resolve => {
+        timer = setTimeout(() => resolve('__timeout__'), MAIL_TIMEOUT_MS);
+      });
+      const result = await Promise.race([fn(), timeout]);
+      if (result === '__timeout__') {
+        console.error('[notification] mail send timed out after 2s');
+      }
+    } catch (err) {
+      console.error('[notification] mail send failed:', err);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && npx jest publisherNotificationService -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/publisherNotificationService.ts backend/src/__tests__/publisherNotificationService.test.ts
+git commit -m "feat(publisher): PublisherNotificationService with streak-transition rule + 2s mail timeout"
+```
+
+---
+
+## Phase 3 — Wire ingest pipeline
+
+### Task 8: Wire run-store + notifier into runIngest
+
+**Files:**
+- Modify: `backend/src/handlers/publisherIngestHandler.ts`
+- Modify: `backend/src/__tests__/publisherIngestHandler.integration.test.ts`
+
+- [ ] **Step 1: Extend ingest deps with the new collaborators**
+
+Find the `IngestDeps` interface in `publisherIngestHandler.ts` (search the file). Add:
+
+```ts
+runStore: PublisherIngestRunStore;
+notifier: PublisherNotificationService;
+// Where the ingest invocation came from. Default 'schedule' from
+// scheduledHandler. /publisher-fetch-now passes 'publisher-fetch-now'.
+// Admin /publishers/run-ingest passes 'admin'. Recorded onto each run row.
+trigger?: IngestRunTrigger;
+```
+
+Update `scheduledHandler` in the same file to construct both new deps from environment variables. The new env var:
+
+- `PUBLISHER_INGEST_RUNS_TABLE_NAME` (Terraform task adds it)
+- `PORTAL_URL` (already passed to other publisher Lambdas; reuse)
+
+- [ ] **Step 2: Add a failing integration test**
+
+Append to `backend/src/__tests__/publisherIngestHandler.integration.test.ts`:
+
+```ts
+describe('runIngest records run rows + fires notifications on transitions', () => {
+  test('OK run records row with counts and does not email when prev was OK', async () => {
+    // Set up: registry with one publisher pub-1; runStore.getMostRecentRun → run({status:'ok'}).
+    // fetcher returns ok feed with 1 new event.
+    // Expect: runStore.recordRun called once with status='ok' and counts.added=1; notifier.notifyIngestRunRecorded called once with prevRun.status='ok' and newRun.status='ok' (no email actually sent — that's notifier's decision, not the test's).
+  });
+
+  test('OK→failure transition triggers failure email', async () => {
+    // Set up: runStore.getMostRecentRun → run({status:'ok'}).
+    // fetcher returns parse_error.
+    // Mock mailService directly. Expect sendIngestFailureEmail called.
+  });
+
+  test('threshold_halt records a run row and marks halt; first transition emails', async () => {
+    // Set up: fetcher returns a feed that triggers the reconciler threshold halt.
+    // Expect: runStore.recordRun called with status='threshold_halt'; existing setThresholdHalt also called.
+  });
+
+  test('mail failure does not break ingest', async () => {
+    // mailService.sendIngestFailureEmail rejects. runIngest still resolves; runStore.recordRun still called.
+  });
+});
+```
+
+- [ ] **Step 3: Run failing test**
+
+Run: `cd backend && npx jest publisherIngestHandler.integration -v`
+Expected: FAIL.
+
+- [ ] **Step 4: Wire the calls in `runIngest`**
+
+Inside the `for (const p of publishers)` loop in `runIngest`, after the existing logic that calls `recordFetchOutcome`, add (in each branch):
+
+```ts
+// After: deps.registry.recordFetchOutcome(p.id, { status: f.fetchStatus, message }) for fetch failures
+const prevRun = await deps.runStore.getMostRecentRun(p.id).catch(() => undefined);
+const newRun: IngestRunRow = {
+  publisherId: p.id,
+  runAt: deps.now.toISOString(),
+  status: f.fetchStatus,
+  message,
+  triggeredBy: deps.trigger ?? 'schedule',
+};
+await deps.runStore.recordRun(newRun).catch(err => {
+  console.error(`[publisher-ingest] failed to record run for ${p.id}:`, err);
+});
+await deps.notifier.notifyIngestRunRecorded({ publisher: p, prevRun, newRun });
+continue;
+```
+
+For the threshold-halt branch, the row's `status` is `'threshold_halt'` and `message` is `result.haltedByThreshold!.reason`.
+
+For the OK branch (after `applyDiff` succeeds), the row carries `counts` derived from `result.diff`:
+
+```ts
+const counts: IngestRunCounts = {
+  added: result.diff.inserts.length,
+  updated: result.diff.updates.length,
+  retracted: result.diff.removals.length,
+  unchanged: result.diff.unchanged,
+};
+const prevRun = await deps.runStore.getMostRecentRun(p.id).catch(() => undefined);
+const newRun: IngestRunRow = {
+  publisherId: p.id,
+  runAt: deps.now.toISOString(),
+  status: 'ok',
+  counts,
+  triggeredBy: deps.trigger ?? 'schedule',
+};
+await deps.runStore.recordRun(newRun).catch(err => {
+  console.error(`[publisher-ingest] failed to record run for ${p.id}:`, err);
+});
+await deps.notifier.notifyIngestRunRecorded({ publisher: p, prevRun, newRun });
+```
+
+For the unhandled-throw catch block (network errors, DDB errors), also record a run row with `status: 'network_error'` and the same swallow-on-failure pattern.
+
+- [ ] **Step 5: Run integration tests**
+
+Run: `cd backend && npx jest publisherIngestHandler.integration -v`
+Expected: PASS.
+
+- [ ] **Step 6: Run full backend test suite**
+
+Run: `cd backend && npm test`
+Expected: PASS — full suite green; coverage at or above existing floor.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/src/handlers/publisherIngestHandler.ts backend/src/__tests__/publisherIngestHandler.integration.test.ts
+git commit -m "feat(publisher): record ingest runs + fire notifications in runIngest loop"
+```
+
+---
+
+## Phase 4 — Wire admin reject
+
+### Task 9: Admin reject accepts reason and notifies
+
+**Files:**
+- Modify: `backend/src/handlers/adminHandler.ts:765-774`
+- Modify: `backend/src/services/publisherAdminService.ts` (the `rejectEvent` method that calls into `publisherEventStore.rejectEvent`)
+- Modify: `backend/src/__tests__/adminHandler.publishers.test.ts` (or create `adminHandler.publisherEvents.test.ts` — pick whichever matches existing layout)
+
+- [ ] **Step 1: Add failing tests**
+
+Find the existing test that covers `POST /publisher-events/<pid>/<eid>/reject` and extend it. The new pins:
+
+```ts
+test('reject with body { reason } passes reason through to eventStore', async () => {
+  const mockReject = jest.fn().mockResolvedValue(undefined);
+  // Wire the admin path through; supply request body { reason: 'duplicate of upstream' }.
+  // Assert eventStore.rejectEvent called with ('pub-1', 'ev-1', 'duplicate of upstream').
+  // Assert notifier.notifyEventRejected called with the same reason.
+});
+
+test('reject with empty body succeeds and passes undefined reason', async () => {
+  // body {} or no body.
+  // Assert eventStore.rejectEvent called with ('pub-1', 'ev-1', undefined).
+});
+
+test('reject caps reason at 500 chars before passing through', async () => {
+  // body { reason: 'x'.repeat(600) }
+  // Assert eventStore.rejectEvent received a 500-char string.
+});
+
+test('reject returns 204 on success', async () => {});
+
+test('reject returns 500 if eventStore throws', async () => {});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd backend && npx jest adminHandler -v -t "reject"`
+Expected: FAIL.
+
+- [ ] **Step 3: Update admin reject path**
+
+In `adminHandler.ts` around line 765 replace the existing block with:
+
+```ts
+const matchReject = path.match(/^\/publisher-events\/([^/]+)\/([^/]+)\/reject$/);
+if (matchReject && httpMethod === 'POST') {
+  try {
+    const publisherId = decodeURIComponent(matchReject[1]);
+    const eventId = decodeURIComponent(matchReject[2]);
+    const body = parseJsonBody(event.body) as { reason?: unknown } | null;
+    const rawReason = typeof body?.reason === 'string' ? body.reason : undefined;
+    const trimmed = rawReason?.trim();
+    const reason = trimmed && trimmed.length > 0 ? trimmed.slice(0, 500) : undefined;
+    const event_ = await publisherAdmin().getEvent(publisherId, eventId); // for notifier
+    await publisherAdmin().rejectEvent(publisherId, eventId, reason);
+    if (event_) {
+      const publisher = await publisherRegistry().get(publisherId);
+      if (publisher) {
+        await notifier().notifyEventRejected({ publisher, event: event_, reason });
+      }
+    }
+    return createResponse(204, {});
+  } catch (error) {
+    console.error('Error rejecting publisher event:', error);
+    return createResponse(500, { error: 'Failed to reject event' });
+  }
+}
+```
+
+You'll need to:
+- Add a `getEvent(publisherId, eventId)` method on `publisherAdminService` that returns the `StoredPublisherEvent` or `undefined`. Mirror existing `getApplication` shape.
+- Add a `notifier()` factory function near the top of `adminHandler.ts` mirroring `publisherAdmin()` / `publisherRegistry()` (lazy-construct from env vars; cache the instance).
+- Update `publisherAdmin().rejectEvent(publisherId, eventId, reason?)` signature to forward the third arg to `eventStore.rejectEvent(publisherId, eventId, reason)`.
+- `parseJsonBody` likely exists already; if not, write `function parseJsonBody(b: string | null): unknown { try { return b ? JSON.parse(b) : null; } catch { return null; } }`.
+
+The `notifier.notifyEventRejected` call is `await`ed but its internal `guarded()` swallows failures, so it cannot fail this handler.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `cd backend && npx jest adminHandler -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/handlers/adminHandler.ts backend/src/services/publisherAdminService.ts backend/src/__tests__/adminHandler.publishers.test.ts
+git commit -m "feat(admin): reject endpoint accepts optional reason; notifier emails publisher"
+```
+
+---
+
+## Phase 5 — New endpoints
+
+### Task 10: GET /publisher-runs
+
+**Files:**
+- Modify: `backend/src/handlers/publisherPortalHandler.ts`
+- Modify: `backend/src/__tests__/publisherPortalHandler.status.test.ts` (or create `publisherPortalHandler.runs.test.ts`)
+
+- [ ] **Step 1: Failing test**
+
+Append (or new file):
+
+```ts
+describe('GET /publisher-runs', () => {
+  test('returns last 30 runs for the JWT publisher', async () => {
+    // Mock requirePublisherSession to return { publisherId: 'pub-1', tokenVersion: 0 }
+    // Mock runStore.listRecentRuns → an array of 30 IngestRunRow.
+    // Call handler with method=GET path=/publisher-runs.
+    // Expect 200 + JSON { runs: [...] } where runs.length === 30.
+    // Expect runStore.listRecentRuns called with ('pub-1', 30).
+  });
+
+  test('401 when no session', async () => {});
+  test('returns empty array when no runs', async () => {});
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd backend && npx jest publisherPortalHandler -v -t "publisher-runs"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the endpoint**
+
+In `publisherPortalHandler.ts`, add a new route handler near `/publisher-status`:
+
+```ts
+// ─── GET /publisher-runs (publisher JWT) ─────────────────────────────────
+//
+// Returns the caller's own ingest-run history (last 30, newest-first). Used by
+// the IngestHistoryPanel on /publish/status/. Pending/rejected applicants get
+// the same 401 path as /publisher-status — only approved publishers see runs.
+export async function handlePublisherRuns(
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> {
+  try {
+    const session = await requirePublisherSession(event);
+    if (session.kind !== 'ok') return session.response;
+    const runs = await runStore().listRecentRuns(session.publisherId, 30);
+    return createResponse(200, { runs });
+  } catch (err) {
+    console.error('Error in /publisher-runs:', err);
+    return createResponse(500, { error: 'Internal server error' });
+  }
+}
+```
+
+Add `runStore()` factory near the existing `statusRegistry()` / `publisherProfile()` factories. Read the table name from `PUBLISHER_INGEST_RUNS_TABLE_NAME`.
+
+Wire the route in the handler dispatcher (alongside `case '/publisher-status'` etc.):
+
+```ts
+if (path === '/publisher-runs' && httpMethod === 'GET') {
+  return handlePublisherRuns(event);
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && npx jest publisherPortalHandler -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/handlers/publisherPortalHandler.ts backend/src/__tests__/publisherPortalHandler.runs.test.ts
+git commit -m "feat(publisher): GET /publisher-runs endpoint"
+```
+
+---
+
+### Task 11: GET /publisher-events
+
+**Files:**
+- Modify: `backend/src/handlers/publisherPortalHandler.ts`
+- Test: alongside Task 10 tests
+
+- [ ] **Step 1: Failing test**
+
+```ts
+describe('GET /publisher-events', () => {
+  test('returns event summaries for the JWT publisher', async () => {
+    // Mock eventStore.listForPublisher → 3 rows: published, pending, rejected.
+    // Call handler with method=GET path=/publisher-events.
+    // Expect 200 + JSON { events: [...] } with three items.
+    // Each item has eventId, title, startDate, endDate, state. Rejected one has rejectionReason + rejectedAt. payload is NOT included.
+  });
+
+  test('401 when no session', async () => {});
+
+  test('cross-publisher isolation: scoped to JWT publisherId', async () => {
+    // listForPublisher should be called with the JWT publisherId, never another value.
+  });
+});
+```
+
+- [ ] **Step 2: Run failing test**
+
+Run: `cd backend && npx jest publisherPortalHandler -v -t "publisher-events"`
+Expected: FAIL.
+
+- [ ] **Step 3: Add the endpoint**
+
+```ts
+// ─── GET /publisher-events (publisher JWT) ───────────────────────────────
+export interface PublisherEventSummary {
+  eventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  state: 'published' | 'pending' | 'rejected';
+  rejectionReason?: string;
+  rejectedAt?: string;
+  updatedAt: string;
+}
+
+function toSummary(e: StoredPublisherEvent): PublisherEventSummary {
+  const out: PublisherEventSummary = {
+    eventId: e.eventId,
+    title: (e.payload as { title?: string }).title ?? '(untitled)',
+    startDate: e.startDate,
+    endDate: e.endDate,
+    state: e.state,
+    updatedAt: e.updatedAt,
+  };
+  if (e.rejectionReason) out.rejectionReason = e.rejectionReason;
+  if (e.rejectedAt) out.rejectedAt = e.rejectedAt;
+  return out;
+}
+
+export async function handlePublisherEvents(
+  event: APIGatewayProxyEvent,
+): Promise<APIGatewayProxyResult> {
+  try {
+    const session = await requirePublisherSession(event);
+    if (session.kind !== 'ok') return session.response;
+    const rows = await eventStore().listForPublisher(session.publisherId);
+    return createResponse(200, { events: rows.map(toSummary) });
+  } catch (err) {
+    console.error('Error in /publisher-events:', err);
+    return createResponse(500, { error: 'Internal server error' });
+  }
+}
+```
+
+Wire the route:
+
+```ts
+if (path === '/publisher-events' && httpMethod === 'GET') {
+  return handlePublisherEvents(event);
+}
+```
+
+Note: `/publisher-events/pending` already exists on the *admin* handler. The new `/publisher-events` here is on the *portal* handler (different Lambda, different IAM, different auth gate). API Gateway routing must point `GET /publisher-events` (no suffix) to the portal Lambda. Verify the Terraform routing assignment when wiring infra.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && npx jest publisherPortalHandler -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/handlers/publisherPortalHandler.ts backend/src/__tests__/publisherPortalHandler.runs.test.ts
+git commit -m "feat(publisher): GET /publisher-events endpoint (publisher-scoped event summaries)"
+```
+
+---
+
+### Task 12: PATCH /publisher-profile accepts notificationsEnabled
+
+**Files:**
+- Modify: `backend/src/services/publisherProfileService.ts`
+- Modify: `backend/src/services/publisherRegistryService.ts`
+- Modify: `backend/src/handlers/publisherPortalHandler.ts` (the existing PATCH /publisher-profile path, around line 538)
+- Modify: `backend/src/__tests__/publisherProfileService.test.ts` and `backend/src/__tests__/publisherPortalHandler.profile.test.ts`
+
+- [ ] **Step 1: Failing tests**
+
+In `publisherProfileService.test.ts`:
+
+```ts
+test('updateProfile accepts notificationsEnabled boolean', async () => {
+  // Call svc.updateProfile('pub-1', { notificationsEnabled: false }).
+  // Assert registry.updateProfile called with { notificationsEnabled: false }.
+});
+
+test('updateProfile rejects non-boolean notificationsEnabled with validation error', async () => {
+  await expect(svc.updateProfile('pub-1', { notificationsEnabled: 'yes' as never }))
+    .rejects.toThrow();
+});
+```
+
+In `publisherPortalHandler.profile.test.ts` (extend existing tests):
+
+```ts
+test('PATCH /publisher-profile { notificationsEnabled: false } persists', async () => {
+  // Hit handler with body { notificationsEnabled: false }.
+  // Expect 200; the returned PublisherStatusRecord includes notificationsEnabled: false.
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd backend && npx jest publisherProfileService publisherPortalHandler.profile -v`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+In `publisherProfileService.ts`, extend the patch input type / validator to allow `notificationsEnabled?: boolean`. Look at the existing field allow-list and mirror.
+
+In `publisherRegistryService.ts` `updateProfile` method (around line 211), include `notificationsEnabled` in the `setParts` builder allow-list. Skip if `undefined`; allow explicit `false`.
+
+In `publisherPortalHandler.ts` PATCH handler around line 538, surface `notificationsEnabled` in the returned `PublisherStatusRecord` payload (it's just a passthrough of the field).
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd backend && npx jest -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/services/publisherProfileService.ts backend/src/services/publisherRegistryService.ts backend/src/handlers/publisherPortalHandler.ts backend/src/__tests__/publisherProfileService.test.ts backend/src/__tests__/publisherPortalHandler.profile.test.ts
+git commit -m "feat(publisher): PATCH /publisher-profile accepts notificationsEnabled toggle"
+```
+
+---
+
+## Phase 6 — Frontend
+
+### Task 13: publisherStatusApi additions
+
+**Files:**
+- Modify: `frontend/src/lib/publisherStatusApi.ts`
+
+- [ ] **Step 1: Add types and fetchers**
+
+Append:
+
+```ts
+export interface IngestRunCounts {
+  added: number;
+  updated: number;
+  retracted: number;
+  unchanged: number;
+}
+
+export type IngestRunStatus = 'ok' | 'parse_error' | 'validation_error' | 'network_error' | 'threshold_halt';
+
+export interface IngestRunSummary {
+  publisherId: string;
+  runAt: string;
+  status: IngestRunStatus;
+  message?: string;
+  counts?: IngestRunCounts;
+  triggeredBy: 'schedule' | 'admin' | 'publisher-fetch-now';
+}
+
+export interface PublisherEventSummary {
+  eventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  state: 'published' | 'pending' | 'rejected';
+  rejectionReason?: string;
+  rejectedAt?: string;
+  updatedAt: string;
+}
+
+export async function getPublisherRuns(): Promise<IngestRunSummary[]> {
+  const res = await authedFetch('/publisher-runs');
+  if (!res.ok) throw new Error(`Failed to load runs: ${res.status}`);
+  const body = (await res.json()) as { runs: IngestRunSummary[] };
+  return body.runs;
+}
+
+export async function getPublisherEvents(): Promise<PublisherEventSummary[]> {
+  const res = await authedFetch('/publisher-events');
+  if (!res.ok) throw new Error(`Failed to load events: ${res.status}`);
+  const body = (await res.json()) as { events: PublisherEventSummary[] };
+  return body.events;
+}
+```
+
+Extend `PublisherStatusRecord` to include `notificationsEnabled?: boolean`. Extend `patchPublisherProfile` input type to allow `{ notificationsEnabled?: boolean }`.
+
+- [ ] **Step 2: Lint/typecheck**
+
+Run: `cd frontend && npm run validate`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/lib/publisherStatusApi.ts
+git commit -m "feat(publisher-frontend): API helpers for runs, events, notifications toggle"
+```
+
+---
+
+### Task 14: IngestHistoryPanel component
+
+**Files:**
+- Create: `frontend/src/app/publish/status/IngestHistoryPanel.tsx`
+- Test: `frontend/src/app/publish/status/__tests__/IngestHistoryPanel.test.tsx`
+
+- [ ] **Step 1: Write failing tests**
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/preact';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { IngestHistoryPanel } from '../IngestHistoryPanel';
+
+vi.mock('@/lib/publisherStatusApi', () => ({
+  getPublisherRuns: vi.fn(),
+}));
+import { getPublisherRuns } from '@/lib/publisherStatusApi';
+
+describe('IngestHistoryPanel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('renders empty state when no runs', async () => {
+    (getPublisherRuns as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/No ingest runs yet/i)).toBeInTheDocument());
+  });
+
+  test('renders OK run with counts', async () => {
+    (getPublisherRuns as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'ok', counts: { added: 12, updated: 3, retracted: 1, unchanged: 5 }, triggeredBy: 'schedule' },
+    ]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/\+12/)).toBeInTheDocument());
+    expect(screen.getByText(/~3/)).toBeInTheDocument();
+    expect(screen.getByText(/-1/)).toBeInTheDocument();
+  });
+
+  test('renders failure run with message', async () => {
+    (getPublisherRuns as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'parse_error', message: 'unexpected token }', triggeredBy: 'schedule' },
+    ]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/unexpected token/)).toBeInTheDocument());
+    // status badge text should match
+    expect(screen.getByText(/parse error|failed/i)).toBeInTheDocument();
+  });
+
+  test('renders error state on API failure', async () => {
+    (getPublisherRuns as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/Failed to load|Error/i)).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd frontend && npx vitest run IngestHistoryPanel`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the component**
+
+```tsx
+import { useEffect, useState } from 'preact/hooks';
+import { getPublisherRuns, type IngestRunSummary } from '@/lib/publisherStatusApi';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; runs: IngestRunSummary[] }
+  | { kind: 'error'; message: string };
+
+function statusLabel(s: IngestRunSummary['status']): string {
+  switch (s) {
+    case 'ok': return 'OK';
+    case 'parse_error': return 'Parse error';
+    case 'validation_error': return 'Validation error';
+    case 'network_error': return 'Network error';
+    case 'threshold_halt': return 'Threshold halt';
+  }
+}
+
+function statusBadgeClasses(s: IngestRunSummary['status']): string {
+  if (s === 'ok') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+  if (s === 'threshold_halt') return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300';
+  return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+}
+
+function relativeTime(iso: string, now = new Date()): string {
+  const ms = now.getTime() - Date.parse(iso);
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function IngestHistoryPanel() {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    getPublisherRuns()
+      .then(runs => { if (!cancelled) setState({ kind: 'ok', runs }); })
+      .catch(err => {
+        if (!cancelled) setState({ kind: 'error', message: err instanceof Error ? err.message : 'Failed to load runs' });
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (state.kind === 'loading') {
+    return <div className="text-sm text-gray-500 dark:text-gray-400">Loading ingest history…</div>;
+  }
+  if (state.kind === 'error') {
+    return <div className="text-sm text-red-700 dark:text-red-300">Failed to load ingest history: {state.message}</div>;
+  }
+  if (state.runs.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400">
+        No ingest runs yet — your first scheduled fetch will appear here within an hour.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead className="text-xs uppercase text-gray-500 dark:text-gray-400">
+          <tr>
+            <th className="text-left py-2 pr-4">When</th>
+            <th className="text-left py-2 pr-4">Status</th>
+            <th className="text-left py-2 pr-4">Counts</th>
+            <th className="text-left py-2 pr-4">Trigger</th>
+            <th className="text-left py-2">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.runs.map(r => (
+            <tr key={r.runAt} className="border-t border-gray-200 dark:border-gray-700">
+              <td className="py-2 pr-4" title={r.runAt}>{relativeTime(r.runAt)}</td>
+              <td className="py-2 pr-4">
+                <span className={`inline-block px-2 py-0.5 rounded text-xs ${statusBadgeClasses(r.status)}`}>
+                  {statusLabel(r.status)}
+                </span>
+              </td>
+              <td className="py-2 pr-4 font-mono text-xs">
+                {r.counts ? `+${r.counts.added} ~${r.counts.updated} -${r.counts.retracted}` : '—'}
+              </td>
+              <td className="py-2 pr-4 text-xs text-gray-500 dark:text-gray-400">{r.triggeredBy}</td>
+              <td className="py-2 text-xs text-gray-700 dark:text-gray-300">
+                {r.message ? <span className="break-words">{r.message}</span> : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd frontend && npx vitest run IngestHistoryPanel`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/publish/status/IngestHistoryPanel.tsx frontend/src/app/publish/status/__tests__/IngestHistoryPanel.test.tsx
+git commit -m "feat(publisher-frontend): IngestHistoryPanel — last-30 runs with status badges + counts"
+```
+
+---
+
+### Task 15: PublisherEventsPanel component
+
+**Files:**
+- Create: `frontend/src/app/publish/status/PublisherEventsPanel.tsx`
+- Test: `frontend/src/app/publish/status/__tests__/PublisherEventsPanel.test.tsx`
+
+- [ ] **Step 1: Failing tests**
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/preact';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { PublisherEventsPanel } from '../PublisherEventsPanel';
+
+vi.mock('@/lib/publisherStatusApi', () => ({ getPublisherEvents: vi.fn() }));
+import { getPublisherEvents } from '@/lib/publisherStatusApi';
+
+describe('PublisherEventsPanel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('empty state', async () => {
+    (getPublisherEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/No events ingested yet/i)).toBeInTheDocument());
+  });
+
+  test('renders all three states with badges', async () => {
+    (getPublisherEvents as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { eventId: 'a', title: 'Concert', startDate: '2026-07-01T18:00:00Z', endDate: '2026-07-01T20:00:00Z', state: 'published', updatedAt: 'x' },
+      { eventId: 'b', title: 'Lecture', startDate: '2026-07-02T18:00:00Z', endDate: '2026-07-02T19:00:00Z', state: 'pending', updatedAt: 'x' },
+      { eventId: 'c', title: 'Panel', startDate: '2026-07-03T18:00:00Z', endDate: '2026-07-03T19:00:00Z', state: 'rejected', rejectionReason: 'duplicate', rejectedAt: '2026-05-05T10:00:00Z', updatedAt: 'x' },
+    ]);
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/Concert/)).toBeInTheDocument());
+    expect(screen.getByText(/Published/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pending review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rejected/i)).toBeInTheDocument();
+    expect(screen.getByText(/duplicate/)).toBeInTheDocument();
+  });
+
+  test('rejected without reason shows generic line', async () => {
+    (getPublisherEvents as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { eventId: 'c', title: 'Panel', startDate: '2026-07-03T18:00:00Z', endDate: '2026-07-03T19:00:00Z', state: 'rejected', updatedAt: 'x' },
+    ]);
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/Removed by admin/i)).toBeInTheDocument());
+  });
+
+  test('error state', async () => {
+    (getPublisherEvents as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('boom'));
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/Failed to load|Error/i)).toBeInTheDocument());
+  });
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd frontend && npx vitest run PublisherEventsPanel`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement**
+
+```tsx
+import { useEffect, useState } from 'preact/hooks';
+import { getPublisherEvents, type PublisherEventSummary } from '@/lib/publisherStatusApi';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; events: PublisherEventSummary[] }
+  | { kind: 'error'; message: string };
+
+function badge(state: PublisherEventSummary['state']): { label: string; cls: string } {
+  if (state === 'published')
+    return { label: 'Published', cls: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300' };
+  if (state === 'pending')
+    return { label: 'Pending review', cls: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300' };
+  return { label: 'Rejected', cls: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300' };
+}
+
+function sortEvents(es: PublisherEventSummary[], now = Date.now()): PublisherEventSummary[] {
+  const future = es.filter(e => Date.parse(e.startDate) >= now).sort((a, b) => a.startDate.localeCompare(b.startDate));
+  const past = es.filter(e => Date.parse(e.startDate) < now).sort((a, b) => b.startDate.localeCompare(a.startDate));
+  return [...future, ...past];
+}
+
+export function PublisherEventsPanel() {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    getPublisherEvents()
+      .then(events => { if (!cancelled) setState({ kind: 'ok', events }); })
+      .catch(err => { if (!cancelled) setState({ kind: 'error', message: err instanceof Error ? err.message : 'Failed to load events' }); });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (state.kind === 'loading') return <div className="text-sm text-gray-500 dark:text-gray-400">Loading events…</div>;
+  if (state.kind === 'error') return <div className="text-sm text-red-700 dark:text-red-300">Failed to load events: {state.message}</div>;
+  if (state.events.length === 0) return <div className="text-sm text-gray-500 dark:text-gray-400">No events ingested yet.</div>;
+
+  const sorted = sortEvents(state.events);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead className="text-xs uppercase text-gray-500 dark:text-gray-400">
+          <tr>
+            <th className="text-left py-2 pr-4">Event</th>
+            <th className="text-left py-2 pr-4">Start</th>
+            <th className="text-left py-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(e => {
+            const b = badge(e.state);
+            const showReason = e.state === 'rejected';
+            const reasonLine = e.rejectionReason && e.rejectionReason.length > 0
+              ? e.rejectionReason
+              : 'Removed by admin.';
+            return (
+              <tr key={e.eventId} className="border-t border-gray-200 dark:border-gray-700">
+                <td className="py-2 pr-4">
+                  <div className="font-medium">{e.title}</div>
+                  {showReason && (
+                    <div className="text-xs italic text-gray-500 dark:text-gray-400">Reason: {reasonLine}</div>
+                  )}
+                </td>
+                <td className="py-2 pr-4 text-xs text-gray-500 dark:text-gray-400">
+                  {new Date(e.startDate).toLocaleString()}
+                </td>
+                <td className="py-2">
+                  <span className={`inline-block px-2 py-0.5 rounded text-xs ${b.cls}`}>{b.label}</span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd frontend && npx vitest run PublisherEventsPanel`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/publish/status/PublisherEventsPanel.tsx frontend/src/app/publish/status/__tests__/PublisherEventsPanel.test.tsx
+git commit -m "feat(publisher-frontend): PublisherEventsPanel — published/pending/rejected with reason"
+```
+
+---
+
+### Task 16: Mount panels and notifications toggle on /publish/status/
+
+**Files:**
+- Modify: `frontend/src/app/publish/status/page.tsx`
+- Modify: `frontend/src/app/publish/status/__tests__/page.test.tsx`
+
+- [ ] **Step 1: Add a failing test**
+
+In `page.test.tsx`, add cases that:
+- Assert both new panels render when status is `'approved'` (mock the two API helpers).
+- Assert toggling the notifications checkbox calls `patchPublisherProfile({ notificationsEnabled: false })`.
+
+```tsx
+test('approved publisher sees IngestHistoryPanel and PublisherEventsPanel', async () => {
+  // status = approved with notificationsEnabled: true, id: 'pub-1', etc.
+  // Mock getPublisherRuns / getPublisherEvents to return short arrays.
+  // Render. Wait for headings 'Ingest history' and 'Your events' to appear.
+});
+
+test('toggling notifications calls patch and updates state', async () => {
+  // approved status with notificationsEnabled: true.
+  // Click the toggle. Expect patchPublisherProfile({ notificationsEnabled: false }).
+});
+
+test('pending applicants do NOT see panels', async () => {
+  // status = pending. Assert panels' headings absent.
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd frontend && npx vitest run page.test`
+Expected: FAIL.
+
+- [ ] **Step 3: Wire panels into the page**
+
+In `page.tsx`, in the approved branch (after the existing `IngestControls` / `EmailChangePanel` blocks), add:
+
+```tsx
+<section className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mt-6">
+  <h2 className="text-lg font-semibold mb-3">Ingest history</h2>
+  <IngestHistoryPanel />
+</section>
+
+<section className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 mt-6">
+  <h2 className="text-lg font-semibold mb-3">Your events</h2>
+  <PublisherEventsPanel />
+</section>
+```
+
+In the existing profile/settings section, add the notifications toggle. Mirror the EditableField pattern. Specifically a labeled checkbox that calls `patchPublisherProfile({ notificationsEnabled: !current })` and on success calls `handleRecordUpdated(updatedRec)`.
+
+```tsx
+<label className="flex items-center gap-2 mt-4 text-sm">
+  <input
+    type="checkbox"
+    checked={status.rec.notificationsEnabled !== false}
+    onInput={async (e) => {
+      const next = (e.currentTarget as HTMLInputElement).checked;
+      const updated = await patchPublisherProfile({ notificationsEnabled: next });
+      handleRecordUpdated(updated);
+    }}
+  />
+  Email me when my feed breaks or an event is rejected
+</label>
+```
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `cd frontend && npm run validate && npx vitest run`
+Expected: PASS. Run `npm run build` to confirm no production-build regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/publish/status/page.tsx frontend/src/app/publish/status/__tests__/page.test.tsx
+git commit -m "feat(publisher-frontend): mount history + events panels and notifications toggle"
+```
+
+---
+
+### Task 17: Admin reject UI — optional reason textarea
+
+**Files:**
+- Modify: `frontend/src/app/admin/publisher-events/page.tsx`
+- Modify: matching test file (look for `frontend/src/app/admin/publisher-events/__tests__/page.test.tsx` or similar)
+
+- [ ] **Step 1: Failing test**
+
+Find the existing reject button test and extend:
+
+```tsx
+test('reject button opens textarea, submit POSTs body { reason }', async () => {
+  // Render the admin events page with one pending event.
+  // Click 'Reject'. Assert textarea appears.
+  // Type 'duplicate'. Click 'Confirm reject'.
+  // Assert fetch called with body.reason === 'duplicate'.
+});
+
+test('reject with empty textarea POSTs body { reason: undefined }', async () => {
+  // Click 'Reject'. Don't type anything. Click 'Confirm reject'.
+  // Assert fetch called with no reason or reason omitted.
+});
+```
+
+- [ ] **Step 2: Run failing tests**
+
+Run: `cd frontend && npx vitest run admin/publisher-events`
+Expected: FAIL.
+
+- [ ] **Step 3: Update the page**
+
+Replace the inline reject button's click handler with a small inline form: clicking "Reject" reveals a `<textarea>` and a "Confirm reject" button. Submit posts JSON `{ reason }` to the existing endpoint. The textarea is optional; if empty, omit `reason` from the body. Match the existing component's styling patterns.
+
+- [ ] **Step 4: Run tests + build**
+
+Run: `cd frontend && npx vitest run && npm run build`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/admin/publisher-events/page.tsx frontend/src/app/admin/publisher-events/__tests__/page.test.tsx
+git commit -m "feat(admin-frontend): optional rejection-reason textarea on publisher-events reject"
+```
+
+---
+
+## Phase 7 — Infrastructure
+
+### Task 18: Terraform — new DDB table + IAM grants
+
+**Files:**
+- Modify: `infrastructure/publisher-ingest.tf`
+- Modify: any `*.tf` file that grants the publisher-portal Lambda DDB access (search for `publisher_events.arn` → mirror)
+
+- [ ] **Step 1: Add the table**
+
+Append to `infrastructure/publisher-ingest.tf`:
+
+```hcl
+resource "aws_dynamodb_table" "publisher_ingest_runs" {
+  name         = "${var.app_name}-publisher-ingest-runs"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "publisherId"
+  range_key    = "runAt"
+
+  attribute {
+    name = "publisherId"
+    type = "S"
+  }
+
+  attribute {
+    name = "runAt"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = {
+    Name        = "${var.app_name}-publisher-ingest-runs"
+    Environment = var.environment
+  }
+}
+```
+
+- [ ] **Step 2: Grant the publisher-ingest Lambda PutItem + Query**
+
+In the Lambda's IAM policy (search for the `aws_dynamodb_table.publisher_events.arn` reference in the existing role policy and mirror), add a new statement:
+
+```hcl
+{
+  Effect = "Allow"
+  Action = [
+    "dynamodb:PutItem",
+    "dynamodb:Query",
+  ]
+  Resource = aws_dynamodb_table.publisher_ingest_runs.arn
+}
+```
+
+- [ ] **Step 3: Grant the publisher-portal Lambda Query**
+
+```hcl
+{
+  Effect = "Allow"
+  Action = ["dynamodb:Query"]
+  Resource = aws_dynamodb_table.publisher_ingest_runs.arn
+}
+```
+
+- [ ] **Step 4: Pass the table name as an env var**
+
+In every Lambda function definition that needs it (publisher-ingest and publisher-portal), add:
+
+```hcl
+PUBLISHER_INGEST_RUNS_TABLE_NAME = aws_dynamodb_table.publisher_ingest_runs.name
+```
+
+- [ ] **Step 5: API Gateway routing**
+
+Confirm that `GET /publisher-runs` and `GET /publisher-events` route to the publisher-portal Lambda (not the admin Lambda or the ingest Lambda). If routes are defined explicitly, add them; if there's a catch-all proxy, no change needed.
+
+- [ ] **Step 6: terraform validate / plan locally**
+
+Run: `cd infrastructure && terraform fmt && terraform validate && terraform plan`
+Expected: plan shows the new table + IAM additions; no destructive diffs.
+
+- [ ] **Step 7: Commit (do NOT apply)**
+
+```bash
+git add infrastructure/publisher-ingest.tf infrastructure/main.tf  # or wherever the IAM policies live
+git commit -m "infra(publisher): publisher-ingest-runs DDB table + IAM grants + env var"
+```
+
+The `terraform apply` is a manual step the user runs after merge.
+
+---
+
+## Phase 8 — Smoke + integration
+
+### Task 19: Extend post-deploy publisher smoke
+
+**Files:**
+- Modify: `scripts/post-deploy-publisher-smoke.ts` (or wherever the existing harness lives — search for `SMOKE_BBTEST_EMAIL` consumers)
+
+- [ ] **Step 1: Read the existing smoke harness**
+
+Run: `grep -rn 'SMOKE_BBTEST_EMAIL\|smoke-magic-token-by-email\|smoke-reset-bbtest' scripts/ backend/ 2>/dev/null | head -20`
+
+Identify the smoke driver entry point.
+
+- [ ] **Step 2: Add new assertions**
+
+After the existing "invoke publisher-ingest and assert event count" step, add:
+
+1. `GET /publisher-runs` with the bbtest publisher's JWT — assert 200, response shape `{ runs: [...] }`, at least one row whose `status === 'ok'`.
+2. `GET /publisher-events` with the bbtest publisher's JWT — assert 200, response shape `{ events: [...] }`, at least 2 events for bbtest.
+
+The smoke runs after the explicit invoke step, so the new ingest-runs row will already exist.
+
+- [ ] **Step 3: Run the smoke locally against a stack with the new endpoints**
+
+(May not be possible from the dev box; CI will run it post-merge against prod.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/post-deploy-publisher-smoke.ts
+git commit -m "test(smoke): assert publisher-runs and publisher-events return expected shape"
+```
+
+---
+
+### Task 20: Backend integration test for new endpoints
+
+**Files:**
+- Create: `backend/src/__tests__/integration/publisherRunsAndEvents.test.ts`
+
+Pattern: follow the existing `backend/src/__tests__/integration/` files (use `InMemoryDocClient` from PR #106's harness).
+
+- [ ] **Step 1: Write the test**
+
+```ts
+import { handler } from '../../handlers/publisherPortalHandler';
+import { InMemoryDocClient } from './support/inMemoryDocClient';
+import { issueTestPublisherJwt } from './support/testJwt';
+
+describe('publisher portal observability endpoints', () => {
+  let docClient: InMemoryDocClient;
+  beforeEach(() => {
+    docClient = new InMemoryDocClient();
+    // seed publishers table with pub-1 (approved, enabled, notificationsEnabled: true)
+    // seed publisher-events table with three rows for pub-1: published, pending, rejected
+    // seed publisher-ingest-runs table with two run rows for pub-1
+    // wire portal handler with these tables via the existing _setXxxForTests injection
+  });
+
+  test('GET /publisher-runs returns last 30 newest-first', async () => {
+    const jwt = issueTestPublisherJwt('pub-1');
+    const res = await handler({
+      httpMethod: 'GET',
+      path: '/publisher-runs',
+      headers: { Authorization: `Bearer ${jwt}` },
+      body: null,
+    } as never);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.runs.length).toBeGreaterThan(0);
+    // Newest first: runs[0].runAt > runs[1].runAt
+    expect(Date.parse(body.runs[0].runAt)).toBeGreaterThanOrEqual(Date.parse(body.runs[1]?.runAt ?? '1970'));
+  });
+
+  test('GET /publisher-events returns published + pending + rejected, scoped to JWT', async () => {
+    const jwt = issueTestPublisherJwt('pub-1');
+    const res = await handler({
+      httpMethod: 'GET',
+      path: '/publisher-events',
+      headers: { Authorization: `Bearer ${jwt}` },
+      body: null,
+    } as never);
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.events).toHaveLength(3);
+    expect(new Set(body.events.map((e: any) => e.state))).toEqual(new Set(['published', 'pending', 'rejected']));
+    // Rejected row carries the reason
+    const rejected = body.events.find((e: any) => e.state === 'rejected');
+    expect(rejected.rejectionReason).toBeDefined();
+  });
+
+  test('cross-publisher: pub-1 JWT cannot see pub-2 events', async () => {
+    // Seed pub-2 with one event. pub-1 JWT calls /publisher-events. Result has only pub-1 rows.
+  });
+
+  test('PATCH /publisher-profile { notificationsEnabled: false } persists', async () => {
+    // Initial state: notificationsEnabled === true.
+    // Patch to false; re-GET /publisher-status; expect notificationsEnabled === false.
+  });
+
+  test('GET /publisher-runs without JWT returns 401', async () => {});
+});
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `cd backend && npx jest integration/publisherRunsAndEvents -v`
+Expected: PASS.
+
+- [ ] **Step 3: Coverage check**
+
+Run: `cd backend && npm run coverage`
+Expected: PASS — line coverage at or above the existing floor (`.coverage-floor.json`). If the floor barely budges down due to the new code being mostly covered already, that's fine. If it dips below the floor, write additional tests until it doesn't.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/__tests__/integration/publisherRunsAndEvents.test.ts
+git commit -m "test(integration): publisher-runs + publisher-events scoping and notifications toggle"
+```
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Full backend suite + coverage**
+
+Run: `cd backend && npm test && npm run coverage`
+Expected: PASS, coverage meets the floor.
+
+- [ ] **Step 2: Full frontend suite + build + coverage**
+
+Run: `cd frontend && npm run validate && npm run build && npx vitest run --coverage`
+Expected: PASS, coverage at/above `.coverage-floor.json` floor.
+
+- [ ] **Step 3: Open PR**
+
+```bash
+git push -u origin spec/publisher-observability
+gh pr create --title "Publisher observability: ingest history, per-event status, notifications" --body "$(cat <<'EOF'
+## Summary
+- New `/publish/status/` panels: ingest history (last 30 runs) and per-event status (published / pending / rejected with reason).
+- Smart-immediate emails on ingest streak transitions (OK→fail, fail→OK) and admin event rejection. Single opt-out toggle.
+- New DDB table `${app_name}-publisher-ingest-runs` (90-day TTL).
+- Admin reject path now soft-deletes events (state='rejected') with optional reason; reconciler preserves rejected state across re-ingest.
+
+Spec: docs/superpowers/specs/2026-05-06-publisher-observability-design.md
+Plan: docs/superpowers/plans/2026-05-06-publisher-observability-plan.md
+
+## Test plan
+- [ ] Backend `npm test` green; coverage at or above floor
+- [ ] Frontend `npm run validate && npm run build` green; vitest coverage at or above floor
+- [ ] `terraform plan` shows new table + IAM grants only (no destructive diffs)
+- [ ] Post-deploy smoke step exercises `/publisher-runs` and `/publisher-events`
+- [ ] Manual: log into bbtest publisher portal in prod after deploy; confirm both new panels render and the notifications toggle round-trips
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 4: After PR review and merge, manual ops**
+
+The user runs `terraform apply` to provision the new DDB table + IAM updates. Verify in CloudWatch that publisher-ingest writes run rows on the next scheduled fetch.
+
+---
+
+## Coverage discipline reminder
+
+Per `.coverage-floor.json` and the project CLAUDE.md, **every PR must maintain or improve line coverage** for both `backend` and `frontend` packages. Each task in this plan ships its own tests; the final verification step re-runs the full suites with coverage to confirm. If you find yourself committing source without tests, stop and add the tests first.

--- a/docs/superpowers/specs/2026-05-06-publisher-observability-design.md
+++ b/docs/superpowers/specs/2026-05-06-publisher-observability-design.md
@@ -1,0 +1,230 @@
+# Publisher Observability — Design
+
+**Date:** 2026-05-06
+**Status:** Approved (brainstorm)
+**Author:** Brainstormed with Claude (session 2026-05-06)
+
+## Goal
+
+Turn `/publish/status/` from a configuration screen into an operations dashboard. A publisher should be able to answer three questions without contacting an admin:
+
+1. **Is my feed actually being ingested?** (history of fetch runs with counts)
+2. **Which of my events are live, pending review, or rejected — and why?** (per-event status grid)
+3. **Will I find out if something breaks?** (email notifications on failure, recovery, and rejection)
+
+## Non-goals
+
+- Threshold-halt as a separate notification category (folded into "feed broke")
+- Per-category notification toggles (single on/off switch only)
+- Approval-on-each-event emails (seam exists, no-op for now)
+- Rate-limiting changes on new endpoints (existing publisher-JWT entry rate-limit covers them)
+- Backfill of historical ingest data (day-one history starts at deploy time)
+- Pagination on the events grid (acceptable to return all of a publisher's events; revisit if any single publisher exceeds ~500 events)
+
+## Architectural fork chosen
+
+**Approach A — inline `notificationService`.** Email dispatch happens in the ingest Lambda's request path (with a 2s SES timeout that swallows failures). No SQS, no separate notifier Lambda. Volume is small, the existing `mailService` is already used inline for magic-link emails. Refactor to SQS-decoupled later if SES latency or failure rate ever matters.
+
+## Data model
+
+### New DDB table — `chautauqua-calendar-publisher-ingest-runs`
+
+| Field | Type | Notes |
+|---|---|---|
+| `publisherId` | S, partition key | |
+| `runAt` | S, sort key | ISO 8601; descending sort gives newest-first |
+| `status` | S | `'ok' \| 'parse_error' \| 'validation_error' \| 'network_error' \| 'threshold_halt'` (matches existing `FetchStatus`) |
+| `message` | S, optional | Error/halt reason; same 500-char cap as existing `lastFetchMessage` |
+| `counts` | M, optional | `{ added, updated, retracted, unchanged }` — only set when `status === 'ok'` |
+| `triggeredBy` | S | `'schedule' \| 'admin' \| 'publisher-fetch-now'` |
+| `ttl` | N, optional | Unix seconds, ~90 days out — every row auto-expires; bounds storage without a cleanup job |
+
+Reads use `Query(publisherId)` with `ScanIndexForward=false`. UI listing is `Limit=30`; streak detection is `Limit=1`. No GSIs.
+
+The new ingest-runs row is the single source of truth for the timeline and for streak detection. The existing `lastFetchedAt` / `lastFetchStatus` / `lastFetchMessage` fields on the publisher row stay (they're cheap and used for at-a-glance display in the admin index).
+
+### Reconciler / event-store changes for soft-delete reject
+
+- `StoredPublisherEvent.state` becomes `'published' \| 'pending' \| 'rejected'` (extension of the existing union; absent rows still parse)
+- `StoredPublisherEvent.rejectionReason?: string`
+- `StoredPublisherEvent.rejectedAt?: string`
+
+`publisherReconciler.toStored` already preserves admin-set `state` (PR #100). Extend that merge so when the existing row has `state === 'rejected'`, both `rejectionReason` and `rejectedAt` are also preserved. If the publisher *removes* the event from their feed, the reconciler treats it as a normal removal and `applyDiff` deletes it — matches the agreed lifetime ("kept until publisher feed drops the event").
+
+The sidecar publisher (`publisherSidecarPublisher.ts`) currently filters out `state === 'pending'`. Extend the filter to also drop `state === 'rejected'` so rejected events never appear on the public calendar.
+
+### `PublisherRecord` additions
+
+- `notificationsEnabled?: boolean` — default-treated-as-true. Toggled in the existing `/publish/status/` profile section.
+
+## Backend services
+
+### New — `publisherIngestRunStore.ts`
+
+Thin wrapper around the new DDB table.
+
+```ts
+export interface PublisherIngestRunStore {
+  recordRun(row: IngestRunRow): Promise<void>;
+  getMostRecentRun(publisherId: string): Promise<IngestRunRow | undefined>;
+  listRecentRuns(publisherId: string, limit?: number): Promise<IngestRunRow[]>;
+}
+```
+
+`recordRun` failure must be caught + logged in the caller; the run already happened, the audit row is best-effort (same posture as `recordFetchOutcome`).
+
+### New — `notificationService.ts`
+
+```ts
+export interface PublisherNotificationService {
+  notifyIngestRunRecorded(args: {
+    publisher: PublisherRecord;
+    prevRun: IngestRunRow | undefined;
+    newRun: IngestRunRow;
+  }): Promise<void>;
+
+  notifyEventRejected(args: {
+    publisher: PublisherRecord;
+    event: StoredPublisherEvent;
+    reason: string | undefined;
+  }): Promise<void>;
+}
+```
+
+**Streak rule** for `notifyIngestRunRecorded`:
+
+| `prevRun.status` | `newRun.status` | Action |
+|---|---|---|
+| `'ok'` (or undefined) | non-`'ok'` | send `sendIngestFailureEmail` |
+| non-`'ok'` | `'ok'` | send `sendIngestRecoveryEmail` |
+| any other | any other | no-op |
+
+Each notify call:
+1. Short-circuits if `publisher.notificationsEnabled === false`.
+2. `await mailService.sendX(...)` with a `Promise.race` 2s timeout.
+3. Catches and logs any error or timeout. **A failed notification never fails the caller.**
+
+### Existing service changes
+
+`publisherEventStore.rejectEvent(publisherId, eventId, reason?)` — semantics change:
+- Today: `DeleteCommand` with condition `state = pending`.
+- New: `UpdateCommand` setting `state = 'rejected'`, `rejectionReason` (omitted when blank/undefined), `rejectedAt = now`. Same `attribute_exists + state = pending` condition.
+- Approve-after-reject must continue to fail. The `approveEvent` ConditionExpression `state = pending` already enforces this.
+
+`publisherIngestHandler.runIngest` — per-iteration changes:
+1. Read `prevRun = runStore.getMostRecentRun(p.id)` once, before recording the new outcome.
+2. Compute `counts` from `result.diff` (today they're computed and dropped on the floor).
+3. Build `newRun: IngestRunRow` and call `runStore.recordRun(newRun)`.
+4. Continue to call `registry.recordFetchOutcome(...)` (preserves at-a-glance fields and is what the admin index reads).
+5. `await notificationService.notifyIngestRunRecorded({ publisher: p, prevRun, newRun })`.
+
+`adminHandler` reject path:
+- Parse `reason?: string` from request body. Trim. If non-empty, cap to 500 chars; if empty/missing, pass `undefined`.
+- Call `eventStore.rejectEvent(publisherId, eventId, reason)`.
+- Call `notificationService.notifyEventRejected({ publisher, event, reason })`.
+
+## Endpoints
+
+| Method | Path | Auth | Returns |
+|---|---|---|---|
+| `GET` | `/publisher-runs` | Publisher JWT (`requirePublisherSession`) | `{ runs: IngestRunRow[] }` (last 30, newest first) |
+| `GET` | `/publisher-events` | Publisher JWT | `{ events: PublisherEventSummary[] }` (all events for the caller's publisher) |
+| `PATCH` | `/publisher-profile` | Publisher JWT | (existing) — extended to accept `notificationsEnabled` |
+
+Both new GETs scope to the JWT's `publisherId` claim. A request that tries to read another publisher's data should never even reach the data layer — the existing `requirePublisherSession` already pins identity.
+
+`PublisherEventSummary` shape (excludes the raw feed payload to keep response size reasonable):
+
+```ts
+interface PublisherEventSummary {
+  eventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  state: 'published' | 'pending' | 'rejected';
+  rejectionReason?: string;
+  rejectedAt?: string;
+  updatedAt: string;
+}
+```
+
+`IngestRunRow` is the same shape that lives in the table.
+
+## Admin UI changes
+
+`/admin/publisher-events/` — reject action gains an optional reason textarea (placeholder: "Why was this rejected? (optional, will be shown to the publisher)"). Submit calls the existing reject endpoint with the reason field. Existing approve action is unchanged.
+
+## Frontend — `/publish/status/` additions
+
+Two new collapsible panels rendered after the existing portal sections:
+
+1. **`IngestHistoryPanel.tsx`** — table of last 30 runs:
+   - Columns: timestamp (relative + absolute on hover), status badge (green/red/amber), counts (`+12 ~3 -1`) when present, `triggeredBy`, error message (truncated, expand-on-click).
+   - Loaded via new `getPublisherRuns()` in `frontend/src/lib/publisherStatusApi.ts`.
+   - Empty state: "No ingest runs yet — your first scheduled fetch will appear here within an hour."
+
+2. **`PublisherEventsPanel.tsx`** — table of the publisher's own events:
+   - Columns: title, start date, status badge (`Published` / `Pending review` / `Rejected`), rejection reason (italic muted text under the title when present and non-empty; generic "Removed by admin" when status is rejected and reason is empty).
+   - Sort: future events ascending, then past events descending (matches the admin event table pattern).
+   - Loaded via new `getPublisherEvents()`.
+   - Empty state: "No events ingested yet."
+
+3. **Notifications toggle** added to the existing profile section: a single checkbox "Email me when my feed breaks or an event is rejected" wired through the existing `EditableField`/`patchPublisherProfile` flow.
+
+Both panels follow the existing skeleton/loading/error patterns used elsewhere in `/publish/status/`.
+
+## Email templates
+
+Three new methods on `MailService` and three new bodies in `mailService.ts`:
+
+| Method | Trigger | Subject | Body summary |
+|---|---|---|---|
+| `sendIngestFailureEmail` | first failure after OK streak | "Your feed broke" | Status, error message, "What to do" line, link to `/publish/status/` |
+| `sendIngestRecoveryEmail` | first OK after failure streak | "Your feed is working again" | Counts from this run, link to `/publish/status/` |
+| `sendEventRejectedEmail` | admin reject | "Event removed: <title>" | Event title/date, reason (or generic line if blank), link to `/publish/status/` |
+
+All three follow the existing `<pre>`-for-monospace pattern (Outlook 2010–2016 strips font-family from `<p>`). All three are gated by `publisher.notificationsEnabled !== false`.
+
+## Error handling
+
+- Email send failures: caught and logged inside `notificationService`, never propagated.
+- New ingest-runs DDB write failure: caught and logged in the caller; the ingest run itself is still considered successful.
+- Race — admin deletes publisher mid-ingest: `runIngest` already snapshots `allPublishers` at top. The `notificationService` call uses that snapshot's `notificationsEnabled` value. If SES then fails because the publisher row is gone, the catch-and-log absorbs it.
+- Approve-after-reject: still fails, because `approveEvent` requires `state = pending`. The condition's error message becomes user-visible to admin: "cannot approve … not pending or no longer exists."
+
+## Testing
+
+Coverage discipline: this change must maintain or improve the per-package line coverage floors (`backend` 81.1, `frontend` 74.3, enforced via `.coverage-floor.json`). Each new module ships with tests that hit happy path and at least one failure mode.
+
+Backend (jest):
+- `notificationService.test.ts` — streak transitions (ok→fail, fail→ok, ok→ok no-op, fail→fail no-op), `notificationsEnabled === false` short-circuit, mail timeout swallow, mail throw swallow.
+- `publisherIngestRunStore.test.ts` — record + list ordering + 30-row cap + TTL set.
+- `publisherIngestHandler.test.ts` — extend existing tests to assert run rows are written with correct counts and notifications fire on transitions and only on transitions.
+- `publisherReconciler.test.ts` — extend the PR #100 preserve-state test to also pin `state='rejected'` + `rejectionReason` + `rejectedAt` survival across re-ingest of unchanged feed events; pin removal-from-feed deletes a rejected row.
+- `publisherEventStore.test.ts` — `rejectEvent` now soft-deletes; pin that approve-after-reject fails; pin that the row carries `rejectionReason` and `rejectedAt`.
+- `adminHandler.test.ts` — reject body parsing for present/blank/missing/oversized reason.
+- Integration: `integration/publisherRunsAndEvents.test.ts` — new GETs scoped to publisher JWT; cross-publisher 403; `notificationsEnabled` toggle persists; ingest-run history populates after a single ingest.
+
+Frontend (vitest + @testing-library/preact):
+- `IngestHistoryPanel.test.tsx`, `PublisherEventsPanel.test.tsx` — happy path, empty state, error state, badge mapping, expand-on-click for long error messages.
+- Extend `frontend/src/app/publish/status/__tests__/page.test.tsx` to assert the new panels mount and the notifications toggle round-trips through `patchPublisherProfile`.
+
+Smoke test extension: `scripts/post-deploy-publisher-smoke.ts` — add steps that assert `GET /publisher-runs` and `GET /publisher-events` respond 200 with the bbtest publisher's JWT, and that the bbtest publisher accumulates at least one ingest-run row after the smoke's invoke step.
+
+## Migration / rollout
+
+- Terraform — add the new DDB table (`chautauqua-calendar-publisher-ingest-runs`) and grant publisher-ingest Lambda + admin Lambda + portal Lambda read/write as appropriate. TTL attribute = `ttl`.
+- IAM — extend the existing publisher-portal Lambda's policy with `dynamodb:Query` on the new table.
+- No backfill: the table starts empty and accumulates from the first ingest after deploy. The frontend handles "no runs yet" as a normal empty state, not an error.
+- The reject semantic change (delete → soft-delete) is one-way. After deploy any new rejection lands as `state='rejected'`. Pre-existing rejected events were already deleted and don't come back. No data migration needed.
+- The `notificationsEnabled` field is optional and absent on existing rows; treated as true. No migration.
+
+## Open questions
+
+None remaining. All design forks resolved during brainstorming:
+- Soft-delete with optional reason (not required) — chosen
+- New DDB table for ingest runs with last-30 visibility — chosen
+- Smart immediate emails (transition-only, single opt-out) — chosen
+- Two separate panels, not unified feed — chosen
+- Rejected events linger until publisher drops them from feed — chosen
+- Inline `notificationService` (not SQS) — chosen

--- a/frontend/src/__tests__/components/admin/PendingEventCard.test.tsx
+++ b/frontend/src/__tests__/components/admin/PendingEventCard.test.tsx
@@ -61,7 +61,21 @@ describe('PendingEventCard', () => {
     expect(onApprove).toHaveBeenCalledWith('pub-123', 'evt-456');
   });
 
-  it('clicking Reject calls onReject with publisherId and eventId', () => {
+  it('clicking Reject reveals textarea and Confirm reject button', () => {
+    render(
+      <PendingEventCard
+        event={makeEvent()}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    expect(screen.getByPlaceholderText(/Why was this rejected/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Confirm reject' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Cancel' })).toBeTruthy();
+  });
+
+  it('Confirm reject with non-empty reason calls onReject with reason', () => {
     const onReject = vi.fn();
     render(
       <PendingEventCard
@@ -71,32 +85,73 @@ describe('PendingEventCard', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    fireEvent.input(screen.getByPlaceholderText(/Why was this rejected/), {
+      target: { value: 'duplicate' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
     expect(onReject).toHaveBeenCalledTimes(1);
-    expect(onReject).toHaveBeenCalledWith('pub-123', 'evt-456');
+    expect(onReject).toHaveBeenCalledWith('pub-123', 'evt-456', 'duplicate');
   });
 
-  it('both buttons are disabled and clicks do not fire handlers when disabled=true', () => {
-    const onApprove = vi.fn();
+  it('Confirm reject with empty textarea calls onReject with empty reason', () => {
     const onReject = vi.fn();
     render(
       <PendingEventCard
         event={makeEvent()}
-        onApprove={onApprove}
+        onApprove={vi.fn()}
         onReject={onReject}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    // Leave textarea empty
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reject' }));
+    expect(onReject).toHaveBeenCalledTimes(1);
+    expect(onReject).toHaveBeenCalledWith('pub-123', 'evt-456', '');
+  });
+
+  it('Cancel button hides the textarea without calling onReject', () => {
+    const onReject = vi.fn();
+    render(
+      <PendingEventCard
+        event={makeEvent()}
+        onApprove={vi.fn()}
+        onReject={onReject}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Reject' }));
+    expect(screen.getByPlaceholderText(/Why was this rejected/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByPlaceholderText(/Why was this rejected/)).toBeNull();
+    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('Approve button is disabled and does not fire handler when disabled=true', () => {
+    const onApprove = vi.fn();
+    render(
+      <PendingEventCard
+        event={makeEvent()}
+        onApprove={onApprove}
+        onReject={vi.fn()}
         disabled={true}
       />,
     );
 
     const approveBtn = screen.getByRole('button', { name: 'Approve' }) as HTMLButtonElement;
-    const rejectBtn = screen.getByRole('button', { name: 'Reject' }) as HTMLButtonElement;
-
     expect(approveBtn.disabled).toBe(true);
-    expect(rejectBtn.disabled).toBe(true);
-
     fireEvent.click(approveBtn);
-    fireEvent.click(rejectBtn);
-
     expect(onApprove).not.toHaveBeenCalled();
-    expect(onReject).not.toHaveBeenCalled();
+  });
+
+  it('Reject button is disabled when disabled=true', () => {
+    render(
+      <PendingEventCard
+        event={makeEvent()}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        disabled={true}
+      />,
+    );
+    const rejectBtn = screen.getByRole('button', { name: 'Reject' }) as HTMLButtonElement;
+    expect(rejectBtn.disabled).toBe(true);
   });
 });

--- a/frontend/src/__tests__/lib/publisherStatusApi.test.ts
+++ b/frontend/src/__tests__/lib/publisherStatusApi.test.ts
@@ -1,0 +1,182 @@
+// Unit tests for the observability additions to publisherStatusApi.ts:
+// getPublisherRuns and getPublisherEvents (Phase 7).
+//
+// We test the happy path, 401 redirect, non-ok error, and malformed response
+// for each function — mirroring the coverage pattern used for adminPublisherApi.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getPublisherRuns, getPublisherEvents, PublisherStatusError } from '@/lib/publisherStatusApi';
+
+// ---------------------------------------------------------------------------
+// Auth client mock — getPublisherJwt always returns a token; clearPublisherSession
+// is a no-op. window.location.replace is stubbed to avoid jsdom navigation errors.
+// ---------------------------------------------------------------------------
+
+vi.mock('@/lib/publisherAuthClient', () => ({
+  getPublisherJwt: vi.fn(() => 'test-jwt'),
+  clearPublisherSession: vi.fn(),
+}));
+
+import { getPublisherJwt, clearPublisherSession } from '@/lib/publisherAuthClient';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeOk(body: unknown, status = 200): Response {
+  return {
+    ok: true,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+function makeError(status: number, body: unknown = {}): Response {
+  return {
+    ok: false,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+let fetchMock: any;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  globalThis.fetch = fetchMock as typeof globalThis.fetch;
+  // Prevent jsdom from complaining about navigation
+  Object.defineProperty(window, 'location', {
+    value: { replace: vi.fn() },
+    writable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// getPublisherRuns
+// ---------------------------------------------------------------------------
+
+describe('getPublisherRuns', () => {
+  it('returns the runs array on a 200 response', async () => {
+    const runs = [
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'ok', counts: { added: 1, updated: 0, retracted: 0, unchanged: 5 }, triggeredBy: 'schedule' },
+    ];
+    fetchMock.mockResolvedValueOnce(makeOk({ runs }));
+    const result = await getPublisherRuns();
+    expect(result).toEqual(runs);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/publisher-runs$/),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('sends the JWT in the Authorization header', async () => {
+    fetchMock.mockResolvedValueOnce(makeOk({ runs: [] }));
+    await getPublisherRuns();
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer test-jwt');
+  });
+
+  it('throws PublisherStatusError on non-ok response with error body', async () => {
+    fetchMock.mockResolvedValueOnce(makeError(500, { error: 'Internal server error' }));
+    await expect(getPublisherRuns()).rejects.toMatchObject({
+      name: 'PublisherStatusError',
+      status: 500,
+      message: 'Internal server error',
+    });
+  });
+
+  it('throws PublisherStatusError on non-ok response without error body', async () => {
+    fetchMock.mockResolvedValueOnce(makeError(503, {}));
+    await expect(getPublisherRuns()).rejects.toMatchObject({
+      name: 'PublisherStatusError',
+      status: 503,
+    });
+  });
+
+  it('throws PublisherStatusError on malformed response (no runs array)', async () => {
+    fetchMock.mockResolvedValueOnce(makeOk({ wrong: 'shape' }));
+    await expect(getPublisherRuns()).rejects.toMatchObject({
+      name: 'PublisherStatusError',
+      status: 500,
+      message: 'Malformed response.',
+    });
+  });
+
+  it('clears session and throws on 401', async () => {
+    fetchMock.mockResolvedValueOnce(makeError(401));
+    await expect(getPublisherRuns()).rejects.toMatchObject({ status: 401 });
+    expect(clearPublisherSession).toHaveBeenCalled();
+  });
+
+  it('throws and redirects when no JWT is present', async () => {
+    (getPublisherJwt as any).mockReturnValueOnce(null);
+    await expect(getPublisherRuns()).rejects.toMatchObject({ status: 401 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getPublisherEvents
+// ---------------------------------------------------------------------------
+
+describe('getPublisherEvents', () => {
+  it('returns the events array on a 200 response', async () => {
+    const events = [
+      { eventId: 'e1', title: 'Concert', startDate: '2030-07-01T18:00:00Z', endDate: '2030-07-01T20:00:00Z', state: 'published', updatedAt: 'x' },
+    ];
+    fetchMock.mockResolvedValueOnce(makeOk({ events }));
+    const result = await getPublisherEvents();
+    expect(result).toEqual(events);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringMatching(/\/api\/publisher-events$/),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('sends the JWT in the Authorization header', async () => {
+    fetchMock.mockResolvedValueOnce(makeOk({ events: [] }));
+    await getPublisherEvents();
+    const [, opts] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect((opts.headers as Record<string, string>)['Authorization']).toBe('Bearer test-jwt');
+  });
+
+  it('throws PublisherStatusError on non-ok response with error body', async () => {
+    fetchMock.mockResolvedValueOnce(makeError(500, { error: 'Something went wrong' }));
+    await expect(getPublisherEvents()).rejects.toMatchObject({
+      name: 'PublisherStatusError',
+      status: 500,
+      message: 'Something went wrong',
+    });
+  });
+
+  it('throws PublisherStatusError on non-ok response without error body', async () => {
+    fetchMock.mockResolvedValueOnce(makeError(502, {}));
+    await expect(getPublisherEvents()).rejects.toMatchObject({
+      name: 'PublisherStatusError',
+      status: 502,
+    });
+  });
+
+  it('throws PublisherStatusError on malformed response (no events array)', async () => {
+    fetchMock.mockResolvedValueOnce(makeOk({ wrong: 'shape' }));
+    await expect(getPublisherEvents()).rejects.toMatchObject({
+      name: 'PublisherStatusError',
+      status: 500,
+      message: 'Malformed response.',
+    });
+  });
+
+  it('clears session and throws on 401', async () => {
+    fetchMock.mockResolvedValueOnce(makeError(401));
+    await expect(getPublisherEvents()).rejects.toMatchObject({ status: 401 });
+    expect(clearPublisherSession).toHaveBeenCalled();
+  });
+
+  it('throws and redirects when no JWT is present', async () => {
+    (getPublisherJwt as any).mockReturnValueOnce(null);
+    await expect(getPublisherEvents()).rejects.toMatchObject({ status: 401 });
+  });
+});

--- a/frontend/src/app/admin/publisher-events/PendingEventCard.tsx
+++ b/frontend/src/app/admin/publisher-events/PendingEventCard.tsx
@@ -1,16 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import type { PendingEvent } from '@/lib/adminPublisherApi';
 
 export interface Props {
   event: PendingEvent;
   onApprove: (publisherId: string, eventId: string) => void;
-  onReject: (publisherId: string, eventId: string) => void;
+  onReject: (publisherId: string, eventId: string, reason?: string) => void;
   disabled?: boolean;
 }
 
 export function PendingEventCard({ event, onApprove, onReject, disabled = false }: Props) {
   const start = new Date(event.payload.startDate).toLocaleString();
   const end = new Date(event.payload.endDate).toLocaleString();
+  const [rejecting, setRejecting] = useState(false);
+  const [rejectReason, setRejectReason] = useState('');
+
+  function handleRejectClick() {
+    if (!disabled) setRejecting(true);
+  }
+
+  function handleCancel() {
+    setRejecting(false);
+    setRejectReason('');
+  }
+
+  function handleConfirmReject() {
+    if (!disabled) {
+      onReject(event.publisherId, event.eventId, rejectReason);
+      setRejecting(false);
+      setRejectReason('');
+    }
+  }
 
   return (
     <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-800">
@@ -35,15 +54,44 @@ export function PendingEventCard({ event, onApprove, onReject, disabled = false 
           >
             Approve
           </button>
-          <button
-            onClick={() => !disabled && onReject(event.publisherId, event.eventId)}
-            disabled={disabled}
-            className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            Reject
-          </button>
+          {!rejecting ? (
+            <button
+              onClick={handleRejectClick}
+              disabled={disabled}
+              className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Reject
+            </button>
+          ) : null}
         </div>
       </div>
+
+      {rejecting && (
+        <div className="mt-3 flex flex-col gap-2">
+          <textarea
+            value={rejectReason}
+            onInput={(e) => setRejectReason((e.currentTarget as HTMLTextAreaElement).value)}
+            placeholder="Why was this rejected? (optional, will be shown to the publisher)"
+            className="w-full text-sm border rounded p-2 dark:bg-gray-800 dark:border-gray-600"
+            rows={2}
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleConfirmReject}
+              disabled={disabled}
+              className="px-3 py-1 text-xs rounded bg-red-600 text-white hover:bg-red-700 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Confirm reject
+            </button>
+            <button
+              onClick={handleCancel}
+              className="px-3 py-1 text-xs rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/app/admin/publisher-events/page.tsx
+++ b/frontend/src/app/admin/publisher-events/page.tsx
@@ -87,11 +87,11 @@ export default function PublisherEventsPage() {
   );
 
   const handleReject = useCallback(
-    async (publisherId: string, eventId: string) => {
+    async (publisherId: string, eventId: string, reason?: string) => {
       const key = `evt:${publisherId}:${eventId}`;
       setInFlight(prev => new Set(prev).add(key));
       try {
-        await rejectEvent(publisherId, eventId);
+        await rejectEvent(publisherId, eventId, reason);
         await fetchPending();
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to reject event.');

--- a/frontend/src/app/publish/status/IngestHistoryPanel.tsx
+++ b/frontend/src/app/publish/status/IngestHistoryPanel.tsx
@@ -13,6 +13,10 @@ function statusLabel(s: IngestRunSummary['status']): string {
     case 'validation_error': return 'Validation error';
     case 'network_error': return 'Network error';
     case 'threshold_halt': return 'Threshold halt';
+    // Fallback for forward-compat: if a future backend deploy ships a new
+    // status string before the frontend deploy catches up, render the raw
+    // value rather than blanking the cell.
+    default: return s;
   }
 }
 

--- a/frontend/src/app/publish/status/IngestHistoryPanel.tsx
+++ b/frontend/src/app/publish/status/IngestHistoryPanel.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useState } from 'preact/hooks';
+import { getPublisherRuns, type IngestRunSummary } from '@/lib/publisherStatusApi';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; runs: IngestRunSummary[] }
+  | { kind: 'error'; message: string };
+
+function statusLabel(s: IngestRunSummary['status']): string {
+  switch (s) {
+    case 'ok': return 'OK';
+    case 'parse_error': return 'Parse error';
+    case 'validation_error': return 'Validation error';
+    case 'network_error': return 'Network error';
+    case 'threshold_halt': return 'Threshold halt';
+  }
+}
+
+function statusBadgeClasses(s: IngestRunSummary['status']): string {
+  if (s === 'ok') return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300';
+  if (s === 'threshold_halt') return 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300';
+  return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
+}
+
+function relativeTime(iso: string, now = new Date()): string {
+  const ms = now.getTime() - Date.parse(iso);
+  const minutes = Math.floor(ms / 60_000);
+  if (minutes < 1) return 'just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function IngestHistoryPanel() {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    getPublisherRuns()
+      .then(runs => { if (!cancelled) setState({ kind: 'ok', runs }); })
+      .catch(err => {
+        if (!cancelled) setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Failed to load runs',
+        });
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (state.kind === 'loading') {
+    return <div className="text-sm text-gray-500 dark:text-gray-400">Loading ingest history…</div>;
+  }
+  if (state.kind === 'error') {
+    return <div className="text-sm text-red-700 dark:text-red-300">Failed to load ingest history: {state.message}</div>;
+  }
+  if (state.runs.length === 0) {
+    return (
+      <div className="text-sm text-gray-500 dark:text-gray-400">
+        No ingest runs yet — your first scheduled fetch will appear here within an hour.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead className="text-xs uppercase text-gray-500 dark:text-gray-400">
+          <tr>
+            <th className="text-left py-2 pr-4">When</th>
+            <th className="text-left py-2 pr-4">Status</th>
+            <th className="text-left py-2 pr-4">Counts</th>
+            <th className="text-left py-2 pr-4">Trigger</th>
+            <th className="text-left py-2">Message</th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.runs.map(r => (
+            <tr key={r.runAt} className="border-t border-gray-200 dark:border-gray-700">
+              <td className="py-2 pr-4" title={r.runAt}>{relativeTime(r.runAt)}</td>
+              <td className="py-2 pr-4">
+                <span className={`inline-block px-2 py-0.5 rounded text-xs ${statusBadgeClasses(r.status)}`}>
+                  {statusLabel(r.status)}
+                </span>
+              </td>
+              <td className="py-2 pr-4 font-mono text-xs">
+                {r.counts ? `+${r.counts.added} ~${r.counts.updated} -${r.counts.retracted}` : '—'}
+              </td>
+              <td className="py-2 pr-4 text-xs text-gray-500 dark:text-gray-400">{r.triggeredBy}</td>
+              <td className="py-2 text-xs text-gray-700 dark:text-gray-300">
+                {r.message ? <span className="break-words">{r.message}</span> : null}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/app/publish/status/PublisherEventsPanel.tsx
+++ b/frontend/src/app/publish/status/PublisherEventsPanel.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'preact/hooks';
+import { getPublisherEvents, type PublisherEventSummary } from '@/lib/publisherStatusApi';
+
+type State =
+  | { kind: 'loading' }
+  | { kind: 'ok'; events: PublisherEventSummary[] }
+  | { kind: 'error'; message: string };
+
+function badge(state: PublisherEventSummary['state']): { label: string; cls: string } {
+  if (state === 'published')
+    return { label: 'Published', cls: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300' };
+  if (state === 'pending')
+    return { label: 'Pending review', cls: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300' };
+  return { label: 'Rejected', cls: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300' };
+}
+
+function sortEvents(es: PublisherEventSummary[], now = Date.now()): PublisherEventSummary[] {
+  const future = es.filter(e => Date.parse(e.startDate) >= now).sort((a, b) => a.startDate.localeCompare(b.startDate));
+  const past = es.filter(e => Date.parse(e.startDate) < now).sort((a, b) => b.startDate.localeCompare(a.startDate));
+  return [...future, ...past];
+}
+
+export function PublisherEventsPanel() {
+  const [state, setState] = useState<State>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    getPublisherEvents()
+      .then(events => { if (!cancelled) setState({ kind: 'ok', events }); })
+      .catch(err => {
+        if (!cancelled) setState({
+          kind: 'error',
+          message: err instanceof Error ? err.message : 'Failed to load events',
+        });
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  if (state.kind === 'loading') return <div className="text-sm text-gray-500 dark:text-gray-400">Loading events…</div>;
+  if (state.kind === 'error') return <div className="text-sm text-red-700 dark:text-red-300">Failed to load events: {state.message}</div>;
+  if (state.events.length === 0) return <div className="text-sm text-gray-500 dark:text-gray-400">No events ingested yet.</div>;
+
+  const sorted = sortEvents(state.events);
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead className="text-xs uppercase text-gray-500 dark:text-gray-400">
+          <tr>
+            <th className="text-left py-2 pr-4">Event</th>
+            <th className="text-left py-2 pr-4">Start</th>
+            <th className="text-left py-2">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map(e => {
+            const b = badge(e.state);
+            const showReason = e.state === 'rejected';
+            const reasonLine = e.rejectionReason && e.rejectionReason.length > 0
+              ? e.rejectionReason
+              : 'Removed by admin.';
+            return (
+              <tr key={e.eventId} className="border-t border-gray-200 dark:border-gray-700">
+                <td className="py-2 pr-4">
+                  <div className="font-medium">{e.title}</div>
+                  {showReason && (
+                    <div className="text-xs italic text-gray-500 dark:text-gray-400">Reason: {reasonLine}</div>
+                  )}
+                </td>
+                <td className="py-2 pr-4 text-xs text-gray-500 dark:text-gray-400">
+                  {new Date(e.startDate).toLocaleString()}
+                </td>
+                <td className="py-2">
+                  <span className={`inline-block px-2 py-0.5 rounded text-xs ${b.cls}`}>{b.label}</span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/app/publish/status/__tests__/IngestHistoryPanel.test.tsx
+++ b/frontend/src/app/publish/status/__tests__/IngestHistoryPanel.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, waitFor } from '@testing-library/preact';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { IngestHistoryPanel } from '../IngestHistoryPanel';
+
+vi.mock('@/lib/publisherStatusApi', () => ({
+  getPublisherRuns: vi.fn(),
+}));
+
+import { getPublisherRuns } from '@/lib/publisherStatusApi';
+
+describe('IngestHistoryPanel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('renders empty state when no runs', async () => {
+    (getPublisherRuns as any).mockResolvedValue([]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/No ingest runs yet/i)).toBeInTheDocument());
+  });
+
+  test('renders OK run with counts (+12 ~3 -1)', async () => {
+    (getPublisherRuns as any).mockResolvedValue([
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'ok', counts: { added: 12, updated: 3, retracted: 1, unchanged: 5 }, triggeredBy: 'schedule' },
+    ]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/\+12/)).toBeInTheDocument());
+    expect(screen.getByText(/~3/)).toBeInTheDocument();
+    expect(screen.getByText(/-1/)).toBeInTheDocument();
+  });
+
+  test('renders failure run with status badge and message', async () => {
+    (getPublisherRuns as any).mockResolvedValue([
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'parse_error', message: 'unexpected token }', triggeredBy: 'schedule' },
+    ]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/unexpected token/)).toBeInTheDocument());
+    expect(screen.getByText(/parse error/i)).toBeInTheDocument();
+  });
+
+  test('renders threshold_halt with amber/warning styling and reason', async () => {
+    (getPublisherRuns as any).mockResolvedValue([
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'threshold_halt', message: 'Would remove 12 of 20 future events', triggeredBy: 'schedule' },
+    ]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/threshold halt|halt/i)).toBeInTheDocument());
+    expect(screen.getByText(/Would remove 12/)).toBeInTheDocument();
+  });
+
+  test('renders error state on API failure', async () => {
+    (getPublisherRuns as any).mockRejectedValue(new Error('boom'));
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/Failed to load|Error/i)).toBeInTheDocument());
+  });
+
+  test('shows triggered-by label', async () => {
+    (getPublisherRuns as any).mockResolvedValue([
+      { publisherId: 'p1', runAt: '2026-05-06T12:00:00Z', status: 'ok', counts: { added: 0, updated: 0, retracted: 0, unchanged: 5 }, triggeredBy: 'publisher-fetch-now' },
+    ]);
+    render(<IngestHistoryPanel />);
+    await waitFor(() => expect(screen.getByText(/publisher-fetch-now/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/app/publish/status/__tests__/PublisherEventsPanel.test.tsx
+++ b/frontend/src/app/publish/status/__tests__/PublisherEventsPanel.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, waitFor } from '@testing-library/preact';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { PublisherEventsPanel } from '../PublisherEventsPanel';
+
+vi.mock('@/lib/publisherStatusApi', () => ({ getPublisherEvents: vi.fn() }));
+import { getPublisherEvents } from '@/lib/publisherStatusApi';
+
+describe('PublisherEventsPanel', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('empty state', async () => {
+    (getPublisherEvents as any).mockResolvedValue([]);
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/No events ingested yet/i)).toBeInTheDocument());
+  });
+
+  test('renders all three states with badges', async () => {
+    (getPublisherEvents as any).mockResolvedValue([
+      { eventId: 'a', title: 'Concert', startDate: '2030-07-01T18:00:00Z', endDate: '2030-07-01T20:00:00Z', state: 'published', updatedAt: 'x' },
+      { eventId: 'b', title: 'Lecture', startDate: '2030-07-02T18:00:00Z', endDate: '2030-07-02T19:00:00Z', state: 'pending', updatedAt: 'x' },
+      { eventId: 'c', title: 'Panel', startDate: '2030-07-03T18:00:00Z', endDate: '2030-07-03T19:00:00Z', state: 'rejected', rejectionReason: 'duplicate', rejectedAt: '2026-05-05T10:00:00Z', updatedAt: 'x' },
+    ]);
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/Concert/)).toBeInTheDocument());
+    expect(screen.getByText(/Published/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pending review/i)).toBeInTheDocument();
+    expect(screen.getByText(/Rejected/i)).toBeInTheDocument();
+    expect(screen.getByText(/duplicate/)).toBeInTheDocument();
+  });
+
+  test('rejected without reason shows "Removed by admin." generic line', async () => {
+    (getPublisherEvents as any).mockResolvedValue([
+      { eventId: 'c', title: 'Panel', startDate: '2030-07-03T18:00:00Z', endDate: '2030-07-03T19:00:00Z', state: 'rejected', updatedAt: 'x' },
+    ]);
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/Removed by admin/i)).toBeInTheDocument());
+  });
+
+  test('error state', async () => {
+    (getPublisherEvents as any).mockRejectedValue(new Error('boom'));
+    render(<PublisherEventsPanel />);
+    await waitFor(() => expect(screen.getByText(/Failed to load|Error/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/app/publish/status/__tests__/page.test.tsx
+++ b/frontend/src/app/publish/status/__tests__/page.test.tsx
@@ -13,6 +13,8 @@ vi.mock('@/lib/publisherStatusApi', () => ({
   getPublisherStatus: vi.fn(),
   patchPublisherProfile: vi.fn(),
   previewPublisherFeed: vi.fn(),
+  getPublisherRuns: vi.fn(),
+  getPublisherEvents: vi.fn(),
 }));
 vi.mock('@/lib/publisherAuthClient', () => ({
   isPublisherAuthenticated: () => true,
@@ -46,6 +48,9 @@ function makeRecord(overrides: Partial<PublisherStatusRecord> = {}): PublisherSt
 describe('PublishStatusPage — Phase 2 profile wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default empty arrays for the new panels so they don't cause unhandled promise rejections
+    (api.getPublisherRuns as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (api.getPublisherEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
   });
 
   it('renders the EditableField for Name on an approved publisher', async () => {
@@ -129,5 +134,49 @@ describe('PublishStatusPage — Phase 2 profile wiring', () => {
         sourceType: 'html',
       }),
     );
+  });
+});
+
+describe('PublishStatusPage — observability panels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (api.getPublisherRuns as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+    (api.getPublisherEvents as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+  });
+
+  it('approved publisher sees Ingest history, Your events, and Email notifications headings', async () => {
+    (api.getPublisherStatus as ReturnType<typeof vi.fn>).mockResolvedValue(makeRecord());
+    render(<PublishStatusPage />);
+    await waitFor(() => expect(screen.getByText('Ingest history')).toBeTruthy());
+    expect(screen.getByText('Your events')).toBeTruthy();
+    expect(screen.getByText('Email notifications')).toBeTruthy();
+  });
+
+  it('toggling notifications calls patchPublisherProfile with the inverted value', async () => {
+    (api.getPublisherStatus as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeRecord({ notificationsEnabled: true }),
+    );
+    (api.patchPublisherProfile as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeRecord({ notificationsEnabled: false }),
+    );
+    render(<PublishStatusPage />);
+    await waitFor(() => expect(screen.getByText('Email notifications')).toBeTruthy());
+    const checkbox = screen.getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    fireEvent.input(checkbox, { target: { checked: false } });
+    await waitFor(() =>
+      expect(api.patchPublisherProfile).toHaveBeenCalledWith({ notificationsEnabled: false }),
+    );
+  });
+
+  it('pending applicants do NOT see the new panels', async () => {
+    (api.getPublisherStatus as ReturnType<typeof vi.fn>).mockResolvedValue(
+      makeRecord({ applicationStatus: 'pending' }),
+    );
+    render(<PublishStatusPage />);
+    await waitFor(() => expect(screen.getByText('Old Name')).toBeTruthy());
+    expect(screen.queryByText('Ingest history')).toBeNull();
+    expect(screen.queryByText('Your events')).toBeNull();
+    expect(screen.queryByText('Email notifications')).toBeNull();
   });
 });

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -15,7 +15,7 @@ import { useEffect, useState } from 'preact/hooks';
 // `react-jsx` runtime + the project's @types/react alias mean the children
 // slot expects React.ReactNode. Importing the type only keeps the runtime
 // alignment with preact (the `preact/compat` alias handles the actual JSX).
-import type { ReactNode } from 'react';
+import type { FormEvent, ReactNode } from 'react';
 import {
   clearPublisherSession,
   getPublisherSession,
@@ -32,6 +32,8 @@ import { SourceEditPanel } from './SourceEditPanel';
 import { EmailChangePanel } from './EmailChangePanel';
 import { IngestControls } from './IngestControls';
 import { DangerZone } from './DangerZone';
+import { IngestHistoryPanel } from './IngestHistoryPanel';
+import { PublisherEventsPanel } from './PublisherEventsPanel';
 
 type Status =
   | { kind: 'loading' }
@@ -235,6 +237,24 @@ function StatusView({
       {applicationStatus === 'approved' && <LastFetchPanel rec={rec} />}
 
       {applicationStatus === 'approved' && (
+        <section className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Ingest history</h2>
+          <IngestHistoryPanel />
+        </section>
+      )}
+
+      {applicationStatus === 'approved' && (
+        <section className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">Your events</h2>
+          <PublisherEventsPanel />
+        </section>
+      )}
+
+      {applicationStatus === 'approved' && (
+        <NotificationsPanel rec={rec} onUpdated={onUpdated} />
+      )}
+
+      {applicationStatus === 'approved' && (
         <IngestControls publisher={rec} onChanged={handleEmailChanged} />
       )}
 
@@ -432,6 +452,56 @@ function LastFetchPanel({ rec }: { rec: PublisherStatusRecord }) {
         )}
       </dl>
     </div>
+  );
+}
+
+function NotificationsPanel({
+  rec,
+  onUpdated,
+}: {
+  rec: PublisherStatusRecord;
+  onUpdated: (rec: PublisherStatusRecord) => void;
+}) {
+  // Default-treated-as-true so legacy rows opt in.
+  const enabled = rec.notificationsEnabled !== false;
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleToggle(e: FormEvent<HTMLInputElement>) {
+    const next = (e.currentTarget as HTMLInputElement).checked;
+    setBusy(true);
+    setError(null);
+    try {
+      const updated = await patchPublisherProfile({ notificationsEnabled: next });
+      onUpdated(updated);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-white mb-3">
+        Email notifications
+      </h2>
+      <label className="flex items-start gap-3 text-sm text-gray-700 dark:text-gray-200">
+        <input
+          type="checkbox"
+          checked={enabled}
+          disabled={busy}
+          onInput={handleToggle}
+          className="mt-1"
+        />
+        <span>
+          Email me when my feed breaks or an event is rejected.
+        </span>
+      </label>
+      {error && (
+        <p className="mt-2 text-sm text-red-700 dark:text-red-300">{error}</p>
+      )}
+    </section>
   );
 }
 

--- a/frontend/src/lib/adminPublisherApi.ts
+++ b/frontend/src/lib/adminPublisherApi.ts
@@ -175,11 +175,20 @@ export const approveEvent = (publisherId: string, eventId: string): Promise<void
     { method: 'POST' }
   );
 
-export const rejectEvent = (publisherId: string, eventId: string): Promise<void> =>
-  req<void>(
+export const rejectEvent = (
+  publisherId: string,
+  eventId: string,
+  reason?: string,
+): Promise<void> => {
+  const trimmed = reason?.trim();
+  return req<void>(
     `/publisher-events/${encodeURIComponent(publisherId)}/${encodeURIComponent(eventId)}/reject`,
-    { method: 'POST' }
+    {
+      method: 'POST',
+      ...(trimmed ? { body: JSON.stringify({ reason: trimmed }) } : {}),
+    },
   );
+};
 
 // ---------------------------------------------------------------------------
 // Threshold halts

--- a/frontend/src/lib/publisherStatusApi.ts
+++ b/frontend/src/lib/publisherStatusApi.ts
@@ -32,6 +32,7 @@ export interface PublisherStatusRecord {
   // unset the publisher is considered active.
   paused?: boolean;
   selfPausedAt?: string;
+  notificationsEnabled?: boolean;
 }
 
 const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
@@ -101,6 +102,7 @@ export interface PublisherProfilePatch {
   organization?: string;
   sourceUrl?: string;
   sourceType?: 'json' | 'html';
+  notificationsEnabled?: boolean;
 }
 
 export class PublisherProfileError extends PublisherStatusError {
@@ -436,4 +438,91 @@ export async function cancelEmailChangeBySelf(): Promise<void> {
       r.status,
     );
   }
+}
+
+// ─── Observability (Phase 7 — ingest history + per-event status) ─────────
+
+export type IngestRunStatus = 'ok' | 'parse_error' | 'validation_error' | 'network_error' | 'threshold_halt';
+
+export interface IngestRunCounts {
+  added: number;
+  updated: number;
+  retracted: number;
+  unchanged: number;
+}
+
+export interface IngestRunSummary {
+  publisherId: string;
+  runAt: string;
+  status: IngestRunStatus;
+  message?: string;
+  counts?: IngestRunCounts;
+  triggeredBy: 'schedule' | 'admin' | 'publisher-fetch-now';
+}
+
+export interface PublisherEventSummary {
+  eventId: string;
+  title: string;
+  startDate: string;
+  endDate: string;
+  state: 'published' | 'pending' | 'rejected';
+  rejectionReason?: string;
+  rejectedAt?: string;
+  updatedAt: string;
+}
+
+export async function getPublisherRuns(): Promise<IngestRunSummary[]> {
+  const jwt = getPublisherJwt();
+  if (!jwt) {
+    redirectToLogin();
+    throw new PublisherStatusError('No publisher session.', 401);
+  }
+  const r = await fetch(`${API_BASE}/api/publisher-runs`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${jwt}` },
+  });
+  if (r.status === 401) {
+    clearPublisherSession();
+    redirectToLogin();
+    throw new PublisherStatusError('Session expired.', 401);
+  }
+  const body = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    throw new PublisherStatusError(
+      typeof body?.error === 'string' ? body.error : `Request failed (${r.status}).`,
+      r.status,
+    );
+  }
+  if (!body || !Array.isArray(body.runs)) {
+    throw new PublisherStatusError('Malformed response.', 500);
+  }
+  return body.runs as IngestRunSummary[];
+}
+
+export async function getPublisherEvents(): Promise<PublisherEventSummary[]> {
+  const jwt = getPublisherJwt();
+  if (!jwt) {
+    redirectToLogin();
+    throw new PublisherStatusError('No publisher session.', 401);
+  }
+  const r = await fetch(`${API_BASE}/api/publisher-events`, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${jwt}` },
+  });
+  if (r.status === 401) {
+    clearPublisherSession();
+    redirectToLogin();
+    throw new PublisherStatusError('Session expired.', 401);
+  }
+  const body = await r.json().catch(() => ({}));
+  if (!r.ok) {
+    throw new PublisherStatusError(
+      typeof body?.error === 'string' ? body.error : `Request failed (${r.status}).`,
+      r.status,
+    );
+  }
+  if (!body || !Array.isArray(body.events)) {
+    throw new PublisherStatusError('Malformed response.', 500);
+  }
+  return body.events as PublisherEventSummary[];
 }

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -964,15 +964,16 @@ resource "aws_lambda_function" "admin_handler" {
 
   environment {
     variables = {
-      FEEDBACK_TABLE_NAME         = aws_dynamodb_table.feedback.name
-      ENVIRONMENT                 = var.environment
-      JWT_SECRET                  = var.jwt_secret
-      GOOGLE_CLIENT_ID            = var.google_client_id
-      GOOGLE_CLIENT_SECRET        = var.google_client_secret
-      ADMIN_EMAIL_WHITELIST       = var.admin_email_whitelist
-      ADMIN_API_URL               = "https://admin-api.${var.domain_name}"
-      PUBLISHERS_TABLE_NAME       = aws_dynamodb_table.publishers.name
-      PUBLISHER_EVENTS_TABLE_NAME = aws_dynamodb_table.publisher_events.name
+      FEEDBACK_TABLE_NAME              = aws_dynamodb_table.feedback.name
+      ENVIRONMENT                      = var.environment
+      JWT_SECRET                       = var.jwt_secret
+      GOOGLE_CLIENT_ID                 = var.google_client_id
+      GOOGLE_CLIENT_SECRET             = var.google_client_secret
+      ADMIN_EMAIL_WHITELIST            = var.admin_email_whitelist
+      ADMIN_API_URL                    = "https://admin-api.${var.domain_name}"
+      PUBLISHERS_TABLE_NAME            = aws_dynamodb_table.publishers.name
+      PUBLISHER_EVENTS_TABLE_NAME      = aws_dynamodb_table.publisher_events.name
+      PUBLISHER_INGEST_RUNS_TABLE_NAME = aws_dynamodb_table.publisher_ingest_runs.name
       # Admin "Run ingest now" button on /admin/publishers/ async-invokes
       # this function via lambda:InvokeFunction.
       PUBLISHER_INGEST_FUNCTION_NAME = aws_lambda_function.publisher_ingest.function_name

--- a/infrastructure/publisher-ingest.tf
+++ b/infrastructure/publisher-ingest.tf
@@ -161,6 +161,16 @@ resource "aws_iam_role_policy" "publisher_ingest_scoped" {
             "s3:prefix" = ["cache/calendar-cache/publisher-events-*"]
           }
         }
+      },
+      {
+        # PublisherNotificationService (constructed in scheduledHandler) calls
+        # SES via SesMailService for ingest-failure / ingest-recovery emails.
+        # Without this grant the SDK call AccessDeniedExceptions and is
+        # silently swallowed by guarded(), so emails would never deliver.
+        # Same scope/shape as the portal Lambda's SES grant in publisher-portal.tf.
+        Effect   = "Allow",
+        Action   = ["ses:SendEmail"],
+        Resource = "arn:aws:ses:${var.aws_region}:*:identity/${var.domain_name}"
       }
     ]
   })

--- a/infrastructure/publisher-ingest.tf
+++ b/infrastructure/publisher-ingest.tf
@@ -70,6 +70,41 @@ resource "aws_dynamodb_table" "publisher_events" {
   }
 }
 
+resource "aws_dynamodb_table" "publisher_ingest_runs" {
+  name         = "${var.app_name}-publisher-ingest-runs"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "publisherId"
+  range_key    = "runAt"
+
+  attribute {
+    name = "publisherId"
+    type = "S"
+  }
+
+  attribute {
+    name = "runAt"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
+  point_in_time_recovery {
+    enabled = true
+  }
+
+  server_side_encryption {
+    enabled = true
+  }
+
+  tags = {
+    Name        = "${var.app_name}-publisher-ingest-runs"
+    Environment = var.environment
+  }
+}
+
 resource "aws_iam_role" "publisher_ingest_role" {
   name = "${var.app_name}-publisher-ingest-role"
   assume_role_policy = jsonencode({
@@ -108,7 +143,8 @@ resource "aws_iam_role_policy" "publisher_ingest_scoped" {
         Resource = [
           aws_dynamodb_table.publishers.arn,
           aws_dynamodb_table.publisher_events.arn,
-          "${aws_dynamodb_table.publisher_events.arn}/index/by-state"
+          "${aws_dynamodb_table.publisher_events.arn}/index/by-state",
+          aws_dynamodb_table.publisher_ingest_runs.arn
         ]
       },
       {
@@ -146,10 +182,13 @@ resource "aws_lambda_function" "publisher_ingest" {
 
   environment {
     variables = {
-      PUBLISHERS_TABLE_NAME       = aws_dynamodb_table.publishers.name
-      PUBLISHER_EVENTS_TABLE_NAME = aws_dynamodb_table.publisher_events.name
-      CACHE_S3_BUCKET             = aws_s3_bucket.frontend_bucket.bucket
-      CACHE_S3_KEY_PREFIX         = "cache/calendar-cache"
+      PUBLISHERS_TABLE_NAME            = aws_dynamodb_table.publishers.name
+      PUBLISHER_EVENTS_TABLE_NAME      = aws_dynamodb_table.publisher_events.name
+      PUBLISHER_INGEST_RUNS_TABLE_NAME = aws_dynamodb_table.publisher_ingest_runs.name
+      CACHE_S3_BUCKET                  = aws_s3_bucket.frontend_bucket.bucket
+      CACHE_S3_KEY_PREFIX              = "cache/calendar-cache"
+      SES_FROM_ADDRESS                 = "no-reply@${var.domain_name}"
+      SITE_BASE_URL                    = "https://www.${var.domain_name}"
     }
   }
 
@@ -207,7 +246,8 @@ resource "aws_iam_role_policy" "admin_publisher_access" {
       Resource = [
         aws_dynamodb_table.publishers.arn,
         aws_dynamodb_table.publisher_events.arn,
-        "${aws_dynamodb_table.publisher_events.arn}/index/by-state"
+        "${aws_dynamodb_table.publisher_events.arn}/index/by-state",
+        aws_dynamodb_table.publisher_ingest_runs.arn
       ]
     }]
   })

--- a/scripts/smoke/lib/apiClient.ts
+++ b/scripts/smoke/lib/apiClient.ts
@@ -114,6 +114,20 @@ export class SmokeApiClient {
         body,
         headers: { Authorization: `Bearer ${jwt}` },
       }),
+
+    runs: (jwt: string) =>
+      this.request<{ runs: Array<{ publisherId: string; runAt: string; status: string; message?: string; counts?: { added: number; updated: number; retracted: number; unchanged: number }; triggeredBy: string }> }>({
+        method: 'GET',
+        path: '/api/publisher-runs',
+        headers: { Authorization: `Bearer ${jwt}` },
+      }),
+
+    events: (jwt: string) =>
+      this.request<{ events: Array<{ eventId: string; title: string; startDate: string; endDate: string; state: 'published' | 'pending' | 'rejected'; rejectionReason?: string; rejectedAt?: string; updatedAt: string }> }>({
+        method: 'GET',
+        path: '/api/publisher-events',
+        headers: { Authorization: `Bearer ${jwt}` },
+      }),
   };
 
   // ─── Admin endpoints (smoke-bot Bearer token) ─────────────────────────

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -131,8 +131,13 @@ describeMaybe('post-deploy publisher lifecycle', () => {
 
     const eventsResp = await api.publisher.events(publisherJwt);
     expect(eventsResp.events.length).toBe(publishedCount);
+    // bbtest is created with trustLevel='review' (consumeApplyByEmail in
+    // adminHandler.ts hardcodes that), so freshly-ingested events sit in
+    // 'pending' until an admin approves each one. The smoke does not
+    // approve individual events, so we assert the contract (a valid state
+    // and the projection shape) rather than a specific state.
     for (const e of eventsResp.events) {
-      expect(e.state).toBe('published');
+      expect(['published', 'pending']).toContain(e.state);
       expect(typeof e.eventId).toBe('string');
       expect(typeof e.title).toBe('string');
     }

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -122,6 +122,21 @@ describeMaybe('post-deploy publisher lifecycle', () => {
     );
     expect(publishedCount).toBeGreaterThan(0);
 
+    // 4b. Assert the new observability endpoints reflect the publish.
+    const runsResp = await api.publisher.runs(publisherJwt);
+    expect(runsResp.runs.length).toBeGreaterThan(0);
+    const mostRecent = runsResp.runs[0];
+    expect(mostRecent.status).toBe('ok');
+    expect(mostRecent.counts?.added).toBeGreaterThan(0);
+
+    const eventsResp = await api.publisher.events(publisherJwt);
+    expect(eventsResp.events.length).toBe(publishedCount);
+    for (const e of eventsResp.events) {
+      expect(e.state).toBe('published');
+      expect(typeof e.eventId).toBe('string');
+      expect(typeof e.title).toBe('string');
+    }
+
     // 5. Pause + ingest. Event count should remain unchanged (paused
     //    publishers are skipped in the ingest loop; existing events stay).
     await api.publisher.pause(publisherJwt);
@@ -153,5 +168,14 @@ describeMaybe('post-deploy publisher lifecycle', () => {
       { timeoutMs: 90_000, description: 'retract after self-disable' },
     );
     expect(afterDisable).toBe(0);
+
+    // 7b. After self-disable + retract, both observability endpoints should
+    //     still return 200 (publisher row exists, just disabled), but events
+    //     will be empty and the most-recent run will reflect the retraction.
+    const runsAfterDisable = await api.publisher.runs(publisherJwt);
+    expect(runsAfterDisable.runs.length).toBeGreaterThan(0);
+
+    const eventsAfterDisable = await api.publisher.events(publisherJwt);
+    expect(eventsAfterDisable.events.length).toBe(0);
   }, 5 * 60 * 1000);
 });


### PR DESCRIPTION
## Summary
Bundle of three publisher-experience features so a publisher can self-diagnose feed problems and learn about admin actions without contacting an admin:

1. **Ingest history timeline** — new DDB table `${app_name}-publisher-ingest-runs` (90-day TTL) with last-30-runs panel on `/publish/status/`.
2. **Per-event status grid** — publisher portal shows their own events with `Published`/`Pending review`/`Rejected` badges and admin reason. Admin reject is now a soft-delete (`state='rejected'`) preserved across re-ingest until the publisher drops the event from their feed.
3. **Email notifications** — smart-immediate emails on streak transitions (OK→fail, fail→OK) and admin event rejection. Single opt-out toggle (`notificationsEnabled`) on the publisher record. Inline `notificationService` (no SQS), 2s SES timeout, swallow-on-failure.

24 commits delivered via TDD; per-package coverage maintained or improved (backend 84.19% statements vs 81.1% floor; frontend 76.32% lines vs 74.3% floor).

**Spec:** `docs/superpowers/specs/2026-05-06-publisher-observability-design.md`
**Plan:** `docs/superpowers/plans/2026-05-06-publisher-observability-plan.md`

## Architectural notes
- Soft-delete reject is one-way; pre-existing rejected events (which were hard-deleted) don't come back. No data migration needed.
- Reconciler preserves `state='rejected'` + `rejectionReason` + `rejectedAt` across re-ingest, parallel to PR #100's `state='published'` preservation.
- Sidecar publisher tightened to a positive `state === 'published'` filter (rejected rows never reach the public calendar).
- New Terraform: `aws_dynamodb_table.publisher_ingest_runs` + IAM grants to publisher-ingest and admin Lambdas + new env var `PUBLISHER_INGEST_RUNS_TABLE_NAME`. The publisher-ingest Lambda also now gets `SES_FROM_ADDRESS` and `SITE_BASE_URL` (needed by the inline notifier).
- Smoke test extended to assert `/publisher-runs` and `/publisher-events` shape against the bbtest publisher.

## Post-merge ops
- Run `terraform apply` to provision the new DDB table + IAM + env vars.
- Verify in CloudWatch that publisher-ingest writes run rows on the next scheduled fetch.

## Test plan
- [x] Backend `npx jest` green (789 tests / 54 suites)
- [x] Backend coverage at/above floor (84.19% > 81.1%)
- [x] Frontend `vitest run` green (285 tests / 34 files)
- [x] Frontend coverage at/above floor (76.32% > 74.3%)
- [x] Frontend `npm run build` green
- [x] `terraform validate` green
- [ ] Post-deploy smoke runs the new endpoints (will run automatically via deploy-production.yml)
- [ ] Manual: log into bbtest publisher portal in prod after deploy; confirm both new panels render and the notifications toggle round-trips

🤖 Generated with [Claude Code](https://claude.com/claude-code)