### PR TITLE
chore: clear ESLint warnings + plans for backend lint + docs cleanup

### DIFF
--- a/docs/plans/2026-05-12-backend-lint-and-cleanup-plan.md
+++ b/docs/plans/2026-05-12-backend-lint-and-cleanup-plan.md
@@ -40,16 +40,18 @@ DynamoDB DocumentClient. Frontend lint stack (already proven on the same repo):
 
 **Files:**
 - Modify: `backend/package.json`
-- Create: `backend/.eslintrc.cjs` (or `backend/eslint.config.mjs` if matching
-  the frontend's flat-config style — check what `frontend/` uses first and
-  match it; consistency across workspaces beats theoretical purity).
+- Create: `backend/eslint.config.mjs` (flat-config; matches the frontend's
+  `frontend/eslint.config.mjs`. Don't introduce a legacy `.eslintrc.*`
+  alongside the existing flat config — one style per repo).
 - Create: `backend/.eslintignore` (entries for `dist/`, `coverage/`,
-  `node_modules/`, and any other generated paths)
+  `node_modules/`, and any other generated paths). With flat config the
+  ignore patterns can live inside `eslint.config.mjs` instead; either
+  shape is fine, but pick one and don't have both.
 
 **Steps:**
-1. Inspect `frontend/eslint.config.*` (or `.eslintrc.*`) for the version of
-   eslint and `@typescript-eslint/*` it uses. Match the major version. The
-   goal is one ESLint version in the repo, not two.
+1. Inspect `frontend/eslint.config.mjs` for the version of eslint and
+   `@typescript-eslint/*` it uses. Match the major version. The goal is
+   one ESLint version in the repo, not two.
 2. Add eslint + typescript-eslint deps to `backend/package.json` under
    `devDependencies`. Pin to the same major as frontend.
 3. Author the backend config:
@@ -154,6 +156,17 @@ prod code — it's a losing battle and adds noise without value.
 
 **Files:**
 - Modify: `.github/workflows/build-and-test.yml`
+
+> ⚠️ **Permission note for automated agents:** GitHub blocks the default
+> `GITHUB_TOKEN` (and most installed GitHub Apps, including Claude Code)
+> from modifying files under `.github/workflows/` — this step usually
+> requires a human-authored commit, or a personal access token with the
+> `workflow` scope wired through `actions/checkout`. If the agent's commit
+> is rejected with `refusing to allow a GitHub App to create or update
+> workflow .github/workflows/build-and-test.yml`, hand off this task to a
+> human collaborator and proceed with the rest of the plan; the lint
+> script and config can ship without the CI wiring and someone can land
+> the workflow change in a follow-up commit.
 
 **Steps:**
 1. The workflow already runs frontend `npm run validate` (type-check + lint).

--- a/docs/plans/2026-05-12-backend-lint-and-cleanup-plan.md
+++ b/docs/plans/2026-05-12-backend-lint-and-cleanup-plan.md
@@ -1,0 +1,259 @@
+# Backend ESLint + Code Cleanup Plan
+
+> **For agentic workers:** Self-contained plan for a fresh session. Use
+> `superpowers:executing-plans` or `superpowers:subagent-driven-development` to
+> work through phases. Tasks within a phase that don't share files can be done
+> in parallel; phases themselves are sequential because later ones consume
+> outputs from earlier ones.
+
+**Goal:** Bring the backend up to the same lint/type discipline the frontend
+already enforces, then fix anything the new lint pass surfaces. Wire it into CI
+so regressions can't ship.
+
+**Why this exists:** As of 2026-05-12 the backend has TypeScript, jest tests,
+and a multi-target esbuild bundle, but no ESLint config and no `lint` script.
+`npm run lint --workspace=chautauqua-backend` errors with "Missing script". The
+frontend cleanup PR (#123) closed the last two frontend ESLint warnings; the
+backend has never had a pass run against it.
+
+**Tech stack:** Node 22 / TypeScript 5 / jest / esbuild bundler / AWS SDK v3 /
+DynamoDB DocumentClient. Frontend lint stack (already proven on the same repo):
+`eslint`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`.
+
+---
+
+## Out of Scope
+
+- **Migrating jest → vitest.** Different initiative; mention only if it
+  happens to come up while reading test files.
+- **Adding pre-commit hooks.** Could be a follow-up, but CI enforcement is
+  enough for first pass.
+- **Adding ESLint to `tools/publisher-format/`.** That package builds the
+  `dist/refs` schemas the backend consumes. Same approach would work but
+  belongs in its own PR — it changes a different `package.json`.
+
+---
+
+## Phase 1: Install + configure ESLint
+
+### Task 1A: Add dependencies + config
+
+**Files:**
+- Modify: `backend/package.json`
+- Create: `backend/.eslintrc.cjs` (or `backend/eslint.config.mjs` if matching
+  the frontend's flat-config style — check what `frontend/` uses first and
+  match it; consistency across workspaces beats theoretical purity).
+- Create: `backend/.eslintignore` (entries for `dist/`, `coverage/`,
+  `node_modules/`, and any other generated paths)
+
+**Steps:**
+1. Inspect `frontend/eslint.config.*` (or `.eslintrc.*`) for the version of
+   eslint and `@typescript-eslint/*` it uses. Match the major version. The
+   goal is one ESLint version in the repo, not two.
+2. Add eslint + typescript-eslint deps to `backend/package.json` under
+   `devDependencies`. Pin to the same major as frontend.
+3. Author the backend config:
+   - Extends: `eslint:recommended`, `plugin:@typescript-eslint/recommended`
+     (or the flat-config equivalents)
+   - `parserOptions.project: ['./tsconfig.json']`
+   - Override rules for test files (`**/__tests__/**`) to allow `as any` and
+     looser unused-var rules — backend tests use type-erasing casts heavily
+     in mock setup; mirror what the frontend's lint config does for tests
+     before reinventing.
+4. Add scripts to `backend/package.json`:
+   ```json
+   "lint": "eslint src/",
+   "validate": "tsc --noEmit && npm run lint"
+   ```
+5. Run `npm install` at the repo root (workspaces) to update the lockfile.
+6. Sanity-check: `npm run lint --workspace=chautauqua-backend` exits with a
+   real lint result (success or warnings), not "Missing script".
+
+**Verification:**
+- `npm run lint --workspace=chautauqua-backend` runs to completion
+- No new dependencies in `frontend/` (deps belong in the workspace that uses them)
+- Lockfile committed
+
+### Task 1B: Capture baseline + categorize findings
+
+**Files:** none — investigation only
+
+**Steps:**
+1. Run `npm run lint --workspace=chautauqua-backend 2>&1 | tee /tmp/backend-lint.log`
+2. Categorize hits into buckets:
+   - **Real bugs** (e.g., `no-undef`, shadowed variables, unused imports
+     hiding broken refactors) — fix in Phase 2
+   - **Style/consistency** (e.g., `prefer-const`, `no-unused-vars`) — fix in
+     Phase 2
+   - **Type-safety** (e.g., `@typescript-eslint/no-explicit-any`) — may need
+     a rule-level decision; document each in the plan as you fix
+   - **Genuinely-noisy rules** (e.g., `no-non-null-assertion` if it triggers
+     constantly on `process.env.X!` patterns) — consider disabling the rule
+     globally rather than `// eslint-disable-next-line`ing dozens of sites
+3. Write the categorized count back into this file's "Baseline" section
+   below, so the next executor knows what they're walking into.
+
+**Baseline** (fill in after running):
+- Total problems: TBD
+- Errors: TBD
+- Warnings: TBD
+- Top 5 rules by hit count: TBD
+
+---
+
+## Phase 2: Fix what lint surfaces
+
+Sequential because each fix may touch shared files, but tasks can be split by
+subdirectory if hit count is high.
+
+### Task 2A: Auto-fix the trivially mechanical
+
+**Files:** whatever `eslint --fix` touches
+
+**Steps:**
+1. Run `npm run lint --workspace=chautauqua-backend -- --fix`
+2. Review the diff carefully — auto-fix is reasonable for `prefer-const`,
+   unused-import removal, and quote/semi normalization, but NOT for
+   `no-explicit-any` and similar judgment-call rules.
+3. Commit auto-fixes in a single commit:
+   `chore(backend): eslint --fix mechanical cleanups`
+4. Run the test suite (`npm test --workspace=chautauqua-backend`) to verify
+   nothing broke.
+
+### Task 2B: Manual cleanups by category
+
+For each remaining hit, decide:
+- **Fix** — edit the code (preferred for real bugs and style nits)
+- **Suppress at site** with `// eslint-disable-next-line <rule>` and a
+  comment explaining why — only when the rule is wrong for that specific
+  context (e.g., a deliberately-broad `any` in a JSON parser)
+- **Disable the rule globally** — only when the rule fires >20 times across
+  the codebase and is genuinely not catching real issues. Add a justification
+  comment in the config explaining the decision.
+
+**Files:** TBD based on Phase 1B output
+
+**Commit shape:** one commit per category if they're cleanly separable
+(e.g., `chore(backend): fix no-unused-vars across handlers`,
+`chore(backend): replace as-any in registry service with typed shapes`).
+This keeps reverts narrow if review surfaces a regression.
+
+### Task 2C: Test files
+
+Backend tests almost certainly have `as any` casts for mock setup and a few
+`@ts-ignore`s for shimming DDB types. The frontend takes the position that
+tests can be looser than prod code; mirror that in the eslint override for
+`backend/src/__tests__/**`. Don't try to lint tests to the same standard as
+prod code — it's a losing battle and adds noise without value.
+
+---
+
+## Phase 3: Wire into CI
+
+### Task 3A: Add backend lint to the build-and-test workflow
+
+**Files:**
+- Modify: `.github/workflows/build-and-test.yml`
+
+**Steps:**
+1. The workflow already runs frontend `npm run validate` (type-check + lint).
+   Add an equivalent step for the backend workspace.
+2. Use the existing `test-backend` job matrix as the host — don't create a
+   new job, just add a `Run backend lint` step before or after the existing
+   test step. Lint failures should block the same way test failures do.
+3. Verify in CI before merging by intentionally introducing a lint error on
+   the PR branch and confirming the check fails.
+
+**Verification:**
+- The build-and-test workflow now runs `npm run lint --workspace=chautauqua-backend`
+- An intentional lint error fails the PR check
+- Removing the intentional error restores green
+
+### Task 3B: Document the lint expectation
+
+**Files:**
+- Modify: `CLAUDE.md` (project root)
+
+**Steps:**
+1. The verification checklist section says "Run this after every set of
+   changes" and lists `npm run validate` (frontend only). Update it to
+   include the backend equivalent.
+2. Mention that the backend now has its own ESLint config and that new code
+   should pass it before being committed.
+
+---
+
+## Phase 4: Non-lint cleanup (opportunistic)
+
+These don't need ESLint to surface but are worth doing while you're already
+in the backend. Skip any that turn out to be noisy or risky — none are
+blocking.
+
+### Task 4A: Dead-code scan
+
+**Tooling:** `ts-prune` or `knip` (whichever the executor prefers — both
+identify unused exports). One-shot install, run, capture output, evaluate.
+
+**Steps:**
+1. `npx ts-prune --project backend/tsconfig.json | tee /tmp/backend-deadcode.log`
+2. Categorize each hit:
+   - **True dead code** — delete it
+   - **Used only by tests** — keep but mark with `// @internal` in a
+     doc-comment or move to a `__test-helpers__` directory if there are
+     several
+   - **Public API surface (e.g., handler entries)** — false positive,
+     ignore
+3. Commit deletions in one commit per logical group.
+
+### Task 4B: Comment cleanup
+
+Backend has accumulated some long comment blocks that explain code that has
+since been simplified, plus a few `// removed` / `// TODO` markers.
+
+**Steps:**
+1. Grep: `grep -rn 'TODO\|FIXME\|// removed\|// REMOVED' backend/src --include='*.ts'`
+2. For each hit, either resolve the TODO, file a GitHub issue and remove
+   the comment, or leave it if it's a genuine open question.
+3. Per `CLAUDE.md` (root): "Default to writing no comments. Only add one
+   when the WHY is non-obvious." Drop comments that just narrate WHAT the
+   code does.
+
+### Task 4C: `dist/` cleanliness
+
+`backend/dist/` is committed to git in this repo (it's the bundled Lambda
+output). After landing big refactors there's sometimes stale `dist/refs/`
+content. Confirm `dist/` regenerates byte-for-byte the same on `npm run
+build:prod` from a clean tree before declaring this task done.
+
+**Verification:**
+- `rm -rf backend/dist && npm run build:prod --workspace=chautauqua-backend`
+  produces the same content as git HEAD (modulo any timestamp embeds)
+
+---
+
+## Phase 5: Open the PR
+
+Use the same shape as PRs #116, #122, #123:
+
+- One feature branch per phase if hit counts are high
+- One PR per branch
+- PR body: list each commit's purpose, link Phase 1B's baseline output, note
+  any rules globally disabled with justification
+
+If Phase 2 produces a very large diff, split it into review-sized chunks
+rather than one mega-PR. Each chunk should leave `npm run lint` and
+`npm test` green.
+
+---
+
+## Self-review
+
+Before opening the PR(s):
+- [ ] `npm run lint --workspace=chautauqua-backend` exits 0 (or with only
+      deliberately-allowed warnings)
+- [ ] `npm test --workspace=chautauqua-backend` green
+- [ ] CI workflow change tested by intentionally breaking lint on the PR
+      branch
+- [ ] No new ESLint major version diverges from the frontend's
+- [ ] No comments left in code that reference "PR #N" — those belong in PR
+      descriptions, not source files

--- a/docs/plans/2026-05-12-backend-lint-and-cleanup-plan.md
+++ b/docs/plans/2026-05-12-backend-lint-and-cleanup-plan.md
@@ -16,7 +16,9 @@ and a multi-target esbuild bundle, but no ESLint config and no `lint` script.
 frontend cleanup PR (#123) closed the last two frontend ESLint warnings; the
 backend has never had a pass run against it.
 
-**Tech stack:** Node 22 / TypeScript 5 / jest / esbuild bundler / AWS SDK v3 /
+**Tech stack:** Node 24 (per `backend/package.json` `engines.node: >=24.0.0`
+and esbuild `--target=node24`; the build-and-test matrix runs 24 and 25) /
+TypeScript 5 / jest / esbuild bundler / AWS SDK v3 /
 DynamoDB DocumentClient. Frontend lint stack (already proven on the same repo):
 `eslint`, `@typescript-eslint/eslint-plugin`, `@typescript-eslint/parser`.
 

--- a/docs/plans/2026-05-12-docs-cleanup-plan.md
+++ b/docs/plans/2026-05-12-docs-cleanup-plan.md
@@ -1,0 +1,258 @@
+# Docs Cleanup Plan
+
+> **For agentic workers:** Self-contained plan for a fresh session. Use
+> `superpowers:executing-plans` to work through phases. Most tasks are
+> reversible (move/edit/delete), but some touch `CLAUDE.md` which agents read
+> at session start — get those right.
+
+**Goal:** Bring `docs/` from "29 shipped plans + a stale top-level optimization
+doc + scattered architecture refs" down to "current state docs + archived
+historical plans, with `CLAUDE.md` pointing at things that still exist."
+
+**Why this exists:** As of 2026-05-12:
+- `docs/OPTIMIZATION_PLAN.md` (928 lines) describes a Next.js 15 + React 19
+  codebase. The repo has since migrated to Vite + Preact. `CLAUDE.md` still
+  treats this file as the source-of-truth for "what to work on," which is
+  now actively misleading for any agent starting fresh.
+- `docs/plans/` holds 29 plan docs (≈14,500 lines) — all but one or two
+  belong to shipped initiatives. None are archived.
+- Several top-level docs (`API_INTEGRATION_DESIGN.md`, `DESIGN.md`,
+  `DEVELOPMENT_HISTORY.md`) predate the publisher portal entirely. Some
+  describe an architecture that no longer exists.
+
+**Tech stack:** Markdown only. No code changes; no test impact.
+
+---
+
+## Out of Scope
+
+- **`docs/runbooks/`** — operational, keep current. If something is stale,
+  fix it in place; don't delete.
+- **`docs/publisher/`** — public-facing publisher docs served at
+  `/publish/docs/`. Treat as live content. Out of scope unless something is
+  factually wrong, in which case fix in place.
+- **Memory files** at `~/.claude/projects/-Users-bernard-src-chq-chq-calendar/`.
+  They're cross-session state, not project docs.
+- **Authoring NEW architecture docs.** This plan is about consolidating
+  what's there, not generating new prose.
+
+---
+
+## Phase 1: Audit current state
+
+### Task 1A: Inventory top-level `docs/`
+
+**Files:** read-only — investigation
+
+**Steps:**
+1. For each file in `docs/` (top level), open and skim:
+   - `API_INTEGRATION_DESIGN.md` (450L)
+   - `CACHING_ARCHITECTURE.md` (350L)
+   - `coverage.md` (69L)
+   - `DEPLOYMENT.md` (261L)
+   - `DESIGN.md` (721L)
+   - `DEVELOPMENT_HISTORY.md` (413L)
+   - `DEVELOPMENT_WORKFLOW.md` (194L)
+   - `OAuth-Setup.md` (61L)
+   - `OPTIMIZATION_PLAN.md` (928L)
+   - `YEAR_CONFIGURATION.md` (156L)
+2. For each, mark one of:
+   - **Current** — keep, no edits
+   - **Needs refresh** — content is mostly right but references stale
+     tooling/paths/decisions
+   - **Historical** — describes a past architecture that's been replaced;
+     move to an `archive/` subdirectory rather than delete (git history is
+     authoritative; archived docs add searchable context)
+   - **Delete** — duplicated elsewhere or actively misleading
+3. Capture the categorization in this file's "Audit Results" section below.
+   The next executor needs the verdicts to act on.
+
+**Known starting point:** `OPTIMIZATION_PLAN.md` is "Historical" — it
+describes the pre-Vite/Preact migration and is referenced by `CLAUDE.md` as
+if it were active. Both the doc and the reference need attention.
+
+**Audit Results** (fill in during the task):
+- TBD
+
+### Task 1B: Inventory `docs/plans/`
+
+29 files. Most map to a PR that's already shipped. Don't read every line of
+every file — read the first 30 lines for status / scope, then check git log
+for whether the plan's PR shipped.
+
+**Steps:**
+1. For each plan, capture:
+   - Was the work it describes shipped? (Check git log for matching PR /
+     commit references in the plan doc; memory files at
+     `~/.claude/projects/-Users-bernard-src-chq-chq-calendar/memory/` cover
+     most of these.)
+   - Is it actionable as a future reference? (Some shipped plans contain
+     architectural notes worth keeping; some are pure execution scripts
+     that have no further value.)
+2. Categorize as:
+   - **Archive** — shipped, no ongoing reference value; move to
+     `docs/plans/archive/`
+   - **Reference** — shipped but contains useful architectural reasoning;
+     keep in `docs/plans/` and prepend a status line:
+     `> **Status:** Shipped via PR #N (<commit>). Kept for architectural context.`
+   - **Active** — not yet shipped or in active use; keep as-is
+3. The active plans from PR #123's session (as of 2026-05-12) are:
+   - `2026-05-12-backend-lint-and-cleanup-plan.md` (this PR's sibling)
+   - This file
+   - Possibly `2026-05-08-close-out-backlog-plan.md` if any tasks remain
+     (check first — most likely fully shipped)
+
+### Task 1C: Inventory subdirectories
+
+`docs/superpowers/` has `plans/` and `specs/` mirroring `docs/plans/`'s shape
+but only contains the publisher-observability pair. Decide:
+- **Consolidate into `docs/plans/`** — one location for everything. Recommended.
+- **Keep separate** — only worth it if the executor expects more
+  `superpowers/`-tagged content to land there. As of 2026-05-12 nothing
+  suggests that's the trajectory.
+
+`docs/runbooks/` and `docs/publisher/` are out of scope per the top of this
+plan.
+
+---
+
+## Phase 2: Restructure
+
+### Task 2A: Create `docs/plans/archive/`
+
+**Files:**
+- Create: `docs/plans/archive/` (directory; git tracks it via the files
+  moved into it)
+- Optional: `docs/plans/archive/README.md` — one short paragraph explaining
+  the directory's purpose (shipped plans kept for searchability)
+
+### Task 2B: Move "Archive" plans
+
+For each plan classified Archive in Phase 1B:
+```bash
+git mv docs/plans/<plan-name>.md docs/plans/archive/<plan-name>.md
+```
+
+`git mv` preserves history. Don't `mv` then `git add` — use `git mv` so
+`git log --follow` works after the move.
+
+### Task 2C: Annotate "Reference" plans
+
+For each plan classified Reference in Phase 1B, edit the file's top to add
+a status banner:
+
+```markdown
+> **Status:** Shipped via PR #<N> (commit `<sha>`). Kept for architectural
+> context — the reasoning here informed later decisions and is worth reading
+> alongside the code, not as a TODO list.
+```
+
+The banner goes at the very top of the file, above the H1. Don't move the
+file — these stay in `docs/plans/`.
+
+### Task 2D: Refresh top-level docs
+
+For each top-level doc classified "Needs refresh" in Phase 1A:
+1. Update tooling references (Next.js → Vite + Preact where applicable).
+2. Update file paths if any reference a path that's moved.
+3. Drop sections that describe architecture that no longer exists; do NOT
+   try to rewrite the whole doc into a new shape — that's a separate
+   initiative.
+
+For each classified "Historical":
+- Move to `docs/archive/` (create the directory if it doesn't exist).
+- Use `git mv` for history preservation.
+
+---
+
+## Phase 3: Fix the references in `CLAUDE.md`
+
+`CLAUDE.md` (project root) currently does several things that become wrong
+after this cleanup:
+
+1. **References `docs/OPTIMIZATION_PLAN.md` as the source-of-truth for
+   "what to work on."** The phrases "MANDATORY FIRST ACTION", "Read the
+   optimization plan", and "If asked to 'continue optimizing'... the answer
+   is ALWAYS in `docs/OPTIMIZATION_PLAN.md`" all assume that plan is live.
+   After Phase 2D this plan will either be archived or refreshed; either
+   way `CLAUDE.md` needs to stop demanding agents read it as the first
+   action of every session.
+2. **Describes a phase/task structure** that no longer reflects what the
+   project is actively working on. The Active Optimization Plan section
+   describes 7 phases that are largely complete or moot.
+3. **Other doc references** — grep `CLAUDE.md` for `docs/` and verify each
+   path still exists after Phase 2.
+
+### Task 3A: Decide what should replace "MANDATORY FIRST ACTION"
+
+Options for the new shape of `CLAUDE.md`'s opening:
+
+- **A — Drop the mandatory action entirely.** Let agents start from the
+  project overview and act on the conversation. Honest reflection of how
+  work actually happens post-optimization.
+- **B — Point at a generic status doc** like `docs/STATUS.md` (would need
+  to be created) that's lightweight and updated when initiatives finish.
+- **C — Point at memory files** which already index recently-shipped work
+  and known-open follow-ups. Lowest-maintenance.
+
+Recommendation: **A**. The optimization initiative is over; the project is
+in steady-state delivery mode. Mandating a daily read of any file invites
+exactly the kind of stale-pointer problem this cleanup is addressing.
+
+### Task 3B: Rewrite `CLAUDE.md`'s opening sections
+
+**Files:**
+- Modify: `CLAUDE.md` (root)
+
+**Steps:**
+1. Replace the "MANDATORY FIRST ACTION" block with a short "Project status"
+   summary: where the project is, what's stable, what's actively changing.
+   Keep it concise — agents will read it on every session start.
+2. Remove or shrink the "Active Optimization Plan" section. If a few tasks
+   from it are still genuinely actionable, list those tasks inline; don't
+   point at the plan doc.
+3. Grep `CLAUDE.md` for any other `docs/` paths and verify each. Fix or
+   delete each broken reference.
+
+### Task 3C: Verify
+
+After all of Phase 3:
+- A fresh agent reading `CLAUDE.md` top-to-bottom doesn't see any broken
+  doc references
+- The mandatory `cat docs/OPTIMIZATION_PLAN.md` step is gone (or, if kept,
+  the file actually reflects current reality)
+- Section ordering still makes sense — opening with "Project overview",
+  then "Code patterns", then "Common pitfalls" is a natural shape
+
+---
+
+## Phase 4: Open the PR
+
+One PR, one logical change ("docs: reorganize and refresh"). Even though
+this touches many files, every change is mechanical or copy-edit; reviewers
+can scan the diff in one pass.
+
+**Branch:** `chore/docs-cleanup`
+
+**PR body should list:**
+- Plans archived (count + linked directory)
+- Plans annotated (count)
+- Top-level docs refreshed (list each)
+- `CLAUDE.md` opening rewritten — link to the diff line range
+- Any subdirectory consolidation
+
+---
+
+## Self-review
+
+Before opening the PR:
+- [ ] `git log --follow` works on at least one moved plan (proves `git mv`
+      was used)
+- [ ] `grep -rn 'docs/' CLAUDE.md` returns only paths that still exist
+- [ ] No agent-facing "mandatory first action" left in `CLAUDE.md` unless
+      its target is verified current
+- [ ] The new `CLAUDE.md` reads naturally to a fresh agent — try imagining
+      what an agent starting a brand-new session would understand from it
+- [ ] No content was *lost* — archived material is still in the repo, just
+      moved. Anyone running `git log --all --oneline -- docs/plans/<file>`
+      can find any plan that was moved

--- a/docs/plans/2026-05-12-docs-cleanup-plan.md
+++ b/docs/plans/2026-05-12-docs-cleanup-plan.md
@@ -31,8 +31,10 @@ historical plans, with `CLAUDE.md` pointing at things that still exist."
 - **`docs/publisher/`** — public-facing publisher docs served at
   `/publish/docs/`. Treat as live content. Out of scope unless something is
   factually wrong, in which case fix in place.
-- **Memory files** at `~/.claude/projects/-Users-bernard-src-chq-chq-calendar/`.
-  They're cross-session state, not project docs.
+- **Claude Code memory files.** The agent's persistent memory directory is
+  per-user, per-machine (e.g. `~/.claude/projects/<project-dir-slug>/` —
+  the exact slug depends on each contributor's local checkout path). It's
+  cross-session state outside the repo, not project docs.
 - **Authoring NEW architecture docs.** This plan is about consolidating
   what's there, not generating new prose.
 
@@ -83,9 +85,10 @@ for whether the plan's PR shipped.
 **Steps:**
 1. For each plan, capture:
    - Was the work it describes shipped? (Check git log for matching PR /
-     commit references in the plan doc; memory files at
-     `~/.claude/projects/-Users-bernard-src-chq-chq-calendar/memory/` cover
-     most of these.)
+     commit references in the plan doc. If running Claude Code with
+     existing memory for this project, the agent's local memory directory
+     also covers most of these; otherwise rely on `git log --grep` and PR
+     history.)
    - Is it actionable as a future reference? (Some shipped plans contain
      architectural notes worth keeping; some are pure execution scripts
      that have no further value.)

--- a/frontend/src/__tests__/integration/adminPublishers.test.tsx
+++ b/frontend/src/__tests__/integration/adminPublishers.test.tsx
@@ -16,7 +16,7 @@
  *  - Last-fetch detail row renders status badge + lastFetchMessage
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { fireEvent, screen, waitFor, within } from '@testing-library/preact';
 import AdminPublishersPage from '@/app/admin/publishers/page';
 import { renderPage, installNavigationStub, type NavigationStub } from './helpers/render';

--- a/frontend/src/__tests__/lib/publisherStatusApi.test.ts
+++ b/frontend/src/__tests__/lib/publisherStatusApi.test.ts
@@ -5,7 +5,7 @@
 // for each function — mirroring the coverage pattern used for adminPublisherApi.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { getPublisherRuns, getPublisherEvents, PublisherStatusError } from '@/lib/publisherStatusApi';
+import { getPublisherRuns, getPublisherEvents } from '@/lib/publisherStatusApi';
 
 // ---------------------------------------------------------------------------
 // Auth client mock — getPublisherJwt always returns a token; clearPublisherSession

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_RECAPTCHA_SITE_KEY: string;
+  readonly VITE_ENABLE_PUBLISHER_FEEDS: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

Two unrelated cleanups bundled into one merge:

### 1. Frontend ESLint warnings cleared (commit `7d020f8`)
- `adminPublishers.test.tsx:19` — drop unused `beforeEach` from the vitest import. Only `afterEach` is used.
- `publisherStatusApi.test.ts:8` — drop unused `PublisherStatusError` import. Referenced only as the string `'PublisherStatusError'` in `err.name` assertions, never as a value or type.
- `vite-env.d.ts` — add `VITE_ENABLE_PUBLISHER_FEEDS` alongside the other two declared VITE_* vars. The variable is read at `useEventData.ts:69` and stubbed via `vi.stubEnv` in tests; brings typing in line with the existing convention.

`npm run lint` now reports zero warnings.

### 2. Plans for follow-up cleanup work (commit `7f3fc9f`)
Two self-contained plan docs added to `docs/plans/` for a future session to pick up:

- **`2026-05-12-backend-lint-and-cleanup-plan.md`** — install + configure ESLint for the backend workspace (currently no `lint` script and no eslint config), fix what it surfaces, wire into CI.
- **`2026-05-12-docs-cleanup-plan.md`** — audit and reorganize `docs/`. Biggest single fix: remove the \"MANDATORY FIRST ACTION → cat OPTIMIZATION_PLAN.md\" block in `CLAUDE.md`, which points at a doc describing a Next.js/React 19 architecture the project no longer has.

Both plans include out-of-scope sections, verification criteria, and enough context for a fresh agent session to execute them without re-discovery.

## Scope notes
- No prod runtime code is touched. The `String(import.meta.env.VITE_ENABLE_PUBLISHER_FEEDS) === 'true'` defensive pattern at `useEventData.ts:69` is intentionally left as-is.
- Backend ESLint setup is deliberately NOT in this PR — it's a toolchain addition. The new plan doc captures how to do it cleanly.

## Test plan
- [x] `npm run validate` (frontend) — zero warnings, zero errors
- [x] `npm run build` (frontend) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)