### PR TITLE
hotfix(ingest): use enabledAt for ci-e2e safety net signal

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -567,11 +567,19 @@ jobs:
           #    ConditionalCheckFailedException instead of silently
           #    upserting a partial {id, enabled} row that the next hourly
           #    ingest would choke on.
+          #
+          #    enabledAt is set alongside enabled so the publisher-ingest
+          #    Lambda's auto-disable safety net can distinguish "row was
+          #    just enabled by an active CI run" from "row enabled but
+          #    abandoned for >1h" (autoDisableStaleCiE2e). Without this
+          #    timestamp the safety net would trip on every CI run that
+          #    follows >1h after the previous one.
+          NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)
           aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
             --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
             --condition-expression 'attribute_exists(id)' \
-            --update-expression 'SET enabled = :t' \
-            --expression-attribute-values '{":t":{"BOOL":true}}'
+            --update-expression 'SET enabled = :t, enabledAt = :now' \
+            --expression-attribute-values "{\":t\":{\"BOOL\":true},\":now\":{\"S\":\"$NOW_ISO\"}}"
 
           # 3. Trigger ingest synchronously. Capture STDOUT metadata
           #    (StatusCode, FunctionError, ExecutedVersion) separately
@@ -753,11 +761,14 @@ jobs:
 
           # 2. Re-enable the test publisher (strict update — fails if
           #    the row is missing rather than upserting a partial row).
+          #    enabledAt also stamped — see the full-scan step above for
+          #    rationale (autoDisableStaleCiE2e safety net).
+          NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)
           aws dynamodb update-item --table-name "$PUBLISHERS_TABLE" \
             --key "{\"id\":{\"S\":\"$PUBLISHER_ID\"}}" \
             --condition-expression 'attribute_exists(id)' \
-            --update-expression 'SET enabled = :t' \
-            --expression-attribute-values '{":t":{"BOOL":true}}'
+            --update-expression 'SET enabled = :t, enabledAt = :now' \
+            --expression-attribute-values "{\":t\":{\"BOOL\":true},\":now\":{\"S\":\"$NOW_ISO\"}}"
 
           # 3. Invoke the Lambda with singlePublisherId — synchronous so
           #    we can assert no FunctionError. Payload mirrors what

--- a/backend/src/__tests__/publisherIngestHandler.integration.test.ts
+++ b/backend/src/__tests__/publisherIngestHandler.integration.test.ts
@@ -1261,6 +1261,42 @@ describe('runIngest records run rows and triggers notifications', () => {
       expect(registry.setEnabledFlag).not.toHaveBeenCalled();
     });
 
+    it('does NOT auto-disable when enabledAt is unparseable garbage', async () => {
+      // Defensive: a malformed enabledAt (manual edit, schema drift) yields
+      // NaN from Date.parse. Without an explicit NaN guard, NaN <= threshold
+      // is false → the function would proceed to disable on garbage input.
+      const now = new Date('2026-06-01T12:00:00Z');
+      const ciE2e = {
+        id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
+        sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't',
+        enabledAt: 'not-a-real-timestamp',
+      };
+      const registry = {
+        listAll: jest.fn().mockResolvedValue([ciE2e]),
+        get: jest.fn().mockResolvedValue(ciE2e),
+        recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
+        setThresholdHalt: jest.fn().mockResolvedValue(undefined),
+        setEnabledFlag: jest.fn().mockResolvedValue(undefined),
+      };
+      const fetcher = fetcherForCiE2e();
+      const { store, sidecar } = makeStoreAndSidecar();
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await runIngest({
+        registry: registry as any, store: store as any, sidecar: sidecar as any,
+        fetcher: fetcher as any, now,
+        publishersTableName: 'chq-publishers',
+        runStore: makeFakeRunStore() as any, notifier: makeFakeNotifier() as any,
+      });
+
+      expect(registry.setEnabledFlag).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/unparseable enabledAt/),
+      );
+      warnSpy.mockRestore();
+    });
+
     it('does NOT auto-disable when enabledAt is missing entirely (legacy/unknown row state)', async () => {
       // Defensive: if enabledAt was never stamped (e.g. someone enabled the
       // row outside the workflow), the safety net deliberately does nothing

--- a/backend/src/__tests__/publisherIngestHandler.integration.test.ts
+++ b/backend/src/__tests__/publisherIngestHandler.integration.test.ts
@@ -1134,13 +1134,26 @@ describe('runIngest records run rows and triggers notifications', () => {
       };
     }
 
-    it('disables ci-e2e-test when enabled=true and lastFetchedAt is older than 1h', async () => {
+    function fetcherForCiE2e() {
+      return jest.fn().mockResolvedValue({
+        fetchStatus: 'ok', report: { ok: true, errors: [], warnings: [] },
+        feed: {
+          formatVersion: '1.0',
+          publisher: { id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x' },
+          events: [],
+        },
+      });
+    }
+
+    it('disables ci-e2e-test when enabled=true and enabledAt is older than 1h', async () => {
       const now = new Date('2026-06-01T12:00:00Z');
-      const stale = new Date(now.getTime() - 90 * 60 * 1000).toISOString(); // 90 min old
+      const staleEnabledAt = new Date(now.getTime() - 90 * 60 * 1000).toISOString();
       const ciE2e = {
         id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
         sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't',
-        lastFetchedAt: stale,
+        enabledAt: staleEnabledAt,
+        // lastFetchedAt could be anything — irrelevant to the safety net now.
+        lastFetchedAt: '2026-05-01T00:00:00Z',
       };
       const registry = {
         listAll: jest.fn().mockResolvedValue([ciE2e]),
@@ -1166,13 +1179,17 @@ describe('runIngest records run rows and triggers notifications', () => {
       expect(store.deleteAllForPublisher).toHaveBeenCalledWith('ci-e2e-test');
     });
 
-    it('leaves ci-e2e-test alone when lastFetchedAt is fresh (<1h)', async () => {
+    it('leaves ci-e2e-test alone when enabledAt is fresh (active CI run)', async () => {
       const now = new Date('2026-06-01T12:00:00Z');
-      const fresh = new Date(now.getTime() - 5 * 60 * 1000).toISOString(); // 5 min old
+      const freshEnabledAt = new Date(now.getTime() - 30 * 1000).toISOString(); // 30s old
+      // Stale lastFetchedAt from a previous deploy — this is the bug-causing
+      // shape: the row was just enabled by the workflow, but lastFetchedAt
+      // is from the last successful CI run a day or more ago.
       const ciE2e = {
         id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
         sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't',
-        lastFetchedAt: fresh,
+        enabledAt: freshEnabledAt,
+        lastFetchedAt: '2026-05-01T00:00:00Z',
       };
       const registry = {
         listAll: jest.fn().mockResolvedValue([ciE2e]),
@@ -1181,14 +1198,7 @@ describe('runIngest records run rows and triggers notifications', () => {
         setThresholdHalt: jest.fn().mockResolvedValue(undefined),
         setEnabledFlag: jest.fn().mockResolvedValue(undefined),
       };
-      const fetcher = jest.fn().mockResolvedValue({
-        fetchStatus: 'ok', report: { ok: true, errors: [], warnings: [] },
-        feed: {
-          formatVersion: '1.0',
-          publisher: { id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x' },
-          events: [],
-        },
-      });
+      const fetcher = fetcherForCiE2e();
       const { store, sidecar } = makeStoreAndSidecar();
 
       await runIngest({
@@ -1199,17 +1209,18 @@ describe('runIngest records run rows and triggers notifications', () => {
       });
 
       expect(registry.setEnabledFlag).not.toHaveBeenCalled();
-      // Still gets fetched as a normal active publisher.
+      // Crucial: the row gets fetched normally so the workflow's "events
+      // appeared in sidecar" assertion can pass.
       expect(fetcher).toHaveBeenCalled();
     });
 
     it('leaves ci-e2e-test alone when enabled=false (the baseline)', async () => {
       const now = new Date('2026-06-01T12:00:00Z');
-      const stale = new Date(now.getTime() - 90 * 60 * 1000).toISOString();
       const ciE2e = {
         id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
         sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: false, createdAt: 't',
-        lastFetchedAt: stale,
+        // enabledAt may persist from last test run; still a no-op while disabled.
+        enabledAt: '2026-05-01T00:00:00Z',
       };
       const registry = {
         listAll: jest.fn().mockResolvedValue([ciE2e]),
@@ -1250,50 +1261,16 @@ describe('runIngest records run rows and triggers notifications', () => {
       expect(registry.setEnabledFlag).not.toHaveBeenCalled();
     });
 
-    it('disables ci-e2e-test when enabled=true and lastFetchedAt is unset but createdAt is stale', async () => {
-      // Edge case: row was just enabled but ingest never recorded a fetch
-      // before the runner died. lastFetchedAt is absent. Fall back to
-      // createdAt for the staleness compare.
+    it('does NOT auto-disable when enabledAt is missing entirely (legacy/unknown row state)', async () => {
+      // Defensive: if enabledAt was never stamped (e.g. someone enabled the
+      // row outside the workflow), the safety net deliberately does nothing
+      // rather than risk disabling a row that's actively being tested.
       const now = new Date('2026-06-01T12:00:00Z');
-      const staleCreatedAt = new Date(now.getTime() - 90 * 60 * 1000).toISOString();
       const ciE2e = {
         id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
-        sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true,
-        createdAt: staleCreatedAt,
-        // lastFetchedAt deliberately absent
-      };
-      const registry = {
-        listAll: jest.fn().mockResolvedValue([ciE2e]),
-        recordFetchOutcome: jest.fn().mockResolvedValue(undefined),
-        setThresholdHalt: jest.fn().mockResolvedValue(undefined),
-        setEnabledFlag: jest.fn().mockResolvedValue(undefined),
-      };
-      const fetcher = jest.fn();
-      const { store, sidecar } = makeStoreAndSidecar();
-
-      await runIngest({
-        registry: registry as any, store: store as any, sidecar: sidecar as any,
-        fetcher: fetcher as any, now,
-        publishersTableName: 'chq-publishers',
-        runStore: makeFakeRunStore() as any, notifier: makeFakeNotifier() as any,
-      });
-
-      expect(registry.setEnabledFlag).toHaveBeenCalledWith('ci-e2e-test', false);
-      // Should retract via the disabled bucket since we mirrored enabled=false.
-      expect(store.deleteAllForPublisher).toHaveBeenCalledWith('ci-e2e-test');
-    });
-
-    it('leaves ci-e2e-test alone when enabled=true and createdAt is fresh (grace period)', async () => {
-      // A row that was JUST created with enabled=true (e.g. terraform-apply
-      // gave a baseline state of true by mistake, or a runner enabled it
-      // moments before this run) shouldn't be auto-disabled — give the next
-      // ingest run a chance to populate lastFetchedAt.
-      const now = new Date('2026-06-01T12:00:00Z');
-      const freshCreatedAt = new Date(now.getTime() - 5 * 60 * 1000).toISOString();
-      const ciE2e = {
-        id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
-        sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true,
-        createdAt: freshCreatedAt,
+        sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't',
+        // enabledAt deliberately absent
+        lastFetchedAt: '2026-05-01T00:00:00Z',
       };
       const registry = {
         listAll: jest.fn().mockResolvedValue([ciE2e]),
@@ -1302,14 +1279,7 @@ describe('runIngest records run rows and triggers notifications', () => {
         setThresholdHalt: jest.fn().mockResolvedValue(undefined),
         setEnabledFlag: jest.fn().mockResolvedValue(undefined),
       };
-      const fetcher = jest.fn().mockResolvedValue({
-        fetchStatus: 'ok', report: { ok: true, errors: [], warnings: [] },
-        feed: {
-          formatVersion: '1.0',
-          publisher: { id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x' },
-          events: [],
-        },
-      });
+      const fetcher = fetcherForCiE2e();
       const { store, sidecar } = makeStoreAndSidecar();
 
       await runIngest({
@@ -1320,15 +1290,16 @@ describe('runIngest records run rows and triggers notifications', () => {
       });
 
       expect(registry.setEnabledFlag).not.toHaveBeenCalled();
+      expect(fetcher).toHaveBeenCalled();
     });
 
     it('does NOT auto-disable on single-publisher runs (singlePublisherId path)', async () => {
       const now = new Date('2026-06-01T12:00:00Z');
-      const stale = new Date(now.getTime() - 90 * 60 * 1000).toISOString();
+      const staleEnabledAt = new Date(now.getTime() - 90 * 60 * 1000).toISOString();
       const ciE2e = {
         id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x', sourceUrl: 'https://x',
         sourceType: 'json' as const, trustLevel: 'auto' as const, enabled: true, createdAt: 't',
-        lastFetchedAt: stale,
+        enabledAt: staleEnabledAt,
       };
       const registry = {
         listAll: jest.fn(),
@@ -1337,14 +1308,7 @@ describe('runIngest records run rows and triggers notifications', () => {
         setThresholdHalt: jest.fn().mockResolvedValue(undefined),
         setEnabledFlag: jest.fn().mockResolvedValue(undefined),
       };
-      const fetcher = jest.fn().mockResolvedValue({
-        fetchStatus: 'ok', report: { ok: true, errors: [], warnings: [] },
-        feed: {
-          formatVersion: '1.0',
-          publisher: { id: 'ci-e2e-test', name: 'CI', contactEmail: 'ci@x' },
-          events: [],
-        },
-      });
+      const fetcher = fetcherForCiE2e();
       const { store, sidecar } = makeStoreAndSidecar();
 
       await runIngest({

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -79,8 +79,10 @@ async function recordRunAndNotify(
 // enable step and its cleanup step, the ci-e2e-test publisher could still be
 // enabled with [CI-E2E] events live on the public sidecar. This threshold is
 // the cutoff after which the next ingest run auto-disables it. Set well above
-// the workflow's expected runtime (~5min) and well below the hourly cadence
-// so a stuck runner is recovered within one ingest cycle.
+// the workflow's expected runtime (~5min); the EventBridge ingest rule fires
+// hourly so worst-case recovery is ~2h (a runner that dies just after one
+// ingest run won't trip the threshold for the next one — the run after that
+// catches it).
 //
 // We compare against `enabledAt` (the timestamp the workflow writes
 // alongside enabled=true), NOT lastFetchedAt — lastFetchedAt persists
@@ -93,7 +95,10 @@ async function recordRunAndNotify(
 // If enabledAt is missing entirely (legacy rows enabled before the
 // workflow started writing it) we deliberately do nothing — better to
 // leak a row across one safety-net cycle than to disable a publisher
-// that's actively being tested by an in-flight runner.
+// that's actively being tested by an in-flight runner. Same policy
+// applies if enabledAt is present but unparseable: NaN compares as
+// false against the threshold, so without an explicit guard the function
+// would proceed to disable on garbage input.
 export const CI_E2E_PUBLISHER_ID = 'ci-e2e-test';
 export const CI_E2E_STALE_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
 
@@ -103,7 +108,14 @@ async function autoDisableStaleCiE2e(
 ): Promise<void> {
   const ciE2e = publishers.find(p => p.id === CI_E2E_PUBLISHER_ID);
   if (!ciE2e || !ciE2e.enabled || !ciE2e.enabledAt) return;
-  const ageMs = deps.now.getTime() - new Date(ciE2e.enabledAt).getTime();
+  const enabledAtMs = new Date(ciE2e.enabledAt).getTime();
+  if (Number.isNaN(enabledAtMs)) {
+    console.warn(
+      `[publisher-ingest] ci-e2e-safety: ignoring unparseable enabledAt=${JSON.stringify(ciE2e.enabledAt)} on ${CI_E2E_PUBLISHER_ID}`,
+    );
+    return;
+  }
+  const ageMs = deps.now.getTime() - enabledAtMs;
   if (ageMs <= CI_E2E_STALE_THRESHOLD_MS) return;
   const ageMin = Math.round(ageMs / 60_000);
   console.warn(

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -81,32 +81,33 @@ async function recordRunAndNotify(
 // the cutoff after which the next ingest run auto-disables it. Set well above
 // the workflow's expected runtime (~5min) and well below the hourly cadence
 // so a stuck runner is recovered within one ingest cycle.
+//
+// We compare against `enabledAt` (the timestamp the workflow writes
+// alongside enabled=true), NOT lastFetchedAt — lastFetchedAt persists
+// across CI runs, so an enabled-true row at the start of a fresh CI test
+// always shows a stale lastFetchedAt from the previous deploy. Using
+// enabledAt makes "fresh CI run" and "abandoned runner" actually
+// distinguishable: a fresh run has enabledAt = ~now; an abandoned runner
+// has enabledAt = >threshold ago.
+//
+// If enabledAt is missing entirely (legacy rows enabled before the
+// workflow started writing it) we deliberately do nothing — better to
+// leak a row across one safety-net cycle than to disable a publisher
+// that's actively being tested by an in-flight runner.
 export const CI_E2E_PUBLISHER_ID = 'ci-e2e-test';
 export const CI_E2E_STALE_THRESHOLD_MS = 60 * 60 * 1000; // 1 hour
 
-// Used in unit tests to fix the wall clock for the threshold comparison.
-// Production code reads deps.now and the registry's lastFetchedAt.
 async function autoDisableStaleCiE2e(
   deps: IngestDeps,
   publishers: PublisherRecord[],
 ): Promise<void> {
   const ciE2e = publishers.find(p => p.id === CI_E2E_PUBLISHER_ID);
-  if (!ciE2e || !ciE2e.enabled) return;
-  // Fall back to createdAt when lastFetchedAt is absent — the only path that
-  // produces enabled=true with no lastFetchedAt is "row was just enabled but
-  // ingest hasn't run yet OR ran but failed to record." Comparing against
-  // createdAt means an old row enabled by a runner that died still gets
-  // auto-disabled, while a freshly-created row gets a grace period.
-  const referenceIso = ciE2e.lastFetchedAt ?? ciE2e.createdAt;
-  if (!referenceIso) return;
-  const ageMs = deps.now.getTime() - new Date(referenceIso).getTime();
+  if (!ciE2e || !ciE2e.enabled || !ciE2e.enabledAt) return;
+  const ageMs = deps.now.getTime() - new Date(ciE2e.enabledAt).getTime();
   if (ageMs <= CI_E2E_STALE_THRESHOLD_MS) return;
   const ageMin = Math.round(ageMs / 60_000);
-  const reason = ciE2e.lastFetchedAt
-    ? `lastFetchedAt is ${ageMin}m old`
-    : `lastFetchedAt unset and createdAt is ${ageMin}m old`;
   console.warn(
-    `[publisher-ingest] ci-e2e-safety: disabling ${CI_E2E_PUBLISHER_ID}: enabled=true and ${reason}`,
+    `[publisher-ingest] ci-e2e-safety: disabling ${CI_E2E_PUBLISHER_ID}: enabled=true and enabledAt is ${ageMin}m old`,
   );
   try {
     await deps.registry.setEnabledFlag(CI_E2E_PUBLISHER_ID, false);

--- a/backend/src/handlers/publisherIngestHandler.ts
+++ b/backend/src/handlers/publisherIngestHandler.ts
@@ -111,7 +111,7 @@ async function autoDisableStaleCiE2e(
   const enabledAtMs = new Date(ciE2e.enabledAt).getTime();
   if (Number.isNaN(enabledAtMs)) {
     console.warn(
-      `[publisher-ingest] ci-e2e-safety: ignoring unparseable enabledAt=${JSON.stringify(ciE2e.enabledAt)} on ${CI_E2E_PUBLISHER_ID}`,
+      `[publisher-ingest] ci-e2e-safety: ignoring unparseable enabledAt on ${CI_E2E_PUBLISHER_ID}`,
     );
     return;
   }

--- a/backend/src/types/publisher.ts
+++ b/backend/src/types/publisher.ts
@@ -38,6 +38,12 @@ export interface PublisherRecord {
   // auto-expires by passing the timestamp; no cleanup needed. ISO 8601.
   emailChangeLockedUntil?: string;
   createdAt: string;
+  // Wall-clock time at which `enabled` last transitioned from false → true.
+  // Currently written only by the deploy workflow's CI E2E enable steps so
+  // the publisher-ingest Lambda's autoDisableStaleCiE2e safety net can tell
+  // "row was just enabled by an active CI run" from "row enabled but
+  // abandoned." Optional and only consulted for the ci-e2e-test row.
+  enabledAt?: string;
   lastFetchedAt?: string;
   lastFetchStatus?: FetchStatus;
   lastFetchMessage?: string;

--- a/infrastructure/ci-e2e-publisher.tf
+++ b/infrastructure/ci-e2e-publisher.tf
@@ -11,10 +11,11 @@
 # the next `terraform apply`.
 #
 # Safety net: if a CI runner dies mid-test leaving enabled=true, the hourly
-# publisher-ingest Lambda will auto-disable this row when it's been stale
-# for more than ~1h. Staleness compares against lastFetchedAt, falling back
-# to createdAt when no fetch has been recorded yet (covers the case of a
-# runner that enabled the row but died before any successful ingest). See
+# publisher-ingest Lambda auto-disables this row once `enabledAt` is more
+# than ~1h old. The deploy workflow stamps enabledAt alongside enabled=true
+# so a fresh CI run is distinguishable from an abandoned-runner state.
+# Rows missing enabledAt entirely are left alone (defensive — better to
+# leak across one cycle than disable an actively-running test). See
 # backend/src/handlers/publisherIngestHandler.ts (CI_E2E_STALE_THRESHOLD_MS,
 # autoDisableStaleCiE2e) for the implementation.
 


### PR DESCRIPTION
## Summary

Hotfix for the deploy failure on `main` after #116. My ci-e2e safety net was using `lastFetchedAt` as the staleness signal, but that's the wrong field — `lastFetchedAt` persists across CI runs, so an enabled-true row at the start of a fresh CI test always shows a stale `lastFetchedAt` from the previous deploy. The safety net was auto-disabling the row in the 30s window between "workflow enables it" and "ingest fetches it," and the deploy step `Test events did not appear in sidecar within 30s` timed out.

Switch the signal to a dedicated `enabledAt` timestamp written by the workflow alongside `enabled = true`. This makes "fresh CI run" (enabledAt ≈ now) and "abandoned runner" (enabledAt > 1h old) actually distinguishable.

## Changes

- **Workflow** — both ci-e2e enable steps (full-scan + single-publisher) now `SET enabled = :t, enabledAt = :now`.
- **Lambda** — `autoDisableStaleCiE2e` reads `enabledAt`. Missing `enabledAt` → deliberate no-op (defensive: don't disable a row that might be actively tested out-of-band).
- **Type** — `PublisherRecord.enabledAt?: string` declared.
- **Tests** — 6 ingest cases rewritten to use the `enabledAt` signal. Adds explicit "missing enabledAt → no-op" case.
- **Terraform comment** — updated to match.

## Test plan

- [x] Backend tests (807 pass)
- [ ] Post-merge: deploy workflow's "Publisher disable→retract end-to-end test" step passes
- [ ] Post-merge: `aws dynamodb get-item ... ci-e2e-test` shows `enabledAt` written by the next CI run

## Production state at hotfix time

- ci-e2e-test publisher: `enabled = false` (cleanup trap worked); no `enabledAt` field yet — that's expected, the next deploy after this hotfix will start writing it.
- No event-data corruption — failed deploy didn't ship, but the failed deploy's intermediate ingest invocations did run against the new safety net code (which is what caused the failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)