### PR TITLE
feat(admin): cross-page nav (back to /admin/ + publishers ↔ events)

### DIFF
--- a/frontend/src/app/admin/feedback/page.tsx
+++ b/frontend/src/app/admin/feedback/page.tsx
@@ -234,9 +234,17 @@ export default function FeedbackManagementPage() {
                 height={32}
                 className="w-8 h-8 mr-3"
               />
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
-                Feedback Management
-              </h1>
+              <div>
+                <a
+                  href="/admin/"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
+                >
+                  ← Admin
+                </a>
+                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                  Feedback Management
+                </h1>
+              </div>
             </div>
             <div className="flex items-center gap-4">
               {/* Development Mode Indicator */}

--- a/frontend/src/app/admin/feedback/page.tsx
+++ b/frontend/src/app/admin/feedback/page.tsx
@@ -226,17 +226,18 @@ export default function FeedbackManagementPage() {
       <header className="bg-white dark:bg-gray-800 shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center">
+            <div className="flex items-center gap-4">
               <img
                 src="/chq-calendar-icon-256.svg"
                 alt="Chautauqua Calendar Logo"
                 width={32}
                 height={32}
-                className="w-8 h-8 mr-3"
+                className="w-8 h-8"
               />
               <div>
                 <a
                   href="/admin/"
+                  aria-label="Back to Admin"
                   className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
                 >
                   ← Admin

--- a/frontend/src/app/admin/publisher-events/page.tsx
+++ b/frontend/src/app/admin/publisher-events/page.tsx
@@ -186,6 +186,7 @@ export default function PublisherEventsPage() {
               <div>
                 <a
                   href="/admin/"
+                  aria-label="Back to Admin"
                   className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
                 >
                   ← Admin
@@ -196,6 +197,7 @@ export default function PublisherEventsPage() {
               </div>
               <a
                 href="/admin/publishers/"
+                aria-label="Go to Publisher Management"
                 className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
               >
                 ← Publishers

--- a/frontend/src/app/admin/publisher-events/page.tsx
+++ b/frontend/src/app/admin/publisher-events/page.tsx
@@ -175,17 +175,31 @@ export default function PublisherEventsPage() {
       <header className="bg-white dark:bg-gray-800 shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center">
+            <div className="flex items-center gap-4">
               <img
                 src="/chq-calendar-icon-256.svg"
                 alt="Chautauqua Calendar Logo"
                 width={32}
                 height={32}
-                className="w-8 h-8 mr-3"
+                className="w-8 h-8"
               />
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
-                Publisher Events
-              </h1>
+              <div>
+                <a
+                  href="/admin/"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
+                >
+                  ← Admin
+                </a>
+                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                  Publisher Events
+                </h1>
+              </div>
+              <a
+                href="/admin/publishers/"
+                className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
+              >
+                ← Publishers
+              </a>
             </div>
             <div className="flex items-center gap-4">
               {isLocalhost && (

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -444,17 +444,31 @@ export default function PublishersPage() {
       <header className="bg-white dark:bg-gray-800 shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex items-center justify-between py-4">
-            <div className="flex items-center">
+            <div className="flex items-center gap-4">
               <img
                 src="/chq-calendar-icon-256.svg"
                 alt="Chautauqua Calendar Logo"
                 width={32}
                 height={32}
-                className="w-8 h-8 mr-3"
+                className="w-8 h-8"
               />
-              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
-                Publisher Management
-              </h1>
+              <div>
+                <a
+                  href="/admin/"
+                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
+                >
+                  ← Admin
+                </a>
+                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                  Publisher Management
+                </h1>
+              </div>
+              <a
+                href="/admin/publisher-events/"
+                className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
+              >
+                Publisher events →
+              </a>
             </div>
             <div className="flex items-center gap-4">
               {isLocalhost && (

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -455,6 +455,7 @@ export default function PublishersPage() {
               <div>
                 <a
                   href="/admin/"
+                  aria-label="Back to Admin"
                   className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
                 >
                   ← Admin
@@ -465,6 +466,7 @@ export default function PublishersPage() {
               </div>
               <a
                 href="/admin/publisher-events/"
+                aria-label="Go to Publisher Events"
                 className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
               >
                 Publisher events →


### PR DESCRIPTION
## Summary

Per user request: every `/admin/*` subpage gets a small "← Admin" link above the title to return to `/admin/`. Closes the gap where a user lands on a subpage by URL or external link and the browser back button doesn't help.

The two paired pages (`/admin/publishers/` and `/admin/publisher-events/`) also get a sibling-page link inline near the title — these are frequently toggled (approve events from review-tier publishers ↔ check publisher status).

## Layout

```
[icon] [← Admin]                    [Dev Mode] [counts] [user] [Logout]
       Publisher Management         [Publisher events →]   ← inline button
```

The "← Admin" link sits above the H1 in each subpage. The sibling link is hidden on small screens (`hidden sm:inline-flex`) to avoid header crowding; "← Admin" is always visible.

## Test plan

- [x] `npm run validate` (type-check + lint) — clean
- [x] `npm run build` — clean
- [x] Existing admin tests still pass (319/319)
- [ ] Manual visual check: I edited the headers but did not exercise the dev server in a browser — please confirm the spacing and responsive behavior look right.
- [ ] Manual: clicking "← Admin" from each subpage lands on `/admin/`
- [ ] Manual: clicking the sibling button on `/publishers/` lands on `/publisher-events/` and vice-versa

## Implementation notes

- Three in-place header edits — no shared `AdminPageHeader` component. With only three pages and a small variation per page, extracting one would have been over-engineering. Easy to refactor later if a fourth admin page lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)