### PR TITLE
fix(frontend): inert VITE_* env in vitest + mirror deploy env in PR checks

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,8 +76,8 @@ jobs:
           # Falls back to a non-secret placeholder so fork PRs (where GitHub
           # withholds repo secrets) still exercise the "non-empty key" path
           # — that's the path that previously broke vitest in CI.
-          # vitest.config.ts has a `define` override forcing this value to '
-          # ' for tests; mirroring it here ensures any future regression of
+          # vitest.config.ts has a `define` override forcing this value to ''
+          # for tests; mirroring it here ensures any future regression of
           # that override surfaces pre-merge instead of crashing the deploy.
           VITE_API_URL: ""
           VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY || 'ci-placeholder-key' }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,18 +71,16 @@ jobs:
       - name: Build frontend (includes type checking and linting)
         run: npm run build --workspace=frontend
         env:
-          # Mirror the deploy-production.yml frontend-build env so PR checks
+          # Mirror deploy-production.yml's frontend-build env so PR checks
           # reproduce the same vitest run conditions as the deploy build.
-          # Without VITE_RECAPTCHA_SITE_KEY set here, the apply-page integration
-          # tests pass on the PR check but fail post-merge during deploy
-          # (vitest's `import.meta.env` reads VITE_* from process.env at
-          # transform time; the apply page tries to load grecaptcha which
-          # jsdom can't execute). vitest.config.ts has a `define` override
-          # that forces the value to '' for tests — so this env var is
-          # consumed only by `vite build`, but mirroring it here ensures any
-          # future regression of that override surfaces pre-merge.
+          # Falls back to a non-secret placeholder so fork PRs (where GitHub
+          # withholds repo secrets) still exercise the "non-empty key" path
+          # — that's the path that previously broke vitest in CI.
+          # vitest.config.ts has a `define` override forcing this value to '
+          # ' for tests; mirroring it here ensures any future regression of
+          # that override surfaces pre-merge instead of crashing the deploy.
           VITE_API_URL: ""
-          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY || 'ci-placeholder-key' }}
           VITE_ENABLE_PUBLISHER_FEEDS: "true"
 
       - name: Upload frontend build artifacts

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,19 @@ jobs:
       - name: Build frontend (includes type checking and linting)
         run: npm run build --workspace=frontend
         env:
+          # Mirror the deploy-production.yml frontend-build env so PR checks
+          # reproduce the same vitest run conditions as the deploy build.
+          # Without VITE_RECAPTCHA_SITE_KEY set here, the apply-page integration
+          # tests pass on the PR check but fail post-merge during deploy
+          # (vitest's `import.meta.env` reads VITE_* from process.env at
+          # transform time; the apply page tries to load grecaptcha which
+          # jsdom can't execute). vitest.config.ts has a `define` override
+          # that forces the value to '' for tests — so this env var is
+          # consumed only by `vite build`, but mirroring it here ensures any
+          # future regression of that override surfaces pre-merge.
           VITE_API_URL: ""
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY }}
+          VITE_ENABLE_PUBLISHER_FEEDS: "true"
 
       - name: Upload frontend build artifacts
         uses: actions/upload-artifact@v4

--- a/frontend/src/app/publish/apply/page.tsx
+++ b/frontend/src/app/publish/apply/page.tsx
@@ -46,7 +46,11 @@ type Status =
   | { kind: 'error'; message: string; field?: string };
 
 const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
-const RECAPTCHA_SITE_KEY = (import.meta as any).env?.VITE_RECAPTCHA_SITE_KEY as string | undefined;
+// Read directly via `import.meta.env.VITE_RECAPTCHA_SITE_KEY` (no cast or
+// optional chain) so vitest.config.ts's compile-time `define` for that exact
+// expression substitutes deterministically. Empty string is treated as
+// "captcha disabled" by the falsy checks below.
+const RECAPTCHA_SITE_KEY: string = import.meta.env.VITE_RECAPTCHA_SITE_KEY ?? '';
 
 // If the reCAPTCHA script doesn't report ready within this many ms (ad
 // blocker, network problem, Google blip), give up waiting and let the user

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,13 +3,17 @@ import preact from '@preact/preset-vite';
 import { resolve } from 'path';
 import floor from '../.coverage-floor.json';
 
-// Force VITE_* env vars to inert values for tests, regardless of process
-// env. Without this, `npm run build --workspace=frontend` (which runs
-// `vitest run --coverage` before `vite build`) inherits production values
-// like VITE_RECAPTCHA_SITE_KEY, which makes the apply page try to load
-// grecaptcha — never resolves in jsdom, submit short-circuits, tests fail
-// in CI but pass locally. `define` is compile-time replacement, so it
-// wins over whatever's in process.env.
+// Force VITE_RECAPTCHA_SITE_KEY to an empty string for the test phase,
+// regardless of process.env. Without this, `npm run build --workspace=frontend`
+// (which runs `vitest run --coverage` before `vite build`) inherits the
+// production secret and makes the apply page try to load grecaptcha — never
+// resolves in jsdom, submit short-circuits, tests fail in CI but pass locally.
+// `define` is compile-time AST replacement on the literal expression
+// `import.meta.env.VITE_RECAPTCHA_SITE_KEY`, so the apply page must read the
+// key via that exact expression (not `(import.meta as any).env?...`) for the
+// substitution to fire. Other VITE_* vars are not overridden here — tests
+// that depend on them (e.g. useEventData.publisherFeed.test.ts) use
+// `vi.stubEnv` per-test instead, which `define` would silently break.
 const TEST_ENV_DEFINES = {
   'import.meta.env.VITE_RECAPTCHA_SITE_KEY': JSON.stringify(''),
 };

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -3,8 +3,20 @@ import preact from '@preact/preset-vite';
 import { resolve } from 'path';
 import floor from '../.coverage-floor.json';
 
+// Force VITE_* env vars to inert values for tests, regardless of process
+// env. Without this, `npm run build --workspace=frontend` (which runs
+// `vitest run --coverage` before `vite build`) inherits production values
+// like VITE_RECAPTCHA_SITE_KEY, which makes the apply page try to load
+// grecaptcha — never resolves in jsdom, submit short-circuits, tests fail
+// in CI but pass locally. `define` is compile-time replacement, so it
+// wins over whatever's in process.env.
+const TEST_ENV_DEFINES = {
+  'import.meta.env.VITE_RECAPTCHA_SITE_KEY': JSON.stringify(''),
+};
+
 export default defineConfig({
   plugins: [preact()],
+  define: TEST_ENV_DEFINES,
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
## Why

The deploy-production frontend-build step was failing because `npm run build --workspace=frontend` runs `vitest run --coverage` (introduced in PR #107 and floored in #109) before `vite build`. The deploy step injects `VITE_RECAPTCHA_SITE_KEY` from a GitHub secret, so vitest sees a non-empty site key, the apply page tries to load grecaptcha, jsdom can't execute the script, and 5 apply integration tests fail.

This wasn't caught pre-merge because the existing PR check (`build-and-test.yml`) didn't set `VITE_RECAPTCHA_SITE_KEY`, so the frontend tests passed there but the same `npm run build` failed during deploy.

## What

1. **vitest.config.ts** — top-level `define` forces `import.meta.env.VITE_RECAPTCHA_SITE_KEY` to `''` for the test phase, regardless of process.env. `define` is compile-time replacement so it wins over the env-var read. The subsequent `vite build` still uses the real key from process.env.

2. **build-and-test.yml** — the frontend PR-check step now mirrors deploy-production.yml's env (`VITE_RECAPTCHA_SITE_KEY` + `VITE_ENABLE_PUBLISHER_FEEDS=true`). The vitest define makes tests inert to those values, but mirroring the env in the PR check ensures any future regression of that override surfaces pre-merge.

## Reproduction

Before fix:

```bash
VITE_RECAPTCHA_SITE_KEY=test-key npx vitest run apply.test.tsx
# 5 of 6 fail
```

After fix:

```bash
VITE_RECAPTCHA_SITE_KEY=test-key npx vitest run apply.test.tsx
# 6 of 6 pass

VITE_RECAPTCHA_SITE_KEY=test-key VITE_API_URL='' VITE_ENABLE_PUBLISHER_FEEDS=true \
  npm run build --workspace=frontend
# ✓ built — full validate + test:ci + vite build green
```

## Test plan

- [x] Reproduce failure locally with secret-set env
- [x] Verify fix with same env
- [x] Full frontend build green with deploy-equivalent env
- [ ] PR check on this branch should now run with VITE_RECAPTCHA_SITE_KEY set and pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)