### PR TITLE
feat(publisher-portal): PR #98 deferred follow-ups (modal a11y, contactEmail GSI, etc.)

### DIFF
--- a/backend/src/__tests__/integration/emailFlowE2E.test.ts
+++ b/backend/src/__tests__/integration/emailFlowE2E.test.ts
@@ -1,0 +1,143 @@
+// Happy-path E2E for the publisher email-flow chain:
+//
+//   apply → admin approve → login → profile edit → email change
+//     (initiate, verify) → re-login forced (old JWT invalid; old email
+//     no longer authenticates; new email does).
+//
+// Closes deferred follow-up #5 from PR #98. The deferred memo asked for
+// "needs SES mocking infrastructure that doesn't exist in CI today" —
+// that's true for *real* SES. At the service layer we already have an
+// in-memory MailCapture that records every send call, which is enough
+// to drive the chain end-to-end without touching network.
+//
+// Each step assertions:
+//   - Apply: a magic link is mailed; verify produces a JWT.
+//   - Admin approve: applicationStatus flips and an approval mail is sent.
+//   - Login: a login magic link is mailed; verify produces a fresh JWT.
+//   - Profile edit: PATCH is reflected on subsequent /publisher-status.
+//   - Email change initiate: BOTH addresses are mailed (verify to new,
+//     warning to old).
+//   - Email change verify: registry contactEmail flips, tokenVersion bumps,
+//     committed-email notifications go to BOTH addresses.
+//   - Forced re-login: old-email login no longer mails a magic link;
+//     new-email login does. The original JWT no longer authenticates
+//     /publisher-status (tokenVersion mismatch → unauthorized).
+
+jest.unmock('@aws-sdk/lib-dynamodb');
+jest.unmock('@aws-sdk/client-dynamodb');
+
+import { createHarness, type Harness } from './harness/harness';
+import { tokenFromMagicLink } from './harness/testHelpers';
+
+function tokenFromMail(h: Harness, email: string, kind: string, urlField: string): string {
+  const sent = h.mail.byKind(kind as never).filter(m => m.to.toLowerCase() === email.toLowerCase()).pop();
+  if (!sent) throw new Error(`no '${kind}' mail captured to ${email}`);
+  const url = sent.data[urlField] as string;
+  if (!url) throw new Error(`'${kind}' mail to ${email} had no '${urlField}' field`);
+  return tokenFromMagicLink(url);
+}
+
+describe('publisher email-flow happy path', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await createHarness({ now: '2026-06-01T00:00:00Z' });
+  });
+  afterEach(() => {
+    h.dispose();
+  });
+
+  it('apply → approve → login → edit → email-change → forced re-login', async () => {
+    const oldEmail = 'before@example.com';
+    const newEmail = 'after@example.com';
+
+    // ── 1. Apply ─────────────────────────────────────────────────────────
+    await h.actors.publisher.apply({
+      name: 'Email Flow Co',
+      email: oldEmail,
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+    });
+    const applyToken = (() => {
+      const sent = h.mail.lastTo(oldEmail);
+      if (!sent) throw new Error('no apply mail captured');
+      return tokenFromMagicLink(sent.data.magicLinkUrl as string);
+    })();
+    const applied = await h.actors.publisher.verifyApplyMagicLink(applyToken);
+    expect(applied.publisherId).toMatch(/^pub-/);
+    const publisherId = applied.publisherId;
+
+    // ── 2. Admin approve ────────────────────────────────────────────────
+    await h.actors.admin.approveApplication(publisherId);
+    const approvedRow = await h.registry.get(publisherId);
+    expect(approvedRow?.applicationStatus).toBe('approved');
+    expect(h.mail.byKind('approval').some(m => m.to === oldEmail)).toBe(true);
+
+    // ── 3. Login (using the *post-approve* path, separate from apply) ──
+    h.mail.clear();
+    await h.actors.publisher.loginRequest(oldEmail);
+    const loginToken = tokenFromMail(h, oldEmail, 'login', 'magicLinkUrl');
+    const loggedIn = await h.actors.publisher.verifyLoginMagicLink(loginToken);
+    expect(loggedIn.publisherId).toBe(publisherId);
+    const oldJwt = loggedIn.jwt;
+
+    // Sanity: status endpoint accepts the JWT.
+    const status1 = await h.actors.publisher.status(oldJwt);
+    expect(status1.publisher.id).toBe(publisherId);
+    expect(status1.publisher.contactEmail).toBe(oldEmail);
+
+    // ── 4. Profile edit ─────────────────────────────────────────────────
+    await h.actors.publisher.updateProfile(oldJwt, { name: 'Email Flow Renamed' });
+    const status2 = await h.actors.publisher.status(oldJwt);
+    expect(status2.publisher.name).toBe('Email Flow Renamed');
+
+    // ── 5. Email change initiate ────────────────────────────────────────
+    h.mail.clear();
+    await h.actors.publisher.requestEmailChange(oldJwt, newEmail);
+    // Both verify (to new) and warning (to old) emails are sent.
+    expect(h.mail.byKind('email_change_verify').some(m => m.to === newEmail)).toBe(true);
+    expect(h.mail.byKind('email_change_warning').some(m => m.to === oldEmail)).toBe(true);
+
+    // Status endpoint surfaces the pending change.
+    const status3 = await h.actors.publisher.status(oldJwt);
+    expect(status3.publisher.pendingEmailChange?.newEmail).toBe(newEmail);
+
+    // ── 6. Email change verify (clicked from new address inbox) ─────────
+    const verifyToken = tokenFromMail(h, newEmail, 'email_change_verify', 'verifyUrl');
+    const verifyResult = await h.actors.publisher.confirmEmailChange(verifyToken);
+    expect(verifyResult.kind).toBe('ok');
+    expect(verifyResult.newEmail).toBe(newEmail);
+
+    // Registry: contactEmail flipped + tokenVersion bumped.
+    const postChangeRow = await h.registry.get(publisherId);
+    expect(postChangeRow?.contactEmail).toBe(newEmail);
+
+    // Both addresses were notified that the change committed.
+    const committed = h.mail.byKind('email_change_committed');
+    expect(committed.some(m => m.to === oldEmail)).toBe(true);
+    expect(committed.some(m => m.to === newEmail)).toBe(true);
+
+    // ── 7. Forced re-login ──────────────────────────────────────────────
+    // Old JWT no longer authenticates because tokenVersion was bumped.
+    await expect(h.actors.publisher.status(oldJwt)).rejects.toThrow();
+
+    // Old email no longer issues a login magic link (the address is no
+    // longer associated with any publisher row).
+    h.mail.clear();
+    await h.actors.publisher.loginRequest(oldEmail);
+    expect(h.mail.byKind('login').some(m => m.to === oldEmail)).toBe(false);
+
+    // New email DOES issue a login magic link, and verifying it yields a
+    // fresh JWT bound to the same publisher.
+    await h.actors.publisher.loginRequest(newEmail);
+    const reLoginToken = tokenFromMail(h, newEmail, 'login', 'magicLinkUrl');
+    const reLoggedIn = await h.actors.publisher.verifyLoginMagicLink(reLoginToken);
+    expect(reLoggedIn.publisherId).toBe(publisherId);
+    expect(reLoggedIn.email).toBe(newEmail);
+
+    // The fresh JWT authenticates /publisher-status with the new email.
+    const finalStatus = await h.actors.publisher.status(reLoggedIn.jwt);
+    expect(finalStatus.publisher.contactEmail).toBe(newEmail);
+    // Pending email change was cleared by the verify step.
+    expect(finalStatus.publisher.pendingEmailChange).toBeUndefined();
+  });
+});

--- a/backend/src/__tests__/integration/emailFlowE2E.test.ts
+++ b/backend/src/__tests__/integration/emailFlowE2E.test.ts
@@ -118,7 +118,10 @@ describe('publisher email-flow happy path', () => {
 
     // ── 7. Forced re-login ──────────────────────────────────────────────
     // Old JWT no longer authenticates because tokenVersion was bumped.
-    await expect(h.actors.publisher.status(oldJwt)).rejects.toThrow();
+    // Match the actor's HandlerError shape — assert on the 401 status code
+    // so a regression to a generic 500 (or worse, a silent 200) wouldn't
+    // make this assertion accidentally pass.
+    await expect(h.actors.publisher.status(oldJwt)).rejects.toMatchObject({ statusCode: 401 });
 
     // Old email no longer issues a login magic link (the address is no
     // longer associated with any publisher row).

--- a/backend/src/__tests__/integration/harness/harness.ts
+++ b/backend/src/__tests__/integration/harness/harness.ts
@@ -58,7 +58,11 @@ const RATE_LIMIT_TABLE = 'rate-limit';
 const PUBLISHER_INGEST_RUNS_TABLE = 'publisher-ingest-runs';
 
 const TABLE_SPECS: TableSpec[] = [
-  { name: PUBLISHERS_TABLE, hashKey: 'id' },
+  {
+    name: PUBLISHERS_TABLE,
+    hashKey: 'id',
+    gsis: [{ name: 'by-contactEmail', hashKey: 'contactEmail' }],
+  },
   {
     name: PUBLISHER_EVENTS_TABLE,
     hashKey: 'publisherId',

--- a/backend/src/__tests__/publisherApproval.test.ts
+++ b/backend/src/__tests__/publisherApproval.test.ts
@@ -1,0 +1,20 @@
+import { isApprovedPublisher } from '../utils/publisherApproval';
+
+describe('isApprovedPublisher', () => {
+  it('returns true when applicationStatus is undefined (legacy admin-created row)', () => {
+    expect(isApprovedPublisher({})).toBe(true);
+    expect(isApprovedPublisher({ applicationStatus: undefined })).toBe(true);
+  });
+
+  it('returns true when applicationStatus is "approved"', () => {
+    expect(isApprovedPublisher({ applicationStatus: 'approved' })).toBe(true);
+  });
+
+  it('returns false when applicationStatus is "pending"', () => {
+    expect(isApprovedPublisher({ applicationStatus: 'pending' })).toBe(false);
+  });
+
+  it('returns false when applicationStatus is "rejected"', () => {
+    expect(isApprovedPublisher({ applicationStatus: 'rejected' })).toBe(false);
+  });
+});

--- a/backend/src/__tests__/publisherRegistryService.test.ts
+++ b/backend/src/__tests__/publisherRegistryService.test.ts
@@ -102,12 +102,15 @@ describe('PublisherRegistryService', () => {
 
   // ─── Phase B (publisher portal apply flow) ─────────────────────────────
 
-  it('getByEmail normalizes to lowercase before scanning', async () => {
+  it('getByEmail queries the by-contactEmail GSI with normalized lowercase input', async () => {
     mockSend.mockResolvedValue({ Items: [] });
     await svc.getByEmail('  Foo@Bar.COM  ');
     const cmd: any = mockSend.mock.calls[0][0];
-    expect(cmd.input.FilterExpression).toBe('contactEmail = :e');
+    expect(cmd.input.IndexName).toBe('by-contactEmail');
+    expect(cmd.input.KeyConditionExpression).toBe('contactEmail = :e');
     expect(cmd.input.ExpressionAttributeValues[':e']).toBe('foo@bar.com');
+    // It's a Query, not a Scan — so no FilterExpression.
+    expect(cmd.input.FilterExpression).toBeUndefined();
   });
 
   it('getByEmail returns matched publishers with pagination', async () => {
@@ -122,6 +125,41 @@ describe('PublisherRegistryService', () => {
     const r = await svc.getByEmail('x@y.com');
     expect(r.map(p => p.id)).toEqual(['a', 'b']);
     expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it('getByEmail falls back to Scan when the GSI is missing (deploy-window race)', async () => {
+    // Simulate the ValidationException DDB throws before the Terraform apply
+    // has propagated the new index. The fallback path Scans and logs a warn
+    // — caller still gets a correct result rather than a 500.
+    const missingIndexErr = Object.assign(new Error('The table does not have the specified index: by-contactEmail'), {
+      name: 'ValidationException',
+    });
+    mockSend
+      .mockRejectedValueOnce(missingIndexErr)
+      .mockResolvedValueOnce({ Items: [{ id: 'a', contactEmail: 'x@y.com' }] });
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const r = await svc.getByEmail('x@y.com');
+      expect(r.map(p => p.id)).toEqual(['a']);
+      // First call was the Query, second call was the Scan fallback.
+      expect(mockSend).toHaveBeenCalledTimes(2);
+      const fallbackCmd: any = mockSend.mock.calls[1][0];
+      expect(fallbackCmd.input.FilterExpression).toBe('contactEmail = :e');
+      expect(fallbackCmd.input.IndexName).toBeUndefined();
+      expect(warnSpy).toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('getByEmail surfaces non-validation DDB errors unchanged (no fallback)', async () => {
+    const throttle = Object.assign(new Error('throttled'), {
+      name: 'ProvisionedThroughputExceededException',
+    });
+    mockSend.mockRejectedValueOnce(throttle);
+    await expect(svc.getByEmail('x@y.com')).rejects.toBe(throttle);
+    // Did NOT fall back to Scan.
+    expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
   it('listPending filters on applicationStatus = pending', async () => {

--- a/backend/src/__tests__/publisherRegistryService.test.ts
+++ b/backend/src/__tests__/publisherRegistryService.test.ts
@@ -162,6 +162,29 @@ describe('PublisherRegistryService', () => {
     expect(mockSend).toHaveBeenCalledTimes(1);
   });
 
+  it('upsert normalizes contactEmail before persisting (lowercase + trim)', async () => {
+    // Without write-side normalization, an admin who entered 'Foo@Bar.COM '
+    // would write a row that getByEmail('foo@bar.com') misses on the GSI.
+    // The registry enforces this at the boundary so callers don't have to
+    // remember.
+    mockSend.mockResolvedValue({});
+    await svc.upsert({
+      id: 'pub-1',
+      name: 'Mixed',
+      contactEmail: '  Foo@Bar.COM  ',
+      sourceUrl: 'https://example.com/feed.json',
+      sourceType: 'json',
+      trustLevel: 'review',
+      enabled: true,
+      createdAt: '2026-01-01T00:00:00Z',
+    });
+    const cmd: any = mockSend.mock.calls[0][0];
+    expect(cmd.input.Item.contactEmail).toBe('foo@bar.com');
+    // Other fields untouched.
+    expect(cmd.input.Item.id).toBe('pub-1');
+    expect(cmd.input.Item.name).toBe('Mixed');
+  });
+
   it('listPending filters on applicationStatus = pending', async () => {
     mockSend.mockResolvedValue({
       Items: [{ id: 'p1', applicationStatus: 'pending' }],

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -750,27 +750,26 @@ function sanitizePublisher(rec: PublisherRecord) {
 
 // ─── Email-change service singleton (Phase 4) ────────────────────────────
 //
-// Distinct from `appService` because the email-change service composes the
-// same registry + magic-token + mail collaborators but with different
-// orchestration. Sharing wouldn't reduce cold-start work meaningfully and
-// would couple the two flows together unnecessarily.
+// Distinct from `appService` because the email-change service composes a
+// different orchestration over the same collaborators. Reuses the
+// statusRegistry singleton — registry has no per-flow state and a single
+// shared instance trims one PublisherRegistryService allocation per cold
+// start. (magic-tokens and mail still have their own instances; the
+// application service keeps its own registry because it constructs SES +
+// Secrets Manager clients eagerly that the status path explicitly avoids.)
 
 let _emailChangeService: PublisherEmailChangeService | null = null;
 
 function emailChangeService(): PublisherEmailChangeService {
   if (!_emailChangeService) {
     const docClient = buildDocClient();
-    const registry = new PublisherRegistryService(
-      docClient,
-      process.env.PUBLISHERS_TABLE_NAME ?? 'chautauqua-calendar-publishers',
-    );
     const tokens = new MagicTokenService(
       docClient,
       process.env.PUBLISHER_MAGIC_TOKEN_TABLE_NAME ?? 'chautauqua-calendar-publisher-magic-tokens',
     );
     const mail = new SesMailService();
     _emailChangeService = new PublisherEmailChangeService({
-      registry,
+      registry: statusRegistry(),
       tokens,
       mail,
       siteBaseUrl: process.env.SITE_BASE_URL ?? 'https://www.chqcal.org',

--- a/backend/src/handlers/publisherPortalHandler.ts
+++ b/backend/src/handlers/publisherPortalHandler.ts
@@ -53,6 +53,7 @@ import {
 import type { ApplyFormPayload, PublisherRecord, StoredPublisherEvent, SourceType } from '../types/publisher';
 import { PublisherIngestRunStore } from '../services/publisherIngestRunStore';
 import { PublisherEventStore } from '../services/publisherEventStore';
+import { isApprovedPublisher } from '../utils/publisherApproval';
 
 // ─── Doc-client helper ───────────────────────────────────────────────────
 //
@@ -950,8 +951,7 @@ async function gateApprovedPublisher(
   const sess = await requirePublisherSession(event, statusRegistry());
   if (sess.kind === 'unauthorized') return json(401, { error: sess.message });
   if (sess.kind === 'publisher_missing') return json(404, { error: 'Publisher not found' });
-  if (sess.publisher.applicationStatus !== undefined &&
-      sess.publisher.applicationStatus !== 'approved') {
+  if (!isApprovedPublisher(sess.publisher)) {
     return json(403, {
       error: 'This action is only available to approved publishers.',
     });

--- a/backend/src/services/publisherAdminService.ts
+++ b/backend/src/services/publisherAdminService.ts
@@ -63,7 +63,13 @@ export class PublisherAdminService {
     const rec: PublisherRecord = {
       id: input.id,
       name: input.name,
-      contactEmail: input.contactEmail,
+      // Pre-normalize contactEmail so the returned record matches what the
+      // registry will persist. registry.upsert also normalizes (the load-
+      // bearing enforcement), but doing it here too keeps the in-memory
+      // value handed back to the admin API response self-consistent —
+      // otherwise an admin who entered 'Foo@Bar.COM' would see the mixed
+      // case on the create response and the lowercase on the next refresh.
+      contactEmail: input.contactEmail.trim().toLowerCase(),
       sourceUrl: input.sourceUrl,
       sourceType: input.sourceType,
       trustLevel: input.trustLevel ?? 'review',
@@ -80,6 +86,11 @@ export class PublisherAdminService {
       throw new Error(`unknown publisher ${id}`);
     }
     const merged: PublisherRecord = { ...existing, ...patch, id };
+    // Pre-normalize so the returned record matches what registry.upsert
+    // will persist — see createPublisher comment for the rationale.
+    if (typeof merged.contactEmail === 'string') {
+      merged.contactEmail = merged.contactEmail.trim().toLowerCase();
+    }
     await this.registry.upsert(merged);
     return merged;
   }

--- a/backend/src/services/publisherRegistryService.ts
+++ b/backend/src/services/publisherRegistryService.ts
@@ -101,7 +101,19 @@ export class PublisherRegistryService {
   }
 
   async upsert(rec: PublisherRecord): Promise<void> {
-    await this.db.send(new PutCommand({ TableName: this.tableName, Item: rec }));
+    // Normalize contactEmail at the registry boundary so every write path —
+    // apply, admin create/update, smoke test, anything else that builds a
+    // PublisherRecord — produces rows that match getByEmail's normalized
+    // GSI Query. Previously each caller had to remember to normalize; the
+    // admin POST/PATCH /publishers paths did not, so an admin who entered
+    // 'Foo@Bar.COM' would write a row that getByEmail('foo@bar.com') would
+    // miss. trim() handles paste-with-trailing-spaces; toLowerCase folds
+    // casing variations.
+    const normalized: PublisherRecord = {
+      ...rec,
+      contactEmail: rec.contactEmail.trim().toLowerCase(),
+    };
+    await this.db.send(new PutCommand({ TableName: this.tableName, Item: normalized }));
   }
 
   async delete(id: string): Promise<void> {

--- a/backend/src/services/publisherRegistryService.ts
+++ b/backend/src/services/publisherRegistryService.ts
@@ -1,6 +1,12 @@
 import type { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
-import { DeleteCommand, GetCommand, PutCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+import { DeleteCommand, GetCommand, PutCommand, QueryCommand, ScanCommand, UpdateCommand } from '@aws-sdk/lib-dynamodb';
 import type { ApplicationStatus, FetchStatus, PublisherRecord } from '../types/publisher';
+
+// Name of the GSI defined in infrastructure/publisher-ingest.tf on the
+// publishers table. Hash-only on contactEmail (lowercase + trimmed at write
+// time). Used by getByEmail to avoid a full-table Scan once the publishers
+// table grows past a few hundred rows.
+const CONTACT_EMAIL_INDEX = 'by-contactEmail';
 
 // Thrown by setApplicationStatus when the optional `expectedFromStatus` does
 // not match the current row state. Caller should treat as "another writer
@@ -26,6 +32,19 @@ export class PublisherNotFoundError extends Error {
     super(`publisher ${publisherId} not found during ${operation}`);
     this.name = 'PublisherNotFoundError';
   }
+}
+
+// DDB throws ValidationException with a message containing
+// "specified index" or "Index not found" when a Query targets a GSI that
+// does not exist on the table. Match by name and message rather than the
+// SDK's error class so the recovery doesn't couple to the Dynamo SDK
+// internals.
+function isMissingIndexError(err: unknown): boolean {
+  const e = err as { name?: string; message?: string } | undefined;
+  if (!e) return false;
+  if (e.name !== 'ValidationException') return false;
+  const msg = e.message ?? '';
+  return /specified index|index .* not (?:found|exist)/i.test(msg);
 }
 
 // Profile fields the publisher portal is allowed to clear (REMOVE) by passing
@@ -128,13 +147,49 @@ export class PublisherRegistryService {
 
   // ─── Phase B (publisher portal apply flow) ─────────────────────────────
   //
-  // Email lookup uses Scan because there is no GSI on contactEmail and the
-  // publishers table is small (low double-digits expected). If the table
-  // grows past a few hundred rows, add `by-contactEmail` GSI and switch.
-  // Email comparison is case-insensitive (we store lowercase, but defensively
-  // normalize the query too).
+  // Email lookup queries the by-contactEmail GSI. Email comparison is
+  // case-insensitive — we store lowercase + trimmed at write time, but
+  // defensively normalize the query input here too so a caller passing a
+  // mixed-case address still hits the right index entry.
+  //
+  // Fallback: if the index is not yet present (deploy-window race where the
+  // Lambda code lands before the Terraform GSI apply completes), the SDK
+  // throws ValidationException. Fall back to Scan once and log a warning so
+  // the deploy doesn't fail user-facing flows. This branch can be removed
+  // after the GSI has been live in production for one full release cycle.
   async getByEmail(email: string): Promise<PublisherRecord[]> {
     const normalized = email.trim().toLowerCase();
+    try {
+      const out: PublisherRecord[] = [];
+      let last: Record<string, unknown> | undefined;
+      do {
+        const r = await this.db.send(new QueryCommand({
+          TableName: this.tableName,
+          IndexName: CONTACT_EMAIL_INDEX,
+          KeyConditionExpression: 'contactEmail = :e',
+          ExpressionAttributeValues: { ':e': normalized },
+          ExclusiveStartKey: last,
+        }));
+        out.push(...((r.Items ?? []) as PublisherRecord[]));
+        last = r.LastEvaluatedKey;
+      } while (last);
+      return out;
+    } catch (err) {
+      if (isMissingIndexError(err)) {
+        console.warn(
+          `[publishers] ${CONTACT_EMAIL_INDEX} GSI not yet live — falling back to Scan. ` +
+          `Remove this branch after the GSI is live in production.`,
+        );
+        return this.getByEmailScan(normalized);
+      }
+      throw err;
+    }
+  }
+
+  // Fallback path for getByEmail when the GSI is missing. Identical
+  // semantics to the pre-GSI implementation — kept private so callers
+  // don't accidentally take this slower path.
+  private async getByEmailScan(normalized: string): Promise<PublisherRecord[]> {
     const out: PublisherRecord[] = [];
     let last: Record<string, unknown> | undefined;
     do {

--- a/backend/src/services/publisherRegistryService.ts
+++ b/backend/src/services/publisherRegistryService.ts
@@ -34,16 +34,21 @@ export class PublisherNotFoundError extends Error {
   }
 }
 
-// DDB throws ValidationException with a message containing
-// "specified index" or "Index not found" when a Query targets a GSI that
-// does not exist on the table. Match by name and message rather than the
-// SDK's error class so the recovery doesn't couple to the Dynamo SDK
-// internals.
+// DDB throws ValidationException with a message mentioning the missing
+// index name when a Query targets a GSI that does not exist on the table.
+// We require the message to mention CONTACT_EMAIL_INDEX specifically so a
+// typo in the constant doesn't produce a permanent silent fall-back to
+// Scan: a misspelled index name would Validation-fail with a different
+// message that doesn't match this guard, so the error propagates as a
+// proper failure instead of degrading getByEmail to O(n) scans forever.
+// Match by name + message string rather than the SDK's error class so the
+// recovery doesn't couple to the Dynamo SDK internals.
 function isMissingIndexError(err: unknown): boolean {
   const e = err as { name?: string; message?: string } | undefined;
   if (!e) return false;
   if (e.name !== 'ValidationException') return false;
   const msg = e.message ?? '';
+  if (!msg.includes(CONTACT_EMAIL_INDEX)) return false;
   return /specified index|index .* not (?:found|exist)/i.test(msg);
 }
 
@@ -408,15 +413,23 @@ export class PublisherRegistryService {
   // consistent but the publisher's already-issued JWT is now mismatched
   // against contactEmail rather than tokenVersion, causing them to fail
   // requirePublisherSession with the wrong reason.
+  //
+  // The email is normalized (trim + lowercase) before the write so the
+  // value stored on the row matches the normalization performed by
+  // getByEmail. Callers (PublisherEmailChangeService) already normalize
+  // before invocation; this is defense-in-depth so a stray un-normalized
+  // call site can't quietly desync the GSI lookup from the row state.
+  //
   // attribute_exists(id) guard — see PublisherNotFoundError.
   async commitEmailChange(id: string, newEmail: string): Promise<void> {
+    const normalized = newEmail.trim().toLowerCase();
     try {
       await this.db.send(new UpdateCommand({
         TableName: this.tableName,
         Key: { id },
         ConditionExpression: 'attribute_exists(id)',
         UpdateExpression: 'SET contactEmail = :e ADD tokenVersion :one',
-        ExpressionAttributeValues: { ':e': newEmail, ':one': 1 },
+        ExpressionAttributeValues: { ':e': normalized, ':one': 1 },
       }));
     } catch (err) {
       if ((err as { name?: string })?.name === 'ConditionalCheckFailedException') {

--- a/backend/src/utils/publisherApproval.ts
+++ b/backend/src/utils/publisherApproval.ts
@@ -1,0 +1,18 @@
+import type { ApplicationStatus } from '../types/publisher';
+
+// A publisher is "approved" — and therefore eligible for self-service routes
+// like profile edit, ingest controls, email change — when:
+//   - applicationStatus === 'approved' (the standard case after admin
+//     accepts the application), OR
+//   - applicationStatus is undefined (legacy admin-created rows that pre-date
+//     the application flow; treated as approved for backwards compatibility).
+//
+// Pending/rejected applicants are gated out (HTTP 403 in the handler;
+// non-editable view in the frontend).
+//
+// Mirror of frontend/src/lib/publisherApproval.ts. The two files duplicate
+// ~5 lines deliberately rather than introducing a shared workspace package
+// across backend and frontend builds.
+export function isApprovedPublisher(rec: { applicationStatus?: ApplicationStatus }): boolean {
+  return rec.applicationStatus === undefined || rec.applicationStatus === 'approved';
+}

--- a/docs/plans/2026-05-08-pr98-deferred-followups-plan.md
+++ b/docs/plans/2026-05-08-pr98-deferred-followups-plan.md
@@ -69,16 +69,16 @@ The two files (one backend, one frontend) deliberately avoid a shared module —
 The three publisher-portal modals (DangerZone, PauseConfirm, ChangeEmail) hand-roll the same dialog scaffolding. None implement Esc-to-close or focus trap. Same gap exists on apply/SourceEdit, but those weren't in PR #98's scope.
 
 **Files:**
-- Create: `frontend/src/components/Modal.tsx` — reusable `<Modal title onClose isOpen>` with:
-  - `role="dialog" aria-modal="true"` wrapper.
-  - Esc key handler attached on mount, removed on unmount, calling `onClose`.
-  - Focus trap: on open, focus the first focusable child; on Tab/Shift-Tab at boundaries, wrap focus.
-  - Backdrop click → `onClose` (existing modals don't do this; opt-in via prop `closeOnBackdrop` default true; **DangerZone passes false** because the typed-confirmation gate is meant to deter accidental dismissal).
+- Create: `frontend/src/components/Modal.tsx` — reusable `<Modal onClose titleId closeOnEsc? className?>` (caller controls mount via conditional render — no `open` prop) with:
+  - `role="dialog" aria-modal="true" aria-labelledby={titleId}` on the inner card (the focused element), with a plain backdrop overlay that has no role.
+  - Esc key handler attached on mount, removed on unmount, calling `onClose`. Disable via `closeOnEsc={false}` for typed-confirmation gates (DangerZone) or `closeOnEsc={!busy}` to guard against in-flight dismissal (Pause / EmailChange).
+  - Focus trap: on open, focus the first focusable child; on Tab/Shift-Tab at boundaries (or when focus has escaped the modal), wrap focus.
   - Restore focus to the previously focused element on close.
-- Create: `frontend/src/components/__tests__/Modal.test.tsx` — Esc closes, Tab cycles, focus restored.
-- Modify: `frontend/src/app/publish/status/DangerZone.tsx` — wrap `DisableConfirmModal` body in `<Modal>`, remove hand-rolled `fixed inset-0 z-50 ...` wrapper.
-- Modify: `frontend/src/app/publish/status/IngestControls.tsx` — same for `PauseConfirmModal`.
-- Modify: `frontend/src/app/publish/status/EmailChangePanel.tsx` — same for `ChangeEmailModal`.
+  - **Backdrop-click-to-close: not implemented** in this PR. Existing modals didn't do this; adding it is net-new UX worth a separate decision. Tracked as a follow-up.
+- Create: `frontend/src/components/__tests__/Modal.test.tsx` — Esc closes, closeOnEsc=false suppresses, Tab cycles, focus restored.
+- Modify: `frontend/src/app/publish/status/DangerZone.tsx` — wrap `DisableConfirmModal` body in `<Modal>` with `closeOnEsc={false}`.
+- Modify: `frontend/src/app/publish/status/IngestControls.tsx` — wrap `PauseConfirmModal` with `closeOnEsc={!busy}`.
+- Modify: `frontend/src/app/publish/status/EmailChangePanel.tsx` — wrap `ChangeEmailModal` with `closeOnEsc={!busy}`.
 - Update tests: `DangerZone.test.tsx`, `IngestControls.test.tsx`, `EmailChangePanel.test.tsx` if they assert on the dropped wrapper structure.
 
 **Steps:**

--- a/docs/plans/2026-05-08-pr98-deferred-followups-plan.md
+++ b/docs/plans/2026-05-08-pr98-deferred-followups-plan.md
@@ -1,0 +1,145 @@
+# PR #98 Deferred Follow-ups — Implementation Plan
+
+> **Execution mode:** Inline (single PR for all 6 items per user direction). One commit per item.
+
+**Goal:** Land all six deferred follow-ups from PR #98 (publisher self-service) as a single bundled cleanup PR.
+
+**Architecture:** Each item is independent; commits are sequential by ascending complexity so an early-stage review failure doesn't block trivial fixes. No schema breaks; the only infra change is an additive GSI.
+
+**Branch:** `feat/pr98-deferred-followups` (already created off `main` at `1b178f1`).
+
+---
+
+## Item ordering rationale
+
+1. **Item 6** — `handleEmailChanged` → `handleStatusRefresh` rename. 30-second mechanical change, no behavior shift.
+2. **Item 3** — Extract `isApproved` helper. Small, type-driven; consumed by Items 1, 2 paths nearby.
+3. **Item 2** — Dedup `PublisherRegistryService` construction in `emailChangeService()` factory.
+4. **Item 1** — Modal a11y (reusable `<Modal>` with Esc + focus trap), applied to DangerZone, PauseConfirm, ChangeEmail.
+5. **Item 4** — `contactEmail` GSI on publishers table; switch `getByEmail` Scan→Query.
+6. **Item 5** — Email-flow happy-path integration test exercising apply→approve→login→edit→email-change→re-login at the service layer using the existing in-memory DDB harness + mocked SES.
+
+## Item 6 — Rename `handleEmailChanged`
+
+**Files:**
+- Modify: `frontend/src/app/publish/status/page.tsx` (3 occurrences: declaration line 190, 2 callsites lines 233, 258)
+
+**Steps:**
+- Replace `handleEmailChanged` with `handleStatusRefresh` (3 sites).
+- Update the function-doc comment if it explicitly references "email" — generalize.
+- Run frontend tests: `npm --workspace=frontend test`.
+- Commit: `refactor(publisher-portal): rename handleEmailChanged → handleStatusRefresh`.
+
+## Item 3 — `isApproved` helper
+
+Today the rule "applicationStatus is undefined OR === 'approved'" is duplicated between `gateApprovedPublisher` (`publisherPortalHandler.ts:953`) and the frontend `editable` derivation in `publish/status/page.tsx:166-167`. The default-undefined-to-approved logic is the legacy-row contract documented in both places.
+
+**Files:**
+- Create: `backend/src/utils/publisherApproval.ts` exporting `isApprovedPublisher(rec: { applicationStatus?: ApplicationStatus }): boolean`.
+- Create: `frontend/src/lib/publisherApproval.ts` mirroring the helper for the frontend (same logic, frontend-typed input).
+- Modify: `backend/src/handlers/publisherPortalHandler.ts:953-954` use helper.
+- Modify: `frontend/src/app/publish/status/page.tsx:166-167` use helper.
+- Test: `backend/src/__tests__/publisherApproval.test.ts` covers undefined/approved/pending/rejected.
+
+The two files (one backend, one frontend) deliberately avoid a shared module — there's no shared package between backend and frontend in this monorepo. Two ~5-line files with identical logic is cheaper than introducing a shared workspace.
+
+**Steps:**
+- Write the backend helper + unit tests; run backend tests.
+- Write the frontend helper.
+- Replace the inline checks in handler and page.
+- Run `npm run validate && npm run build` from `frontend/`.
+- Run backend tests.
+- Commit: `refactor(publisher-portal): extract isApprovedPublisher helper`.
+
+## Item 2 — Dedup registry construction in `emailChangeService()`
+
+`publisherPortalHandler.ts:759-779` constructs a fresh `PublisherRegistryService` even though `statusRegistry()` already maintains one for the same Lambda. Cold-start cost is negligible (microseconds), but it's an avoidable extra allocation and it makes the dependency graph slightly noisier.
+
+**Files:**
+- Modify: `backend/src/handlers/publisherPortalHandler.ts:759-779` — `emailChangeService()` reuses `statusRegistry()` instead of constructing its own. Remove the comment at lines 752-755 about "Sharing wouldn't reduce cold-start work meaningfully" since we're now sharing.
+
+**Steps:**
+- Change `const registry = new PublisherRegistryService(...)` to `const registry = statusRegistry()`.
+- Update the introducing comment (lines 750-755) to explain the singleton sharing.
+- Run handler tests: `cd backend && npm test -- publisherPortalHandler`.
+- Commit: `refactor(publisher-portal): share registry singleton across status + email-change services`.
+
+## Item 1 — Modal a11y refactor
+
+The three publisher-portal modals (DangerZone, PauseConfirm, ChangeEmail) hand-roll the same dialog scaffolding. None implement Esc-to-close or focus trap. Same gap exists on apply/SourceEdit, but those weren't in PR #98's scope.
+
+**Files:**
+- Create: `frontend/src/components/Modal.tsx` — reusable `<Modal title onClose isOpen>` with:
+  - `role="dialog" aria-modal="true"` wrapper.
+  - Esc key handler attached on mount, removed on unmount, calling `onClose`.
+  - Focus trap: on open, focus the first focusable child; on Tab/Shift-Tab at boundaries, wrap focus.
+  - Backdrop click → `onClose` (existing modals don't do this; opt-in via prop `closeOnBackdrop` default true; **DangerZone passes false** because the typed-confirmation gate is meant to deter accidental dismissal).
+  - Restore focus to the previously focused element on close.
+- Create: `frontend/src/components/__tests__/Modal.test.tsx` — Esc closes, Tab cycles, focus restored.
+- Modify: `frontend/src/app/publish/status/DangerZone.tsx` — wrap `DisableConfirmModal` body in `<Modal>`, remove hand-rolled `fixed inset-0 z-50 ...` wrapper.
+- Modify: `frontend/src/app/publish/status/IngestControls.tsx` — same for `PauseConfirmModal`.
+- Modify: `frontend/src/app/publish/status/EmailChangePanel.tsx` — same for `ChangeEmailModal`.
+- Update tests: `DangerZone.test.tsx`, `IngestControls.test.tsx`, `EmailChangePanel.test.tsx` if they assert on the dropped wrapper structure.
+
+**Steps:**
+- Write `Modal.tsx` + tests (TDD: tests first).
+- Run `npm test -- Modal` — should pass.
+- Wire DangerZone, IngestControls, EmailChangePanel to use `<Modal>`.
+- Run full frontend test suite; fix any tests asserting on old DOM shape.
+- Run `npm run validate && npm run build`.
+- Commit: `feat(publisher-portal): reusable Modal with Esc + focus trap`.
+
+## Item 4 — `contactEmail` GSI
+
+`PublisherRegistryService.getByEmail` (line 136) Scans the publishers table. Memory note says this degrades past ~200 publishers; not a today problem, but the deferred item is to add the GSI proactively so future scaling pressure doesn't surface during a hot incident.
+
+**Files:**
+- Modify: `infrastructure/publisher-ingest.tf` — add `global_secondary_index` block on the publishers DDB table with `name = "by-contactEmail"`, `hash_key = "contactEmail"`, `projection_type = "ALL"`. Add `attribute { name = "contactEmail"; type = "S" }`.
+- Modify: `backend/src/services/publisherRegistryService.ts:136-151` — switch `getByEmail` to `QueryCommand` against the new index. Fallback path: if the SDK throws `ValidationException` with "specified index" error (index not yet present in the deployed table), log a warning and fall back to Scan once. This avoids a deploy-window race where Lambda code lands before terraform applies.
+- Modify: tests for `publisherRegistryService.test.ts` covering Query path. The harness's in-memory DDB doesn't enforce GSI presence, so tests already pass; add an explicit Query-vs-Scan assertion.
+- Update memory after deploy.
+
+**Steps:**
+- Add Terraform GSI block + new attribute. `cd infrastructure && terraform fmt && terraform validate`.
+- Update `getByEmail` to Query with Scan fallback.
+- Add unit test verifying Query is preferred and Scan fallback fires on ValidationException.
+- Run backend test suite.
+- Commit: `feat(publishers): contactEmail GSI + getByEmail Query path`.
+- **Defer terraform apply to after merge** (matches project convention — apply comes from main branch).
+
+## Item 5 — Email-flow happy-path integration test
+
+The original deferred memo says "needs SES mocking infrastructure that doesn't exist in CI today." That's true for **end-to-end** tests against deployed AWS. For service-layer integration the existing harness (`backend/src/__tests__/integration/harness/harness.ts`) already provides in-memory DDB + a no-op mail mock pattern. The right test for this item is a service-level happy-path that wires:
+
+- `PublisherApplicationService.requestApply` + `verifyApply` (apply)
+- `PublisherAdminService.approve` (admin approve)
+- `PublisherApplicationService.requestLogin` + `verifyLogin` (login)
+- `PublisherProfileService.updateProfile` (edit name)
+- `PublisherEmailChangeService.initiate` + `verifyByNewAddress` (email change)
+- A second `requestLogin` against the new email to assert the new address authenticates and the old does not (forced re-login)
+
+…against the in-memory harness, asserting on registry state at each step.
+
+**Files:**
+- Create: `backend/src/__tests__/integration/emailFlowE2E.test.ts`.
+
+**Steps:**
+- Read the harness; understand the SES/captcha mocks it already exposes.
+- Write the test as a single `describe('publisher email-flow happy path', ...)` with sequential `it.each` or one big `it` (one big `it` is correct here — the steps share setup state).
+- Run: `cd backend && npm test -- emailFlowE2E`.
+- Commit: `test(publisher-portal): email-flow happy-path integration test`.
+
+## Verification before PR
+
+- `cd frontend && npm run validate && npm run build` — passes.
+- `cd backend && npm test` — passes.
+- `cd backend && npm run build` — passes.
+- `cd infrastructure && terraform fmt && terraform validate` — passes.
+- Memory updated: this plan's outcome is captured for the next session.
+
+## PR
+
+- Title: `feat(publisher-portal): PR #98 deferred follow-ups (modal a11y, contactEmail GSI, email-flow E2E, etc.)`
+- Body: bullet per item, link memory file `publisher-self-service-pr-98-status.md`.
+
+After PR is open: iterate per user CLAUDE.md PR loop — address review comments, request re-reviews, repeat until reviewers empty + checks green + mergeable_state=clean. Do not auto-merge; user merges.

--- a/frontend/src/app/publish/status/DangerZone.tsx
+++ b/frontend/src/app/publish/status/DangerZone.tsx
@@ -17,6 +17,7 @@ import {
   type PublisherStatusRecord,
 } from '@/lib/publisherStatusApi';
 import { clearPublisherSession } from '@/lib/publisherAuthClient';
+import { Modal } from '@/components/Modal';
 
 export interface DangerZoneProps {
   publisher: PublisherStatusRecord;
@@ -96,68 +97,64 @@ function DisableConfirmModal({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="disable-confirm-title"
-    >
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6">
-        <h3
-          id="disable-confirm-title"
-          className="text-lg font-semibold text-red-800 dark:text-red-300 mb-2"
-        >
-          Disable your publisher?
-        </h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">
-          This will retract your events on the next ingest run. Re-enabling
-          requires an admin.
+    // closeOnEsc=false: the typed-confirmation gate is meant to make the
+    // user commit deliberately. A stray Escape from the input field
+    // shouldn't undo that commitment.
+    <Modal onClose={onCancel} titleId="disable-confirm-title" closeOnEsc={false}>
+      <h3
+        id="disable-confirm-title"
+        className="text-lg font-semibold text-red-800 dark:text-red-300 mb-2"
+      >
+        Disable your publisher?
+      </h3>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">
+        This will retract your events on the next ingest run. Re-enabling
+        requires an admin.
+      </p>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
+        To confirm, type the publisher slug{' '}
+        <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">
+          {slug}
+        </code>{' '}
+        exactly:
+      </p>
+      <input
+        type="text"
+        value={typed}
+        onInput={(e) => setTyped((e.target as HTMLInputElement).value)}
+        aria-label="Confirmation slug"
+        autoComplete="off"
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        className="w-full px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-500 mb-3 font-mono"
+        disabled={busy}
+      />
+
+      {error && (
+        <p className="mb-3 text-sm text-red-700 dark:text-red-300" role="alert">
+          {error}
         </p>
-        <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-          To confirm, type the publisher slug{' '}
-          <code className="font-mono bg-gray-100 dark:bg-gray-700 px-1 rounded">
-            {slug}
-          </code>{' '}
-          exactly:
-        </p>
-        <input
-          type="text"
-          value={typed}
-          onInput={(e) => setTyped((e.target as HTMLInputElement).value)}
-          aria-label="Confirmation slug"
-          autoComplete="off"
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          className="w-full px-3 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-red-500 mb-3 font-mono"
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
           disabled={busy}
-        />
-
-        {error && (
-          <p className="mb-3 text-sm text-red-700 dark:text-red-300" role="alert">
-            {error}
-          </p>
-        )}
-
-        <div className="flex gap-2 justify-end">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={busy}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={handleConfirm}
-            disabled={!matches || busy}
-            className="px-3 py-1.5 text-sm rounded-md bg-red-600 text-white font-medium hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed"
-          >
-            {busy ? 'Disabling…' : 'Disable my publisher'}
-          </button>
-        </div>
+          className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleConfirm}
+          disabled={!matches || busy}
+          className="px-3 py-1.5 text-sm rounded-md bg-red-600 text-white font-medium hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed"
+        >
+          {busy ? 'Disabling…' : 'Disable my publisher'}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/frontend/src/app/publish/status/EmailChangePanel.tsx
+++ b/frontend/src/app/publish/status/EmailChangePanel.tsx
@@ -112,7 +112,7 @@ export function EmailChangePanel(props: EmailChangePanelProps) {
           {busy ? 'Cancelling…' : 'Cancel change'}
         </button>
         {error && (
-          <p className="mt-2 text-sm text-red-700 dark:text-red-300">{error}</p>
+          <p className="mt-2 text-sm text-red-700 dark:text-red-300" role="alert">{error}</p>
         )}
       </div>
     );
@@ -221,7 +221,7 @@ function ChangeEmailModal({
         </label>
 
         {error && (
-          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+          <p className="text-sm text-red-700 dark:text-red-300" role="alert">{error}</p>
         )}
 
         <div className="flex gap-2 justify-end pt-2">

--- a/frontend/src/app/publish/status/EmailChangePanel.tsx
+++ b/frontend/src/app/publish/status/EmailChangePanel.tsx
@@ -18,6 +18,7 @@
 
 import { useState } from 'react';
 import type { FormEvent } from 'react';
+import { Modal } from '@/components/Modal';
 import {
   requestEmailChange,
   cancelEmailChangeBySelf,
@@ -192,62 +193,55 @@ function ChangeEmailModal({
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="change-email-title"
-    >
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6">
-        <h3 id="change-email-title" className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-          Change contact email
-        </h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
-          We&apos;ll send a confirmation link to the new address. The change
-          only takes effect once that link is clicked. We&apos;ll also notify
-          your current address ({' '}
-          <span className="font-mono text-xs">{contactEmail}</span>
-          ) so they can cancel if it wasn&apos;t you.
-        </p>
-        <form onSubmit={onSubmit} className="space-y-3">
-          <label className="block">
-            <span className="block text-sm font-medium text-gray-900 dark:text-white mb-1">
-              New email
-            </span>
-            <input
-              type="email"
-              required
-              autoComplete="email"
-              value={newEmail}
-              onInput={e => setNewEmail((e.target as HTMLInputElement).value)}
-              className="block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              placeholder="you@example.com"
-            />
-          </label>
+    <Modal onClose={onClose} titleId="change-email-title">
+      <h3 id="change-email-title" className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
+        Change contact email
+      </h3>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+        We&apos;ll send a confirmation link to the new address. The change
+        only takes effect once that link is clicked. We&apos;ll also notify
+        your current address ({' '}
+        <span className="font-mono text-xs">{contactEmail}</span>
+        ) so they can cancel if it wasn&apos;t you.
+      </p>
+      <form onSubmit={onSubmit} className="space-y-3">
+        <label className="block">
+          <span className="block text-sm font-medium text-gray-900 dark:text-white mb-1">
+            New email
+          </span>
+          <input
+            type="email"
+            required
+            autoComplete="email"
+            value={newEmail}
+            onInput={e => setNewEmail((e.target as HTMLInputElement).value)}
+            className="block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            placeholder="you@example.com"
+          />
+        </label>
 
-          {error && (
-            <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
-          )}
+        {error && (
+          <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
+        )}
 
-          <div className="flex gap-2 justify-end pt-2">
-            <button
-              type="button"
-              onClick={onClose}
-              disabled={busy}
-              className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={busy}
-              className="px-3 py-1.5 text-sm rounded-md bg-blue-600 text-white font-medium hover:bg-blue-700 disabled:opacity-60"
-            >
-              {busy ? 'Sending…' : 'Send confirmation link'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        <div className="flex gap-2 justify-end pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={busy}
+            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={busy}
+            className="px-3 py-1.5 text-sm rounded-md bg-blue-600 text-white font-medium hover:bg-blue-700 disabled:opacity-60"
+          >
+            {busy ? 'Sending…' : 'Send confirmation link'}
+          </button>
+        </div>
+      </form>
+    </Modal>
   );
 }

--- a/frontend/src/app/publish/status/EmailChangePanel.tsx
+++ b/frontend/src/app/publish/status/EmailChangePanel.tsx
@@ -193,7 +193,7 @@ function ChangeEmailModal({
   }
 
   return (
-    <Modal onClose={onClose} titleId="change-email-title">
+    <Modal onClose={onClose} titleId="change-email-title" closeOnEsc={!busy}>
       <h3 id="change-email-title" className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
         Change contact email
       </h3>

--- a/frontend/src/app/publish/status/IngestControls.tsx
+++ b/frontend/src/app/publish/status/IngestControls.tsx
@@ -214,7 +214,7 @@ function PauseConfirmModal({
   onCancel: () => void;
 }) {
   return (
-    <Modal onClose={onCancel} titleId="pause-confirm-title">
+    <Modal onClose={onCancel} titleId="pause-confirm-title" closeOnEsc={!busy}>
       <h3
         id="pause-confirm-title"
         className="text-lg font-semibold text-gray-900 dark:text-white mb-2"

--- a/frontend/src/app/publish/status/IngestControls.tsx
+++ b/frontend/src/app/publish/status/IngestControls.tsx
@@ -17,6 +17,7 @@ import {
   PublisherFetchNowError,
   type PublisherStatusRecord,
 } from '@/lib/publisherStatusApi';
+import { Modal } from '@/components/Modal';
 
 export interface IngestControlsProps {
   publisher: PublisherStatusRecord;
@@ -213,43 +214,36 @@ function PauseConfirmModal({
   onCancel: () => void;
 }) {
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="pause-confirm-title"
-    >
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6">
-        <h3
-          id="pause-confirm-title"
-          className="text-lg font-semibold text-gray-900 dark:text-white mb-2"
+    <Modal onClose={onCancel} titleId="pause-confirm-title">
+      <h3
+        id="pause-confirm-title"
+        className="text-lg font-semibold text-gray-900 dark:text-white mb-2"
+      >
+        Pause fetches?
+      </h3>
+      <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
+        Pausing stops new fetches of your feed. Your previously-published
+        events stay live on the calendar until you Resume or Disable.
+        Pause anyway?
+      </p>
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={busy}
+          className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
         >
-          Pause fetches?
-        </h3>
-        <p className="text-sm text-gray-700 dark:text-gray-300 mb-4">
-          Pausing stops new fetches of your feed. Your previously-published
-          events stay live on the calendar until you Resume or Disable.
-          Pause anyway?
-        </p>
-        <div className="flex gap-2 justify-end">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={busy}
-            className="px-3 py-1.5 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-60"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={busy}
-            className="px-3 py-1.5 text-sm rounded-md bg-amber-600 text-white font-medium hover:bg-amber-700 disabled:opacity-60"
-          >
-            {busy ? 'Pausing…' : 'Pause anyway'}
-          </button>
-        </div>
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={busy}
+          className="px-3 py-1.5 text-sm rounded-md bg-amber-600 text-white font-medium hover:bg-amber-700 disabled:opacity-60"
+        >
+          {busy ? 'Pausing…' : 'Pause anyway'}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -27,6 +27,7 @@ import {
   previewPublisherFeed,
   type PublisherStatusRecord,
 } from '@/lib/publisherStatusApi';
+import { isApprovedPublisher } from '@/lib/publisherApproval';
 import { EditableField } from './EditableField';
 import { SourceEditPanel } from './SourceEditPanel';
 import { EmailChangePanel } from './EmailChangePanel';
@@ -160,11 +161,11 @@ function StatusView({
   rec: PublisherStatusRecord;
   onUpdated: (rec: PublisherStatusRecord) => void;
 }) {
-  // Treat a missing applicationStatus as approved — that's how the backend
-  // treats admin-created rows for ingest, and the same logic should apply
-  // to the publisher-facing view.
+  // Treat a missing applicationStatus as approved — legacy admin-created
+  // rows pre-date the application flow. Shared rule via isApprovedPublisher
+  // so the backend handler and frontend view stay in lockstep.
   const applicationStatus = rec.applicationStatus ?? 'approved';
-  const editable = applicationStatus === 'approved';
+  const editable = isApprovedPublisher(rec);
 
   // The source-edit panel is rendered inline below the card when toggled,
   // not in a modal — keeps the read-only context (current URL, last-fetch

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -185,9 +185,11 @@ function StatusView({
     setSourceEditOpen(false);
   }
 
-  // After an email-change submit/cancel, refetch the status so the banner
-  // (or its absence) reflects the freshly-mutated state.
-  async function handleEmailChanged() {
+  // Refetch the status after any self-service mutation that changes the row
+  // (email-change submit/cancel, pause/resume, fetch-now, etc.) so the panels
+  // reflect freshly-mutated state. Originally introduced for email-change;
+  // generalized when pause/resume/disable started reusing the same pattern.
+  async function handleStatusRefresh() {
     try {
       const fresh = await getPublisherStatus();
       onUpdated(fresh);
@@ -230,7 +232,7 @@ function StatusView({
         <EmailChangePanel
           contactEmail={rec.contactEmail}
           pendingEmailChange={rec.pendingEmailChange ?? null}
-          onChanged={handleEmailChanged}
+          onChanged={handleStatusRefresh}
         />
       )}
 
@@ -255,7 +257,7 @@ function StatusView({
       )}
 
       {applicationStatus === 'approved' && (
-        <IngestControls publisher={rec} onChanged={handleEmailChanged} />
+        <IngestControls publisher={rec} onChanged={handleStatusRefresh} />
       )}
 
       {applicationStatus === 'approved' && <DangerZone publisher={rec} />}

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -507,7 +507,7 @@ function NotificationsPanel({
         </span>
       </label>
       {error && (
-        <p className="mt-2 text-sm text-red-700 dark:text-red-300">{error}</p>
+        <p className="mt-2 text-sm text-red-700 dark:text-red-300" role="alert">{error}</p>
       )}
     </section>
   );

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -190,14 +190,19 @@ function StatusView({
   // (email-change submit/cancel, pause/resume, fetch-now, etc.) so the panels
   // reflect freshly-mutated state. Originally introduced for email-change;
   // generalized when pause/resume/disable started reusing the same pattern.
+  //
+  // Errors are swallowed (the banner stays put rather than showing a
+  // refresh-failure UI) but logged to console so that failures aren't
+  // invisible during development. A 401 inside getPublisherStatus already
+  // triggers its own auth-redirect, so the most-impactful failure mode is
+  // already handled at the API-client layer; what we're swallowing here is
+  // genuinely transient (e.g. network blip mid-render).
   async function handleStatusRefresh() {
     try {
       const fresh = await getPublisherStatus();
       onUpdated(fresh);
-    } catch {
-      // Failure here is rare (status fetch already worked once); if it does
-      // happen, the next mount will catch up. No need to surface the error
-      // through the banner state.
+    } catch (err) {
+      console.error('[publish/status] post-mutation refresh failed; UI may show stale data until next mount', err);
     }
   }
 

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -31,7 +31,11 @@ const FOCUSABLE_SELECTOR = [
   'input:not([disabled])',
   'textarea:not([disabled])',
   'select:not([disabled])',
-  '[tabindex]:not([tabindex="-1"])',
+  // Custom-tabindex elements: still skip if disabled (e.g. a disabled
+  // button with an explicit tabindex). Without the :not([disabled])
+  // guard a disabled element could receive initial focus or be a
+  // focus-trap boundary, which the trap should not allow.
+  '[tabindex]:not([tabindex="-1"]):not([disabled])',
 ].join(', ');
 
 export interface ModalProps {

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,148 @@
+// Reusable accessible modal/dialog wrapper for the publisher portal.
+//
+// Behavior:
+//   - role="dialog" aria-modal="true" with aria-labelledby pointing at the
+//     caller-supplied titleId.
+//   - Esc closes the modal (calls onClose). Disable via closeOnEsc={false}
+//     for typed-confirmation gates where accidental dismissal would defeat
+//     the gate (DangerZone passes false).
+//   - Focus trap: Tab from the last focusable wraps to the first;
+//     Shift+Tab from the first wraps to the last. Focusables: a, button,
+//     input, textarea, select, [tabindex] — minus [disabled] and
+//     tabindex="-1".
+//   - Initial focus: first focusable inside the modal on mount. Falls back
+//     to the modal container itself (so screen readers still announce the
+//     dialog when there are no focusable children — uncommon but possible).
+//   - Restore focus: the previously-focused element when the modal opened
+//     gets focus again on unmount, so keyboard users return to where they
+//     clicked.
+//
+// Caller convention: render the modal conditionally
+//   {open && <Modal onClose={...} titleId="...">...</Modal>}
+// rather than passing an `open` prop. Matches the existing
+// publisher-portal pattern and avoids paying for the document-level
+// listener when the modal isn't shown.
+
+import { useEffect, useRef, type ReactNode } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ');
+
+export interface ModalProps {
+  // Called when Esc is pressed (when closeOnEsc is enabled). Callers wire
+  // this to the same handler their Cancel button uses.
+  onClose: () => void;
+
+  // The id of the heading element inside `children`. Used for
+  // aria-labelledby so screen readers announce the dialog correctly.
+  titleId: string;
+
+  children: ReactNode;
+
+  // Default true. Pass false for typed-confirmation gates where a stray
+  // Esc keypress shouldn't cancel a destructive action the user already
+  // committed to typing through.
+  closeOnEsc?: boolean;
+
+  // Optional override for the inner card classes. Defaults to a max-w-md
+  // panel — matches all current portal modals.
+  className?: string;
+}
+
+export function Modal({
+  onClose,
+  titleId,
+  children,
+  closeOnEsc = true,
+  className = 'bg-white dark:bg-gray-800 rounded-lg shadow-xl max-w-md w-full p-6',
+}: ModalProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  // Captured at mount; restored on unmount. Stored in a ref so the cleanup
+  // sees the original element even after re-renders shuffle focus around.
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previousFocusRef.current = (document.activeElement as HTMLElement | null) ?? null;
+
+    // Focus the first focusable child. If none exist, focus the container
+    // itself so the dialog gets keyboard focus (and screen reader virtual
+    // cursor moves into it). The container has tabIndex={-1} for that.
+    const container = containerRef.current;
+    if (container) {
+      const focusables = container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusables.length > 0) {
+        focusables[0].focus();
+      } else {
+        container.focus();
+      }
+    }
+
+    function handleKeyDown(e: KeyboardEvent): void {
+      if (e.key === 'Escape' && closeOnEsc) {
+        e.stopPropagation();
+        onClose();
+        return;
+      }
+      if (e.key !== 'Tab') return;
+      // Focus trap. Compute focusables fresh on each Tab so dynamically-
+      // disabled buttons (e.g. busy spinners) are accounted for.
+      const c = containerRef.current;
+      if (!c) return;
+      const focusables = Array.from(c.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR));
+      if (focusables.length === 0) {
+        // Nothing to cycle to; keep focus on the container.
+        e.preventDefault();
+        c.focus();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      const active = document.activeElement as HTMLElement | null;
+      if (e.shiftKey) {
+        if (active === first || !c.contains(active)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      // Best-effort focus restore. If the previous element is gone (e.g.
+      // because the parent re-rendered while the modal was open), do
+      // nothing — the browser default focus behavior takes over.
+      const prev = previousFocusRef.current;
+      if (prev && typeof prev.focus === 'function' && document.contains(prev)) {
+        prev.focus();
+      }
+    };
+    // onClose and closeOnEsc are intentionally stable across the modal
+    // lifetime (callers pass inline arrows but the effect re-binds on every
+    // render anyway, which is cheap — one document listener swap).
+  }, [onClose, closeOnEsc]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+    >
+      <div ref={containerRef} tabIndex={-1} className={className}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -104,13 +104,19 @@ export function Modal({
       const first = focusables[0];
       const last = focusables[focusables.length - 1];
       const active = document.activeElement as HTMLElement | null;
+      // Treat "focus is somewhere outside the modal" the same as being at
+      // the boundary in either direction. Otherwise a programmatic focus
+      // change that pushes activeElement behind the modal would let the
+      // very next Tab move into background DOM instead of cycling within
+      // the dialog.
+      const outside = !c.contains(active);
       if (e.shiftKey) {
-        if (active === first || !c.contains(active)) {
+        if (active === first || outside) {
           e.preventDefault();
           last.focus();
         }
       } else {
-        if (active === last) {
+        if (active === last || outside) {
           e.preventDefault();
           first.focus();
         }

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -134,13 +134,18 @@ export function Modal({
   }, [onClose, closeOnEsc]);
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby={titleId}
-    >
-      <div ref={containerRef} tabIndex={-1} className={className}>
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      {/* role/aria/tabIndex live on the focused element (the card), not the
+          backdrop, so screen readers announce the dialog title at the same
+          time keyboard focus enters the dialog content. */}
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={className}
+      >
         {children}
       </div>
     </div>

--- a/frontend/src/components/__tests__/Modal.test.tsx
+++ b/frontend/src/components/__tests__/Modal.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup } from '@testing-library/preact';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/preact';
 import { Modal } from '../Modal';
 
-afterEach(cleanup);
+// Global cleanup runs from frontend/src/__tests__/setup.ts (afterEach hook).
 
 describe('Modal', () => {
   it('renders content with role=dialog and aria-labelledby', () => {

--- a/frontend/src/components/__tests__/Modal.test.tsx
+++ b/frontend/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/preact';
+import { Modal } from '../Modal';
+
+afterEach(cleanup);
+
+describe('Modal', () => {
+  it('renders content with role=dialog and aria-labelledby', () => {
+    render(
+      <Modal onClose={() => {}} titleId="t-1">
+        <h3 id="t-1">My title</h3>
+        <p>body</p>
+      </Modal>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 't-1');
+    expect(screen.getByText('My title')).toBeInTheDocument();
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal onClose={onClose} titleId="t-2">
+        <h3 id="t-2">Heading</h3>
+        <button>OK</button>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClose on Escape when closeOnEsc=false', () => {
+    const onClose = vi.fn();
+    render(
+      <Modal onClose={onClose} titleId="t-3" closeOnEsc={false}>
+        <h3 id="t-3">Heading</h3>
+        <button>OK</button>
+      </Modal>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('focuses the first focusable child on mount', () => {
+    render(
+      <Modal onClose={() => {}} titleId="t-4">
+        <h3 id="t-4">Heading</h3>
+        <input data-testid="first-input" />
+        <button>OK</button>
+      </Modal>,
+    );
+    expect(document.activeElement).toBe(screen.getByTestId('first-input'));
+  });
+
+  it('wraps Tab focus from last to first', () => {
+    render(
+      <Modal onClose={() => {}} titleId="t-5">
+        <h3 id="t-5">Heading</h3>
+        <input data-testid="first" />
+        <button data-testid="last">Last</button>
+      </Modal>,
+    );
+    const first = screen.getByTestId('first');
+    const last = screen.getByTestId('last');
+    last.focus();
+    fireEvent.keyDown(document, { key: 'Tab' });
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('wraps Shift+Tab focus from first to last', () => {
+    render(
+      <Modal onClose={() => {}} titleId="t-6">
+        <h3 id="t-6">Heading</h3>
+        <input data-testid="first" />
+        <button data-testid="last">Last</button>
+      </Modal>,
+    );
+    const first = screen.getByTestId('first');
+    const last = screen.getByTestId('last');
+    first.focus();
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('restores focus to the previously-focused element on unmount', () => {
+    // Render an outer button outside the modal, focus it, then mount the
+    // modal. Unmount should return focus to the outer button.
+    const Wrapper = ({ open }: { open: boolean }) => (
+      <>
+        <button data-testid="outside">Outside</button>
+        {open && (
+          <Modal onClose={() => {}} titleId="t-7">
+            <h3 id="t-7">Heading</h3>
+            <input />
+          </Modal>
+        )}
+      </>
+    );
+    const { rerender } = render(<Wrapper open={false} />);
+    const outside = screen.getByTestId('outside');
+    outside.focus();
+    expect(document.activeElement).toBe(outside);
+
+    rerender(<Wrapper open={true} />);
+    // First focusable inside modal should now have focus.
+    expect(document.activeElement).not.toBe(outside);
+
+    rerender(<Wrapper open={false} />);
+    expect(document.activeElement).toBe(outside);
+  });
+});

--- a/frontend/src/lib/publisherApproval.ts
+++ b/frontend/src/lib/publisherApproval.ts
@@ -1,0 +1,17 @@
+import type { ApplicationStatus } from '@/lib/publisherStatusApi';
+
+// A publisher is "approved" — and therefore eligible for self-service controls
+// like profile edit, ingest controls, email change — when:
+//   - applicationStatus === 'approved' (the standard case after admin
+//     accepts the application), OR
+//   - applicationStatus is undefined (legacy admin-created rows that pre-date
+//     the application flow; treated as approved for backwards compatibility).
+//
+// Pending/rejected applicants see a non-editable view.
+//
+// Mirror of backend/src/utils/publisherApproval.ts. The two files duplicate
+// ~5 lines deliberately rather than introducing a shared workspace package
+// across backend and frontend builds.
+export function isApprovedPublisher(rec: { applicationStatus?: ApplicationStatus }): boolean {
+  return rec.applicationStatus === undefined || rec.applicationStatus === 'approved';
+}

--- a/infrastructure/publisher-ingest.tf
+++ b/infrastructure/publisher-ingest.tf
@@ -8,9 +8,14 @@ resource "aws_dynamodb_table" "publishers" {
     type = "S"
   }
 
-  # GSI key. Email is stored lowercase + trimmed (PublisherApplicationService
-  # normalizes), so the index supports an exact-match Query without a
-  # case-fold step.
+  # GSI key. Email is stored lowercase + trimmed — normalization is
+  # enforced at the registry write boundary (PublisherRegistryService.upsert
+  # and commitEmailChange both normalize), so the index supports an
+  # exact-match Query without a case-fold step. Backfill: any rows
+  # pre-existing this PR with non-normalized contactEmail values (admin
+  # created with mixed-case input under prior code) should be updated
+  # in place via a one-time DDB scan + UpdateItem before relying on the
+  # GSI for uniqueness checks.
   attribute {
     name = "contactEmail"
     type = "S"

--- a/infrastructure/publisher-ingest.tf
+++ b/infrastructure/publisher-ingest.tf
@@ -8,6 +8,28 @@ resource "aws_dynamodb_table" "publishers" {
     type = "S"
   }
 
+  # GSI key. Email is stored lowercase + trimmed (PublisherApplicationService
+  # normalizes), so the index supports an exact-match Query without a
+  # case-fold step.
+  attribute {
+    name = "contactEmail"
+    type = "S"
+  }
+
+  # by-contactEmail powers PublisherRegistryService.getByEmail without a
+  # full-table Scan. Used by the apply uniqueness gate and the email-change
+  # flow's "is the new address already claimed?" check. PROJECTION = ALL
+  # because callers consume the full publisher row to decide approve/reject
+  # branching (see publisherApplicationService.ts requestApply).
+  global_secondary_index {
+    name            = "by-contactEmail"
+    projection_type = "ALL"
+    key_schema {
+      attribute_name = "contactEmail"
+      key_type       = "HASH"
+    }
+  }
+
   point_in_time_recovery {
     enabled = true
   }
@@ -142,6 +164,7 @@ resource "aws_iam_role_policy" "publisher_ingest_scoped" {
         ],
         Resource = [
           aws_dynamodb_table.publishers.arn,
+          "${aws_dynamodb_table.publishers.arn}/index/by-contactEmail",
           aws_dynamodb_table.publisher_events.arn,
           "${aws_dynamodb_table.publisher_events.arn}/index/by-state",
           aws_dynamodb_table.publisher_ingest_runs.arn
@@ -255,6 +278,7 @@ resource "aws_iam_role_policy" "admin_publisher_access" {
       ],
       Resource = [
         aws_dynamodb_table.publishers.arn,
+        "${aws_dynamodb_table.publishers.arn}/index/by-contactEmail",
         aws_dynamodb_table.publisher_events.arn,
         "${aws_dynamodb_table.publisher_events.arn}/index/by-state",
         aws_dynamodb_table.publisher_ingest_runs.arn


### PR DESCRIPTION
## Summary

Bundles all six deferred follow-ups from PR #98 (publisher self-service portal) as a single cleanup PR. One commit per item.

| # | Item | Commit |
|---|------|--------|
| 6 | Rename `handleEmailChanged` → `handleStatusRefresh` (function reused for pause/resume/disable refreshes) | `319780a` |
| 3 | Extract `isApprovedPublisher` helper — used by handler + frontend instead of duplicating the rule | `6ca4eea` |
| 2 | Share `PublisherRegistryService` singleton between `statusRegistry()` and `emailChangeService()` | `cf5707d` |
| 1 | Reusable accessible `<Modal>` with Esc-to-close + focus trap. Applied to DangerZone, IngestControls/Pause, EmailChange. DangerZone passes `closeOnEsc={false}` so a stray Esc doesn't undo the typed-confirmation gate. | `db3c822` |
| 4 | `by-contactEmail` GSI on the publishers DDB table. `getByEmail` Queries the index; falls back to Scan once on `ValidationException` (deploy-window race). | `d860727` |
| 5 | Email-flow happy-path integration test: apply → approve → login → edit → email-change → forced re-login at the service layer with the existing MailCapture mock | `6c6a200` |

Source: deferred items 1–6 in `~/.claude/projects/-Users-bernard-src-chq-chq-calendar/memory/publisher-self-service-pr-98-status.md`. The seventh item (separate reconciler-approval-clobber bug) was already fixed in PR #100.

## Out of scope

- Apply form / SourceEdit modal a11y — the same Esc/focus-trap gap exists there but those modals weren't in PR #98's surface.
- Real-SES post-deploy smoke for the email change chain — would need new CI infrastructure; the service-layer test in this PR is what was actually deferred.
- terraform apply — runs on next merge to main per project convention.

## Test plan

- [x] `cd frontend && npm run validate && npm run build` — passes
- [x] `cd backend && npm test` — 799/799 passing (includes new tests)
- [x] `cd backend && npm run build:prod` — passes
- [x] `cd infrastructure && terraform fmt -check && terraform validate` — passes
- [ ] After merge: `terraform apply` to provision the `by-contactEmail` GSI on the publishers table
- [ ] After deploy: confirm CloudWatch shows no `[publishers] by-contactEmail GSI not yet live` warnings (i.e. Lambda code is hitting the GSI, not the Scan fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)