### PR TITLE
chore: remove Claude from footer copyright attribution

### DIFF
--- a/docs/plans/archive/2026-03-03-multi-year-support-plan.md
+++ b/docs/plans/archive/2026-03-03-multi-year-support-plan.md
@@ -875,12 +875,12 @@ With:
 
 Replace:
 ```tsx
-<p className="text-gray-400">© 2026 Chautauqua Calendar by Bernie and Claude</p>
+<p className="text-gray-400">© 2026 Chautauqua Calendar by Bernie</p>
 ```
 
 With:
 ```tsx
-<p className="text-gray-400">© {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude</p>
+<p className="text-gray-400">© {new Date().getFullYear()} Chautauqua Calendar by Bernie</p>
 ```
 
 **Step 8: Update document title dynamically**

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -179,7 +179,7 @@ function HomeContent() {
       </main>
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
-          <p className="text-gray-400">&copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude</p>
+          <p className="text-gray-400">&copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie</p>
         </div>
       </footer>
     </div>

--- a/frontend/src/app/publish/apply/page.tsx
+++ b/frontend/src/app/publish/apply/page.tsx
@@ -386,7 +386,7 @@ export default function PublishApplyPage() {
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
           <p className="text-gray-400">
-            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie
           </p>
         </div>
       </footer>

--- a/frontend/src/app/publish/docs/page.tsx
+++ b/frontend/src/app/publish/docs/page.tsx
@@ -331,7 +331,7 @@ export default function PublishDocsPage() {
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
           <p className="text-gray-400">
-            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie
           </p>
         </div>
       </footer>

--- a/frontend/src/app/publish/email-change/cancel/page.tsx
+++ b/frontend/src/app/publish/email-change/cancel/page.tsx
@@ -57,7 +57,7 @@ export default function PublishEmailChangeCancelPage() {
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
           <p className="text-gray-400">
-            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie
           </p>
         </div>
       </footer>

--- a/frontend/src/app/publish/email-change/verify/page.tsx
+++ b/frontend/src/app/publish/email-change/verify/page.tsx
@@ -77,7 +77,7 @@ export default function PublishEmailChangeVerifyPage() {
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
           <p className="text-gray-400">
-            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie
           </p>
         </div>
       </footer>

--- a/frontend/src/app/publish/login/page.tsx
+++ b/frontend/src/app/publish/login/page.tsx
@@ -214,7 +214,7 @@ export default function PublishLoginPage() {
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
           <p className="text-gray-400">
-            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie
           </p>
         </div>
       </footer>

--- a/frontend/src/app/publish/status/page.tsx
+++ b/frontend/src/app/publish/status/page.tsx
@@ -118,7 +118,7 @@ export default function PublishStatusPage() {
       <footer className="bg-gray-800 text-white mt-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 text-center">
           <p className="text-gray-400">
-            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie and Claude
+            &copy; {new Date().getFullYear()} Chautauqua Calendar by Bernie
           </p>
         </div>
       </footer>


### PR DESCRIPTION
This pull request updates the copyright notice in the website footer across multiple pages, removing "and Claude" so that it now reads "Chautauqua Calendar by Bernie." The change ensures consistency throughout the app and documentation.

Footer copyright updates:

* Updated the copyright notice in the footer from "Chautauqua Calendar by Bernie and Claude" to "Chautauqua Calendar by Bernie" in the following frontend files:
  - `frontend/src/app/page.tsx`
  - `frontend/src/app/publish/apply/page.tsx`
  - `frontend/src/app/publish/docs/page.tsx`
  - `frontend/src/app/publish/email-change/cancel/page.tsx`
  - `frontend/src/app/publish/email-change/verify/page.tsx`
  - `frontend/src/app/publish/login/page.tsx`
  - `frontend/src/app/publish/status/page.tsx`

Documentation update:

* Updated example code in `docs/plans/archive/2026-03-03-multi-year-support-plan.md` to match the new copyright wording.