### PR TITLE
feat(frontend): active filter chips + remove first-paint Now flicker

### DIFF
--- a/frontend/src/__tests__/components/filters/buildActiveChips.test.ts
+++ b/frontend/src/__tests__/components/filters/buildActiveChips.test.ts
@@ -38,6 +38,12 @@ describe('buildActiveChips', () => {
     expect(buildActiveChips(makeArgs({ searchTerm: '   ' }))).toEqual([]);
   });
 
+  it('trims surrounding whitespace from the search chip label', () => {
+    const chips = buildActiveChips(makeArgs({ searchTerm: '  symphony  ' }));
+    expect(chips).toHaveLength(1);
+    expect(chips[0].label).toBe('"symphony"');
+  });
+
   it('emits a date chip with a friendly label and a remove that resets to "all"', () => {
     const setDateFilter = vi.fn();
     const chips = buildActiveChips(makeArgs({ dateFilter: 'next', setDateFilter }));

--- a/frontend/src/__tests__/components/filters/buildActiveChips.test.ts
+++ b/frontend/src/__tests__/components/filters/buildActiveChips.test.ts
@@ -1,0 +1,113 @@
+/// <reference types="vitest/globals" />
+import { buildActiveChips } from '@/components/filters/buildActiveChips';
+
+function makeArgs(overrides: Partial<Parameters<typeof buildActiveChips>[0]> = {}): Parameters<typeof buildActiveChips>[0] {
+  return {
+    searchTerm: '',
+    setSearchTerm: vi.fn(),
+    dateFilter: 'all',
+    setDateFilter: vi.fn(),
+    selectedWeeks: [],
+    setSelectedWeeks: vi.fn(),
+    selectedLocations: [],
+    toggleLocation: vi.fn(),
+    selectedTags: [],
+    toggleTag: vi.fn(),
+    showFavoritesOnly: false,
+    toggleFavoritesOnly: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('buildActiveChips', () => {
+  it('returns no chips when no filters are active', () => {
+    expect(buildActiveChips(makeArgs())).toEqual([]);
+  });
+
+  it('emits a search chip whose remove callback clears the search term', () => {
+    const setSearchTerm = vi.fn();
+    const chips = buildActiveChips(makeArgs({ searchTerm: 'symphony', setSearchTerm }));
+    expect(chips).toHaveLength(1);
+    expect(chips[0].category).toBe('search');
+    expect(chips[0].label).toBe('"symphony"');
+    chips[0].onRemove();
+    expect(setSearchTerm).toHaveBeenCalledWith('');
+  });
+
+  it('does not emit a search chip for whitespace-only search terms', () => {
+    expect(buildActiveChips(makeArgs({ searchTerm: '   ' }))).toEqual([]);
+  });
+
+  it('emits a date chip with a friendly label and a remove that resets to "all"', () => {
+    const setDateFilter = vi.fn();
+    const chips = buildActiveChips(makeArgs({ dateFilter: 'next', setDateFilter }));
+    expect(chips).toHaveLength(1);
+    expect(chips[0].category).toBe('date');
+    expect(chips[0].label).toBe('Now');
+    chips[0].onRemove();
+    expect(setDateFilter).toHaveBeenCalledWith('all');
+  });
+
+  it('emits no date chip when dateFilter is "all"', () => {
+    expect(buildActiveChips(makeArgs({ dateFilter: 'all' }))).toEqual([]);
+  });
+
+  it('emits one chip per selected week with the label "Week N"', () => {
+    const setSelectedWeeks = vi.fn();
+    const chips = buildActiveChips(makeArgs({ selectedWeeks: [1, 3, 5], setSelectedWeeks }));
+    expect(chips.map(c => c.label)).toEqual(['Week 1', 'Week 3', 'Week 5']);
+  });
+
+  it('week chip remove only filters out its own week (closure captures the right value)', () => {
+    let weeks = [1, 3, 5];
+    const setSelectedWeeks = vi.fn((updater: number[] | ((prev: number[]) => number[])) => {
+      weeks = typeof updater === 'function' ? updater(weeks) : updater;
+    });
+    const chips = buildActiveChips(makeArgs({ selectedWeeks: weeks, setSelectedWeeks }));
+    chips[1].onRemove();
+    expect(weeks).toEqual([1, 5]);
+  });
+
+  it('emits a chip per location and removes via toggleLocation', () => {
+    const toggleLocation = vi.fn();
+    const chips = buildActiveChips(makeArgs({
+      selectedLocations: ['Hall of Philosophy', 'Amphitheater'],
+      toggleLocation,
+    }));
+    expect(chips).toHaveLength(2);
+    chips[0].onRemove();
+    expect(toggleLocation).toHaveBeenCalledWith('Hall of Philosophy');
+  });
+
+  it('emits a chip per tag and removes via toggleTag', () => {
+    const toggleTag = vi.fn();
+    const chips = buildActiveChips(makeArgs({
+      selectedTags: ['Lecture', 'Music'],
+      toggleTag,
+    }));
+    expect(chips).toHaveLength(2);
+    chips[1].onRemove();
+    expect(toggleTag).toHaveBeenCalledWith('Music');
+  });
+
+  it('emits a favorites chip whose remove flips toggleFavoritesOnly', () => {
+    const toggleFavoritesOnly = vi.fn();
+    const chips = buildActiveChips(makeArgs({ showFavoritesOnly: true, toggleFavoritesOnly }));
+    expect(chips).toHaveLength(1);
+    expect(chips[0].category).toBe('favorites');
+    chips[0].onRemove();
+    expect(toggleFavoritesOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits chips in a stable order: search, date, weeks, locations, tags, favorites', () => {
+    const chips = buildActiveChips(makeArgs({
+      searchTerm: 'q',
+      dateFilter: 'today',
+      selectedWeeks: [2],
+      selectedLocations: ['Hall'],
+      selectedTags: ['Lecture'],
+      showFavoritesOnly: true,
+    }));
+    expect(chips.map(c => c.category)).toEqual(['search', 'date', 'week', 'location', 'tag', 'favorites']);
+  });
+});

--- a/frontend/src/__tests__/hooks/useFilterState.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterState.test.ts
@@ -12,6 +12,53 @@ describe('useFilterState', () => {
     expect(result.current.dateFilter).toBe('next');
   });
 
+  it('loads saved dateFilter from localStorage on the very first render (no flicker)', () => {
+    localStorage.setItem('chq-calendar-user-state', JSON.stringify({
+      searchTerm: '', selectedTags: [], selectedLocations: [],
+      dateFilter: 'today', selectedWeeks: [],
+      expandedDescriptions: [], recentLocations: [], recentCategories: [],
+      showFavoritesOnly: false,
+      lastSaved: Date.now(),
+    }));
+    const { result } = renderHook(() => useFilterState());
+    // No act() / no second render — the synchronous lazy initializer must
+    // produce the loaded state on the first render, otherwise the "Now"
+    // button would briefly highlight before the loaded state replaces it.
+    expect(result.current.dateFilter).toBe('today');
+  });
+
+  it('loads saved searchTerm and selections synchronously', () => {
+    localStorage.setItem('chq-calendar-user-state', JSON.stringify({
+      searchTerm: 'symphony',
+      selectedTags: ['Music'], selectedLocations: ['Hall A'],
+      dateFilter: 'all', selectedWeeks: [3, 4],
+      expandedDescriptions: [], recentLocations: [], recentCategories: [],
+      showFavoritesOnly: true,
+      lastSaved: Date.now(),
+    }));
+    const { result } = renderHook(() => useFilterState());
+    expect(result.current.searchTerm).toBe('symphony');
+    expect(result.current.selectedTags).toEqual(['Music']);
+    expect(result.current.selectedLocations).toEqual(['Hall A']);
+    expect(result.current.selectedWeeks).toEqual([3, 4]);
+    expect(result.current.showFavoritesOnly).toBe(true);
+    expect(result.current.dateFilter).toBe('all');
+  });
+
+  it('ignores expired saved state and falls back to defaults', () => {
+    const longAgo = Date.now() - (40 * 24 * 60 * 60 * 1000); // 40 days, expiry is 30
+    localStorage.setItem('chq-calendar-user-state', JSON.stringify({
+      searchTerm: 'stale', selectedTags: [], selectedLocations: [],
+      dateFilter: 'today', selectedWeeks: [],
+      expandedDescriptions: [], recentLocations: [], recentCategories: [],
+      showFavoritesOnly: false,
+      lastSaved: longAgo,
+    }));
+    const { result } = renderHook(() => useFilterState());
+    expect(result.current.searchTerm).toBe('');
+    expect(result.current.dateFilter).toBe('next');
+  });
+
   describe('reconcileFilters', () => {
     it('sets dateFilter to next when reconciling for the current year', () => {
       const { result } = renderHook(() => useFilterState());

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -19,6 +19,7 @@ import { DateFilter } from '@/components/filters/DateFilter';
 import { LocationFilter } from '@/components/filters/LocationFilter';
 import { CategoryFilter } from '@/components/filters/CategoryFilter';
 import { ActiveFilters } from '@/components/filters/ActiveFilters';
+import { buildActiveChips } from '@/components/filters/buildActiveChips';
 import { EventList } from '@/components/calendar/EventList';
 
 function HomeContent() {
@@ -137,7 +138,20 @@ function HomeContent() {
                 pillScroll={categoryScroll} listScroll={categoryListScroll}
               />
             </div>
-            <ActiveFilters filteredCount={filteredEvents.length} totalCount={events.length} hasFilters={!!filters.hasFilters} onClear={filters.clearFilters} />
+            <ActiveFilters
+              filteredCount={filteredEvents.length}
+              totalCount={events.length}
+              hasFilters={!!filters.hasFilters}
+              chips={buildActiveChips({
+                searchTerm: filters.searchTerm, setSearchTerm: filters.setSearchTerm,
+                dateFilter: filters.dateFilter, setDateFilter: filters.setDateFilter,
+                selectedWeeks: filters.selectedWeeks, setSelectedWeeks: filters.setSelectedWeeks,
+                selectedLocations: filters.selectedLocations, toggleLocation: filters.toggleLocation,
+                selectedTags: filters.selectedTags, toggleTag: filters.toggleTag,
+                showFavoritesOnly: filters.showFavoritesOnly, toggleFavoritesOnly: filters.toggleFavoritesOnly,
+              })}
+              onClear={filters.clearFilters}
+            />
           </div>
         </div>
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow">

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -97,6 +97,21 @@ function HomeContent() {
     if (filters.dateFilter !== 'next' || !adaptiveEndDate || !events.length) return false;
     return events.some(e => new Date(e.startDate) > adaptiveEndDate);
   }, [filters.dateFilter, adaptiveEndDate, events]);
+  const activeChips = useMemo(() => buildActiveChips({
+    searchTerm: filters.searchTerm, setSearchTerm: filters.setSearchTerm,
+    dateFilter: filters.dateFilter, setDateFilter: filters.setDateFilter,
+    selectedWeeks: filters.selectedWeeks, setSelectedWeeks: filters.setSelectedWeeks,
+    selectedLocations: filters.selectedLocations, toggleLocation: filters.toggleLocation,
+    selectedTags: filters.selectedTags, toggleTag: filters.toggleTag,
+    showFavoritesOnly: filters.showFavoritesOnly, toggleFavoritesOnly: filters.toggleFavoritesOnly,
+  }), [
+    filters.searchTerm, filters.setSearchTerm,
+    filters.dateFilter, filters.setDateFilter,
+    filters.selectedWeeks, filters.setSelectedWeeks,
+    filters.selectedLocations, filters.toggleLocation,
+    filters.selectedTags, filters.toggleTag,
+    filters.showFavoritesOnly, filters.toggleFavoritesOnly,
+  ]);
   const isThisWeekActive = filters.dateFilter === 'this-week' || (currentWeekNumber !== null && filters.selectedWeeks.length === 1 && filters.selectedWeeks[0] === currentWeekNumber);
   const isWeekHighlighted = (weekNumber: number, isSelected: boolean) => isSelected || (filters.dateFilter === 'this-week' && currentWeekNumber === weekNumber);
 
@@ -141,15 +156,8 @@ function HomeContent() {
             <ActiveFilters
               filteredCount={filteredEvents.length}
               totalCount={events.length}
-              hasFilters={!!filters.hasFilters}
-              chips={buildActiveChips({
-                searchTerm: filters.searchTerm, setSearchTerm: filters.setSearchTerm,
-                dateFilter: filters.dateFilter, setDateFilter: filters.setDateFilter,
-                selectedWeeks: filters.selectedWeeks, setSelectedWeeks: filters.setSelectedWeeks,
-                selectedLocations: filters.selectedLocations, toggleLocation: filters.toggleLocation,
-                selectedTags: filters.selectedTags, toggleTag: filters.toggleTag,
-                showFavoritesOnly: filters.showFavoritesOnly, toggleFavoritesOnly: filters.toggleFavoritesOnly,
-              })}
+              hasFilters={filters.hasFilters}
+              chips={activeChips}
               onClear={filters.clearFilters}
             />
           </div>

--- a/frontend/src/components/filters/ActiveFilters.tsx
+++ b/frontend/src/components/filters/ActiveFilters.tsx
@@ -51,7 +51,7 @@ export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, on
         <div className="mb-2 flex items-start gap-2 flex-wrap">
           <span className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300 pt-1">
             <FilterIcon className="w-4 h-4" />
-            <span className="hidden sm:inline">Filtering by:</span>
+            <span className="sr-only sm:not-sr-only">Filtering by:</span>
           </span>
           <div className="flex flex-wrap gap-1.5 flex-1 min-w-0">
             {chips.map(chip => (

--- a/frontend/src/components/filters/ActiveFilters.tsx
+++ b/frontend/src/components/filters/ActiveFilters.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import type { ActiveChip } from './buildActiveChips';
 
 interface ActiveFiltersProps {
@@ -9,35 +8,10 @@ interface ActiveFiltersProps {
   onClear: () => void;
 }
 
-type Variant = '1' | '2' | '3';
-
-function readVariantFromUrl(): Variant {
-  if (typeof window === 'undefined') return '1';
-  const v = new URLSearchParams(window.location.search).get('fv');
-  return v === '2' || v === '3' ? v : '1';
-}
-
-function useVariant(): Variant {
-  const [variant, setVariant] = useState<Variant>(readVariantFromUrl);
-  useEffect(() => {
-    const onPop = () => setVariant(readVariantFromUrl());
-    window.addEventListener('popstate', onPop);
-    return () => window.removeEventListener('popstate', onPop);
-  }, []);
-  return variant;
-}
-
 const FilterIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
   <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
       d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L15 12.414V19a1 1 0 01-1.447.894l-4-2A1 1 0 019 17v-4.586L3.293 6.707A1 1 0 013 6V4z" />
-  </svg>
-);
-
-const ResetIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
-  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
-      d="M4 4v5h5M20 20v-5h-5M5.5 9A7 7 0 0118 7m1.5 8a7 7 0 01-12.5 2" />
   </svg>
 );
 
@@ -47,98 +21,41 @@ const CloseIcon = ({ className = 'w-3 h-3' }: { className?: string }) => (
   </svg>
 );
 
-function chipClassesFor(variant: Variant): string {
-  if (variant === '1') {
-    return [
-      'inline-flex items-center gap-1 max-w-full px-2 py-1 rounded-md text-xs font-medium',
-      'bg-amber-100 text-amber-900 border border-amber-300',
-      'dark:bg-amber-900/40 dark:text-amber-100 dark:border-amber-700',
-      'hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors',
-    ].join(' ');
-  }
-  if (variant === '2') {
-    return [
-      'inline-flex items-center gap-1 max-w-full px-2 py-1 rounded-md text-xs font-medium',
-      'bg-white text-gray-800 border border-gray-400',
-      'dark:bg-gray-800 dark:text-gray-100 dark:border-gray-500',
-      'hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors',
-    ].join(' ');
-  }
-  return [
-    'inline-flex items-center gap-1 max-w-full px-2.5 py-1 rounded-full text-xs font-medium',
-    'bg-blue-50 text-blue-900 border border-blue-300',
-    'dark:bg-blue-900/30 dark:text-blue-100 dark:border-blue-700',
-    'hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors',
-  ].join(' ');
-}
+const CHIP_CLASSES = [
+  'inline-flex items-center gap-1 max-w-full px-2 py-1 rounded-md text-xs font-medium',
+  'bg-amber-100 text-amber-900 border border-amber-300',
+  'dark:bg-amber-900/40 dark:text-amber-100 dark:border-amber-700',
+  'hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors',
+].join(' ');
 
-function leadingLabelFor(variant: Variant): string {
-  if (variant === '1') return 'Filtering by:';
-  if (variant === '2') return 'Filters:';
-  return 'Active filters:';
-}
-
-function FilterChip({ chip, variant }: { chip: ActiveChip; variant: Variant }) {
-  const showPrefix = variant === '3' && chip.prefix;
+function FilterChip({ chip }: { chip: ActiveChip }) {
   const ariaLabel = chip.prefix ? `Remove filter ${chip.prefix}: ${chip.label}` : `Remove filter ${chip.label}`;
   return (
     <button
       type="button"
       onClick={chip.onRemove}
-      className={chipClassesFor(variant)}
+      className={CHIP_CLASSES}
       aria-label={ariaLabel}
       title={ariaLabel}
     >
-      {showPrefix && <span className="opacity-70">{chip.prefix}:</span>}
       <span className="truncate">{chip.label}</span>
       <CloseIcon className="w-3 h-3 flex-shrink-0 opacity-70" />
     </button>
   );
 }
 
-function ResetAction({ variant, onClear }: { variant: Variant; onClear: () => void }) {
-  if (variant === '2') {
-    return (
-      <button
-        type="button"
-        onClick={onClear}
-        className="flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 text-sm text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
-        aria-label="Show all events"
-        title="Show all events"
-      >
-        <ResetIcon />
-        <span className="hidden sm:inline">Show all</span>
-      </button>
-    );
-  }
-  const label = variant === '1' ? 'Show all events' : 'Reset all';
-  const shortLabel = variant === '1' ? 'Show all' : 'Reset';
-  return (
-    <button
-      type="button"
-      onClick={onClear}
-      className="flex-shrink-0 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
-    >
-      <span className="hidden sm:inline">{label}</span>
-      <span className="sm:hidden">{shortLabel}</span>
-    </button>
-  );
-}
-
 export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, onClear }: ActiveFiltersProps) {
-  const variant = useVariant();
-
   return (
     <div className="mt-2 sm:mt-4 pt-2 sm:pt-3 border-t border-gray-200 dark:border-gray-700">
       {hasFilters && chips.length > 0 && (
         <div className="mb-2 flex items-start gap-2 flex-wrap">
           <span className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300 pt-1">
             <FilterIcon className="w-4 h-4" />
-            <span className="hidden sm:inline">{leadingLabelFor(variant)}</span>
+            <span className="hidden sm:inline">Filtering by:</span>
           </span>
           <div className="flex flex-wrap gap-1.5 flex-1 min-w-0">
             {chips.map(chip => (
-              <FilterChip key={chip.key} chip={chip} variant={variant} />
+              <FilterChip key={chip.key} chip={chip} />
             ))}
           </div>
         </div>
@@ -150,7 +67,17 @@ export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, on
             : `Events (${totalCount})`
           }
         </div>
-        {hasFilters && <ResetAction variant={variant} onClear={onClear} />}
+        {hasFilters && (
+          <button
+            type="button"
+            onClick={onClear}
+            aria-label="Clear all filters and show all events"
+            className="flex-shrink-0 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
+          >
+            <span className="hidden sm:inline">Show all events</span>
+            <span className="sm:hidden">Show all</span>
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/filters/ActiveFilters.tsx
+++ b/frontend/src/components/filters/ActiveFilters.tsx
@@ -1,28 +1,156 @@
+import { useEffect, useState } from 'react';
+import type { ActiveChip } from './buildActiveChips';
+
 interface ActiveFiltersProps {
   filteredCount: number;
   totalCount: number;
   hasFilters: boolean;
+  chips: ActiveChip[];
   onClear: () => void;
 }
 
-export function ActiveFilters({ filteredCount, totalCount, hasFilters, onClear }: ActiveFiltersProps) {
+type Variant = '1' | '2' | '3';
+
+function readVariantFromUrl(): Variant {
+  if (typeof window === 'undefined') return '1';
+  const v = new URLSearchParams(window.location.search).get('fv');
+  return v === '2' || v === '3' ? v : '1';
+}
+
+function useVariant(): Variant {
+  const [variant, setVariant] = useState<Variant>(readVariantFromUrl);
+  useEffect(() => {
+    const onPop = () => setVariant(readVariantFromUrl());
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+  return variant;
+}
+
+const FilterIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2a1 1 0 01-.293.707L15 12.414V19a1 1 0 01-1.447.894l-4-2A1 1 0 019 17v-4.586L3.293 6.707A1 1 0 013 6V4z" />
+  </svg>
+);
+
+const ResetIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M4 4v5h5M20 20v-5h-5M5.5 9A7 7 0 0118 7m1.5 8a7 7 0 01-12.5 2" />
+  </svg>
+);
+
+const CloseIcon = ({ className = 'w-3 h-3' }: { className?: string }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 6l12 12M6 18L18 6" />
+  </svg>
+);
+
+function chipClassesFor(variant: Variant): string {
+  if (variant === '1') {
+    return [
+      'inline-flex items-center gap-1 max-w-full px-2 py-1 rounded-md text-xs font-medium',
+      'bg-amber-100 text-amber-900 border border-amber-300',
+      'dark:bg-amber-900/40 dark:text-amber-100 dark:border-amber-700',
+      'hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors',
+    ].join(' ');
+  }
+  if (variant === '2') {
+    return [
+      'inline-flex items-center gap-1 max-w-full px-2 py-1 rounded-md text-xs font-medium',
+      'bg-white text-gray-800 border border-gray-400',
+      'dark:bg-gray-800 dark:text-gray-100 dark:border-gray-500',
+      'hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors',
+    ].join(' ');
+  }
+  return [
+    'inline-flex items-center gap-1 max-w-full px-2.5 py-1 rounded-full text-xs font-medium',
+    'bg-blue-50 text-blue-900 border border-blue-300',
+    'dark:bg-blue-900/30 dark:text-blue-100 dark:border-blue-700',
+    'hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors',
+  ].join(' ');
+}
+
+function leadingLabelFor(variant: Variant): string {
+  if (variant === '1') return 'Filtering by:';
+  if (variant === '2') return 'Filters:';
+  return 'Active filters:';
+}
+
+function FilterChip({ chip, variant }: { chip: ActiveChip; variant: Variant }) {
+  const showPrefix = variant === '3' && chip.prefix;
+  const ariaLabel = chip.prefix ? `Remove filter ${chip.prefix}: ${chip.label}` : `Remove filter ${chip.label}`;
+  return (
+    <button
+      type="button"
+      onClick={chip.onRemove}
+      className={chipClassesFor(variant)}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+    >
+      {showPrefix && <span className="opacity-70">{chip.prefix}:</span>}
+      <span className="truncate">{chip.label}</span>
+      <CloseIcon className="w-3 h-3 flex-shrink-0 opacity-70" />
+    </button>
+  );
+}
+
+function ResetAction({ variant, onClear }: { variant: Variant; onClear: () => void }) {
+  if (variant === '2') {
+    return (
+      <button
+        type="button"
+        onClick={onClear}
+        className="flex-shrink-0 inline-flex items-center gap-1 px-2 py-1 text-sm text-gray-700 dark:text-gray-200 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
+        aria-label="Show all events"
+        title="Show all events"
+      >
+        <ResetIcon />
+        <span className="hidden sm:inline">Show all</span>
+      </button>
+    );
+  }
+  const label = variant === '1' ? 'Show all events' : 'Reset all';
+  const shortLabel = variant === '1' ? 'Show all' : 'Reset';
+  return (
+    <button
+      type="button"
+      onClick={onClear}
+      className="flex-shrink-0 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
+    >
+      <span className="hidden sm:inline">{label}</span>
+      <span className="sm:hidden">{shortLabel}</span>
+    </button>
+  );
+}
+
+export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, onClear }: ActiveFiltersProps) {
+  const variant = useVariant();
+
   return (
     <div className="mt-2 sm:mt-4 pt-2 sm:pt-3 border-t border-gray-200 dark:border-gray-700">
-      <div className="flex items-center justify-between">
+      {hasFilters && chips.length > 0 && (
+        <div className="mb-2 flex items-start gap-2 flex-wrap">
+          <span className="flex-shrink-0 inline-flex items-center gap-1 text-sm text-gray-600 dark:text-gray-300 pt-1">
+            <FilterIcon className="w-4 h-4" />
+            <span className="hidden sm:inline">{leadingLabelFor(variant)}</span>
+          </span>
+          <div className="flex flex-wrap gap-1.5 flex-1 min-w-0">
+            {chips.map(chip => (
+              <FilterChip key={chip.key} chip={chip} variant={variant} />
+            ))}
+          </div>
+        </div>
+      )}
+      <div className="flex items-center justify-between gap-2">
         <div className="text-sm text-gray-600 dark:text-gray-300 font-medium">
           {hasFilters
             ? `Events (${filteredCount}/${totalCount})`
             : `Events (${totalCount})`
           }
         </div>
-        {hasFilters && (
-          <button
-            onClick={onClear}
-            className="px-3 py-1 sm:px-4 sm:py-2 text-sm text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-700"
-          >
-            Clear All Filters
-          </button>
-        )}
+        {hasFilters && <ResetAction variant={variant} onClear={onClear} />}
       </div>
     </div>
   );

--- a/frontend/src/components/filters/buildActiveChips.ts
+++ b/frontend/src/components/filters/buildActiveChips.ts
@@ -1,4 +1,5 @@
 import { getCategoryDisplayName, getLocationDisplayName } from '@/lib/constants';
+import type { DateFilter } from '@/hooks/useFilterState';
 
 export interface ActiveChip {
   key: string;
@@ -7,8 +8,6 @@ export interface ActiveChip {
   label: string;
   onRemove: () => void;
 }
-
-type DateFilter = 'all' | 'today' | 'next' | 'this-week';
 
 const DATE_LABELS: Record<Exclude<DateFilter, 'all'>, string> = {
   next: 'Now',

--- a/frontend/src/components/filters/buildActiveChips.ts
+++ b/frontend/src/components/filters/buildActiveChips.ts
@@ -33,12 +33,13 @@ interface BuildArgs {
 export function buildActiveChips(args: BuildArgs): ActiveChip[] {
   const chips: ActiveChip[] = [];
 
-  if (args.searchTerm.trim()) {
+  const trimmedSearch = args.searchTerm.trim();
+  if (trimmedSearch) {
     chips.push({
       key: 'search',
       category: 'search',
       prefix: 'Search',
-      label: `"${args.searchTerm}"`,
+      label: `"${trimmedSearch}"`,
       onRemove: () => args.setSearchTerm(''),
     });
   }

--- a/frontend/src/components/filters/buildActiveChips.ts
+++ b/frontend/src/components/filters/buildActiveChips.ts
@@ -1,0 +1,98 @@
+import { getCategoryDisplayName, getLocationDisplayName } from '@/lib/constants';
+
+export interface ActiveChip {
+  key: string;
+  category: 'search' | 'date' | 'week' | 'location' | 'tag' | 'favorites';
+  prefix: string;
+  label: string;
+  onRemove: () => void;
+}
+
+type DateFilter = 'all' | 'today' | 'next' | 'this-week';
+
+const DATE_LABELS: Record<Exclude<DateFilter, 'all'>, string> = {
+  next: 'Now',
+  today: 'Today',
+  'this-week': 'This Week',
+};
+
+interface BuildArgs {
+  searchTerm: string;
+  setSearchTerm: (s: string) => void;
+  dateFilter: DateFilter;
+  setDateFilter: (f: DateFilter) => void;
+  selectedWeeks: number[];
+  setSelectedWeeks: (next: number[] | ((prev: number[]) => number[])) => void;
+  selectedLocations: string[];
+  toggleLocation: (loc: string) => void;
+  selectedTags: string[];
+  toggleTag: (tag: string) => void;
+  showFavoritesOnly: boolean;
+  toggleFavoritesOnly: () => void;
+}
+
+export function buildActiveChips(args: BuildArgs): ActiveChip[] {
+  const chips: ActiveChip[] = [];
+
+  if (args.searchTerm.trim()) {
+    chips.push({
+      key: 'search',
+      category: 'search',
+      prefix: 'Search',
+      label: `"${args.searchTerm}"`,
+      onRemove: () => args.setSearchTerm(''),
+    });
+  }
+
+  if (args.dateFilter !== 'all') {
+    chips.push({
+      key: `date-${args.dateFilter}`,
+      category: 'date',
+      prefix: 'When',
+      label: DATE_LABELS[args.dateFilter],
+      onRemove: () => args.setDateFilter('all'),
+    });
+  }
+
+  for (const week of args.selectedWeeks) {
+    chips.push({
+      key: `week-${week}`,
+      category: 'week',
+      prefix: '',
+      label: `Week ${week}`,
+      onRemove: () => args.setSelectedWeeks(prev => prev.filter(w => w !== week)),
+    });
+  }
+
+  for (const location of args.selectedLocations) {
+    chips.push({
+      key: `loc-${location}`,
+      category: 'location',
+      prefix: 'Location',
+      label: getLocationDisplayName(location),
+      onRemove: () => args.toggleLocation(location),
+    });
+  }
+
+  for (const tag of args.selectedTags) {
+    chips.push({
+      key: `tag-${tag}`,
+      category: 'tag',
+      prefix: 'Category',
+      label: getCategoryDisplayName(tag),
+      onRemove: () => args.toggleTag(tag),
+    });
+  }
+
+  if (args.showFavoritesOnly) {
+    chips.push({
+      key: 'favorites',
+      category: 'favorites',
+      prefix: '',
+      label: '★ Favorites only',
+      onRemove: () => args.toggleFavoritesOnly(),
+    });
+  }
+
+  return chips;
+}

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -32,9 +32,7 @@ type FilterAction =
   | { type: 'ADD_EXTRA_DAY' }
   | { type: 'CLEAR_EXTRA_DAYS' }
   | { type: 'RECONCILE_FILTERS'; payload: { availableCategories: string[]; availableLocations: string[]; isCurrentYear: boolean } }
-  | { type: 'CLEAR_FILTERS' }
-  | { type: 'LOAD_STATE'; payload: Partial<FilterState> }
-  | { type: 'INIT' };
+  | { type: 'CLEAR_FILTERS' };
 
 function addToRecent(item: string, items: string[], max: number = 10): string[] {
   return [item, ...items.filter(i => i !== item)].slice(0, max);
@@ -102,10 +100,6 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
     }
     case 'CLEAR_FILTERS':
       return { ...state, searchTerm: '', selectedTags: [], selectedLocations: [], dateFilter: 'all', selectedWeeks: [], showFavoritesOnly: false, extraDays: 0 };
-    case 'LOAD_STATE':
-      return { ...state, ...action.payload, stateInitialized: true };
-    case 'INIT':
-      return { ...state, stateInitialized: true };
     default:
       return state;
   }
@@ -127,8 +121,33 @@ const initialState: FilterState = {
   stateInitialized: false,
 };
 
+function loadInitialState(): FilterState {
+  try {
+    const saved = typeof window !== 'undefined' ? localStorage.getItem('chq-calendar-user-state') : null;
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      if (parsed.lastSaved && Date.now() - parsed.lastSaved < USER_STATE_EXPIRY_MS) {
+        return {
+          ...initialState,
+          searchTerm: parsed.searchTerm || '',
+          selectedTags: parsed.selectedTags || [],
+          selectedLocations: parsed.selectedLocations || [],
+          dateFilter: parsed.dateFilter || 'next',
+          selectedWeeks: parsed.selectedWeeks || [],
+          expandedDescriptions: new Set<string>(parsed.expandedDescriptions || []),
+          recentLocations: parsed.recentLocations || [],
+          recentCategories: parsed.recentCategories || [],
+          showFavoritesOnly: parsed.showFavoritesOnly || false,
+          stateInitialized: true,
+        };
+      }
+    }
+  } catch (e) { console.warn('Failed to load user state:', e); }
+  return { ...initialState, stateInitialized: true };
+}
+
 export function useFilterState() {
-  const [state, dispatch] = useReducer(filterReducer, initialState);
+  const [state, dispatch] = useReducer(filterReducer, undefined, loadInitialState);
 
   // Actions
   const setSearchTerm = useCallback((term: string) => dispatch({ type: 'SET_SEARCH', payload: term }), []);
@@ -181,31 +200,6 @@ export function useFilterState() {
       } catch (e) { console.warn('Failed to save user state:', e); }
     }
   }, [state]);
-
-  // Restore on mount
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem('chq-calendar-user-state');
-      if (saved) {
-        const parsed = JSON.parse(saved);
-        if (parsed.lastSaved && Date.now() - parsed.lastSaved < USER_STATE_EXPIRY_MS) {
-          dispatch({ type: 'LOAD_STATE', payload: {
-            searchTerm: parsed.searchTerm || '',
-            selectedTags: parsed.selectedTags || [],
-            selectedLocations: parsed.selectedLocations || [],
-            dateFilter: parsed.dateFilter || 'next',
-            selectedWeeks: parsed.selectedWeeks || [],
-            expandedDescriptions: new Set<string>(parsed.expandedDescriptions || []),
-            recentLocations: parsed.recentLocations || [],
-            recentCategories: parsed.recentCategories || [],
-            showFavoritesOnly: parsed.showFavoritesOnly || false,
-          }});
-          return;
-        }
-      }
-    } catch (e) { console.warn('Failed to load user state:', e); }
-    dispatch({ type: 'INIT' });
-  }, []);
 
   // Reset extra days when date filter changes
   useEffect(() => {

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -1,7 +1,7 @@
 import { useReducer, useCallback, useEffect, useMemo } from 'react';
 import { USER_STATE_EXPIRY_MS } from '@/lib/constants';
 
-type DateFilter = 'all' | 'today' | 'next' | 'this-week';
+export type DateFilter = 'all' | 'today' | 'next' | 'this-week';
 
 interface FilterState {
   searchTerm: string;
@@ -16,7 +16,6 @@ interface FilterState {
   availableLocations: string[];
   showFavoritesOnly: boolean;
   extraDays: number;
-  stateInitialized: boolean;
 }
 
 type FilterAction =
@@ -118,7 +117,6 @@ const initialState: FilterState = {
   availableLocations: [],
   showFavoritesOnly: false,
   extraDays: 0,
-  stateInitialized: false,
 };
 
 function loadInitialState(): FilterState {
@@ -138,12 +136,11 @@ function loadInitialState(): FilterState {
           recentLocations: parsed.recentLocations || [],
           recentCategories: parsed.recentCategories || [],
           showFavoritesOnly: parsed.showFavoritesOnly || false,
-          stateInitialized: true,
         };
       }
     }
   } catch (e) { console.warn('Failed to load user state:', e); }
-  return { ...initialState, stateInitialized: true };
+  return initialState;
 }
 
 export function useFilterState() {
@@ -183,27 +180,25 @@ export function useFilterState() {
     state.selectedTags.filter(t => state.availableCategories.includes(t) && !t.startsWith('Week ')).length,
     [state.selectedTags, state.availableCategories]
   );
-  const hasFilters = state.searchTerm || state.selectedTags.length > 0 || state.selectedLocations.length > 0 || state.dateFilter !== 'all' || state.selectedWeeks.length > 0 || state.showFavoritesOnly;
+  const hasFilters: boolean = !!(state.searchTerm || state.selectedTags.length > 0 || state.selectedLocations.length > 0 || state.dateFilter !== 'all' || state.selectedWeeks.length > 0 || state.showFavoritesOnly);
 
   // localStorage persistence
   useEffect(() => {
-    if (state.stateInitialized) {
-      try {
-        localStorage.setItem('chq-calendar-user-state', JSON.stringify({
-          searchTerm: state.searchTerm, selectedTags: state.selectedTags,
-          selectedLocations: state.selectedLocations, dateFilter: state.dateFilter,
-          selectedWeeks: state.selectedWeeks, expandedDescriptions: Array.from(state.expandedDescriptions),
-          recentLocations: state.recentLocations, recentCategories: state.recentCategories,
-          showFavoritesOnly: state.showFavoritesOnly,
-          lastSaved: Date.now(),
-        }));
-      } catch (e) { console.warn('Failed to save user state:', e); }
-    }
+    try {
+      localStorage.setItem('chq-calendar-user-state', JSON.stringify({
+        searchTerm: state.searchTerm, selectedTags: state.selectedTags,
+        selectedLocations: state.selectedLocations, dateFilter: state.dateFilter,
+        selectedWeeks: state.selectedWeeks, expandedDescriptions: Array.from(state.expandedDescriptions),
+        recentLocations: state.recentLocations, recentCategories: state.recentCategories,
+        showFavoritesOnly: state.showFavoritesOnly,
+        lastSaved: Date.now(),
+      }));
+    } catch (e) { console.warn('Failed to save user state:', e); }
   }, [state]);
 
   // Reset extra days when date filter changes
   useEffect(() => {
-    if (state.stateInitialized && state.extraDays > 0) {
+    if (state.extraDays > 0) {
       dispatch({ type: 'CLEAR_EXTRA_DAYS' });
     }
   }, [state.dateFilter]); // intentionally only depends on dateFilter


### PR DESCRIPTION
## Summary

User feedback: "Clear All Filters" doesn't communicate clearly that it's how to show all events. This PR replaces the button with a more discoverable, per-filter chip pattern, and fixes a small flicker on reload.

- **Active filter chips strip** above the result count: one removable chip per applied filter (search, date, each selected week, each location, each tag, favorites-only) with an inline ✕ to drop just that one. Leading filter icon + `Filtering by:` label collapses to icon-only on mobile.
- **Contextual reset action** replacing "Clear All Filters" — `Show all events` / `Show all` text link next to the result count, so the "show me everything" affordance lives next to "Events (47/505)".
- **Visual differentiation from existing pills.** Existing Location/Category selectors are blue `rounded-full` capsules; new chips are `rounded-md`, amber-toned, bordered, with an explicit ✕ icon — different shape, color, and prefix label so the two pill systems don't blur together.
- **Three switchable variants via `?fv=1|2|3`** for A/B iteration on this PR (default amber rounded-md, outlined neutral with ↻ reset icon, soft-blue capsules with `Category:` prefix). We can pick one and rip the others out before merge.
- **First-paint flicker fix.** `useFilterState` was initializing with `dateFilter: 'next'` and loading saved state in a post-mount `useEffect`, so the "Now" button briefly highlighted on every reload before the loaded state replaced it. Moved the localStorage read into `useReducer`'s lazy initializer so the very first render already has the persisted state.

## Test plan

- [ ] Apply filters, refresh — no "Now" button flash before the saved state loads
- [ ] Apply a search term, see "Search: foo" chip — click ✕ removes only the search
- [ ] Click a date chip ✕ — date filter clears, other filters stay applied
- [ ] Click a week-N chip ✕ — only that week is removed from the selection
- [ ] Click "Show all events" / "Show all" — every filter clears
- [ ] Mobile width (≤640px): leading text hides, only filter icon remains; reset link reads "Show all"
- [ ] Try `?fv=2` and `?fv=3` to compare visual variants
- [ ] `npm run validate && npm run build` clean
- [ ] `npx vitest run` — all 285 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)