### PR TITLE
refactor(admin): extract AdminHeader component (PR #119 follow-up)

### DIFF
--- a/docs/plans/2026-05-11-admin-header-component-design.md
+++ b/docs/plans/2026-05-11-admin-header-component-design.md
@@ -1,0 +1,99 @@
+# AdminHeader component — design
+
+**Date**: 2026-05-11
+**Branch**: `refactor/admin-header-component`
+**Origin**: Open follow-up from PR #119 ("wrap header so long emails don't collide"). Three admin pages — `/admin/feedback`, `/admin/publishers`, `/admin/publisher-events` — currently inline near-identical header markup, including the responsive-wrap classes added in #119. Drift risk is real: PR #119 had to fan the same fix across three files.
+
+## Goals
+
+1. One shared component that renders the admin top-of-page header.
+2. Eliminate the ~25–35 lines of duplicated JSX per page.
+3. Keep all three pages visually and behaviorally identical to today's `main` (post-#120).
+4. Resolve the open `break-all` vs `break-words` preference on the email span.
+
+## Non-goals
+
+- No changes to `/admin/` index page header (different layout — stacked, has the "Signed in as" row already).
+- No changes to `/admin/login/`.
+- No new features. Pure refactor + the one CSS tweak.
+- No prop changes to per-page widgets that move into `children` — they stay as-is, just relocated.
+
+## Component API
+
+`frontend/src/components/admin/AdminHeader.tsx`:
+
+```tsx
+interface AdminHeaderProps {
+  title: string;
+  siblingLink?: {
+    href: string;
+    label: string;         // e.g. "Publisher events →" or "← Publishers"
+    ariaLabel?: string;    // defaults to label
+  };
+  user: { email: string } | null;
+  onLogout: () => void;
+  children?: ComponentChildren; // optional right-side extras rendered before email/logout
+}
+```
+
+Behavior:
+- Renders the `← Admin` breadcrumb back-link (always; matches current).
+- Renders the logo + title block (always).
+- Renders the optional sibling link inside the left group, after the title block — exactly where the three pages put it today.
+- Dev-mode pill: internalized. Component checks `window.location.hostname === 'localhost' || '127.0.0.1'` (matches existing `isLocalhost` pattern). The per-page `isLocalhost` constants in `publishers/page.tsx` and `publisher-events/page.tsx` are only used for this pill (verified: 2 refs each = definition + pill), so both definitions get removed. `feedback/page.tsx` defines its own `isLocalhost` inside a callback for auth-bypass logic; that one is untouched.
+- Right-side `children` slot renders between the dev-mode pill and the email/logout pair, mirroring the current order.
+- Email span uses `break-words` (decision: nicer for typical emails; min-w-0 on the wrapper + shrink-0 on the button still prevent layout blowout for pathological tokens).
+- All Tailwind classes preserved verbatim from the post-#119 markup so no visual regression.
+
+## Call sites
+
+```tsx
+// feedback/page.tsx
+<AdminHeader title="Feedback Management" user={user} onLogout={logout}>
+  <div className="text-sm text-gray-600 dark:text-gray-300">
+    {filteredFeedbacks.length} feedback item(s)
+  </div>
+</AdminHeader>
+
+// publishers/page.tsx
+<AdminHeader
+  title="Publishers Management"
+  siblingLink={{ href: '/admin/publisher-events/', label: 'Publisher events →' }}
+  user={user}
+  onLogout={logout}
+>
+  {/* existing total/enabled/disabled counts block, unchanged */}
+</AdminHeader>
+
+// publisher-events/page.tsx
+<AdminHeader
+  title="Publisher Events"
+  siblingLink={{ href: '/admin/publishers/', label: '← Publishers' }}
+  user={user}
+  onLogout={logout}
+/>
+```
+
+## Testing
+
+`frontend/src/components/__tests__/AdminHeader.test.tsx` (matches Modal.test.tsx convention):
+
+- renders title + back-to-admin link
+- renders optional sibling link when provided; omits it when not
+- renders `children` between dev-mode pill and email/logout
+- renders email and logout button when `user` is non-null
+- omits the email/logout block when `user` is null
+- calls `onLogout` when the logout button is clicked
+- Dev-mode pill: skip browser-dependent assertion in jsdom (current pages do the same `typeof window` check; we just match behavior, no need to test).
+
+Existing admin page tests (`adminFeedback.test.tsx`, `adminPublishers.test.tsx`, `PublishersPage.runIngest.test.tsx`) should continue to pass without modification — same DOM output.
+
+## Risks
+
+- DOM shape might shift slightly enough to break a brittle test selector. Mitigation: keep exact class strings; if a test breaks, prefer adjusting the test selector to a more robust one rather than reshaping the component.
+- `break-words` is a behavior change vs current `break-all`. Single ugly-long token would now overflow visually instead of breaking mid-character. Mitigation: `min-w-0` on the parent and `shrink-0` on the logout button stay; pathological case is "email with no `@` and no `.`" which isn't a real email. Acceptable.
+
+## Out of scope (follow-ups, not this PR)
+
+- No move of `/admin/` index header into the component — different shape.
+- No extraction of the dev-mode pill into its own component — only used in 3 places now, and once inlined here it'll be only 1 place (this component) plus the `/admin/` index.

--- a/docs/plans/2026-05-11-admin-header-component-design.md
+++ b/docs/plans/2026-05-11-admin-header-component-design.md
@@ -43,7 +43,7 @@ Behavior:
 - Dev-mode pill: internalized. Component checks `window.location.hostname === 'localhost' || '127.0.0.1'` (matches existing `isLocalhost` pattern). The per-page `isLocalhost` constants in `publishers/page.tsx` and `publisher-events/page.tsx` are only used for this pill (verified: 2 refs each = definition + pill), so both definitions get removed. `feedback/page.tsx` defines its own `isLocalhost` inside a callback for auth-bypass logic; that one is untouched.
 - Right-side `children` slot renders between the dev-mode pill and the email/logout pair, mirroring the current order.
 - Email span uses `break-words` (decision: nicer for typical emails; min-w-0 on the wrapper + shrink-0 on the button still prevent layout blowout for pathological tokens).
-- All Tailwind classes preserved verbatim from the post-#119 markup so no visual regression.
+- Tailwind classes preserved from the post-#119 markup with one deliberate change: the email span swaps `break-all` for `break-words` (see Risks below). All other classes are unchanged so the rest of the layout is visually identical.
 
 ## Call sites
 
@@ -91,7 +91,7 @@ Existing admin page tests (`adminFeedback.test.tsx`, `adminPublishers.test.tsx`,
 ## Risks
 
 - DOM shape might shift slightly enough to break a brittle test selector. Mitigation: keep exact class strings; if a test breaks, prefer adjusting the test selector to a more robust one rather than reshaping the component.
-- `break-words` is a behavior change vs current `break-all`. Single ugly-long token would now overflow visually instead of breaking mid-character. Mitigation: `min-w-0` on the parent and `shrink-0` on the logout button stay; pathological case is "email with no `@` and no `.`" which isn't a real email. Acceptable.
+- `break-words` is a behavior change vs current `break-all`. Both prevent overflow; the difference is *where* they break. `break-all` (word-break: break-all) splits at every character boundary, which on a long email looks like `verylongus`-newline-`er@example.com`. `break-words` (overflow-wrap: break-word) prefers natural breakpoints (`@`, `.`, `-`) and only breaks mid-word as a last resort, so a normal email like `someone@verylongdomain.example.com` wraps cleanly at the `@` or `.` instead of mid-token. `min-w-0` on the parent and `shrink-0` on the logout button stay either way.
 
 ## Out of scope (follow-ups, not this PR)
 

--- a/frontend/src/app/admin/feedback/page.tsx
+++ b/frontend/src/app/admin/feedback/page.tsx
@@ -3,6 +3,7 @@ import { API_BASE_URL } from '@/lib/api';
 import { useAdminAuth } from '@/hooks/useAdminAuth';
 import { getAuthToken, logout } from '@/lib/auth';
 import { Modal } from '@/components/Modal';
+import { AdminHeader } from '@/components/admin/AdminHeader';
 
 interface FeedbackRecord {
   id: string;
@@ -222,59 +223,11 @@ export default function FeedbackManagementPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
-      {/* Header */}
-      <header className="bg-white dark:bg-gray-800 shadow-lg">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-              <img
-                src="/chq-calendar-icon-256.svg"
-                alt="Chautauqua Calendar Logo"
-                width={32}
-                height={32}
-                className="w-8 h-8"
-              />
-              <div>
-                <a
-                  href="/admin/"
-                  aria-label="Back to Admin"
-                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
-                >
-                  ← Admin
-                </a>
-                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
-                  Feedback Management
-                </h1>
-              </div>
-            </div>
-            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
-              {/* Development Mode Indicator */}
-              {typeof window !== 'undefined' &&
-                (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1') && (
-                <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
-                  Dev Mode
-                </div>
-              )}
-              <div className="text-sm text-gray-600 dark:text-gray-300">
-                {filteredFeedbacks.length} feedback item(s)
-              </div>
-              {user && (
-                <div className="flex items-center gap-3 min-w-0">
-                  <span className="text-sm text-gray-600 dark:text-gray-300 break-all">
-                    {user.email}
-                  </span>
-                  <button
-                    onClick={logout}
-                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
-                  >
-                    Logout
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
+      <AdminHeader title="Feedback Management" user={user} onLogout={logout}>
+        <div className="text-sm text-gray-600 dark:text-gray-300">
+          {filteredFeedbacks.length} feedback item(s)
         </div>
-      </header>
+      </AdminHeader>
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/frontend/src/app/admin/publisher-events/page.tsx
+++ b/frontend/src/app/admin/publisher-events/page.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/lib/adminPublisherApi';
 import { useAdminAuth } from '@/hooks/useAdminAuth';
 import { logout } from '@/lib/auth';
+import { AdminHeader } from '@/components/admin/AdminHeader';
 import { PendingEventCard } from './PendingEventCard';
 
 export default function PublisherEventsPage() {
@@ -152,10 +153,6 @@ export default function PublisherEventsPage() {
   // -------------------------------------------------------------------------
   // Loading / unauthenticated guard
   // -------------------------------------------------------------------------
-  const isLocalhost =
-    typeof window !== 'undefined' &&
-    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
-
   if (!user || (loading && pending.length === 0 && halts.length === 0)) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 flex items-center justify-center">
@@ -171,59 +168,16 @@ export default function PublisherEventsPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
-      {/* Header */}
-      <header className="bg-white dark:bg-gray-800 shadow-lg">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-              <img
-                src="/chq-calendar-icon-256.svg"
-                alt="Chautauqua Calendar Logo"
-                width={32}
-                height={32}
-                className="w-8 h-8"
-              />
-              <div>
-                <a
-                  href="/admin/"
-                  aria-label="Back to Admin"
-                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
-                >
-                  ← Admin
-                </a>
-                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
-                  Publisher Events
-                </h1>
-              </div>
-              <a
-                href="/admin/publishers/"
-                aria-label="Go to Publisher Management"
-                className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
-              >
-                ← Publishers
-              </a>
-            </div>
-            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
-              {isLocalhost && (
-                <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
-                  Dev Mode
-                </div>
-              )}
-              {user && (
-                <div className="flex items-center gap-3 min-w-0">
-                  <span className="text-sm text-gray-600 dark:text-gray-300 break-all">{user.email}</span>
-                  <button
-                    onClick={logout}
-                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
-                  >
-                    Logout
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
-        </div>
-      </header>
+      <AdminHeader
+        title="Publisher Events"
+        siblingLink={{
+          href: '/admin/publishers/',
+          label: '← Publishers',
+          ariaLabel: 'Go to Publisher Management',
+        }}
+        user={user}
+        onLogout={logout}
+      />
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-10">

--- a/frontend/src/app/admin/publishers/page.tsx
+++ b/frontend/src/app/admin/publishers/page.tsx
@@ -12,6 +12,7 @@ import {
 import { useAdminAuth } from '@/hooks/useAdminAuth';
 import { logout } from '@/lib/auth';
 import { Modal } from '@/components/Modal';
+import { AdminHeader } from '@/components/admin/AdminHeader';
 import { PublisherForm } from './PublisherForm';
 import { PendingApplications } from './PendingApplications';
 
@@ -430,10 +431,6 @@ export default function PublishersPage() {
     p => p.applicationStatus !== 'pending',
   );
 
-  const isLocalhost =
-    typeof window !== 'undefined' &&
-    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
-
   const statusBadgeClass = (status: PublisherRecord['lastFetchStatus'] | undefined): string => {
     switch (status) {
       case 'ok':
@@ -535,67 +532,25 @@ export default function PublishersPage() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
-      {/* Header */}
-      <header className="bg-white dark:bg-gray-800 shadow-lg">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
-            <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
-              <img
-                src="/chq-calendar-icon-256.svg"
-                alt="Chautauqua Calendar Logo"
-                width={32}
-                height={32}
-                className="w-8 h-8"
-              />
-              <div>
-                <a
-                  href="/admin/"
-                  aria-label="Back to Admin"
-                  className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
-                >
-                  ← Admin
-                </a>
-                <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
-                  Publisher Management
-                </h1>
-              </div>
-              <a
-                href="/admin/publisher-events/"
-                aria-label="Go to Publisher Events"
-                className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
-              >
-                Publisher events →
-              </a>
-            </div>
-            <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
-              {isLocalhost && (
-                <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
-                  Dev Mode
-                </div>
-              )}
-              <div className="text-sm text-gray-600 dark:text-gray-300">
-                {nonPendingPublishers.length} publisher{nonPendingPublishers.length !== 1 ? 's' : ''}
-                {pending.length > 0 && (
-                  <span className="ml-1 text-amber-700 dark:text-amber-400">
-                    · {pending.length} pending
-                  </span>
-                )}
-              </div>
-              {user && (
-                <div className="flex items-center gap-3 min-w-0">
-                  <span className="text-sm text-gray-600 dark:text-gray-300 break-all">{user.email}</span>
-                  <button
-                    onClick={logout}
-                    className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
-                  >
-                    Logout
-                  </button>
-                </div>
-              )}
-            </div>
-          </div>
+      <AdminHeader
+        title="Publisher Management"
+        siblingLink={{
+          href: '/admin/publisher-events/',
+          label: 'Publisher events →',
+          ariaLabel: 'Go to Publisher Events',
+        }}
+        user={user}
+        onLogout={logout}
+      >
+        <div className="text-sm text-gray-600 dark:text-gray-300">
+          {nonPendingPublishers.length} publisher{nonPendingPublishers.length !== 1 ? 's' : ''}
+          {pending.length > 0 && (
+            <span className="ml-1 text-amber-700 dark:text-amber-400">
+              · {pending.length} pending
+            </span>
+          )}
         </div>
-      </header>
+      </AdminHeader>
 
       {/* Main Content */}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">

--- a/frontend/src/components/__tests__/AdminHeader.test.tsx
+++ b/frontend/src/components/__tests__/AdminHeader.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/preact';
+import { AdminHeader } from '../admin/AdminHeader';
+
+// Global cleanup runs from frontend/src/__tests__/setup.ts (afterEach hook).
+
+describe('AdminHeader', () => {
+  it('renders the title and the "← Admin" back link', () => {
+    render(<AdminHeader title="Feedback Management" user={null} onLogout={() => {}} />);
+    expect(screen.getByRole('heading', { name: 'Feedback Management' })).toBeInTheDocument();
+    const back = screen.getByRole('link', { name: 'Back to Admin' });
+    expect(back).toHaveAttribute('href', '/admin/');
+    expect(back).toHaveTextContent('← Admin');
+  });
+
+  it('renders the optional sibling link when provided', () => {
+    render(
+      <AdminHeader
+        title="Publishers Management"
+        siblingLink={{ href: '/admin/publisher-events/', label: 'Publisher events →' }}
+        user={null}
+        onLogout={() => {}}
+      />,
+    );
+    const link = screen.getByRole('link', { name: 'Publisher events →' });
+    expect(link).toHaveAttribute('href', '/admin/publisher-events/');
+  });
+
+  it('omits the sibling link when not provided', () => {
+    render(<AdminHeader title="Feedback Management" user={null} onLogout={() => {}} />);
+    // Only the "← Admin" link should be present.
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAccessibleName('Back to Admin');
+  });
+
+  it('uses ariaLabel override on the sibling link when provided', () => {
+    render(
+      <AdminHeader
+        title="Publisher Events"
+        siblingLink={{
+          href: '/admin/publishers/',
+          label: '← Publishers',
+          ariaLabel: 'Go to Publisher Management',
+        }}
+        user={null}
+        onLogout={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('link', { name: 'Go to Publisher Management' }),
+    ).toHaveAttribute('href', '/admin/publishers/');
+  });
+
+  it('renders the email and logout button when user is non-null', () => {
+    render(
+      <AdminHeader
+        title="Feedback Management"
+        user={{ email: 'someone@example.com' }}
+        onLogout={() => {}}
+      />,
+    );
+    expect(screen.getByText('someone@example.com')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Logout' })).toBeInTheDocument();
+  });
+
+  it('omits the email/logout block when user is null', () => {
+    render(<AdminHeader title="Feedback Management" user={null} onLogout={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'Logout' })).not.toBeInTheDocument();
+  });
+
+  it('calls onLogout when the logout button is clicked', () => {
+    const onLogout = vi.fn();
+    render(
+      <AdminHeader
+        title="Feedback Management"
+        user={{ email: 'a@b.com' }}
+        onLogout={onLogout}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Logout' }));
+    expect(onLogout).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders children between the dev-mode pill and the email/logout pair', () => {
+    render(
+      <AdminHeader
+        title="Feedback Management"
+        user={{ email: 'a@b.com' }}
+        onLogout={() => {}}
+      >
+        <div data-testid="extras">12 items</div>
+      </AdminHeader>,
+    );
+    const extras = screen.getByTestId('extras');
+    expect(extras).toBeInTheDocument();
+    // Extras must precede the email span in document order so the
+    // visual ordering (dev pill → extras → email → logout) is preserved.
+    const email = screen.getByText('a@b.com');
+    expect(extras.compareDocumentPosition(email) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('applies break-words (not break-all) to the email span', () => {
+    render(
+      <AdminHeader
+        title="Feedback Management"
+        user={{ email: 'someone@example.com' }}
+        onLogout={() => {}}
+      />,
+    );
+    const email = screen.getByText('someone@example.com');
+    expect(email.className).toMatch(/\bbreak-words\b/);
+    expect(email.className).not.toMatch(/\bbreak-all\b/);
+  });
+});

--- a/frontend/src/components/admin/AdminHeader.tsx
+++ b/frontend/src/components/admin/AdminHeader.tsx
@@ -2,10 +2,12 @@
 // publisher-events). The /admin/ index page has a different layout and
 // does NOT use this component.
 //
-// Layout matches the post-PR #119 markup verbatim so visual output is
-// unchanged: flex-wrap rows that collapse the right-side group below
-// the left side when there isn't enough room for a long signed-in email
-// to fit on one line.
+// Layout structure and Tailwind classes come from the post-PR #119
+// markup, with one deliberate change: the email span uses `break-words`
+// instead of `break-all` (less aggressive splitting on typical emails;
+// still prevents overflow). The flex-wrap rows collapse the right-side
+// group below the left side when there isn't enough horizontal room
+// for a long signed-in email to fit on one line.
 
 import type { ReactNode } from 'react';
 

--- a/frontend/src/components/admin/AdminHeader.tsx
+++ b/frontend/src/components/admin/AdminHeader.tsx
@@ -1,0 +1,104 @@
+// Shared top-of-page header for /admin/* sub-pages (feedback, publishers,
+// publisher-events). The /admin/ index page has a different layout and
+// does NOT use this component.
+//
+// Layout matches the post-PR #119 markup verbatim so visual output is
+// unchanged: flex-wrap rows that collapse the right-side group below
+// the left side when there isn't enough room for a long signed-in email
+// to fit on one line.
+
+import type { ReactNode } from 'react';
+
+export interface AdminHeaderSiblingLink {
+  href: string;
+  label: string;
+  ariaLabel?: string;
+}
+
+export interface AdminHeaderProps {
+  title: string;
+  // Optional inline link rendered to the right of the title block. Used
+  // for the publishers ↔ publisher-events cross-link added in PR #118.
+  siblingLink?: AdminHeaderSiblingLink;
+  // null = not logged in; the email/logout pair is hidden in that case.
+  user: { email: string } | null;
+  onLogout: () => void;
+  // Right-side extras rendered between the dev-mode pill and the
+  // email/logout pair — e.g. the publishers page's enabled/disabled
+  // counts or the feedback page's filtered-item count.
+  children?: ReactNode;
+}
+
+function isLocalhost(): boolean {
+  if (typeof window === 'undefined') return false;
+  const h = window.location.hostname;
+  return h === 'localhost' || h === '127.0.0.1';
+}
+
+export function AdminHeader({
+  title,
+  siblingLink,
+  user,
+  onLogout,
+  children,
+}: AdminHeaderProps) {
+  return (
+    <header className="bg-white dark:bg-gray-800 shadow-lg">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-3 py-4">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+            <img
+              src="/chq-calendar-icon-256.svg"
+              alt="Chautauqua Calendar Logo"
+              width={32}
+              height={32}
+              className="w-8 h-8"
+            />
+            <div>
+              <a
+                href="/admin/"
+                aria-label="Back to Admin"
+                className="text-xs text-gray-500 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400"
+              >
+                ← Admin
+              </a>
+              <h1 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white">
+                {title}
+              </h1>
+            </div>
+            {siblingLink && (
+              <a
+                href={siblingLink.href}
+                aria-label={siblingLink.ariaLabel ?? siblingLink.label}
+                className="hidden sm:inline-flex items-center px-3 py-1.5 text-sm font-medium text-blue-700 dark:text-blue-300 bg-blue-50 dark:bg-blue-900/30 hover:bg-blue-100 dark:hover:bg-blue-900/50 rounded-md"
+              >
+                {siblingLink.label}
+              </a>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
+            {isLocalhost() && (
+              <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
+                Dev Mode
+              </div>
+            )}
+            {children}
+            {user && (
+              <div className="flex items-center gap-3 min-w-0">
+                <span className="text-sm text-gray-600 dark:text-gray-300 break-words">
+                  {user.email}
+                </span>
+                <button
+                  onClick={onLogout}
+                  className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
+                >
+                  Logout
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/frontend/src/components/admin/AdminHeader.tsx
+++ b/frontend/src/components/admin/AdminHeader.tsx
@@ -29,11 +29,11 @@ export interface AdminHeaderProps {
   children?: ReactNode;
 }
 
-function isLocalhost(): boolean {
-  if (typeof window === 'undefined') return false;
-  const h = window.location.hostname;
-  return h === 'localhost' || h === '127.0.0.1';
-}
+// window.location.hostname doesn't change during a session, so resolve
+// once at module load instead of on every render.
+const IS_LOCALHOST =
+  typeof window !== 'undefined' &&
+  (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
 
 export function AdminHeader({
   title,
@@ -77,7 +77,7 @@ export function AdminHeader({
             )}
           </div>
           <div className="flex flex-wrap items-center justify-end gap-x-4 gap-y-2 ml-auto">
-            {isLocalhost() && (
+            {IS_LOCALHOST && (
               <div className="px-2 py-1 bg-yellow-100 text-yellow-800 text-xs font-medium rounded-md">
                 Dev Mode
               </div>
@@ -89,6 +89,7 @@ export function AdminHeader({
                   {user.email}
                 </span>
                 <button
+                  type="button"
                   onClick={onLogout}
                   className="px-3 py-1 bg-red-600 text-white rounded-md hover:bg-red-700 text-sm shrink-0"
                 >


### PR DESCRIPTION
## Summary

- Extract a shared `<AdminHeader>` component for the three admin sub-pages (feedback, publishers, publisher-events). PR #119 had to fan the long-email wrap fix across all three files; this collapses the boilerplate so the next tweak lands in one place.
- Internalize the dev-mode pill — both `publishers/page.tsx` and `publisher-events/page.tsx` had a local `isLocalhost` const used *only* for that pill (verified via grep), so both consts are removed. `feedback/page.tsx`'s in-callback `isLocalhost` (used for the localhost auth-bypass, not the pill) is untouched.
- Resolve the open `break-all` vs `break-words` preference on the email span in favor of `break-words` — nicer for typical emails; `min-w-0` on the wrapper plus `shrink-0` on the logout button still prevent layout blowout for pathological tokens.
- 329 frontend tests pass (was 320; +9 new in `AdminHeader.test.tsx`).
- Net diff: −173 lines of duplicated JSX, +254 (component + tests + small per-page wiring).

## API

```tsx
<AdminHeader
  title="Publisher Management"
  siblingLink={{ href: '/admin/publisher-events/', label: 'Publisher events →' }}
  user={user}
  onLogout={logout}
>
  {/* arbitrary right-side extras — counts, badges */}
</AdminHeader>
```

`siblingLink` is optional (feedback page omits it). `children` render between the dev-mode pill and the email/logout pair, mirroring today's visual order.

## Spec

`docs/plans/2026-05-11-admin-header-component-design.md` (committed in the design commit on this branch).

## Out of scope

- `/admin/` index header — different layout (stacks "Signed in as" below the title); intentionally untouched.
- `/admin/login/` — login screen has its own surrounding chrome.

## Test plan

- [x] `npm run validate` — clean (no new errors; pre-existing warnings unchanged)
- [x] `npm run build` — clean, all entry chunks built
- [x] `npx vitest run` — 38 files, 329 tests pass
- [ ] Manual on /admin/feedback — long email wraps; filtered count visible; logout works
- [ ] Manual on /admin/publishers — long email wraps; counts visible; sibling link to publisher-events works
- [ ] Manual on /admin/publisher-events — long email wraps; sibling link to publishers works

🤖 Generated with [Claude Code](https://claude.com/claude-code)