### PR TITLE
feat(admin/publishers): mobile-friendly card layout on narrow screens

### DIFF
--- a/frontend/src/__tests__/integration/adminPublishers.test.tsx
+++ b/frontend/src/__tests__/integration/adminPublishers.test.tsx
@@ -329,12 +329,16 @@ describe('AdminPublishersPage (integration)', () => {
   });
 
   it('renders publishers as a card list (not a table) on narrow viewports', async () => {
-    // Force matchMedia(...max-width: 767px) to report matches: true so the
+    // Force matchMedia('(max-width: 767px)') to report matches: true so the
     // page's useIsNarrow() hook returns true and the card layout mounts
-    // instead of the table.
+    // instead of the table. Exact-query match (rather than a substring
+    // check) keeps the override scoped to the narrow-viewport probe so a
+    // future matchMedia call on a different query isn't accidentally
+    // co-opted.
+    const NARROW_QUERY = '(max-width: 767px)';
     const originalMatchMedia = window.matchMedia;
     window.matchMedia = ((query: string) => ({
-      matches: query.includes('max-width'),
+      matches: query === NARROW_QUERY,
       media: query,
       onchange: null,
       addListener: () => {},
@@ -359,8 +363,11 @@ describe('AdminPublishersPage (integration)', () => {
 
       // No <table> should be rendered in the narrow layout.
       expect(document.querySelector('table')).toBeNull();
-      // Action buttons (identified by aria-label) still render so admins can
-      // manage publishers from the card view.
+      // All four action buttons (identified by aria-label) still render so
+      // admins can manage publishers from the card view.
+      expect(
+        screen.getByRole('button', { name: /^Edit Active Publisher$/i }),
+      ).toBeInTheDocument();
       expect(
         screen.getByRole('button', { name: /^Pause Active Publisher$/i }),
       ).toBeInTheDocument();

--- a/frontend/src/__tests__/integration/adminPublishers.test.tsx
+++ b/frontend/src/__tests__/integration/adminPublishers.test.tsx
@@ -327,4 +327,51 @@ describe('AdminPublishersPage (integration)', () => {
     // Dialog should still be present.
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
+
+  it('renders publishers as a card list (not a table) on narrow viewports', async () => {
+    // Force matchMedia(...max-width: 767px) to report matches: true so the
+    // page's useIsNarrow() hook returns true and the card layout mounts
+    // instead of the table.
+    const originalMatchMedia = window.matchMedia;
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes('max-width'),
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    })) as typeof window.matchMedia;
+
+    try {
+      nav = installNavigationStub();
+      mock = installFetchMock();
+      loginAsAdmin();
+      mock.on('GET', /\/admin\/api\/publishers$/, { publishers: [SAMPLE_PUBLISHER] });
+      mock.on('GET', /\/admin\/api\/publisher-applications\/pending$/, { applications: [] });
+
+      renderPage(<AdminPublishersPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Active Publisher')).toBeInTheDocument();
+      });
+
+      // No <table> should be rendered in the narrow layout.
+      expect(document.querySelector('table')).toBeNull();
+      // Action buttons (identified by aria-label) still render so admins can
+      // manage publishers from the card view.
+      expect(
+        screen.getByRole('button', { name: /^Pause Active Publisher$/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^Disable Active Publisher$/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: /^Delete Active Publisher$/i }),
+      ).toBeInTheDocument();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
 });

--- a/frontend/src/__tests__/setup.ts
+++ b/frontend/src/__tests__/setup.ts
@@ -17,6 +17,25 @@ const localStorageMock = (() => {
 
 Object.defineProperty(globalThis, 'localStorage', { value: localStorageMock });
 
+// JSDOM does not implement window.matchMedia. Default to `matches: false` so
+// CSS media-query feature checks (e.g. responsive layouts in admin pages)
+// don't crash under test. Individual tests can override per-case if needed.
+if (typeof window !== 'undefined' && typeof window.matchMedia !== 'function') {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
 // Clean up between tests so DOM and storage don't bleed across cases.
 afterEach(() => {
   cleanup();

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -87,8 +87,31 @@ const TrashIcon = ({ className = 'w-5 h-5' }: IconProps) => (
   </svg>
 );
 
+// Breakpoint matches Tailwind's `md` (≥768px). Below this we render publishers
+// as cards instead of the 6-column table, which is unusable on phones.
+const NARROW_QUERY = '(max-width: 767px)';
+
+// Render-time check rather than a class-based show/hide so JSDOM (which
+// ignores CSS) doesn't see duplicate copies of every publisher row when the
+// integration tests query by text/role.
+function useIsNarrow(): boolean {
+  const [narrow, setNarrow] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return window.matchMedia(NARROW_QUERY).matches;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mq = window.matchMedia(NARROW_QUERY);
+    const handler = (e: MediaQueryListEvent) => setNarrow(e.matches);
+    mq.addEventListener('change', handler);
+    return () => mq.removeEventListener('change', handler);
+  }, []);
+  return narrow;
+}
+
 export default function PublishersPage() {
   const user = useAdminAuth();
+  const isNarrow = useIsNarrow();
   const [publishers, setPublishers] = useState<PublisherRecord[]>([]);
   const [pending, setPending] = useState<PublisherRecord[]>([]);
   const [loading, setLoading] = useState(true);
@@ -608,6 +631,127 @@ export default function PublishersPage() {
             <div className="p-8 text-center text-gray-500 dark:text-gray-400">
               No publishers yet. Click &quot;+ New publisher&quot; to add one.
             </div>
+          ) : isNarrow ? (
+            // Card list for narrow screens (<768px). The 6-column table below
+            // is too dense for phones, so we render the same data as cards
+            // here and only mount the table on wider viewports.
+            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+              {nonPendingPublishers.map(p => (
+                <li key={p.id} className={`p-4 ${p.enabled ? '' : 'opacity-60'}`}>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="text-sm font-medium text-gray-900 dark:text-gray-100 break-words">{p.name}</div>
+                      <div className="text-xs text-gray-500 dark:text-gray-400 font-mono break-all">{p.id}</div>
+                    </div>
+                    <span className="shrink-0 inline-flex px-2 py-1 text-xs font-medium rounded-full bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300">
+                      {p.trustLevel}
+                    </span>
+                  </div>
+
+                  <div className="mt-2 text-sm">
+                    <a
+                      href={p.sourceUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 underline break-all"
+                    >
+                      {p.sourceUrl}
+                    </a>
+                  </div>
+
+                  <div className="mt-2 flex flex-wrap gap-1.5">
+                    <span
+                      className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                        p.enabled
+                          ? 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-400'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400'
+                      }`}
+                    >
+                      {p.enabled ? 'Enabled' : 'Disabled'}
+                    </span>
+                    {p.enabled && p.paused && (
+                      <span className="inline-flex px-2 py-1 text-xs font-semibold rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-400">
+                        Paused
+                      </span>
+                    )}
+                    {p.lastFetchStatus && (
+                      <span
+                        className={`inline-flex px-2 py-1 text-xs font-medium rounded-full ${statusBadgeClass(p.lastFetchStatus)}`}
+                      >
+                        {p.lastFetchStatus}
+                      </span>
+                    )}
+                  </div>
+
+                  {p.lastFetchedAt && (
+                    <div className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                      Last fetch: {formatFetchedAt(p.lastFetchedAt)}
+                    </div>
+                  )}
+                  {p.lastFetchStatus && p.lastFetchStatus !== 'ok' && p.lastFetchMessage && (
+                    <div
+                      className="mt-1 text-xs text-red-700 dark:text-red-400 whitespace-pre-wrap break-words font-mono leading-snug"
+                      title={p.lastFetchMessage}
+                    >
+                      {p.lastFetchMessage}
+                    </div>
+                  )}
+
+                  <div className="mt-3 flex items-center gap-1">
+                    <button
+                      onClick={() => setFormMode({ kind: 'edit', publisher: p })}
+                      disabled={formMode.kind !== 'closed'}
+                      title="Edit"
+                      aria-label={`Edit ${p.name}`}
+                      className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <PencilIcon />
+                    </button>
+                    <button
+                      onClick={() => handleToggleEnabled(p)}
+                      disabled={togglingIds.has(p.id)}
+                      title={p.enabled ? 'Disable (retracts events)' : 'Enable'}
+                      aria-label={p.enabled ? `Disable ${p.name}` : `Enable ${p.name}`}
+                      className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
+                        p.enabled
+                          ? 'text-yellow-600 dark:text-yellow-400 hover:bg-yellow-50 dark:hover:bg-yellow-900/30'
+                          : 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
+                      }`}
+                    >
+                      {p.enabled ? <NoSymbolIcon /> : <CheckCircleIcon />}
+                    </button>
+                    <button
+                      onClick={() => handleTogglePaused(p)}
+                      disabled={pausingIds.has(p.id) || !p.enabled}
+                      title={
+                        !p.enabled
+                          ? 'Pause is only available for enabled publishers'
+                          : p.paused
+                            ? 'Resume ingest'
+                            : 'Pause ingest (keeps existing events)'
+                      }
+                      aria-label={p.paused ? `Resume ${p.name}` : `Pause ${p.name}`}
+                      className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
+                        p.paused
+                          ? 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
+                          : 'text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30'
+                      }`}
+                    >
+                      {p.paused ? <PlayIcon /> : <PauseIcon />}
+                    </button>
+                    <button
+                      onClick={() => setDeleteTarget(p)}
+                      disabled={deletingIds.has(p.id)}
+                      title="Delete publisher and all their events"
+                      aria-label={`Delete ${p.name}`}
+                      className="p-1.5 rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      <TrashIcon />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
           ) : (
             <div className="overflow-x-auto">
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -95,15 +95,17 @@ const NARROW_QUERY = '(max-width: 767px)';
 // ignores CSS) doesn't see duplicate copies of every publisher row when the
 // integration tests query by text/role.
 function useIsNarrow(): boolean {
-  const [narrow, setNarrow] = useState<boolean>(() => {
-    if (typeof window === 'undefined') return false;
-    return window.matchMedia(NARROW_QUERY).matches;
-  });
+  // Start `false` (desktop). The effect below syncs to the real value
+  // immediately after mount, which closes the tiny render→effect gap where
+  // a resize between first render and listener attach could leave state
+  // stale. One `matchMedia(...)` call total instead of two.
+  const [narrow, setNarrow] = useState<boolean>(false);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const mq = window.matchMedia(NARROW_QUERY);
     const handler = (e: MediaQueryListEvent) => setNarrow(e.matches);
     mq.addEventListener('change', handler);
+    setNarrow(mq.matches);
     return () => mq.removeEventListener('change', handler);
   }, []);
   return narrow;
@@ -445,6 +447,66 @@ export default function PublishersPage() {
     return d.toLocaleString();
   };
 
+  // Action buttons (Edit / Enable-Disable / Pause-Resume / Delete) — shared
+  // between the card layout and the table layout. Defined inline so it can
+  // close over the in-flight state sets and handler callbacks without prop
+  // drilling. Keeping a single source of truth here means new actions or
+  // aria-label tweaks land in one place instead of diverging across layouts.
+  const renderActions = (p: PublisherRecord) => (
+    <div className="flex items-center gap-1">
+      <button
+        onClick={() => setFormMode({ kind: 'edit', publisher: p })}
+        disabled={formMode.kind !== 'closed'}
+        title="Edit"
+        aria-label={`Edit ${p.name}`}
+        className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <PencilIcon />
+      </button>
+      <button
+        onClick={() => handleToggleEnabled(p)}
+        disabled={togglingIds.has(p.id)}
+        title={p.enabled ? 'Disable (retracts events)' : 'Enable'}
+        aria-label={p.enabled ? `Disable ${p.name}` : `Enable ${p.name}`}
+        className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
+          p.enabled
+            ? 'text-yellow-600 dark:text-yellow-400 hover:bg-yellow-50 dark:hover:bg-yellow-900/30'
+            : 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
+        }`}
+      >
+        {p.enabled ? <NoSymbolIcon /> : <CheckCircleIcon />}
+      </button>
+      <button
+        onClick={() => handleTogglePaused(p)}
+        disabled={pausingIds.has(p.id) || !p.enabled}
+        title={
+          !p.enabled
+            ? 'Pause is only available for enabled publishers'
+            : p.paused
+              ? 'Resume ingest'
+              : 'Pause ingest (keeps existing events)'
+        }
+        aria-label={p.paused ? `Resume ${p.name}` : `Pause ${p.name}`}
+        className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
+          p.paused
+            ? 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
+            : 'text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30'
+        }`}
+      >
+        {p.paused ? <PlayIcon /> : <PauseIcon />}
+      </button>
+      <button
+        onClick={() => setDeleteTarget(p)}
+        disabled={deletingIds.has(p.id)}
+        title="Delete publisher and all their events"
+        aria-label={`Delete ${p.name}`}
+        className="p-1.5 rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <TrashIcon />
+      </button>
+    </div>
+  );
+
   // -------------------------------------------------------------------------
   // Loading / unauthenticated guard
   // -------------------------------------------------------------------------
@@ -634,8 +696,10 @@ export default function PublishersPage() {
           ) : isNarrow ? (
             // Card list for narrow screens (<768px). The 6-column table below
             // is too dense for phones, so we render the same data as cards
-            // here and only mount the table on wider viewports.
-            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+            // here and only mount the table on wider viewports. aria-label
+            // gives screen-reader users an accessible name for the list
+            // (the desktop <table> is implicitly self-describing).
+            <ul aria-label="Publishers" className="divide-y divide-gray-200 dark:divide-gray-700">
               {nonPendingPublishers.map(p => (
                 <li key={p.id} className={`p-4 ${p.enabled ? '' : 'opacity-60'}`}>
                   <div className="flex items-start justify-between gap-3">
@@ -697,58 +761,7 @@ export default function PublishersPage() {
                     </div>
                   )}
 
-                  <div className="mt-3 flex items-center gap-1">
-                    <button
-                      onClick={() => setFormMode({ kind: 'edit', publisher: p })}
-                      disabled={formMode.kind !== 'closed'}
-                      title="Edit"
-                      aria-label={`Edit ${p.name}`}
-                      className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      <PencilIcon />
-                    </button>
-                    <button
-                      onClick={() => handleToggleEnabled(p)}
-                      disabled={togglingIds.has(p.id)}
-                      title={p.enabled ? 'Disable (retracts events)' : 'Enable'}
-                      aria-label={p.enabled ? `Disable ${p.name}` : `Enable ${p.name}`}
-                      className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
-                        p.enabled
-                          ? 'text-yellow-600 dark:text-yellow-400 hover:bg-yellow-50 dark:hover:bg-yellow-900/30'
-                          : 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
-                      }`}
-                    >
-                      {p.enabled ? <NoSymbolIcon /> : <CheckCircleIcon />}
-                    </button>
-                    <button
-                      onClick={() => handleTogglePaused(p)}
-                      disabled={pausingIds.has(p.id) || !p.enabled}
-                      title={
-                        !p.enabled
-                          ? 'Pause is only available for enabled publishers'
-                          : p.paused
-                            ? 'Resume ingest'
-                            : 'Pause ingest (keeps existing events)'
-                      }
-                      aria-label={p.paused ? `Resume ${p.name}` : `Pause ${p.name}`}
-                      className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
-                        p.paused
-                          ? 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
-                          : 'text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30'
-                      }`}
-                    >
-                      {p.paused ? <PlayIcon /> : <PauseIcon />}
-                    </button>
-                    <button
-                      onClick={() => setDeleteTarget(p)}
-                      disabled={deletingIds.has(p.id)}
-                      title="Delete publisher and all their events"
-                      aria-label={`Delete ${p.name}`}
-                      className="p-1.5 rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
-                    >
-                      <TrashIcon />
-                    </button>
-                  </div>
+                  <div className="mt-3">{renderActions(p)}</div>
                 </li>
               ))}
             </ul>
@@ -844,58 +857,7 @@ export default function PublishersPage() {
                         </div>
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm font-medium">
-                        <div className="flex items-center gap-1">
-                          <button
-                            onClick={() => setFormMode({ kind: 'edit', publisher: p })}
-                            disabled={formMode.kind !== 'closed'}
-                            title="Edit"
-                            aria-label={`Edit ${p.name}`}
-                            className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
-                          >
-                            <PencilIcon />
-                          </button>
-                          <button
-                            onClick={() => handleToggleEnabled(p)}
-                            disabled={togglingIds.has(p.id)}
-                            title={p.enabled ? 'Disable (retracts events)' : 'Enable'}
-                            aria-label={p.enabled ? `Disable ${p.name}` : `Enable ${p.name}`}
-                            className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
-                              p.enabled
-                                ? 'text-yellow-600 dark:text-yellow-400 hover:bg-yellow-50 dark:hover:bg-yellow-900/30'
-                                : 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
-                            }`}
-                          >
-                            {p.enabled ? <NoSymbolIcon /> : <CheckCircleIcon />}
-                          </button>
-                          <button
-                            onClick={() => handleTogglePaused(p)}
-                            disabled={pausingIds.has(p.id) || !p.enabled}
-                            title={
-                              !p.enabled
-                                ? 'Pause is only available for enabled publishers'
-                                : p.paused
-                                  ? 'Resume ingest'
-                                  : 'Pause ingest (keeps existing events)'
-                            }
-                            aria-label={p.paused ? `Resume ${p.name}` : `Pause ${p.name}`}
-                            className={`p-1.5 rounded-md disabled:opacity-40 disabled:cursor-not-allowed ${
-                              p.paused
-                                ? 'text-green-600 dark:text-green-400 hover:bg-green-50 dark:hover:bg-green-900/30'
-                                : 'text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/30'
-                            }`}
-                          >
-                            {p.paused ? <PlayIcon /> : <PauseIcon />}
-                          </button>
-                          <button
-                            onClick={() => setDeleteTarget(p)}
-                            disabled={deletingIds.has(p.id)}
-                            title="Delete publisher and all their events"
-                            aria-label={`Delete ${p.name}`}
-                            className="p-1.5 rounded-md text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/30 disabled:opacity-40 disabled:cursor-not-allowed"
-                          >
-                            <TrashIcon />
-                          </button>
-                        </div>
+                        {renderActions(p)}
                       </td>
                     </tr>
                   ))}

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -103,10 +103,20 @@ function useIsNarrow(): boolean {
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const mq = window.matchMedia(NARROW_QUERY);
-    const handler = (e: MediaQueryListEvent) => setNarrow(e.matches);
-    mq.addEventListener('change', handler);
-    setNarrow(mq.matches);
-    return () => mq.removeEventListener('change', handler);
+    const handler = () => setNarrow(mq.matches);
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', handler);
+    } else {
+      mq.addListener(handler);
+    }
+    handler();
+    return () => {
+      if (typeof mq.removeEventListener === 'function') {
+        mq.removeEventListener('change', handler);
+      } else {
+        mq.removeListener(handler);
+      }
+    };
   }, []);
   return narrow;
 }
@@ -716,7 +726,7 @@ export default function PublishersPage() {
                     <a
                       href={p.sourceUrl}
                       target="_blank"
-                      rel="noreferrer"
+                      rel="noopener noreferrer"
                       className="text-gray-600 dark:text-gray-300 hover:text-blue-600 dark:hover:text-blue-400 underline break-all"
                     >
                       {p.sourceUrl}
@@ -801,7 +811,7 @@ export default function PublishersPage() {
                         <a
                           href={p.sourceUrl}
                           target="_blank"
-                          rel="noreferrer"
+                          rel="noopener noreferrer"
                           className="hover:text-blue-600 dark:hover:text-blue-400 underline"
                         >
                           {p.sourceUrl}


### PR DESCRIPTION
## Summary
- `/admin/publishers/` 6-column table forced horizontal scrolling on phones. Below 768px (Tailwind's `md`), render each publisher as a stacked card with the same fields and the same four action buttons.
- New `useIsNarrow()` hook subscribes to `matchMedia('(max-width: 767px)')` so the layout flips live on resize/rotate without a reload.
- Conditional render (not CSS show/hide) keeps the DOM clean and avoids duplicate matches in JSDOM-backed integration tests.
- Added a `window.matchMedia` polyfill to `src/__tests__/setup.ts` so JSDOM-based tests don't crash on `useIsNarrow()` (defaults to `matches: false` → existing tests still see the desktop table).

## Test plan
- [x] `npm run validate` — type-check + lint clean
- [x] `npm run build` — full pipeline (validate + vitest + vite build) green; 320 tests passing
- [x] New integration test forces `matches: true` and asserts the card layout renders with no `<table>` and all action buttons reachable by aria-label
- [ ] Manual: open `/admin/publishers/` on a phone (or DevTools narrow viewport) and confirm cards render with all data and buttons functional
- [ ] Manual: resize across the 768px breakpoint and confirm the layout flips live

🤖 Generated with [Claude Code](https://claude.com/claude-code)