### PR TITLE
feat(frontend): more discoverable filter-clear actions, plus 'Keep dates, show all'

### DIFF
--- a/frontend/src/__tests__/hooks/useFilterState.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterState.test.ts
@@ -83,6 +83,8 @@ describe('useFilterState', () => {
       expect(result.current.selectedWeeks).toEqual([2, 3]);
       expect(result.current.hasDateFilters).toBe(true);
       expect(result.current.hasNonDateFilters).toBe(false);
+      // hasFilters stays true because date filters remain
+      expect(result.current.hasFilters).toBe(true);
     });
   });
 
@@ -113,6 +115,19 @@ describe('useFilterState', () => {
       expect(result.current.hasNonDateFilters).toBe(false);
       act(() => { result.current.toggleLocation('Hall'); });
       expect(result.current.hasNonDateFilters).toBe(true);
+      act(() => { result.current.toggleLocation('Hall'); }); // toggle off
+      expect(result.current.hasNonDateFilters).toBe(false);
+      act(() => { result.current.toggleFavoritesOnly(); });
+      expect(result.current.hasNonDateFilters).toBe(true);
+    });
+
+    it('hasNonDateFilters ignores whitespace-only searchTerm to match chip rendering', () => {
+      const { result } = renderHook(() => useFilterState());
+      act(() => { result.current.setSearchTerm('   '); });
+      // buildActiveChips trims before deciding to emit a chip; the boolean
+      // must agree, otherwise the "Keep dates, show all" button can appear
+      // for a filter that has no visible chip.
+      expect(result.current.hasNonDateFilters).toBe(false);
     });
   });
 

--- a/frontend/src/__tests__/hooks/useFilterState.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterState.test.ts
@@ -59,6 +59,63 @@ describe('useFilterState', () => {
     expect(result.current.dateFilter).toBe('next');
   });
 
+  describe('clearNonDateFilters', () => {
+    it('clears search, tags, locations, and favorites but keeps dateFilter and selectedWeeks', () => {
+      const { result } = renderHook(() => useFilterState());
+      act(() => {
+        result.current.setSearchTerm('symphony');
+        result.current.toggleTag('Music');
+        result.current.toggleLocation('Hall A');
+        result.current.toggleFavoritesOnly();
+        result.current.setDateFilter('today');
+        result.current.setSelectedWeeks([2, 3]);
+      });
+      expect(result.current.hasDateFilters).toBe(true);
+      expect(result.current.hasNonDateFilters).toBe(true);
+
+      act(() => { result.current.clearNonDateFilters(); });
+
+      expect(result.current.searchTerm).toBe('');
+      expect(result.current.selectedTags).toEqual([]);
+      expect(result.current.selectedLocations).toEqual([]);
+      expect(result.current.showFavoritesOnly).toBe(false);
+      expect(result.current.dateFilter).toBe('today');
+      expect(result.current.selectedWeeks).toEqual([2, 3]);
+      expect(result.current.hasDateFilters).toBe(true);
+      expect(result.current.hasNonDateFilters).toBe(false);
+    });
+  });
+
+  describe('hasDateFilters / hasNonDateFilters', () => {
+    it('hasDateFilters is true when dateFilter is non-all', () => {
+      const { result } = renderHook(() => useFilterState());
+      expect(result.current.hasDateFilters).toBe(true); // 'next' is the default
+      act(() => { result.current.setDateFilter('all'); });
+      expect(result.current.hasDateFilters).toBe(false);
+      act(() => { result.current.setDateFilter('today'); });
+      expect(result.current.hasDateFilters).toBe(true);
+    });
+
+    it('hasDateFilters is true when any week is selected, even with dateFilter=all', () => {
+      const { result } = renderHook(() => useFilterState());
+      act(() => { result.current.setDateFilter('all'); });
+      expect(result.current.hasDateFilters).toBe(false);
+      act(() => { result.current.setSelectedWeeks([1]); });
+      expect(result.current.hasDateFilters).toBe(true);
+    });
+
+    it('hasNonDateFilters reflects only non-date filters', () => {
+      const { result } = renderHook(() => useFilterState());
+      expect(result.current.hasNonDateFilters).toBe(false);
+      act(() => { result.current.setSearchTerm('q'); });
+      expect(result.current.hasNonDateFilters).toBe(true);
+      act(() => { result.current.setSearchTerm(''); });
+      expect(result.current.hasNonDateFilters).toBe(false);
+      act(() => { result.current.toggleLocation('Hall'); });
+      expect(result.current.hasNonDateFilters).toBe(true);
+    });
+  });
+
   describe('reconcileFilters', () => {
     it('sets dateFilter to next when reconciling for the current year', () => {
       const { result } = renderHook(() => useFilterState());

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -157,8 +157,11 @@ function HomeContent() {
               filteredCount={filteredEvents.length}
               totalCount={events.length}
               hasFilters={filters.hasFilters}
+              hasDateFilters={filters.hasDateFilters}
+              hasNonDateFilters={filters.hasNonDateFilters}
               chips={activeChips}
               onClear={filters.clearFilters}
+              onClearNonDateFilters={filters.clearNonDateFilters}
             />
           </div>
         </div>

--- a/frontend/src/components/filters/ActiveFilters.tsx
+++ b/frontend/src/components/filters/ActiveFilters.tsx
@@ -135,6 +135,7 @@ export function ActiveFilters({
             type="button"
             onClick={onClear}
             aria-label="Clear all filters and show all events"
+            title="Clear all filters and show all events"
             className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
           >
             <span className="hidden sm:inline">Show all events</span>
@@ -146,6 +147,7 @@ export function ActiveFilters({
             type="button"
             onClick={onClearNonDateFilters}
             aria-label="Keep date and week filters but clear all other filters"
+            title="Keep date and week filters but clear all other filters"
             className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
           >
             <span className="hidden sm:inline">Keep dates, show all</span>

--- a/frontend/src/components/filters/ActiveFilters.tsx
+++ b/frontend/src/components/filters/ActiveFilters.tsx
@@ -4,8 +4,11 @@ interface ActiveFiltersProps {
   filteredCount: number;
   totalCount: number;
   hasFilters: boolean;
+  hasDateFilters: boolean;
+  hasNonDateFilters: boolean;
   chips: ActiveChip[];
   onClear: () => void;
+  onClearNonDateFilters: () => void;
 }
 
 const FilterIcon = ({ className = 'w-4 h-4' }: { className?: string }) => (
@@ -21,11 +24,32 @@ const CloseIcon = ({ className = 'w-3 h-3' }: { className?: string }) => (
   </svg>
 );
 
+const ResetIcon = ({ className = 'w-3 h-3' }: { className?: string }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M4 4v5h5M20 20v-5h-5M5.5 9A7 7 0 0118 7m1.5 8a7 7 0 01-12.5 2" />
+  </svg>
+);
+
+const CalendarKeepIcon = ({ className = 'w-3 h-3' }: { className?: string }) => (
+  <svg className={className} fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+      d="M8 7V3m8 4V3M3 11h18M5 5h14a2 2 0 012 2v12a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2zM9 16l2 2 4-4" />
+  </svg>
+);
+
 const CHIP_CLASSES = [
   'inline-flex items-center gap-1 max-w-full px-2 py-1 rounded-md text-xs font-medium',
   'bg-amber-100 text-amber-900 border border-amber-300',
   'dark:bg-amber-900/40 dark:text-amber-100 dark:border-amber-700',
   'hover:bg-amber-200 dark:hover:bg-amber-900/60 transition-colors',
+].join(' ');
+
+const CLEAR_BUTTON_CLASSES = [
+  'inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-semibold whitespace-nowrap',
+  'bg-blue-600 text-white border border-blue-700',
+  'dark:bg-blue-500 dark:text-white dark:border-blue-400',
+  'hover:bg-blue-700 dark:hover:bg-blue-600 transition-colors',
 ].join(' ');
 
 function FilterChip({ chip }: { chip: ActiveChip }) {
@@ -44,7 +68,44 @@ function FilterChip({ chip }: { chip: ActiveChip }) {
   );
 }
 
-export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, onClear }: ActiveFiltersProps) {
+function ShowAllEventsButton({ onClear }: { onClear: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClear}
+      aria-label="Clear all filters and show all events"
+      title="Clear all filters and show all events"
+      className={CLEAR_BUTTON_CLASSES}
+    >
+      <ResetIcon className="w-3 h-3 flex-shrink-0" />
+      <span className="hidden sm:inline">Show all events</span>
+      <span className="sm:hidden">Show all</span>
+    </button>
+  );
+}
+
+function KeepDatesButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Keep date and week filters but clear all other filters"
+      title="Keep date and week filters but clear all other filters"
+      className={CLEAR_BUTTON_CLASSES}
+    >
+      <CalendarKeepIcon className="w-3 h-3 flex-shrink-0" />
+      <span className="hidden sm:inline">Keep dates, show all</span>
+      <span className="sm:hidden">Keep dates</span>
+    </button>
+  );
+}
+
+export function ActiveFilters({
+  filteredCount, totalCount, hasFilters, hasDateFilters, hasNonDateFilters,
+  chips, onClear, onClearNonDateFilters,
+}: ActiveFiltersProps) {
+  const showKeepDates = hasDateFilters && hasNonDateFilters;
+
   return (
     <div className="mt-2 sm:mt-4 pt-2 sm:pt-3 border-t border-gray-200 dark:border-gray-700">
       {hasFilters && chips.length > 0 && (
@@ -53,14 +114,16 @@ export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, on
             <FilterIcon className="w-4 h-4" />
             <span className="sr-only sm:not-sr-only">Filtering by:</span>
           </span>
-          <div className="flex flex-wrap gap-1.5 flex-1 min-w-0">
+          <div className="flex flex-wrap items-center gap-1.5 flex-1 min-w-0">
+            <ShowAllEventsButton onClear={onClear} />
+            {showKeepDates && <KeepDatesButton onClick={onClearNonDateFilters} />}
             {chips.map(chip => (
               <FilterChip key={chip.key} chip={chip} />
             ))}
           </div>
         </div>
       )}
-      <div className="flex items-center justify-between gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         <div className="text-sm text-gray-600 dark:text-gray-300 font-medium">
           {hasFilters
             ? `Events (${filteredCount}/${totalCount})`
@@ -72,10 +135,21 @@ export function ActiveFilters({ filteredCount, totalCount, hasFilters, chips, on
             type="button"
             onClick={onClear}
             aria-label="Clear all filters and show all events"
-            className="flex-shrink-0 text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
+            className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
           >
             <span className="hidden sm:inline">Show all events</span>
             <span className="sm:hidden">Show all</span>
+          </button>
+        )}
+        {showKeepDates && (
+          <button
+            type="button"
+            onClick={onClearNonDateFilters}
+            aria-label="Keep date and week filters but clear all other filters"
+            className="text-sm font-medium text-blue-700 dark:text-blue-300 hover:text-blue-900 dark:hover:text-blue-100 underline underline-offset-2 whitespace-nowrap"
+          >
+            <span className="hidden sm:inline">Keep dates, show all</span>
+            <span className="sm:hidden">Keep dates</span>
           </button>
         )}
       </div>

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -185,7 +185,10 @@ export function useFilterState() {
     [state.selectedTags, state.availableCategories]
   );
   const hasDateFilters: boolean = state.dateFilter !== 'all' || state.selectedWeeks.length > 0;
-  const hasNonDateFilters: boolean = !!(state.searchTerm || state.selectedTags.length > 0 || state.selectedLocations.length > 0 || state.showFavoritesOnly);
+  // Trim searchTerm to stay consistent with buildActiveChips (which only emits a
+  // search chip when the trimmed value is non-empty). Otherwise a whitespace-only
+  // search would set hasNonDateFilters=true with no chip to represent it.
+  const hasNonDateFilters: boolean = !!(state.searchTerm.trim() || state.selectedTags.length > 0 || state.selectedLocations.length > 0 || state.showFavoritesOnly);
   const hasFilters: boolean = hasDateFilters || hasNonDateFilters;
 
   // localStorage persistence

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -31,7 +31,8 @@ type FilterAction =
   | { type: 'ADD_EXTRA_DAY' }
   | { type: 'CLEAR_EXTRA_DAYS' }
   | { type: 'RECONCILE_FILTERS'; payload: { availableCategories: string[]; availableLocations: string[]; isCurrentYear: boolean } }
-  | { type: 'CLEAR_FILTERS' };
+  | { type: 'CLEAR_FILTERS' }
+  | { type: 'CLEAR_NON_DATE_FILTERS' };
 
 function addToRecent(item: string, items: string[], max: number = 10): string[] {
   return [item, ...items.filter(i => i !== item)].slice(0, max);
@@ -99,6 +100,8 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
     }
     case 'CLEAR_FILTERS':
       return { ...state, searchTerm: '', selectedTags: [], selectedLocations: [], dateFilter: 'all', selectedWeeks: [], showFavoritesOnly: false, extraDays: 0 };
+    case 'CLEAR_NON_DATE_FILTERS':
+      return { ...state, searchTerm: '', selectedTags: [], selectedLocations: [], showFavoritesOnly: false };
     default:
       return state;
   }
@@ -158,6 +161,7 @@ export function useFilterState() {
   const toggleFavoritesOnly = useCallback(() => dispatch({ type: 'TOGGLE_FAVORITES_ONLY' }), []);
   const addExtraDay = useCallback(() => dispatch({ type: 'ADD_EXTRA_DAY' }), []);
   const clearFilters = useCallback(() => dispatch({ type: 'CLEAR_FILTERS' }), []);
+  const clearNonDateFilters = useCallback(() => dispatch({ type: 'CLEAR_NON_DATE_FILTERS' }), []);
   const reconcileFilters = useCallback(
     (availableCategories: string[], availableLocations: string[], isCurrentYear: boolean) =>
       dispatch({ type: 'RECONCILE_FILTERS', payload: { availableCategories, availableLocations, isCurrentYear } }),
@@ -180,7 +184,9 @@ export function useFilterState() {
     state.selectedTags.filter(t => state.availableCategories.includes(t) && !t.startsWith('Week ')).length,
     [state.selectedTags, state.availableCategories]
   );
-  const hasFilters: boolean = !!(state.searchTerm || state.selectedTags.length > 0 || state.selectedLocations.length > 0 || state.dateFilter !== 'all' || state.selectedWeeks.length > 0 || state.showFavoritesOnly);
+  const hasDateFilters: boolean = state.dateFilter !== 'all' || state.selectedWeeks.length > 0;
+  const hasNonDateFilters: boolean = !!(state.searchTerm || state.selectedTags.length > 0 || state.selectedLocations.length > 0 || state.showFavoritesOnly);
+  const hasFilters: boolean = hasDateFilters || hasNonDateFilters;
 
   // localStorage persistence
   useEffect(() => {
@@ -214,8 +220,10 @@ export function useFilterState() {
     availableLocations: state.availableLocations, setAvailableLocations,
     recentLocations: state.recentLocations,
     recentCategories: state.recentCategories,
-    selectedTagsLowerSet, selectedLocationsLowerSet, selectedCategoriesCount, hasFilters,
-    toggleDescription, toggleTag, isTagSelected, toggleLocation, isLocationSelected, clearFilters,
+    selectedTagsLowerSet, selectedLocationsLowerSet, selectedCategoriesCount,
+    hasFilters, hasDateFilters, hasNonDateFilters,
+    toggleDescription, toggleTag, isTagSelected, toggleLocation, isLocationSelected,
+    clearFilters, clearNonDateFilters,
     showFavoritesOnly: state.showFavoritesOnly, toggleFavoritesOnly,
     extraDays: state.extraDays, addExtraDay,
     reconcileFilters,


### PR DESCRIPTION
## Summary

Follow-up to #113. The single right-justified \"Show all events\" link was hard to associate with the chip row, and there was no way to drop topics/locations without also losing the selected date range. The audience is >70 year olds with less computer experience, so the design favors equal-prominence affordances over a primary/secondary visual hierarchy.

- **\"Show all events\" pill at the start of the \"Filtering by:\" row.** Fixed location regardless of which chips are present, rendered as a prominent blue capsule with a ↻ leading icon. Reads as a primary action button — visually distinct from the amber removable tag chips (different shape *and* color) so the two systems don't blur together.
- **Inline \"Show all events\" text link kept next to \"Events (3/505)\".** Both placements behave identically; users get the affordance wherever they're looking.
- **New \"Keep dates, show all\" companion action.** Conditionally rendered only when both date *and* non-date filters are active. Clears search, locations, categories, favorites — preserves `dateFilter` and `selectedWeeks`. So a user who picked weeks 1–3 + a category can drop the category without losing the week selection. Same blue filled pill, same size — differentiated by a calendar-with-checkmark icon, not by visual hierarchy.
- **Both labels collapse on mobile** (`Show all events` → `Show all`, `Keep dates, show all` → `Keep dates`) using the same `hidden sm:inline` / `sm:hidden` pattern that's used elsewhere in the page.
- **New reducer action `CLEAR_NON_DATE_FILTERS`** + `clearNonDateFilters` callback + `hasDateFilters` / `hasNonDateFilters` derived booleans on the `useFilterState` return shape.

## Test plan

- [ ] Apply only date filters (e.g. weeks 1–3, no other filters): only `Show all events` appears
- [ ] Apply only topic filters (e.g. a category, no week selection, `dateFilter=all`): only `Show all events` appears
- [ ] Apply both: both buttons appear at the start of the chip row, equal size and color
- [ ] Click `Keep dates, show all`: locations/categories/search/favorites clear; week chips and date chip remain
- [ ] Click `Show all events` from either placement (pill or inline link): every filter clears
- [ ] Mobile (≤640px): button labels collapse to `Show all` / `Keep dates`
- [ ] `npm run validate && npm run build` clean
- [ ] `npx vitest run` — 304/304 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)