### PR TITLE
fix(smoke): static fixture feed + publisherId override so post-deploy smoke actually runs

### DIFF
--- a/backend/src/__tests__/adminHandler.smokeRoutes.test.ts
+++ b/backend/src/__tests__/adminHandler.smokeRoutes.test.ts
@@ -211,4 +211,23 @@ describe('POST /smoke-magic-token-by-email — bbtest email gate', () => {
       if (prior !== undefined) process.env.SMOKE_BBTEST_EMAIL = prior;
     }
   });
+
+  it('rejects publisherId override that is not the allowlisted value', async () => {
+    // The smoke route accepts an optional publisherId override so the
+    // materialized row's id matches the static smoke-fixture feed's
+    // declared publisher.id. The override is allowlisted to a single value
+    // ('smoke-bbtest') — any other value (even from an authenticated smoke
+    // caller) is a 400 so a leaked smoke key can't mint arbitrary ids.
+    const r = await handler(
+      evt({
+        path: '/smoke-magic-token-by-email',
+        httpMethod: 'POST',
+        headers: { Authorization: `Bearer ${makeSmokeBotToken()}` },
+        body: JSON.stringify({ email: BBTEST_EMAIL, publisherId: 'attacker-chosen' }),
+      }),
+      ctx,
+    );
+    expect(r.statusCode).toBe(400);
+    expect(JSON.parse(r.body).error).toMatch(/publisherId override must equal "smoke-bbtest"/);
+  });
 });

--- a/backend/src/__tests__/adminHandler.smokeRoutes.test.ts
+++ b/backend/src/__tests__/adminHandler.smokeRoutes.test.ts
@@ -230,4 +230,16 @@ describe('POST /smoke-magic-token-by-email — bbtest email gate', () => {
     expect(r.statusCode).toBe(400);
     expect(JSON.parse(r.body).error).toMatch(/publisherId override must equal "smoke-bbtest"/);
   });
+
+  // Happy-path coverage gap: a unit test that asserts the accepted override
+  // ('smoke-bbtest') flows through to registry.upsert is not covered here
+  // because the handler reads from a module-level `docClient` directly (the
+  // ScanCommand for the apply-token row), not through the
+  // _setSmokeRouteDepsForTests injection seam. Mocking docClient cleanly
+  // would require either exporting a test setter (production code change for
+  // one test) or jest.mock'ing @aws-sdk/lib-dynamodb (which would break the
+  // sibling tests in this file). The live post-deploy smoke run is the
+  // happy-path coverage; a regression of the override path produces a
+  // mismatched publisher.id at ingest, which the smoke surfaces within the
+  // same minute as a deploy.
 });

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -928,13 +928,13 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
         // override fails fast and doesn't burn read capacity. Allowlist is a
         // single hardcoded value — never accept arbitrary ids even from an
         // authenticated smoke caller.
-        const SMOKE_PUBLISHER_ID_ALLOWED_EARLY = 'smoke-bbtest';
-        const requestedPublisherIdEarly = typeof requestBody?.publisherId === 'string'
+        const ALLOWED_PUBLISHER_ID_OVERRIDE = 'smoke-bbtest';
+        const overridePublisherId = typeof requestBody?.publisherId === 'string'
           ? requestBody.publisherId
           : '';
-        if (requestedPublisherIdEarly.length > 0 && requestedPublisherIdEarly !== SMOKE_PUBLISHER_ID_ALLOWED_EARLY) {
+        if (overridePublisherId.length > 0 && overridePublisherId !== ALLOWED_PUBLISHER_ID_OVERRIDE) {
           return createResponse(400, {
-            error: `publisherId override must equal "${SMOKE_PUBLISHER_ID_ALLOWED_EARLY}"`,
+            error: `publisherId override must equal "${ALLOWED_PUBLISHER_ID_OVERRIDE}"`,
           });
         }
         const deps = smokeRouteDeps();
@@ -976,8 +976,8 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
         // PublisherApplicationService.verifyApply) and delete the magic-
         // token row so it can't be reused. The publisherId override (when
         // present) was already allowlisted above; default to a fresh uuid.
-        const publisherId: string = requestedPublisherIdEarly.length > 0
-          ? requestedPublisherIdEarly
+        const publisherId: string = overridePublisherId.length > 0
+          ? overridePublisherId
           : `pub-${uuidv4()}`;
         const nowIso = new Date().toISOString();
         await deps.registry.upsert({

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -924,6 +924,19 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
           });
           return createResponse(403, { error: 'Email does not match the configured smoke bbtest email' });
         }
+        // Validate publisherId override BEFORE the DDB scan so a malformed
+        // override fails fast and doesn't burn read capacity. Allowlist is a
+        // single hardcoded value — never accept arbitrary ids even from an
+        // authenticated smoke caller.
+        const SMOKE_PUBLISHER_ID_ALLOWED_EARLY = 'smoke-bbtest';
+        const requestedPublisherIdEarly = typeof requestBody?.publisherId === 'string'
+          ? requestBody.publisherId
+          : '';
+        if (requestedPublisherIdEarly.length > 0 && requestedPublisherIdEarly !== SMOKE_PUBLISHER_ID_ALLOWED_EARLY) {
+          return createResponse(400, {
+            error: `publisherId override must equal "${SMOKE_PUBLISHER_ID_ALLOWED_EARLY}"`,
+          });
+        }
         const deps = smokeRouteDeps();
         type SmokeTokenRow = {
           tokenHash: string;
@@ -961,8 +974,11 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
 
         // Materialize the publisher row from the apply payload (mirrors
         // PublisherApplicationService.verifyApply) and delete the magic-
-        // token row so it can't be reused.
-        const publisherId = `pub-${uuidv4()}`;
+        // token row so it can't be reused. The publisherId override (when
+        // present) was already allowlisted above; default to a fresh uuid.
+        const publisherId: string = requestedPublisherIdEarly.length > 0
+          ? requestedPublisherIdEarly
+          : `pub-${uuidv4()}`;
         const nowIso = new Date().toISOString();
         await deps.registry.upsert({
           id: publisherId,

--- a/backend/src/handlers/adminHandler.ts
+++ b/backend/src/handlers/adminHandler.ts
@@ -928,6 +928,10 @@ export const handler = async (event: APIGatewayProxyEvent, context: Context): Pr
         // override fails fast and doesn't burn read capacity. Allowlist is a
         // single hardcoded value — never accept arbitrary ids even from an
         // authenticated smoke caller.
+        //
+        // Keep this string in sync with:
+        //   - scripts/smoke/publisher-lifecycle.test.ts (consumeApplyByEmail call)
+        //   - infrastructure/smoke-publisher-feed.json   (publisher.id field)
         const ALLOWED_PUBLISHER_ID_OVERRIDE = 'smoke-bbtest';
         const overridePublisherId = typeof requestBody?.publisherId === 'string'
           ? requestBody.publisherId

--- a/infrastructure/ci-e2e-publisher.tf
+++ b/infrastructure/ci-e2e-publisher.tf
@@ -71,3 +71,27 @@ resource "aws_dynamodb_table_item" "ci_e2e_publisher" {
     ignore_changes = [item]
   }
 }
+
+# ─── Post-deploy publisher-lifecycle smoke fixture ─────────────────────────
+#
+# Static feed used by scripts/smoke/publisher-lifecycle.test.ts. Unlike the
+# ci-e2e publisher above, the smoke creates+deletes its publisher row each
+# run (it's an apply→approve→...→disable lifecycle test, not a toggle test).
+# What's static is just the feed itself + the publisher.id baked into it.
+# The smoke route in adminHandler.ts honors a `publisherId` override field
+# scoped to this exact id ("smoke-bbtest") so the row gets created with the
+# id that matches the feed's publisher.id (otherwise the fetcher rejects on
+# id mismatch).
+
+locals {
+  smoke_bbtest_feed_s3_key = "cache/smoke/bbtest-feed.json"
+}
+
+resource "aws_s3_object" "smoke_bbtest_feed" {
+  bucket        = aws_s3_bucket.frontend_bucket.id
+  key           = local.smoke_bbtest_feed_s3_key
+  source        = "${path.module}/smoke-bbtest-feed.json"
+  etag          = filemd5("${path.module}/smoke-bbtest-feed.json")
+  content_type  = "application/json"
+  cache_control = "public, max-age=60"
+}

--- a/infrastructure/ci-e2e-publisher.tf
+++ b/infrastructure/ci-e2e-publisher.tf
@@ -90,8 +90,8 @@ locals {
 resource "aws_s3_object" "smoke_bbtest_feed" {
   bucket        = aws_s3_bucket.frontend_bucket.id
   key           = local.smoke_bbtest_feed_s3_key
-  source        = "${path.module}/smoke-bbtest-feed.json"
-  etag          = filemd5("${path.module}/smoke-bbtest-feed.json")
+  source        = "${path.module}/smoke-publisher-feed.json"
+  etag          = filemd5("${path.module}/smoke-publisher-feed.json")
   content_type  = "application/json"
   cache_control = "public, max-age=60"
 }

--- a/infrastructure/ci-e2e-publisher.tf
+++ b/infrastructure/ci-e2e-publisher.tf
@@ -88,6 +88,13 @@ locals {
 }
 
 resource "aws_s3_object" "smoke_bbtest_feed" {
+  # Mirror the count gate on `aws_s3_object.ci_e2e_feed`: in environments
+  # where the CI/smoke infrastructure is deliberately disabled (preview
+  # accounts), don't upload the smoke fixture either. The smoke route in
+  # adminHandler.ts is unreachable in those environments anyway, so the S3
+  # object would be unused dead weight.
+  count = var.enable_ci_e2e_publisher ? 1 : 0
+
   bucket        = aws_s3_bucket.frontend_bucket.id
   key           = local.smoke_bbtest_feed_s3_key
   source        = "${path.module}/smoke-publisher-feed.json"

--- a/infrastructure/smoke-publisher-feed.json
+++ b/infrastructure/smoke-publisher-feed.json
@@ -3,7 +3,7 @@
   "publisher": {
     "id": "smoke-bbtest",
     "name": "[SMOKE] bbtest publisher-lifecycle fixture",
-    "contactEmail": "bernard+bbtest-smoke@thebernsteins.com"
+    "contactEmail": "smoke-bbtest@example.org"
   },
   "events": [
     {

--- a/infrastructure/smoke-publisher-feed.json
+++ b/infrastructure/smoke-publisher-feed.json
@@ -1,0 +1,30 @@
+{
+  "formatVersion": "1.0",
+  "publisher": {
+    "id": "smoke-bbtest",
+    "name": "[SMOKE] bbtest publisher-lifecycle fixture",
+    "contactEmail": "bernard+bbtest-smoke@thebernsteins.com"
+  },
+  "events": [
+    {
+      "id": "smoke-event-keynote",
+      "title": "[SMOKE] Keynote (do not display)",
+      "startDate": "2030-07-04T18:00:00-04:00",
+      "endDate": "2030-07-04T19:30:00-04:00",
+      "category": "Special Lectures",
+      "venueId": "hall-of-philosophy",
+      "presenter": "Smoke Bot",
+      "description": "Synthetic event used by the post-deploy publisher-lifecycle smoke to validate apply→approve→publish→pause→resume→self-disable end-to-end. Far-future date keeps it safely past the reconciler's past-event filter; smoke afterAll resets to baseline (events deleted) so this never reaches the public calendar.",
+      "lastModified": "2026-05-07T00:00:00-04:00"
+    },
+    {
+      "id": "smoke-event-panel",
+      "title": "[SMOKE] Panel (do not display)",
+      "startDate": "2030-07-05T10:30:00-04:00",
+      "endDate": "2030-07-05T12:00:00-04:00",
+      "category": "Special Lectures",
+      "venueId": "hall-of-philosophy",
+      "lastModified": "2026-05-07T00:00:00-04:00"
+    }
+  ]
+}

--- a/scripts/smoke/lib/apiClient.ts
+++ b/scripts/smoke/lib/apiClient.ts
@@ -173,11 +173,16 @@ export class SmokeApiClient {
     // row for `email` and returns the resulting publisher JWT + id. See
     // backend/src/handlers/adminHandler.ts for the rationale (raw tokens
     // aren't recoverable from DDB so the smoke can't replay verifyApply).
-    consumeApplyByEmail: (email: string) =>
+    consumeApplyByEmail: (email: string, opts: { publisherId?: string } = {}) =>
       this.request<{ jwt: string; publisherId: string; email: string }>({
         method: 'POST',
         path: '/admin/api/smoke-magic-token-by-email',
-        body: { email },
+        // The optional publisherId override is gated to a single allowlisted
+        // value ('smoke-bbtest') by the handler; the smoke uses it to make
+        // the materialized publisher row's id match the static smoke feed's
+        // publisher.id, so the publisher-ingest fetcher's id-match check
+        // passes during the run-ingest step.
+        body: opts.publisherId ? { email, publisherId: opts.publisherId } : { email },
         adminAuth: true,
       }),
   };

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -85,10 +85,17 @@ describeMaybe('post-deploy publisher lifecycle', () => {
 
   it('walks bbtest through apply → approve → publish → pause → resume → self-disable', async () => {
     // 1. Apply (with CAPTCHA bypass header).
+    //
+    // sourceUrl points at a static fixture feed at
+    // s3://${frontend}/cache/smoke/bbtest-feed.json (provisioned via TF in
+    // ci-e2e-publisher.tf — colocated with the other deploy-test fixtures).
+    // The feed declares publisher.id = "smoke-bbtest"; the smoke route
+    // creates the publisher row with that exact id (see consumeApplyByEmail
+    // call below) so the fetcher's id-match check passes during ingest.
     const apply = await api.publisher.applyRequest({
       email: SMOKE_BBTEST_EMAIL,
       name: 'bbtest smoke',
-      sourceUrl: 'https://example.com/bbtest.json',
+      sourceUrl: `${SMOKE_API_BASE}/cache/smoke/bbtest-feed.json`,
       sourceType: 'json',
       organization: 'CI smoke run',
       notes: `smoke run @ ${new Date().toISOString()}`,
@@ -98,8 +105,12 @@ describeMaybe('post-deploy publisher lifecycle', () => {
     // 2. Consume the apply token by email (smoke shortcut: replays the
     //    /publisher-apply/verify side-effects without needing the raw token,
     //    since raw tokens are SES-only and not recoverable from DDB).
-    const consumed = await api.admin.consumeApplyByEmail(SMOKE_BBTEST_EMAIL);
-    expect(consumed.publisherId).toMatch(/^pub-/);
+    //    Pass the fixed publisherId so the row matches the static feed's
+    //    declared publisher.id.
+    const consumed = await api.admin.consumeApplyByEmail(SMOKE_BBTEST_EMAIL, {
+      publisherId: 'smoke-bbtest',
+    });
+    expect(consumed.publisherId).toBe('smoke-bbtest');
     const publisherId = consumed.publisherId;
     const publisherJwt = consumed.jwt;
 
@@ -174,13 +185,11 @@ describeMaybe('post-deploy publisher lifecycle', () => {
     );
     expect(afterDisable).toBe(0);
 
-    // 7b. After self-disable + retract, both observability endpoints should
-    //     still return 200 (publisher row exists, just disabled), but events
-    //     will be empty and the most-recent run will reflect the retraction.
-    const runsAfterDisable = await api.publisher.runs(publisherJwt);
-    expect(runsAfterDisable.runs.length).toBeGreaterThan(0);
-
-    const eventsAfterDisable = await api.publisher.events(publisherJwt);
-    expect(eventsAfterDisable.events.length).toBe(0);
+    // No post-disable observability assertions: self-disable bumps the
+    // publisher's tokenVersion, so the publisherJwt captured at apply-time
+    // is now stale and any call to /publisher-runs or /publisher-events
+    // would 401. The 4b block above already covers the happy-path shape;
+    // re-issuing a fresh post-disable JWT just to assert the disabled-row
+    // case isn't worth the smoke-route surface it would require.
   }, 5 * 60 * 1000);
 });

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -88,10 +88,11 @@ describeMaybe('post-deploy publisher lifecycle', () => {
     //
     // sourceUrl points at a static fixture feed at
     // s3://${frontend}/cache/smoke/bbtest-feed.json (provisioned via TF in
-    // ci-e2e-publisher.tf — colocated with the other deploy-test fixtures).
-    // The feed declares publisher.id = "smoke-bbtest"; the smoke route
-    // creates the publisher row with that exact id (see consumeApplyByEmail
-    // call below) so the fetcher's id-match check passes during ingest.
+    // ci-e2e-publisher.tf as `local.smoke_bbtest_feed_s3_key` — keep this
+    // path in sync with that local. The feed declares publisher.id =
+    // "smoke-bbtest"; the smoke route creates the publisher row with that
+    // exact id (see consumeApplyByEmail below) so the fetcher's id-match
+    // check passes during ingest.
     const apply = await api.publisher.applyRequest({
       email: SMOKE_BBTEST_EMAIL,
       name: 'bbtest smoke',

--- a/scripts/smoke/publisher-lifecycle.test.ts
+++ b/scripts/smoke/publisher-lifecycle.test.ts
@@ -93,10 +93,14 @@ describeMaybe('post-deploy publisher lifecycle', () => {
     // "smoke-bbtest"; the smoke route creates the publisher row with that
     // exact id (see consumeApplyByEmail below) so the fetcher's id-match
     // check passes during ingest.
+    // URL constructor (instead of string concat) so a trailing slash on
+    // SMOKE_API_BASE doesn't produce a double-slash path that 404s under
+    // CloudFront's path normalization.
+    const fixtureFeedUrl = new URL('/cache/smoke/bbtest-feed.json', SMOKE_API_BASE).toString();
     const apply = await api.publisher.applyRequest({
       email: SMOKE_BBTEST_EMAIL,
       name: 'bbtest smoke',
-      sourceUrl: `${SMOKE_API_BASE}/cache/smoke/bbtest-feed.json`,
+      sourceUrl: fixtureFeedUrl,
       sourceType: 'json',
       organization: 'CI smoke run',
       notes: `smoke run @ ${new Date().toISOString()}`,


### PR DESCRIPTION
## Why

Post-deploy publisher-lifecycle smoke failed on the first end-to-end run after #111 (deploy itself succeeded; smoke step went red). The smoke applies a fresh publisher with `sourceUrl='https://example.com/bbtest.json'`, which 404s — fetcher returns network_error, zero events ingested, count-poll times out at 90s.

Even pointing at a real feed wasn't enough: the fetcher checks `feed.publisher.id === registeredPublisherId`. The smoke creates a fresh publisher with a `pub-<uuid4>` id each run, so a static feed with a fixed publisher.id wouldn't match.

This is the **first actual end-to-end smoke run** against real production — past deploys self-skipped because the Terraform secrets hadn't propagated until 2026-05-07. So the broken assertions never surfaced.

## What

1. **`infrastructure/smoke-publisher-feed.json`** — static fixture with `publisher.id = "smoke-bbtest"` and two far-future events. Filename deliberately avoids the `*test*.json` gitignore pattern.
2. **`infrastructure/ci-e2e-publisher.tf`** — adds `aws_s3_object.smoke_bbtest_feed` uploading the fixture to `s3://${frontend}/cache/smoke/bbtest-feed.json`. Frontend deploy already excludes `cache/*`, so it persists.
3. **`backend/src/handlers/adminHandler.ts`** — `POST /smoke-magic-token-by-email` accepts an optional `publisherId` field, allowlisted to `"smoke-bbtest"` only. Validation runs **before** the DDB scan so a malformed override fails fast. Default behavior (no override) is unchanged.
4. **`scripts/smoke/lib/apiClient.ts` + `publisher-lifecycle.test.ts`** — pass the override; switch sourceUrl to the static fixture URL; drop the post-self-disable observability assertions (step 7b from #110, which used a JWT that's already invalid post-self-disable due to tokenVersion bump).
5. **`backend/src/__tests__/adminHandler.smokeRoutes.test.ts`** — new test pinning that the override is rejected with 400 for any non-allowlisted value.

## Post-merge ops

After merge, `terraform apply` to provision the new S3 fixture object before the next deploy can pass the smoke. Plan should show one new `aws_s3_object` and zero destroys.

## Test plan

- [x] Backend `npx jest` 792 pass
- [x] `terraform validate` clean
- [ ] Post-merge: `terraform apply` to upload fixture
- [ ] Post-merge: deploy succeeds and smoke now passes (instead of timing out at 90s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)