### PR TITLE
chore(publish): drop (import.meta as any) cast on VITE_API_URL reads

### DIFF
--- a/frontend/src/app/publish/apply/page.tsx
+++ b/frontend/src/app/publish/apply/page.tsx
@@ -45,7 +45,7 @@ type Status =
   | { kind: 'sent'; email: string }
   | { kind: 'error'; message: string; field?: string };
 
-const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 // Read directly via `import.meta.env.VITE_RECAPTCHA_SITE_KEY` (no cast or
 // optional chain) so vitest.config.ts's compile-time `define` for that exact
 // expression substitutes deterministically. Empty string is treated as

--- a/frontend/src/app/publish/email-change/cancel/page.tsx
+++ b/frontend/src/app/publish/email-change/cancel/page.tsx
@@ -9,7 +9,7 @@
 
 import { useEffect, useState } from 'react';
 
-const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
 type Status =
   | { kind: 'pending' }

--- a/frontend/src/app/publish/email-change/verify/page.tsx
+++ b/frontend/src/app/publish/email-change/verify/page.tsx
@@ -13,7 +13,7 @@
 
 import { useEffect, useState } from 'react';
 
-const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
 type Status =
   | { kind: 'pending' }

--- a/frontend/src/app/publish/login/page.tsx
+++ b/frontend/src/app/publish/login/page.tsx
@@ -22,7 +22,7 @@ type Status =
   | { kind: 'sent' }
   | { kind: 'error'; message: string };
 
-const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
 // Window during which the submit button stays disabled after a successful
 // send, to discourage spamming the SES quota. The backend rate-limits to

--- a/frontend/src/app/publish/verify/page.tsx
+++ b/frontend/src/app/publish/verify/page.tsx
@@ -15,7 +15,7 @@ type Status =
   | { kind: 'ok'; email: string; isApply: boolean }
   | { kind: 'error'; message: string };
 
-const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
 export default function PublishVerifyPage() {
   const [status, setStatus] = useState<Status>({ kind: 'pending' });

--- a/frontend/src/lib/publisherStatusApi.ts
+++ b/frontend/src/lib/publisherStatusApi.ts
@@ -35,7 +35,7 @@ export interface PublisherStatusRecord {
   notificationsEnabled?: boolean;
 }
 
-const API_BASE = (import.meta as any).env?.VITE_API_URL ?? '';
+const API_BASE = import.meta.env.VITE_API_URL ?? '';
 
 export class PublisherStatusError extends Error {
   constructor(


### PR DESCRIPTION
## Summary
- `vite-env.d.ts` already declares `VITE_API_URL` as `string`, so the `(import.meta as any).env?.VITE_API_URL ?? ''` cast + optional-chain is unnecessary noise.
- Six call sites in the publisher portal were on the old cast pattern while `RECAPTCHA_SITE_KEY` next door (in `apply/page.tsx`) had already moved to the clean form. Align all six.
- Closes the cosmetic asymmetry flagged in the publisher-observability follow-ups.

## Safety: `define` interaction
- `VITE_API_URL` is intentionally NOT in `vitest.config.ts`'s `TEST_ENV_DEFINES` (only `VITE_RECAPTCHA_SITE_KEY` is). The comment in that file warns that adding more entries silently breaks `vi.stubEnv` for those vars — this change keeps `VITE_API_URL` runtime-readable as before.
- No tests stub `VITE_API_URL` via `vi.stubEnv` (grep confirmed), so there's no test-time dependency to preserve.

## Test plan
- [x] `npm run validate` passes (type-check + lint)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)