### PR TITLE
chore(docs): two follow-ups from PR #125 review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,8 @@ chq-calendar/                    # Root (npm workspaces)
 │   ├── plans/                   # Active plan docs (most are in archive/)
 │   ├── runbooks/                # Operational runbooks
 │   ├── publisher/               # Publisher-facing docs (live content)
-│   └── archive/                 # Historical docs kept for searchability
+│   ├── archive/                 # Historical docs kept for searchability
+│   └── ...                      # Plus DEPLOYMENT.md, DEVELOPMENT_WORKFLOW.md, coverage.md, etc.
 ├── scripts/                     # Deployment scripts
 ├── utils/                       # Dev utilities
 └── docker-compose.yml           # Local dev environment

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -169,7 +169,13 @@ entry in `src/entries/`, and registering it in
 
 ### State Management
 
-**React Hooks with localStorage Persistence:**
+**Hooks with localStorage Persistence:**
+
+The code below uses `useState` and friends imported from `'react'` — a
+deliberate convention: `@preact/preset-vite` aliases `'react'` and
+`'react-dom'` to `'preact/compat'` at build time, which installs the
+`onChange` → `onInput` event normalization that React-style form
+components rely on. See `CLAUDE.md` ("Imports") for the full reasoning.
 ```typescript
 // Main state structure with localStorage integration
 const [events, setEvents] = useState<ChautauquaEvent[]>([]);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -157,7 +157,7 @@ entry in `src/entries/`, and registering it in
 2. **Client-Side Performance**
    - All filtering happens client-side for instant results
    - Memoized components to prevent unnecessary re-renders
-   - Efficient state management with React hooks and localStorage persistence
+   - Efficient state management with hooks and localStorage persistence
    - FIFO recent items tracking (10 most recent, display 3+ as pills)
 
 3. **User Experience**
@@ -176,6 +176,7 @@ deliberate convention: `@preact/preset-vite` aliases `'react'` and
 `'react-dom'` to `'preact/compat'` at build time, which installs the
 `onChange` → `onInput` event normalization that React-style form
 components rely on. See `CLAUDE.md` ("Imports") for the full reasoning.
+
 ```typescript
 // Main state structure with localStorage integration
 const [events, setEvents] = useState<ChautauquaEvent[]>([]);


### PR DESCRIPTION
## Summary

Two trivial follow-ups from claude-review's final pass on PR #125 — both flagged as informational, not blockers, but easy enough to clean up now.

- **`CLAUDE.md` repo tree:** Added a `└── ...` trailer to the `docs/` section. The listing now signals it's representative, not exhaustive (`DEPLOYMENT.md`, `DEVELOPMENT_WORKFLOW.md`, `coverage.md`, `OAuth-Setup.md`, `YEAR_CONFIGURATION.md` also live in `docs/`).

- **`DESIGN.md` State Management heading:** Renamed `**React Hooks with localStorage Persistence:**` → `**Hooks with localStorage Persistence:**` and added a short note explaining the deliberate `'react'`-import convention (`@preact/preset-vite` aliases it to `preact/compat`, which installs the `onChange` → `onInput` event normalization that form components rely on; full reasoning in `CLAUDE.md`'s "Imports" section).

The heading was technically accurate but flagged in PR #125 review round 1 as potentially misleading. Renaming + linking the rationale resolves the mixed-signal concern without changing the convention itself.

## Test plan

- [x] `npm run validate --workspace=frontend` — exit 0
- [x] `npm run validate --workspace=backend` — exit 0
- [ ] Reviewer skim: open `CLAUDE.md` and `DESIGN.md` to confirm the changes read naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)