### PR TITLE
fix(admin): wrap header so long emails don't collide

### DIFF
--- a/frontend/src/app/admin/feedback/page.tsx
+++ b/frontend/src/app/admin/feedback/page.tsx
@@ -247,7 +247,7 @@ export default function FeedbackManagementPage() {
                 </h1>
               </div>
             </div>
-            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
+            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
               {/* Development Mode Indicator */}
               {typeof window !== 'undefined' &&
                 (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') && (
@@ -261,7 +261,7 @@ export default function FeedbackManagementPage() {
               {user && (
                 <div className="flex items-center gap-3 min-w-0">
                   <span className="text-sm text-gray-600 dark:text-gray-300 break-all">
-                    {user?.email}
+                    {user.email}
                   </span>
                   <button
                     onClick={logout}

--- a/frontend/src/app/admin/feedback/page.tsx
+++ b/frontend/src/app/admin/feedback/page.tsx
@@ -225,8 +225,8 @@ export default function FeedbackManagementPage() {
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
               <img
                 src="/chq-calendar-icon-256.svg"
                 alt="Chautauqua Calendar Logo"
@@ -247,7 +247,7 @@ export default function FeedbackManagementPage() {
                 </h1>
               </div>
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
               {/* Development Mode Indicator */}
               {typeof window !== 'undefined' &&
                 (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') && (
@@ -259,13 +259,13 @@ export default function FeedbackManagementPage() {
                 {filteredFeedbacks.length} feedback item(s)
               </div>
               {user && (
-                <div className="flex items-center gap-3">
-                  <span className="text-sm text-gray-600 dark:text-gray-300">
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="text-sm text-gray-600 dark:text-gray-300 break-all">
                     {user?.email}
                   </span>
                   <button
                     onClick={logout}
-                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm"
+                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
                   >
                     Logout
                   </button>

--- a/frontend/src/app/admin/publisher-events/page.tsx
+++ b/frontend/src/app/admin/publisher-events/page.tsx
@@ -174,8 +174,8 @@ export default function PublisherEventsPage() {
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
               <img
                 src="/chq-calendar-icon-256.svg"
                 alt="Chautauqua Calendar Logo"
@@ -203,18 +203,18 @@ export default function PublisherEventsPage() {
                 ← Publishers
               </a>
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
               {isLocalhost && (
                 <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
                   Dev Mode
                 </div>
               )}
               {user && (
-                <div className="flex items-center gap-3">
-                  <span className="text-sm text-gray-600 dark:text-gray-300">{user.email}</span>
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="text-sm text-gray-600 dark:text-gray-300 break-all">{user.email}</span>
                   <button
                     onClick={logout}
-                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm"
+                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
                   >
                     Logout
                   </button>

--- a/frontend/src/app/admin/publisher-events/page.tsx
+++ b/frontend/src/app/admin/publisher-events/page.tsx
@@ -203,7 +203,7 @@ export default function PublisherEventsPage() {
                 ← Publishers
               </a>
             </div>
-            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
+            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
               {isLocalhost && (
                 <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
                   Dev Mode

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -443,8 +443,8 @@ export default function PublishersPage() {
       {/* Header */}
       <header className="bg-white dark:bg-gray-800 shadow-lg">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex items-center justify-between py-4">
-            <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
               <img
                 src="/chq-calendar-icon-256.svg"
                 alt="Chautauqua Calendar Logo"
@@ -472,7 +472,7 @@ export default function PublishersPage() {
                 Publisher events →
               </a>
             </div>
-            <div className="flex items-center gap-4">
+            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
               {isLocalhost && (
                 <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
                   Dev Mode
@@ -487,11 +487,11 @@ export default function PublishersPage() {
                 )}
               </div>
               {user && (
-                <div className="flex items-center gap-3">
-                  <span className="text-sm text-gray-600 dark:text-gray-300">{user.email}</span>
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className="text-sm text-gray-600 dark:text-gray-300 break-all">{user.email}</span>
                   <button
                     onClick={logout}
-                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm"
+                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
                   >
                     Logout
                   </button>

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -472,7 +472,7 @@ export default function PublishersPage() {
                 Publisher events →
               </a>
             </div>
-            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2">
+            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
               {isLocalhost && (
                 <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
                   Dev Mode


### PR DESCRIPTION
## Summary

User reported overlapping text in the admin subpage headers (feedback, publishers, publisher-events). Root cause: the outer header used single-row \`flex items-center justify-between\` between the left group (logo + breadcrumb + title + sibling-link) and the right group (dev pill + counts + email + logout). A long signed-in email made the right side too wide and it overflowed into the left side.

## Fix

- Outer container: \`flex flex-wrap items-center justify-between gap-x-4 gap-y-3\` — the two groups now wrap onto a second row when there's not enough horizontal space.
- Right-side group: same \`flex-wrap\` treatment so individual items (dev pill, counts, email+logout pair) can break onto multiple lines internally when really tight.
- Email span: \`break-all\` so an absurdly long single token (no \`@\` to break on, etc.) can't itself blow the column.
- Logout button: \`shrink-0\` so it remains a fixed pill rather than getting squeezed when the right side compresses.

No behavioral change.

/admin/ index already stacks "Signed in as <email>" below the title, so no change needed there.

## Test plan

- [x] \`npm run validate\` + \`npm run build\` — clean
- [x] 319 frontend tests still pass
- [ ] Manual: with a long email on /admin/feedback, /admin/publishers, /admin/publisher-events — the right-side group wraps below the left side instead of colliding.
- [ ] Manual: at full desktop width with short email, everything fits on one row (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)