### PR TITLE
feat(themes): weekly themes scraper, JSON storage, and hover/popover UI

### DIFF
--- a/.github/workflows/scrape-weekly-themes.yml
+++ b/.github/workflows/scrape-weekly-themes.yml
@@ -42,12 +42,16 @@ jobs:
       - name: Scrape weekly themes (dry run)
         if: ${{ inputs.dry_run }}
         working-directory: backend
-        run: npx ts-node src/scripts/scrapeWeeklyThemes.ts --year=${{ inputs.year }} --dry-run
+        env:
+          YEAR: ${{ inputs.year }}
+        run: npx ts-node src/scripts/scrapeWeeklyThemes.ts --year="${YEAR}" --dry-run
 
       - name: Scrape weekly themes (write file)
         if: ${{ !inputs.dry_run }}
         working-directory: backend
-        run: npx ts-node src/scripts/scrapeWeeklyThemes.ts --year=${{ inputs.year }}
+        env:
+          YEAR: ${{ inputs.year }}
+        run: npx ts-node src/scripts/scrapeWeeklyThemes.ts --year="${YEAR}"
 
       - name: Open PR with updated themes file
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/scrape-weekly-themes.yml
+++ b/.github/workflows/scrape-weekly-themes.yml
@@ -1,0 +1,82 @@
+name: Scrape Weekly Themes
+
+# Manual push-button workflow that re-scrapes chq.org's Weekly Themes page
+# for a given year and opens a PR with the updated JSON file. Themes do
+# not change inside a season — run this once per year (or when the
+# Institution edits the page).
+
+on:
+  workflow_dispatch:
+    inputs:
+      year:
+        description: "Season year to scrape (e.g. 2026)"
+        required: true
+        default: "2026"
+        type: string
+      dry_run:
+        description: "When true, log the parsed JSON and do not commit"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        run: npm ci
+
+      - name: Scrape weekly themes (dry run)
+        if: ${{ inputs.dry_run }}
+        working-directory: backend
+        run: npx ts-node src/scripts/scrapeWeeklyThemes.ts --year=${{ inputs.year }} --dry-run
+
+      - name: Scrape weekly themes (write file)
+        if: ${{ !inputs.dry_run }}
+        working-directory: backend
+        run: npx ts-node src/scripts/scrapeWeeklyThemes.ts --year=${{ inputs.year }}
+
+      - name: Open PR with updated themes file
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          YEAR: ${{ inputs.year }}
+        run: |
+          set -euo pipefail
+          target_file="frontend/public/data/weekly-themes/${YEAR}.json"
+          if git diff --quiet -- "$target_file"; then
+            if git ls-files --error-unmatch "$target_file" >/dev/null 2>&1; then
+              echo "No changes to $target_file; nothing to do."
+              exit 0
+            fi
+          fi
+
+          branch="chore/weekly-themes-${YEAR}"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add "$target_file"
+          git commit -m "chore: refresh weekly themes for ${YEAR}"
+          git push -u origin "$branch" --force-with-lease
+
+          # Open a PR if one doesn't already exist for this branch.
+          if ! gh pr view "$branch" >/dev/null 2>&1; then
+            gh pr create \
+              --base main \
+              --head "$branch" \
+              --title "chore: refresh weekly themes for ${YEAR}" \
+              --body "Automated re-scrape of https://www.chq.org/things-to-do/events/weekly-themes/ for season ${YEAR}. Review the diff before merging."
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ backend/coverage/
 frontend/data/*
 frontend/public/data/*
 !frontend/public/data/years.json
+!frontend/public/data/weekly-themes/
+!frontend/public/data/weekly-themes/*.json
 
 # Build outputs
 backend/dist-all/

--- a/backend/src/__tests__/fixtures/weekly-themes-2026.html
+++ b/backend/src/__tests__/fixtures/weekly-themes-2026.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="en-US">
+<head><meta charset="utf-8"><title>Weekly Themes - Chautauqua Institution</title></head>
+<body>
+<main>
+<h2 class="wp-block-heading">Weekly Themes</h2>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week One 2026</h2>
+  <p class="has-text-align-center">June 27&#8211;July 4 &#8226; Icons and Instigators: Women Who Change the World  </p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-one-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Two 2026</h2>
+  <p class="has-text-align-center">July 4&#8211;11 &#8226; Breaking the News: Charting a New Media Landscape </p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-two-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Three 2026</h2>
+  <p class="has-text-align-center">July 11&#8211;18 &#8226; The 2026 Election: What&#8217;s at Stake?</p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-three-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Four 2026</h2>
+  <p class="has-text-align-center">July 18&#8211;25 &#8226; Wasted: Our Era of Disposability  </p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-four-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Five 2026</h2>
+  <p class="has-text-align-center">July 25&#8211;August 1 &#8226; Art and Artists Against the Odds  </p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-five-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Six 2026</h2>
+  <p class="has-text-align-center">August 1&#8211;8 &#8226; America at 250: In Partnership with The Colonial Williamsburg Foundation </p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-six-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Seven 2026</h2>
+  <p class="has-text-align-center">August 8&#8211;15 &#8226; Global Power and Our Evolving International Order</p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-seven-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Eight 2026</h2>
+  <p class="has-text-align-center">August 15&#8211;22 &#8226; The Future of Food: Climate, Technology and the Next Agricultural Revolution</p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-eight-2026/">Learn More</a></div>
+</div>
+
+<div class="hub-item">
+  <h2 class="has-text-align-center season has-primary-color has-text-color">Week Nine 2026</h2>
+  <p class="has-text-align-center">August 22&#8211;30 &#8226; The Importance of Gathering: A Collaboration with the Smithsonian Folklife Festival</p>
+  <div class="wp-block-button aligncenter"><a class="wp-block-button__link" href="https://www.chq.org/things-to-do/events/weekly-themes/week-nine-2026/">Learn More</a></div>
+</div>
+
+</main>
+</body>
+</html>

--- a/backend/src/__tests__/weeklyThemesScraper.test.ts
+++ b/backend/src/__tests__/weeklyThemesScraper.test.ts
@@ -13,7 +13,7 @@ describe('parseWeeklyThemes', () => {
     expect(weeks.map(w => w.number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
   });
 
-  it('parses week 1 title, dates, and source link', () => {
+  it('parses week 1 title and dates', () => {
     const weeks = parseWeeklyThemes(html, 2026);
     expect(weeks[0]).toEqual({
       number: 1,
@@ -59,13 +59,17 @@ describe('parseWeeklyThemes', () => {
 });
 
 describe('validateWeeklyThemes', () => {
-  const goodWeeks: ParsedWeek[] = Array.from({ length: 9 }, (_, i) => ({
-    number: i + 1,
-    title: `Week ${i + 1} title`,
-    description: '',
-    startDate: '2026-06-27',
-    endDate: '2026-07-04',
-  }));
+  const goodWeeks: ParsedWeek[] = Array.from({ length: 9 }, (_, i) => {
+    const start = new Date(Date.UTC(2026, 5, 27 + i * 7)); // Sat June 27 + i weeks
+    const end = new Date(Date.UTC(2026, 6, 4 + i * 7));
+    return {
+      number: i + 1,
+      title: `Week ${i + 1} title`,
+      description: '',
+      startDate: start.toISOString().slice(0, 10),
+      endDate: end.toISOString().slice(0, 10),
+    };
+  });
 
   it('passes on 9 sequential, titled, dated weeks', () => {
     expect(() => validateWeeklyThemes(goodWeeks, 2026)).not.toThrow();
@@ -97,5 +101,36 @@ describe('validateWeeklyThemes', () => {
     const bad = [...goodWeeks];
     bad[0] = { ...bad[0], startDate: '2025-06-27' };
     expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/2026/);
+  });
+
+  it('throws on an impossible calendar date (e.g. 2026-06-31)', () => {
+    const bad = [...goodWeeks];
+    bad[3] = { ...bad[3], startDate: '2026-06-31' };
+    expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/impossible date/i);
+  });
+
+  it('throws when endDate is not after startDate', () => {
+    const bad = [...goodWeeks];
+    bad[2] = { ...bad[2], startDate: '2026-07-04', endDate: '2026-07-04' };
+    expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/must be after/i);
+  });
+
+  it('throws when weeks are not in chronological order', () => {
+    const sequential: ParsedWeek[] = Array.from({ length: 9 }, (_, i) => ({
+      number: i + 1,
+      title: `Week ${i + 1}`,
+      description: '',
+      startDate: `2026-07-0${i % 9 + 1}`,
+      endDate: `2026-07-0${i % 9 + 1}`,
+    }));
+    // Make all start/end dates real and sequential except week 5 which goes backward.
+    for (let i = 0; i < 9; i++) {
+      const start = new Date(Date.UTC(2026, 5, 27 + i * 7));
+      const end = new Date(Date.UTC(2026, 6, 4 + i * 7));
+      sequential[i].startDate = start.toISOString().slice(0, 10);
+      sequential[i].endDate = end.toISOString().slice(0, 10);
+    }
+    sequential[4].startDate = '2026-06-27'; // earlier than week 4's end
+    expect(() => validateWeeklyThemes(sequential, 2026)).toThrow(/before the previous week/i);
   });
 });

--- a/backend/src/__tests__/weeklyThemesScraper.test.ts
+++ b/backend/src/__tests__/weeklyThemesScraper.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { parseWeeklyThemes, validateWeeklyThemes, ParsedWeek } from '../services/weeklyThemesScraper';
+
+const FIXTURE_PATH = join(__dirname, 'fixtures', 'weekly-themes-2026.html');
+
+describe('parseWeeklyThemes', () => {
+  const html = readFileSync(FIXTURE_PATH, 'utf8');
+
+  it('extracts all 9 weeks from the fixture in order', () => {
+    const weeks = parseWeeklyThemes(html, 2026);
+    expect(weeks).toHaveLength(9);
+    expect(weeks.map(w => w.number)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('parses week 1 title, dates, and source link', () => {
+    const weeks = parseWeeklyThemes(html, 2026);
+    expect(weeks[0]).toEqual({
+      number: 1,
+      title: 'Icons and Instigators: Women Who Change the World',
+      description: '',
+      startDate: '2026-06-27',
+      endDate: '2026-07-04',
+    });
+  });
+
+  it('handles a same-month date range like "July 4–11"', () => {
+    const weeks = parseWeeklyThemes(html, 2026);
+    expect(weeks[1]).toMatchObject({
+      number: 2,
+      title: 'Breaking the News: Charting a New Media Landscape',
+      startDate: '2026-07-04',
+      endDate: '2026-07-11',
+    });
+  });
+
+  it('handles a cross-month range like "July 25–August 1"', () => {
+    const weeks = parseWeeklyThemes(html, 2026);
+    expect(weeks[4]).toMatchObject({
+      number: 5,
+      startDate: '2026-07-25',
+      endDate: '2026-08-01',
+    });
+  });
+
+  it('decodes HTML entities and curly punctuation in titles', () => {
+    const weeks = parseWeeklyThemes(html, 2026);
+    // Week three on chq.org uses a curly apostrophe in "What's at Stake?"
+    expect(weeks[2].title).toBe('The 2026 Election: What’s at Stake?');
+  });
+
+  it('trims trailing whitespace from titles', () => {
+    const weeks = parseWeeklyThemes(html, 2026);
+    for (const w of weeks) {
+      expect(w.title).toBe(w.title.trim());
+      expect(w.title.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('validateWeeklyThemes', () => {
+  const goodWeeks: ParsedWeek[] = Array.from({ length: 9 }, (_, i) => ({
+    number: i + 1,
+    title: `Week ${i + 1} title`,
+    description: '',
+    startDate: '2026-06-27',
+    endDate: '2026-07-04',
+  }));
+
+  it('passes on 9 sequential, titled, dated weeks', () => {
+    expect(() => validateWeeklyThemes(goodWeeks, 2026)).not.toThrow();
+  });
+
+  it('throws when there are not exactly 9 weeks', () => {
+    expect(() => validateWeeklyThemes(goodWeeks.slice(0, 8), 2026)).toThrow(/exactly 9/i);
+  });
+
+  it('throws when weeks are not numbered 1..9 in order', () => {
+    const bad = [...goodWeeks];
+    bad[3] = { ...bad[3], number: 99 };
+    expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/numbered 1\.\.9/i);
+  });
+
+  it('throws when any week is missing a title', () => {
+    const bad = [...goodWeeks];
+    bad[2] = { ...bad[2], title: '' };
+    expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/title/i);
+  });
+
+  it('throws when any week is missing dates', () => {
+    const bad = [...goodWeeks];
+    bad[4] = { ...bad[4], startDate: '' };
+    expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/date/i);
+  });
+
+  it('throws when dates are not in the requested year', () => {
+    const bad = [...goodWeeks];
+    bad[0] = { ...bad[0], startDate: '2025-06-27' };
+    expect(() => validateWeeklyThemes(bad, 2026)).toThrow(/2026/);
+  });
+});

--- a/backend/src/scripts/scrapeWeeklyThemes.ts
+++ b/backend/src/scripts/scrapeWeeklyThemes.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env ts-node
+/**
+ * Scrape the chq.org weekly themes page for a given year and write
+ * frontend/public/data/weekly-themes/<year>.json.
+ *
+ * Usage:
+ *   ts-node src/scripts/scrapeWeeklyThemes.ts --year=2026
+ *   ts-node src/scripts/scrapeWeeklyThemes.ts --year=2026 --dry-run
+ *   ts-node src/scripts/scrapeWeeklyThemes.ts --year=2026 --out=/abs/path/2026.json
+ */
+import { writeFileSync, mkdirSync } from 'fs';
+import { dirname, resolve } from 'path';
+import axios from 'axios';
+import { parseWeeklyThemes, validateWeeklyThemes } from '../services/weeklyThemesScraper';
+
+const SOURCE_URL = 'https://www.chq.org/things-to-do/events/weekly-themes/';
+
+interface CliArgs {
+  year: number;
+  out: string;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const args: Record<string, string | boolean> = {};
+  for (const raw of argv.slice(2)) {
+    const m = raw.match(/^--([^=]+)(?:=(.*))?$/);
+    if (!m) continue;
+    args[m[1]] = m[2] ?? true;
+  }
+  const yearStr = (args.year as string) || String(new Date().getUTCFullYear());
+  const year = parseInt(yearStr, 10);
+  if (!year || year < 2000 || year > 2100) {
+    throw new Error(`--year=<YYYY> is required (got "${yearStr}")`);
+  }
+  const dryRun = args['dry-run'] === true || args.dryRun === true;
+  // Default output is relative to the repo root: backend/.. → frontend/public/...
+  const defaultOut = resolve(__dirname, `../../../frontend/public/data/weekly-themes/${year}.json`);
+  const out = (args.out as string) || defaultOut;
+  return { year, out, dryRun };
+}
+
+async function fetchHtml(url: string): Promise<string> {
+  const res = await axios.get<string>(url, {
+    responseType: 'text',
+    headers: { 'User-Agent': 'chq-calendar-weekly-themes-scraper/1.0' },
+    timeout: 30000,
+    transformResponse: [(d) => d],
+  });
+  return res.data;
+}
+
+async function main() {
+  const { year, out, dryRun } = parseArgs(process.argv);
+
+  const html = await fetchHtml(SOURCE_URL);
+  const weeks = parseWeeklyThemes(html, year);
+  validateWeeklyThemes(weeks, year);
+
+  const payload = {
+    year,
+    scrapedAt: new Date().toISOString(),
+    source: SOURCE_URL,
+    weeks,
+  };
+  const json = JSON.stringify(payload, null, 2) + '\n';
+
+  if (dryRun) {
+    process.stdout.write(json);
+    return;
+  }
+
+  mkdirSync(dirname(out), { recursive: true });
+  writeFileSync(out, json);
+  process.stderr.write(`Wrote ${weeks.length} weeks for ${year} to ${out}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`scrape-weekly-themes failed: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/backend/src/services/weeklyThemesScraper.ts
+++ b/backend/src/services/weeklyThemesScraper.ts
@@ -1,0 +1,125 @@
+import * as cheerio from 'cheerio';
+
+export interface ParsedWeek {
+  number: number;
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+}
+
+const WORD_TO_NUMBER: Record<string, number> = {
+  ONE: 1, TWO: 2, THREE: 3, FOUR: 4, FIVE: 5,
+  SIX: 6, SEVEN: 7, EIGHT: 8, NINE: 9,
+};
+
+const MONTHS: Record<string, number> = {
+  JANUARY: 1, FEBRUARY: 2, MARCH: 3, APRIL: 4, MAY: 5, JUNE: 6,
+  JULY: 7, AUGUST: 8, SEPTEMBER: 9, OCTOBER: 10, NOVEMBER: 11, DECEMBER: 12,
+};
+
+function parseWeekNumber(headingText: string): number | null {
+  const m = headingText.trim().match(/^Week\s+([A-Za-z]+)\b/i);
+  if (!m) return null;
+  return WORD_TO_NUMBER[m[1].toUpperCase()] ?? null;
+}
+
+function toIso(year: number, month: number, day: number): string {
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/**
+ * Parse a chq.org weekly-themes date range like:
+ *   "June 27–July 4"     (cross-month)
+ *   "July 4–11"          (same month)
+ * The separator is a Unicode en-dash (U+2013). Hyphen-minus is tolerated.
+ */
+function parseDateRange(rangeText: string, year: number): { startDate: string; endDate: string } | null {
+  const cleaned = rangeText.replace(/\s+/g, ' ').trim();
+  // Split on en-dash, em-dash, or hyphen-minus.
+  const parts = cleaned.split(/\s*[–—-]\s*/);
+  if (parts.length !== 2) return null;
+
+  const [left, right] = parts;
+  const leftMatch = left.match(/^([A-Za-z]+)\s+(\d{1,2})$/);
+  if (!leftMatch) return null;
+  const startMonth = MONTHS[leftMatch[1].toUpperCase()];
+  const startDay = parseInt(leftMatch[2], 10);
+  if (!startMonth || !startDay) return null;
+
+  // Right side can be "August 1" (cross-month) or just "11" (same month).
+  let endMonth = startMonth;
+  let endDay: number;
+  const rightCross = right.match(/^([A-Za-z]+)\s+(\d{1,2})$/);
+  const rightSame = right.match(/^(\d{1,2})$/);
+  if (rightCross) {
+    const m = MONTHS[rightCross[1].toUpperCase()];
+    if (!m) return null;
+    endMonth = m;
+    endDay = parseInt(rightCross[2], 10);
+  } else if (rightSame) {
+    endDay = parseInt(rightSame[1], 10);
+  } else {
+    return null;
+  }
+
+  return {
+    startDate: toIso(year, startMonth, startDay),
+    endDate: toIso(year, endMonth, endDay),
+  };
+}
+
+export function parseWeeklyThemes(html: string, year: number): ParsedWeek[] {
+  const $ = cheerio.load(html);
+  const weeks: ParsedWeek[] = [];
+
+  $('.hub-item').each((_, el) => {
+    const heading = $(el).find('h2.season').first().text();
+    const number = parseWeekNumber(heading);
+    if (number === null) return;
+
+    const paragraph = $(el).find('p.has-text-align-center').first().text();
+    // Format: "<dates> • <title>" where the bullet is U+2022.
+    const bulletIdx = paragraph.indexOf('•');
+    if (bulletIdx < 0) return;
+
+    const rangeText = paragraph.slice(0, bulletIdx).trim();
+    const title = paragraph.slice(bulletIdx + 1).trim();
+
+    const range = parseDateRange(rangeText, year);
+    if (!range) return;
+
+    weeks.push({
+      number,
+      title,
+      description: '',
+      startDate: range.startDate,
+      endDate: range.endDate,
+    });
+  });
+
+  return weeks;
+}
+
+export function validateWeeklyThemes(weeks: ParsedWeek[], year: number): void {
+  if (weeks.length !== 9) {
+    throw new Error(`Expected exactly 9 weeks, got ${weeks.length}`);
+  }
+  for (let i = 0; i < 9; i++) {
+    if (weeks[i].number !== i + 1) {
+      throw new Error(`Weeks must be numbered 1..9 in order; entry ${i} has number ${weeks[i].number}`);
+    }
+    if (!weeks[i].title || !weeks[i].title.trim()) {
+      throw new Error(`Week ${weeks[i].number} is missing a title`);
+    }
+    const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+    if (!datePattern.test(weeks[i].startDate) || !datePattern.test(weeks[i].endDate)) {
+      throw new Error(`Week ${weeks[i].number} has an unparseable date`);
+    }
+    const startYear = parseInt(weeks[i].startDate.slice(0, 4), 10);
+    const endYear = parseInt(weeks[i].endDate.slice(0, 4), 10);
+    if (startYear !== year || endYear !== year) {
+      throw new Error(`Week ${weeks[i].number} dates are not in year ${year} (got ${weeks[i].startDate}..${weeks[i].endDate})`);
+    }
+  }
+}

--- a/backend/src/services/weeklyThemesScraper.ts
+++ b/backend/src/services/weeklyThemesScraper.ts
@@ -101,25 +101,47 @@ export function parseWeeklyThemes(html: string, year: number): ParsedWeek[] {
   return weeks;
 }
 
+function parseIsoOrThrow(iso: string, weekNumber: number): Date {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(iso)) {
+    throw new Error(`Week ${weekNumber} has an unparseable date "${iso}"`);
+  }
+  const [y, m, d] = iso.split('-').map(s => parseInt(s, 10));
+  const parsed = new Date(Date.UTC(y, m - 1, d));
+  // Round-trip check: rejects impossible day-of-month like 2026-06-31.
+  if (
+    parsed.getUTCFullYear() !== y ||
+    parsed.getUTCMonth() !== m - 1 ||
+    parsed.getUTCDate() !== d
+  ) {
+    throw new Error(`Week ${weekNumber} has an impossible date "${iso}"`);
+  }
+  return parsed;
+}
+
 export function validateWeeklyThemes(weeks: ParsedWeek[], year: number): void {
   if (weeks.length !== 9) {
     throw new Error(`Expected exactly 9 weeks, got ${weeks.length}`);
   }
+  let prevEnd: Date | null = null;
   for (let i = 0; i < 9; i++) {
-    if (weeks[i].number !== i + 1) {
-      throw new Error(`Weeks must be numbered 1..9 in order; entry ${i} has number ${weeks[i].number}`);
+    const w = weeks[i];
+    if (w.number !== i + 1) {
+      throw new Error(`Weeks must be numbered 1..9 in order; entry ${i} has number ${w.number}`);
     }
-    if (!weeks[i].title || !weeks[i].title.trim()) {
-      throw new Error(`Week ${weeks[i].number} is missing a title`);
+    if (!w.title || !w.title.trim()) {
+      throw new Error(`Week ${w.number} is missing a title`);
     }
-    const datePattern = /^\d{4}-\d{2}-\d{2}$/;
-    if (!datePattern.test(weeks[i].startDate) || !datePattern.test(weeks[i].endDate)) {
-      throw new Error(`Week ${weeks[i].number} has an unparseable date`);
+    const start = parseIsoOrThrow(w.startDate, w.number);
+    const end = parseIsoOrThrow(w.endDate, w.number);
+    if (start.getUTCFullYear() !== year || end.getUTCFullYear() !== year) {
+      throw new Error(`Week ${w.number} dates are not in year ${year} (got ${w.startDate}..${w.endDate})`);
     }
-    const startYear = parseInt(weeks[i].startDate.slice(0, 4), 10);
-    const endYear = parseInt(weeks[i].endDate.slice(0, 4), 10);
-    if (startYear !== year || endYear !== year) {
-      throw new Error(`Week ${weeks[i].number} dates are not in year ${year} (got ${weeks[i].startDate}..${weeks[i].endDate})`);
+    if (end <= start) {
+      throw new Error(`Week ${w.number} end date "${w.endDate}" must be after start "${w.startDate}"`);
     }
+    if (prevEnd && start < prevEnd) {
+      throw new Error(`Week ${w.number} starts at "${w.startDate}" before the previous week ended at "${weeks[i - 1].endDate}"`);
+    }
+    prevEnd = end;
   }
 }

--- a/docs/plans/2026-05-17-weekly-themes-design.md
+++ b/docs/plans/2026-05-17-weekly-themes-design.md
@@ -158,9 +158,11 @@ New hook `useWeeklyThemes(year: number)`:
 - The `title` attribute extends to include the theme:
   `Week 1 — "Building a Culture of Empathy" (Jun 27–Jul 4)`. Free
   native tooltip on desktop.
-- Visual affordance that a theme is available: a small dot or thin
-  underline on buttons whose week has a theme entry. (Final styling
-  to be tweaked when we view it.)
+- No visual indicator on themed buttons — they look identical to
+  un-themed ones. Theme info is surfaced only when the user requests
+  it (hover title, right-click, long-press, or `ContextMenu` /
+  `Shift+F10` for keyboard users). This change from the original
+  "dot or underline" sketch came out of mobile review.
 - A new `WeekThemePopover` component:
   - Opens on **long-press** (touch) or **right-click / shift-click /
     keyboard menu** on a week button.
@@ -176,19 +178,30 @@ inside the popover trigger if testing shows long-press is missed.
 
 ### Active filter chip
 
-When a week filter is active, the chip text gains the theme title:
-`Week 1 · "Building a Culture of Empathy"`, truncating with ellipsis
-on narrow widths. Falls back to the existing `Week 1` text if no
-theme is loaded.
+Originally this section proposed extending the chip text to
+`Week 1 · "Building a Culture of Empathy"`. After mobile review the
+chip was left as the bare `Week 1` form to keep the "Filtering by"
+row compact on narrow viewports — the theme is reachable from the
+WeekSelector tooltip / popover, so duplicating it on the chip wasn't
+worth the screen real estate.
+
+### EventList day headers (shipped)
+
+Each day group's header now reads `Day, Month D, YYYY - Week N`. On
+Saturdays — where the canonical Sat-noon-to-Sat-noon boundary splits
+the calendar day across two season weeks — it reads
+`Day, Month D, YYYY - Week N/M`, and the popover stacks both themes.
+`groupEventsByDay` was restructured to return
+`{ key, baseLabel, weekNumbers, events }` so `EventList` can render
+the week portion via a `WeekBadge` with the same hover/long-press
+popover affordances as the filter row.
 
 ### Where else themes could appear (deliberately deferred)
 
-- Section headers in `EventList` when grouped by week.
 - Event cards (one-line theme attribution under the date).
 
-Both are easy to add once we've validated the popover/chip surface.
-Pushing them past v1 keeps the diff small and the iteration loop
-fast.
+Easy to add once we've validated the popover surface. Pushed past v1
+to keep the diff small.
 
 ## Multi-year
 

--- a/docs/plans/2026-05-17-weekly-themes-design.md
+++ b/docs/plans/2026-05-17-weekly-themes-design.md
@@ -1,0 +1,236 @@
+# Weekly themes — design
+
+**Status:** Draft, awaiting user review
+**Date:** 2026-05-17
+**Branch:** `weekly-themes-design`
+
+## Problem
+
+Each Chautauqua season week has a theme published at
+https://www.chq.org/things-to-do/events/weekly-themes/. The page is
+overwritten when the institution rolls forward to the next year, so
+once a season ends we can no longer recover that year's themes from
+the site. The site has nothing in place today to capture or display
+this information; users have to leave the calendar to find it.
+
+We want to:
+
+1. Capture the themes for each year once, store them durably in the
+   repo, and never lose them.
+2. Surface the theme for a given week in the UI without sacrificing
+   screen real estate, particularly on mobile.
+
+## Non-goals
+
+- Automated re-scraping. Themes do not change inside a season — a
+  manual, push-button run per year is enough.
+- Admin UI for editing themes. If a scrape is wrong, the JSON file is
+  edited in a follow-up PR.
+- Surfacing themes inside individual event cards. May be a follow-up
+  once the v1 placement is validated.
+- A separate themes API or DynamoDB table. The dataset is ~9 entries
+  per year; static JSON is the right tool.
+
+## Storage
+
+A static JSON file per year, checked into the repo and served by the
+existing CloudFront distribution:
+
+```
+frontend/public/data/weekly-themes/2026.json
+frontend/public/data/weekly-themes/2027.json
+...
+```
+
+File shape:
+
+```json
+{
+  "year": 2026,
+  "scrapedAt": "2026-05-17T18:42:11.000Z",
+  "source": "https://www.chq.org/things-to-do/events/weekly-themes/",
+  "weeks": [
+    {
+      "number": 1,
+      "title": "Building a Culture of Empathy",
+      "description": "Long-form description as published…",
+      "startDate": "2026-06-27",
+      "endDate":   "2026-07-04"
+    }
+  ]
+}
+```
+
+Notes:
+
+- `startDate` / `endDate` are stored as published on chq.org (Sat–Sat
+  overlapping). They are informational only — they are not used by the
+  filter pipeline. The canonical season boundaries remain in
+  `getChautauquaSeasonWeeks` (Saturday noon → Saturday noon).
+- `description` may be empty if the source page has only a title for a
+  given week.
+- Past-year files stay in the repo forever. Future-year files are
+  absent until that year is scraped — the frontend treats a 404 as
+  "no themes available, render nothing extra".
+
+Why this storage choice (vs. alternatives considered):
+
+- **DynamoDB / API**: 9 rows per year, written once. The infra and
+  Lambda cost would dwarf the payload. Rejected.
+- **Bundled into `all-events.json`**: events refresh hourly via the
+  ingest pipeline; themes are static yearly. Coupling them forces
+  every ingest run to re-emit theme data and entangles two different
+  cadences. Rejected.
+- **`frontend/src/data/`** (compiled into the bundle): would work, but
+  serving from `public/` keeps themes out of the JS bundle and lets us
+  load them lazily.
+
+## Scraper
+
+A single TypeScript script at `scripts/scrape-weekly-themes.ts`,
+runnable two ways:
+
+1. **GitHub Actions, push-button** — the primary path. New workflow
+   `.github/workflows/scrape-weekly-themes.yml` triggered by
+   `workflow_dispatch`. Inputs:
+   - `year` (string, default: current year)
+   - `dry_run` (boolean, default `false`) — when true, log the parsed
+     JSON to the workflow output without committing.
+
+   Steps:
+   - Check out repo.
+   - Set up Node (matches the build matrix — 24).
+   - `npm ci` in repo root.
+   - `npx tsx scripts/scrape-weekly-themes.ts --year=$YEAR --out=frontend/public/data/weekly-themes/$YEAR.json`.
+   - If the file changed, commit on branch `chore/weekly-themes-$YEAR`
+     and open a PR via `gh pr create`. The user reviews and merges
+     normally — nothing lands on `main` without human approval.
+
+   Permissions: `contents: write`, `pull-requests: write`.
+
+2. **Local** — `npx tsx scripts/scrape-weekly-themes.ts --year=2026`
+   for debugging or one-offs.
+
+Implementation:
+
+- Lives in a new `scripts/` npm workspace (or, if simpler, runs under
+  the existing `backend` workspace as `backend/scripts/scrape-weekly-themes.ts`).
+  Implementation plan picks one; the design only requires that
+  `cheerio` and `tsx` are resolvable from the script's location. Both
+  are already in `backend`'s dependency tree.
+- Fetches the source page, locates each week block, extracts
+  `number`, `title`, optional `description`, and the published
+  `startDate` / `endDate`.
+- Validates: exactly 9 weeks numbered 1-9, every week has a title,
+  every week has parseable Sat-to-Sat dates in the requested year.
+  Fails loudly if any check trips — better to fail and re-run than
+  silently ship a half-scraped file.
+- Writes the JSON with a stable key order and a trailing newline so
+  diffs stay clean if re-run.
+
+Saturday handling at scrape time: chq.org lists weeks with
+overlapping Sat–Sat ranges (the last day of one week is the first
+day of the next). The scraper records the dates verbatim. No
+de-duplication, no boundary fix-up — the dates are display data, not
+filter data. The frontend's canonical week boundaries (Saturday noon)
+are untouched.
+
+## Frontend display (v1 — expected to iterate)
+
+This is explicitly v1. The intent is to land something working and
+mobile-testable, then refine after seeing it on a real device.
+
+### Data hook
+
+New hook `useWeeklyThemes(year: number)`:
+
+- Fetches `/data/weekly-themes/${year}.json` on mount.
+- Caches in a module-level `Map<number, Promise<...>>` so multiple
+  consumers share one request.
+- Returns `{ themes: Record<number, WeekTheme>, loading: boolean }`.
+- 404 → returns `{}` (no error surface). A year without themes simply
+  renders without the theme affordance.
+
+### WeekSelector changes
+
+`frontend/src/components/filters/WeekSelector.tsx`:
+
+- Each numbered button keeps its existing tap-to-filter behavior.
+- The `title` attribute extends to include the theme:
+  `Week 1 — "Building a Culture of Empathy" (Jun 27–Jul 4)`. Free
+  native tooltip on desktop.
+- Visual affordance that a theme is available: a small dot or thin
+  underline on buttons whose week has a theme entry. (Final styling
+  to be tweaked when we view it.)
+- A new `WeekThemePopover` component:
+  - Opens on **long-press** (touch) or **right-click / shift-click /
+    keyboard menu** on a week button.
+  - Anchored to the button on desktop; on mobile-narrow viewports
+    becomes a bottom sheet to avoid awkward anchored positioning.
+  - Content: `Week N`, theme title, description, Sat–Sat date range,
+    "View on chq.org" link to the source.
+  - Dismiss: tap outside, Esc, tap the same week again.
+
+Short-tap on mobile keeps current behavior (filter to that week).
+Long-press is the discoverability cost — we'll add a small ⓘ icon
+inside the popover trigger if testing shows long-press is missed.
+
+### Active filter chip
+
+When a week filter is active, the chip text gains the theme title:
+`Week 1 · "Building a Culture of Empathy"`, truncating with ellipsis
+on narrow widths. Falls back to the existing `Week 1` text if no
+theme is loaded.
+
+### Where else themes could appear (deliberately deferred)
+
+- Section headers in `EventList` when grouped by week.
+- Event cards (one-line theme attribution under the date).
+
+Both are easy to add once we've validated the popover/chip surface.
+Pushing them past v1 keeps the diff small and the iteration loop
+fast.
+
+## Multi-year
+
+The file-naming scheme (`{year}.json`) is consistent with the
+existing `2026-03-03-multi-year-support-design.md` plan. The hook
+takes `year` as an argument and is driven by the same season-year
+inference as the rest of the calendar — no new year-routing logic.
+
+## Testing
+
+- **Scraper parser**: fixture HTML committed at
+  `scripts/__fixtures__/weekly-themes-2026.html`. Test asserts the
+  parser produces a golden JSON. A second fixture covers an edge case
+  (missing description, alternate markup) to keep the parser honest.
+- **Validation**: unit tests for the "exactly 9 weeks, all dated,
+  all titled" guards.
+- **`useWeeklyThemes`**: tests for success, 404, and shared-request
+  memoization.
+- **WeekSelector**: existing tests stay green; new tests cover
+  `title` content includes theme text and that the popover opens on
+  long-press / right-click and closes on outside-click and Esc.
+- **ActiveFilters chip**: chip shows theme title when themes are
+  loaded, falls back when not.
+
+## Verification
+
+Standard pre-commit verification per CLAUDE.md:
+
+- `cd frontend && npm run build`
+- `cd backend && npm run validate`
+- Manual dev-server check at `http://localhost:3000` on a narrow
+  viewport (DevTools mobile emulation) plus a real-device pass before
+  we iterate.
+
+## Rollout
+
+1. Land the scraper script + workflow + tests (PR #1). No UI yet.
+2. Run the workflow for 2026, review the resulting PR (#2), merge.
+3. Land the frontend hook + WeekSelector + chip changes (PR #3).
+4. Test on real mobile. Open follow-up PRs to iterate on placement
+   if needed.
+
+Steps 1 and 3 can ship in parallel — the frontend tolerates a
+missing themes file.

--- a/docs/plans/2026-05-17-weekly-themes-design.md
+++ b/docs/plans/2026-05-17-weekly-themes-design.md
@@ -86,7 +86,7 @@ Why this storage choice (vs. alternatives considered):
 
 ## Scraper
 
-A single TypeScript script at `scripts/scrape-weekly-themes.ts`,
+A single TypeScript script at `backend/src/scripts/scrapeWeeklyThemes.ts`,
 runnable two ways:
 
 1. **GitHub Actions, push-button** — the primary path. New workflow
@@ -100,23 +100,23 @@ runnable two ways:
    - Check out repo.
    - Set up Node (matches the build matrix — 24).
    - `npm ci` in repo root.
-   - `npx tsx scripts/scrape-weekly-themes.ts --year=$YEAR --out=frontend/public/data/weekly-themes/$YEAR.json`.
+   - `npx ts-node backend/src/scripts/scrapeWeeklyThemes.ts --year=$YEAR --out=frontend/public/data/weekly-themes/$YEAR.json`.
    - If the file changed, commit on branch `chore/weekly-themes-$YEAR`
      and open a PR via `gh pr create`. The user reviews and merges
      normally — nothing lands on `main` without human approval.
 
    Permissions: `contents: write`, `pull-requests: write`.
 
-2. **Local** — `npx tsx scripts/scrape-weekly-themes.ts --year=2026`
+2. **Local** — `npx ts-node backend/src/scripts/scrapeWeeklyThemes.ts --year=2026`
    for debugging or one-offs.
 
 Implementation:
 
-- Lives in a new `scripts/` npm workspace (or, if simpler, runs under
-  the existing `backend` workspace as `backend/scripts/scrape-weekly-themes.ts`).
-  Implementation plan picks one; the design only requires that
-  `cheerio` and `tsx` are resolvable from the script's location. Both
-  are already in `backend`'s dependency tree.
+- Lives under the existing `backend` workspace at
+  `backend/src/scripts/scrapeWeeklyThemes.ts`, with the parser/validator
+  extracted to `backend/src/services/weeklyThemesScraper.ts` so it is
+  covered by jest. `cheerio` and `ts-node` are already in `backend`'s
+  dependency tree.
 - Fetches the source page, locates each week block, extracts
   `number`, `title`, optional `description`, and the published
   `startDate` / `endDate`.

--- a/docs/plans/2026-05-17-weekly-themes-design.md
+++ b/docs/plans/2026-05-17-weekly-themes-design.md
@@ -1,8 +1,7 @@
 # Weekly themes — design
 
-**Status:** Draft, awaiting user review
+**Status:** Implemented — PR #129 (`weekly-themes-design` branch)
 **Date:** 2026-05-17
-**Branch:** `weekly-themes-design`
 
 ## Problem
 

--- a/frontend/public/data/weekly-themes/2026.json
+++ b/frontend/public/data/weekly-themes/2026.json
@@ -1,0 +1,70 @@
+{
+  "year": 2026,
+  "scrapedAt": "2026-05-18T14:03:21.141Z",
+  "source": "https://www.chq.org/things-to-do/events/weekly-themes/",
+  "weeks": [
+    {
+      "number": 1,
+      "title": "Icons and Instigators: Women Who Change the World",
+      "description": "",
+      "startDate": "2026-06-27",
+      "endDate": "2026-07-04"
+    },
+    {
+      "number": 2,
+      "title": "Breaking the News: Charting a New Media Landscape",
+      "description": "",
+      "startDate": "2026-07-04",
+      "endDate": "2026-07-11"
+    },
+    {
+      "number": 3,
+      "title": "The 2026 Election: What’s at Stake?",
+      "description": "",
+      "startDate": "2026-07-11",
+      "endDate": "2026-07-18"
+    },
+    {
+      "number": 4,
+      "title": "Wasted: Our Era of Disposability",
+      "description": "",
+      "startDate": "2026-07-18",
+      "endDate": "2026-07-25"
+    },
+    {
+      "number": 5,
+      "title": "Art and Artists Against the Odds",
+      "description": "",
+      "startDate": "2026-07-25",
+      "endDate": "2026-08-01"
+    },
+    {
+      "number": 6,
+      "title": "America at 250: In Partnership with The Colonial Williamsburg Foundation",
+      "description": "",
+      "startDate": "2026-08-01",
+      "endDate": "2026-08-08"
+    },
+    {
+      "number": 7,
+      "title": "Global Power and Our Evolving International Order",
+      "description": "",
+      "startDate": "2026-08-08",
+      "endDate": "2026-08-15"
+    },
+    {
+      "number": 8,
+      "title": "The Future of Food: Climate, Technology and the Next Agricultural Revolution",
+      "description": "",
+      "startDate": "2026-08-15",
+      "endDate": "2026-08-22"
+    },
+    {
+      "number": 9,
+      "title": "The Importance of Gathering: A Collaboration with the Smithsonian Folklife Festival",
+      "description": "",
+      "startDate": "2026-08-22",
+      "endDate": "2026-08-30"
+    }
+  ]
+}

--- a/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
+++ b/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
@@ -65,6 +65,16 @@ describe('WeekBadge', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
+  it('closes the popover when the badge itself is clicked again', () => {
+    render(<WeekBadge weekNumbers={[4]} themes={themes} />);
+    const label = screen.getByText('Week 4');
+    fireEvent.click(label);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    fireEvent.mouseDown(label);
+    fireEvent.click(label);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
   it('keeps the popover open across the synthetic click that follows a long-press touch', () => {
     vi.useFakeTimers();
     try {

--- a/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
+++ b/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
@@ -49,6 +49,22 @@ describe('WeekBadge', () => {
     expect(dialog).not.toHaveTextContent('Icons and Instigators');
   });
 
+  it('opens the popover when Enter is pressed and themes are loaded', () => {
+    render(<WeekBadge weekNumbers={[4]} themes={themes} />);
+    const label = screen.getByText('Week 4');
+    label.focus();
+    fireEvent.keyDown(label, { key: 'Enter' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('opens the popover when Space is pressed and themes are loaded', () => {
+    render(<WeekBadge weekNumbers={[4]} themes={themes} />);
+    const label = screen.getByText('Week 4');
+    label.focus();
+    fireEvent.keyDown(label, { key: ' ' });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
   it('does not behave as a clickable button when no themes are loaded', () => {
     render(<WeekBadge weekNumbers={[4]} themes={{}} />);
     fireEvent.click(screen.getByText('Week 4'));

--- a/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
+++ b/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vitest/globals" />
-import { render, screen, fireEvent } from '@testing-library/preact';
+import { render, screen, fireEvent, act } from '@testing-library/preact';
 import { WeekBadge } from '@/components/calendar/WeekBadge';
 import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 
@@ -63,6 +63,24 @@ describe('WeekBadge', () => {
     label.focus();
     fireEvent.keyDown(label, { key: ' ' });
     expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('keeps the popover open across the synthetic click that follows a long-press touch', () => {
+    vi.useFakeTimers();
+    try {
+      render(<WeekBadge weekNumbers={[4]} themes={themes} />);
+      const label = screen.getByText('Week 4');
+
+      fireEvent.touchStart(label);
+      act(() => { vi.advanceTimersByTime(600); });
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+      fireEvent.touchEnd(label);
+      fireEvent.click(label);
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not behave as a clickable button when no themes are loaded', () => {

--- a/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
+++ b/frontend/src/__tests__/components/calendar/WeekBadge.test.tsx
@@ -1,0 +1,57 @@
+/// <reference types="vitest/globals" />
+import { render, screen, fireEvent } from '@testing-library/preact';
+import { WeekBadge } from '@/components/calendar/WeekBadge';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
+
+const themes: Record<number, WeekTheme> = {
+  1: { number: 1, title: 'Icons and Instigators', description: '', startDate: '2026-06-27', endDate: '2026-07-04' },
+  2: { number: 2, title: 'Breaking the News', description: '', startDate: '2026-07-04', endDate: '2026-07-11' },
+  4: { number: 4, title: 'Wasted', description: '', startDate: '2026-07-18', endDate: '2026-07-25' },
+};
+
+describe('WeekBadge', () => {
+  it('renders "Week 4" for a single-week day', () => {
+    render(<WeekBadge weekNumbers={[4]} themes={themes} />);
+    expect(screen.getByText('Week 4')).toBeInTheDocument();
+  });
+
+  it('renders "Week 1/2" for a Saturday spanning two weeks', () => {
+    render(<WeekBadge weekNumbers={[1, 2]} themes={themes} />);
+    expect(screen.getByText('Week 1/2')).toBeInTheDocument();
+  });
+
+  it('renders nothing when weekNumbers is empty', () => {
+    const { container } = render(<WeekBadge weekNumbers={[]} themes={themes} />);
+    expect(container.textContent).toBe('');
+  });
+
+  it('exposes the theme(s) via the title attribute on hover', () => {
+    render(<WeekBadge weekNumbers={[1, 2]} themes={themes} />);
+    const label = screen.getByText('Week 1/2');
+    const title = label.getAttribute('title') ?? '';
+    expect(title).toContain('Icons and Instigators');
+    expect(title).toContain('Breaking the News');
+  });
+
+  it('opens a popover listing both themes when clicked on a Saturday', () => {
+    render(<WeekBadge weekNumbers={[1, 2]} themes={themes} />);
+    fireEvent.click(screen.getByText('Week 1/2'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Icons and Instigators');
+    expect(dialog).toHaveTextContent('Breaking the News');
+  });
+
+  it('opens a popover with only the one theme when clicked on a non-Saturday', () => {
+    render(<WeekBadge weekNumbers={[4]} themes={themes} />);
+    fireEvent.click(screen.getByText('Week 4'));
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveTextContent('Wasted');
+    expect(dialog).not.toHaveTextContent('Icons and Instigators');
+  });
+
+  it('does not behave as a clickable button when no themes are loaded', () => {
+    render(<WeekBadge weekNumbers={[4]} themes={{}} />);
+    fireEvent.click(screen.getByText('Week 4'));
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
+++ b/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
@@ -123,6 +123,21 @@ describe('WeekSelector — weekly theme integration', () => {
     }
   });
 
+  it('opens the popover when Shift+F10 is pressed on a themed week', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...noops()}
+      />
+    );
+    const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+    fireEvent.keyDown(week1, { key: 'F10', shiftKey: true });
+    expect(screen.getByRole('dialog', { name: /Week 1 theme/i })).toBeInTheDocument();
+  });
+
   it('does not crash and renders normally when no themes prop is provided', () => {
     render(
       <WeekSelector

--- a/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
+++ b/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
@@ -123,6 +123,28 @@ describe('WeekSelector — weekly theme integration', () => {
     }
   });
 
+  it('does not invoke the selection handlers when a non-primary mouse button is pressed', () => {
+    const handlers = {
+      ...noops(),
+      onMouseDown: vi.fn(),
+      onMouseUp: vi.fn(),
+    };
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...handlers}
+      />
+    );
+    const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+    fireEvent.mouseDown(week1, { button: 2 }); // right-click
+    fireEvent.mouseUp(week1, { button: 2 });
+    expect(handlers.onMouseDown).not.toHaveBeenCalled();
+    expect(handlers.onMouseUp).not.toHaveBeenCalled();
+  });
+
   it('opens the popover when Shift+F10 is pressed on a themed week', () => {
     render(
       <WeekSelector

--- a/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
+++ b/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
@@ -1,0 +1,143 @@
+/// <reference types="vitest/globals" />
+import { render, screen, fireEvent, act } from '@testing-library/preact';
+import { WeekSelector } from '@/components/filters/WeekSelector';
+import type { SeasonWeek } from '@/lib/types';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
+
+const seasonWeeks: SeasonWeek[] = Array.from({ length: 9 }, (_, i) => ({
+  number: i + 1,
+  start: new Date(`2026-06-${27 + i}T12:00:00Z`),
+  end: new Date(`2026-07-${4 + i}T12:00:00Z`),
+  label: `Week ${i + 1}`,
+}));
+
+const themes: Record<number, WeekTheme> = {
+  1: { number: 1, title: 'Icons and Instigators', description: 'A description.', startDate: '2026-06-27', endDate: '2026-07-04' },
+  3: { number: 3, title: 'The 2026 Election', description: '', startDate: '2026-07-11', endDate: '2026-07-18' },
+};
+
+function noops() {
+  return {
+    isDragging: false,
+    isWeekHighlighted: () => false,
+    onMouseDown: vi.fn(),
+    onMouseEnter: vi.fn(),
+    onMouseUp: vi.fn(),
+    onTap: vi.fn(),
+  };
+}
+
+describe('WeekSelector — weekly theme integration', () => {
+  it('extends the title attribute with theme text and dates when a theme is loaded', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...noops()}
+      />
+    );
+    const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+    expect(week1.getAttribute('title')).toContain('Icons and Instigators');
+  });
+
+  it('keeps the bare label as title when no theme is loaded for that week', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...noops()}
+      />
+    );
+    const week7 = screen.getByRole('button', { name: /^Week 7\b/i });
+    expect(week7.getAttribute('title')).toBe('Week 7');
+  });
+
+  it('opens the popover on right-click and shows the theme title and dates', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...noops()}
+      />
+    );
+    const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+    fireEvent.contextMenu(week1);
+    expect(screen.getByRole('dialog', { name: /Week 1 theme/i })).toBeInTheDocument();
+    expect(screen.getByText('Icons and Instigators')).toBeInTheDocument();
+  });
+
+  it('does not open a popover on right-click for a week with no theme', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...noops()}
+      />
+    );
+    const week7 = screen.getByRole('button', { name: /^Week 7\b/i });
+    fireEvent.contextMenu(week7);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('closes the popover when Escape is pressed', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        themes={themes}
+        {...noops()}
+      />
+    );
+    const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+    fireEvent.contextMenu(week1);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('opens the popover on long-press (touch hold)', () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <WeekSelector
+          seasonWeeks={seasonWeeks}
+          selectedWeeks={[]}
+          size="sm"
+          themes={themes}
+          {...noops()}
+        />
+      );
+      const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+      fireEvent.touchStart(week1);
+      act(() => {
+        vi.advanceTimersByTime(600);
+      });
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not crash and renders normally when no themes prop is provided', () => {
+    render(
+      <WeekSelector
+        seasonWeeks={seasonWeeks}
+        selectedWeeks={[]}
+        size="sm"
+        {...noops()}
+      />
+    );
+    const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
+    expect(week1.getAttribute('title')).toBe('Week 1');
+  });
+});

--- a/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
+++ b/frontend/src/__tests__/components/filters/WeekSelector.test.tsx
@@ -1,15 +1,10 @@
 /// <reference types="vitest/globals" />
 import { render, screen, fireEvent, act } from '@testing-library/preact';
 import { WeekSelector } from '@/components/filters/WeekSelector';
-import type { SeasonWeek } from '@/lib/types';
+import { getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
 import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 
-const seasonWeeks: SeasonWeek[] = Array.from({ length: 9 }, (_, i) => ({
-  number: i + 1,
-  start: new Date(`2026-06-${27 + i}T12:00:00Z`),
-  end: new Date(`2026-07-${4 + i}T12:00:00Z`),
-  label: `Week ${i + 1}`,
-}));
+const seasonWeeks = getChautauquaSeasonWeeks(2026);
 
 const themes: Record<number, WeekTheme> = {
   1: { number: 1, title: 'Icons and Instigators', description: 'A description.', startDate: '2026-06-27', endDate: '2026-07-04' },
@@ -53,7 +48,7 @@ describe('WeekSelector — weekly theme integration', () => {
       />
     );
     const week7 = screen.getByRole('button', { name: /^Week 7\b/i });
-    expect(week7.getAttribute('title')).toBe('Week 7');
+    expect(week7.getAttribute('title')).toBe(seasonWeeks[6].label);
   });
 
   it('opens the popover on right-click and shows the theme title and dates', () => {
@@ -138,6 +133,6 @@ describe('WeekSelector — weekly theme integration', () => {
       />
     );
     const week1 = screen.getByRole('button', { name: /^Week 1\b/i });
-    expect(week1.getAttribute('title')).toBe('Week 1');
+    expect(week1.getAttribute('title')).toBe(seasonWeeks[0].label);
   });
 });

--- a/frontend/src/__tests__/hooks/useWeeklyThemes.test.ts
+++ b/frontend/src/__tests__/hooks/useWeeklyThemes.test.ts
@@ -1,0 +1,105 @@
+/// <reference types="vitest/globals" />
+import { renderHook, waitFor } from '@testing-library/preact';
+import { useWeeklyThemes, __resetWeeklyThemesCacheForTests } from '@/hooks/useWeeklyThemes';
+
+const PAYLOAD_2026 = {
+  year: 2026,
+  scrapedAt: '2026-05-17T18:42:11.000Z',
+  source: 'https://www.chq.org/things-to-do/events/weekly-themes/',
+  weeks: [
+    { number: 1, title: 'Icons and Instigators', description: '', startDate: '2026-06-27', endDate: '2026-07-04' },
+    { number: 2, title: 'Breaking the News', description: '', startDate: '2026-07-04', endDate: '2026-07-11' },
+  ],
+};
+
+describe('useWeeklyThemes', () => {
+  beforeEach(() => {
+    __resetWeeklyThemesCacheForTests();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches /data/weekly-themes/<year>.json and returns themes keyed by week number', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(PAYLOAD_2026),
+    });
+
+    const { result } = renderHook(() => useWeeklyThemes(2026));
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(fetch).toHaveBeenCalledWith('/data/weekly-themes/2026.json');
+    expect(result.current.themes[1]).toEqual(PAYLOAD_2026.weeks[0]);
+    expect(result.current.themes[2]).toEqual(PAYLOAD_2026.weeks[1]);
+  });
+
+  it('returns an empty themes record when the file is missing (404)', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const { result } = renderHook(() => useWeeklyThemes(2099));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.themes).toEqual({});
+  });
+
+  it('returns an empty themes record on network error', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useWeeklyThemes(2026));
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.themes).toEqual({});
+  });
+
+  it('shares one in-flight request across concurrent consumers for the same year', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(PAYLOAD_2026),
+    });
+
+    const { result: a } = renderHook(() => useWeeklyThemes(2026));
+    const { result: b } = renderHook(() => useWeeklyThemes(2026));
+
+    await waitFor(() => {
+      expect(a.current.loading).toBe(false);
+      expect(b.current.loading).toBe(false);
+    });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(a.current.themes[1]).toBeDefined();
+    expect(b.current.themes[1]).toBeDefined();
+  });
+
+  it('caches across remounts and does not refetch the same year', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(PAYLOAD_2026),
+    });
+
+    const first = renderHook(() => useWeeklyThemes(2026));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+
+    const second = renderHook(() => useWeeklyThemes(2026));
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(second.result.current.themes[1]).toBeDefined();
+  });
+});

--- a/frontend/src/__tests__/hooks/useWeeklyThemes.test.ts
+++ b/frontend/src/__tests__/hooks/useWeeklyThemes.test.ts
@@ -87,6 +87,51 @@ describe('useWeeklyThemes', () => {
     expect(b.current.themes[1]).toBeDefined();
   });
 
+  it('retries on transient (non-404) failures across remounts', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    });
+
+    const first = renderHook(() => useWeeklyThemes(2026));
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+    expect(first.result.current.themes).toEqual({});
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    // A second mount should refetch — 500 must not poison the cache.
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(PAYLOAD_2026),
+    });
+    const second = renderHook(() => useWeeklyThemes(2026));
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(second.result.current.themes[1]).toBeDefined();
+  });
+
+  it('clears stale themes when year changes before the new fetch resolves', async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(PAYLOAD_2026),
+    });
+    const view = renderHook(({ year }: { year: number }) => useWeeklyThemes(year), {
+      initialProps: { year: 2026 },
+    });
+    await waitFor(() => expect(view.result.current.loading).toBe(false));
+    expect(view.result.current.themes[1]).toBeDefined();
+
+    // Switch to an uncached year — themes should reset before fetch resolves.
+    let resolveFetch: (v: unknown) => void = () => {};
+    (fetch as ReturnType<typeof vi.fn>).mockReturnValueOnce(new Promise((r) => { resolveFetch = r; }));
+    view.rerender({ year: 2099 });
+    expect(view.result.current.themes).toEqual({});
+    expect(view.result.current.loading).toBe(true);
+
+    resolveFetch({ ok: false, status: 404 });
+    await waitFor(() => expect(view.result.current.loading).toBe(false));
+    expect(view.result.current.themes).toEqual({});
+  });
+
   it('caches across remounts and does not refetch the same year', async () => {
     (fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,

--- a/frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts
+++ b/frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts
@@ -1,0 +1,72 @@
+/// <reference types="vitest/globals" />
+import { groupEventsByDay } from '@/lib/utils/eventHelpers';
+import { getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
+import type { Event } from '@/lib/types';
+
+const seasonWeeks = getChautauquaSeasonWeeks(2026);
+
+function evt(id: string, startDate: string, title = `Event ${id}`): Event {
+  return {
+    id,
+    title,
+    startDate,
+    endDate: startDate,
+  };
+}
+
+describe('groupEventsByDay — week-number metadata on day headers', () => {
+  it('exposes baseLabel and weekNumbers separately (no embedded "Week N" in baseLabel)', () => {
+    const groups = groupEventsByDay([
+      evt('1', '2026-07-06T14:00:00'),
+    ], seasonWeeks);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].baseLabel).toBe('Monday, July 6, 2026');
+    expect(groups[0].weekNumbers).toEqual([2]);
+  });
+
+  it('consolidates all events on the same Saturday into one day group with both adjacent week numbers', () => {
+    // Sat July 4, 2026 — Week 1 ends Sat noon, Week 2 starts Sat noon.
+    const groups = groupEventsByDay([
+      evt('morning', '2026-07-04T09:00:00'),  // belongs to week 1
+      evt('afternoon', '2026-07-04T14:00:00'), // belongs to week 2
+    ], seasonWeeks);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].baseLabel).toBe('Saturday, July 4, 2026');
+    expect(groups[0].weekNumbers).toEqual([1, 2]);
+    expect(groups[0].events.map(e => e.id)).toEqual(['morning', 'afternoon']);
+  });
+
+  it('returns an empty weekNumbers array for events outside the season', () => {
+    const groups = groupEventsByDay([
+      evt('off-season', '2026-05-01T10:00:00'),
+    ], seasonWeeks);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].baseLabel).toBe('Friday, May 1, 2026');
+    expect(groups[0].weekNumbers).toEqual([]);
+  });
+
+  it('keeps events sorted by start time within each day', () => {
+    const groups = groupEventsByDay([
+      evt('late', '2026-07-06T19:00:00'),
+      evt('early', '2026-07-06T09:00:00'),
+      evt('mid', '2026-07-06T13:00:00'),
+    ], seasonWeeks);
+
+    expect(groups[0].events.map(e => e.id)).toEqual(['early', 'mid', 'late']);
+  });
+
+  it('returns day groups sorted by date', () => {
+    const groups = groupEventsByDay([
+      evt('mon', '2026-07-06T10:00:00'),
+      evt('sun', '2026-07-05T10:00:00'),
+    ], seasonWeeks);
+
+    expect(groups.map(g => g.baseLabel)).toEqual([
+      'Sunday, July 5, 2026',
+      'Monday, July 6, 2026',
+    ]);
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,6 +9,7 @@ import { useFilterState } from '@/hooks/useFilterState';
 import { useFavorites } from '@/hooks/useFavorites';
 import { useHorizontalScroll, useVerticalScroll, useWeekDragSelection } from '@/hooks/useScrollState';
 import { useEventData } from '@/hooks/useEventData';
+import { useWeeklyThemes } from '@/hooks/useWeeklyThemes';
 import { GlobalEventDataProvider, useGlobalEventData } from '@/components/providers/GlobalEventDataProvider';
 import { Header } from '@/components/layout/Header';
 import { CountdownBanner } from '@/components/layout/CountdownBanner';
@@ -40,6 +41,7 @@ function HomeContent() {
     locationListScroll.updateScrollState(); categoryListScroll.updateScrollState();
   }, [filters.recentLocations, filters.recentCategories, filters.availableLocations, filters.availableCategories]);
   const { events, loading } = useEventData({ year: selectedYear, globalEventData, seasonWeeks, setAvailableCategories: filters.setAvailableCategories, setAvailableLocations: filters.setAvailableLocations });
+  const { themes: weeklyThemes } = useWeeklyThemes(selectedYear);
   const isCurrentYear = selectedYear === defaultYear;
   const prevYearRef = useRef(selectedYear);
   const pendingYearChangeRef = useRef(false);
@@ -138,6 +140,7 @@ function HomeContent() {
               onToggleFavoritesOnly={filters.toggleFavoritesOnly}
               favoriteCount={favorites.favoriteCount}
               isCurrentYear={isCurrentYear}
+              weeklyThemes={weeklyThemes}
             />
             <div className="space-y-3">
               <LocationFilter
@@ -172,7 +175,7 @@ function HomeContent() {
                 onToggleDescription={filters.toggleDescription} onToggleTag={filters.toggleTag} isTagSelected={filters.isTagSelected}
                 favoriteIds={favorites.favoriteIds} onToggleFavorite={favorites.toggleFavorite}
                 dateFilter={filters.dateFilter} onShowNextDay={filters.addExtraDay}
-                hasMoreDays={hasMoreDays} />
+                hasMoreDays={hasMoreDays} weeklyThemes={weeklyThemes} />
             )}
           </div>
         </div>

--- a/frontend/src/components/calendar/EventList.tsx
+++ b/frontend/src/components/calendar/EventList.tsx
@@ -1,12 +1,10 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import type { Event } from '@/lib/types';
+import type { DayGroup } from '@/lib/utils/eventHelpers';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 import { downloadICS } from '@/lib/utils/icsHelpers';
 import { EventCard } from './EventCard';
-
-interface DayGroup {
-  day: string;
-  events: Event[];
-}
+import { WeekBadge } from './WeekBadge';
 
 interface EventListProps {
   groupedEvents: DayGroup[];
@@ -19,11 +17,12 @@ interface EventListProps {
   dateFilter: string;
   onShowNextDay?: () => void;
   hasMoreDays?: boolean;
+  weeklyThemes?: Record<number, WeekTheme>;
 }
 
 const BATCH_SIZE = 50;
 
-export function EventList({ groupedEvents, expandedDescriptions, onToggleDescription, onToggleTag, isTagSelected, favoriteIds, onToggleFavorite, dateFilter, onShowNextDay, hasMoreDays }: EventListProps) {
+export function EventList({ groupedEvents, expandedDescriptions, onToggleDescription, onToggleTag, isTagSelected, favoriteIds, onToggleFavorite, dateFilter, onShowNextDay, hasMoreDays, weeklyThemes }: EventListProps) {
   const [visibleCount, setVisibleCount] = useState(BATCH_SIZE);
   const sentinelRef = useRef<HTMLDivElement>(null);
 
@@ -49,14 +48,14 @@ export function EventList({ groupedEvents, expandedDescriptions, onToggleDescrip
 
   // Slice day groups to only show visibleCount events total
   let remaining = visibleCount;
-  const visibleGroups: Array<{ day: string; events: Event[] }> = [];
+  const visibleGroups: DayGroup[] = [];
   for (const group of groupedEvents) {
     if (remaining <= 0) break;
     if (group.events.length <= remaining) {
       visibleGroups.push(group);
       remaining -= group.events.length;
     } else {
-      visibleGroups.push({ day: group.day, events: group.events.slice(0, remaining) });
+      visibleGroups.push({ ...group, events: group.events.slice(0, remaining) });
       remaining = 0;
     }
   }
@@ -75,9 +74,17 @@ export function EventList({ groupedEvents, expandedDescriptions, onToggleDescrip
   return (
     <div className="space-y-4 sm:space-y-6">
       {visibleGroups.map((dayGroup) => (
-        <div key={dayGroup.day}>
+        <div key={dayGroup.key}>
           <div className="sticky top-0 bg-white dark:bg-gray-800 z-10 border-b border-gray-200 dark:border-gray-700 pb-1 sm:pb-2 mb-2 sm:mb-4">
-            <h3 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-white">{dayGroup.day}</h3>
+            <h3 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-white">
+              {dayGroup.baseLabel}
+              {dayGroup.weekNumbers.length > 0 && (
+                <>
+                  <span> - </span>
+                  <WeekBadge weekNumbers={dayGroup.weekNumbers} themes={weeklyThemes ?? {}} />
+                </>
+              )}
+            </h3>
           </div>
           <div className="space-y-1">
             {dayGroup.events.map((event, index) => (

--- a/frontend/src/components/calendar/WeekBadge.tsx
+++ b/frontend/src/components/calendar/WeekBadge.tsx
@@ -67,6 +67,14 @@ export function WeekBadge({ weekNumbers, themes }: WeekBadgeProps) {
           }
         }}
         onClick={(e) => {
+          if (longPressFiredRef.current) {
+            // Synthetic click that immediately follows a long-press touch.
+            // Suppress so the popover the long-press just opened doesn't
+            // get re-toggled shut.
+            longPressFiredRef.current = false;
+            e.preventDefault();
+            return;
+          }
           if (hasAnyTheme) {
             e.preventDefault();
             setOpen(o => !o);
@@ -89,8 +97,17 @@ export function WeekBadge({ weekNumbers, themes }: WeekBadgeProps) {
             }, LONG_PRESS_MS);
           }
         }}
-        onTouchEnd={() => {
+        onTouchEnd={(e) => {
           clearLongPress();
+          if (longPressFiredRef.current) {
+            e.preventDefault();
+            // Leave the flag set briefly so the synthetic click that may
+            // follow (despite preventDefault) is also suppressed; auto-clear
+            // so we don't swallow a legitimate later click if the synthetic
+            // one never arrives.
+            window.setTimeout(() => { longPressFiredRef.current = false; }, 50);
+            return;
+          }
           longPressFiredRef.current = false;
         }}
         onTouchMove={() => clearLongPress()}

--- a/frontend/src/components/calendar/WeekBadge.tsx
+++ b/frontend/src/components/calendar/WeekBadge.tsx
@@ -3,13 +3,12 @@ import { createPortal } from 'react-dom';
 import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 import { WeekThemePopover, formatThemeDateRange } from '@/components/filters/WeekThemePopover';
 import { useFloatingCoords } from '@/hooks/useViewportClamp';
+import { LONG_PRESS_MS } from '@/lib/constants';
 
 interface WeekBadgeProps {
   weekNumbers: number[];
   themes: Record<number, WeekTheme>;
 }
-
-const LONG_PRESS_MS = 500;
 
 function buildHoverTitle(weekNumbers: number[], themes: Record<number, WeekTheme>): string {
   const parts = weekNumbers
@@ -69,6 +68,13 @@ export function WeekBadge({ weekNumbers, themes }: WeekBadgeProps) {
         }}
         onClick={(e) => {
           if (hasAnyTheme) {
+            e.preventDefault();
+            setOpen(o => !o);
+          }
+        }}
+        onKeyDown={(e) => {
+          if (!hasAnyTheme) return;
+          if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
             setOpen(o => !o);
           }

--- a/frontend/src/components/calendar/WeekBadge.tsx
+++ b/frontend/src/components/calendar/WeekBadge.tsx
@@ -128,7 +128,7 @@ export function WeekBadge({ weekNumbers, themes }: WeekBadgeProps) {
             visibility: coords ? 'visible' : 'hidden',
           }}
         >
-          <WeekThemePopover themes={availableThemes} onClose={() => setOpen(false)} />
+          <WeekThemePopover themes={availableThemes} onClose={() => setOpen(false)} triggerRef={badgeRef} />
         </span>,
         document.body,
       )}

--- a/frontend/src/components/calendar/WeekBadge.tsx
+++ b/frontend/src/components/calendar/WeekBadge.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
+import { WeekThemePopover, formatThemeDateRange } from '@/components/filters/WeekThemePopover';
+import { useFloatingCoords } from '@/hooks/useViewportClamp';
+
+interface WeekBadgeProps {
+  weekNumbers: number[];
+  themes: Record<number, WeekTheme>;
+}
+
+const LONG_PRESS_MS = 500;
+
+function buildHoverTitle(weekNumbers: number[], themes: Record<number, WeekTheme>): string {
+  const parts = weekNumbers
+    .map(n => themes[n])
+    .filter((t): t is WeekTheme => !!t)
+    .map(t => `Week ${t.number} — "${t.title}" (${formatThemeDateRange(t)})`);
+  if (parts.length === 0) {
+    return `Week ${weekNumbers.join('/')}`;
+  }
+  return parts.join('\n');
+}
+
+export function WeekBadge({ weekNumbers, themes }: WeekBadgeProps) {
+  const [open, setOpen] = useState(false);
+  const badgeRef = useRef<HTMLSpanElement | null>(null);
+  const popoverRef = useRef<HTMLSpanElement | null>(null);
+  const longPressTimer = useRef<number | null>(null);
+  const longPressFiredRef = useRef(false);
+  const coords = useFloatingCoords(open, badgeRef, popoverRef);
+
+  useEffect(() => () => {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current);
+    }
+  }, []);
+
+  if (weekNumbers.length === 0) return null;
+
+  const availableThemes = weekNumbers
+    .map(n => themes[n])
+    .filter((t): t is WeekTheme => !!t);
+  const hasAnyTheme = availableThemes.length > 0;
+  const label = `Week ${weekNumbers.join('/')}`;
+
+  function clearLongPress() {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }
+
+  return (
+    <span className="relative inline-block">
+      <span
+        ref={badgeRef}
+        role={hasAnyTheme ? 'button' : undefined}
+        tabIndex={hasAnyTheme ? 0 : undefined}
+        aria-haspopup={hasAnyTheme ? 'dialog' : undefined}
+        aria-expanded={hasAnyTheme ? open : undefined}
+        title={buildHoverTitle(weekNumbers, themes)}
+        className={hasAnyTheme ? 'cursor-help underline decoration-dotted underline-offset-2' : ''}
+        onContextMenu={(e) => {
+          if (hasAnyTheme) {
+            e.preventDefault();
+            setOpen(true);
+          }
+        }}
+        onClick={(e) => {
+          if (hasAnyTheme) {
+            e.preventDefault();
+            setOpen(o => !o);
+          }
+        }}
+        onTouchStart={() => {
+          longPressFiredRef.current = false;
+          if (hasAnyTheme) {
+            clearLongPress();
+            longPressTimer.current = window.setTimeout(() => {
+              longPressFiredRef.current = true;
+              setOpen(true);
+            }, LONG_PRESS_MS);
+          }
+        }}
+        onTouchEnd={() => {
+          clearLongPress();
+          longPressFiredRef.current = false;
+        }}
+        onTouchMove={() => clearLongPress()}
+        onTouchCancel={() => {
+          clearLongPress();
+          longPressFiredRef.current = false;
+        }}
+      >
+        {label}
+      </span>
+      {open && hasAnyTheme && createPortal(
+        <span
+          ref={popoverRef}
+          className="fixed z-50"
+          style={{
+            top: coords ? `${coords.top}px` : '-9999px',
+            left: coords ? `${coords.left}px` : '0px',
+            visibility: coords ? 'visible' : 'hidden',
+          }}
+        >
+          <WeekThemePopover themes={availableThemes} onClose={() => setOpen(false)} />
+        </span>,
+        document.body,
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/filters/DateFilter.tsx
+++ b/frontend/src/components/filters/DateFilter.tsx
@@ -1,5 +1,6 @@
 import type { SeasonWeek } from '@/lib/types';
 import { WeekSelector } from './WeekSelector';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 
 interface DateFilterProps {
   dateFilter: string;
@@ -21,6 +22,7 @@ interface DateFilterProps {
   onToggleFavoritesOnly: () => void;
   favoriteCount: number;
   isCurrentYear: boolean;
+  weeklyThemes?: Record<number, WeekTheme>;
 }
 
 function DateFilterButton({ label, title, isActive, onClick, ariaLabel }: {
@@ -94,7 +96,7 @@ export function DateFilter({
   currentWeekNumber, seasonWeeks, isThisWeekButtonActive,
   weekDrag, isWeekHighlighted,
   showFavoritesOnly, onToggleFavoritesOnly, favoriteCount,
-  isCurrentYear,
+  isCurrentYear, weeklyThemes,
 }: DateFilterProps) {
   const toggleDateFilter = (filter: 'next' | 'today' | 'this-week') => {
     setDateFilter(dateFilter === filter ? 'all' : filter);
@@ -119,6 +121,7 @@ export function DateFilter({
             onMouseUp={weekDrag.handleWeekMouseUp}
             onTap={weekDrag.handleWeekTap}
             size="sm"
+            themes={weeklyThemes}
           />
         </div>
       </div>
@@ -152,6 +155,7 @@ export function DateFilter({
             onMouseUp={weekDrag.handleWeekMouseUp}
             onTap={weekDrag.handleWeekTap}
             size="lg"
+            themes={weeklyThemes}
           />
         </div>
       </div>

--- a/frontend/src/components/filters/WeekSelector.tsx
+++ b/frontend/src/components/filters/WeekSelector.tsx
@@ -4,6 +4,7 @@ import type { SeasonWeek } from '@/lib/types';
 import { isWeekInPast } from '@/lib/utils/dateHelpers';
 import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 import { useFloatingCoords } from '@/hooks/useViewportClamp';
+import { LONG_PRESS_MS } from '@/lib/constants';
 import { WeekThemePopover, formatThemeDateRange } from './WeekThemePopover';
 
 interface WeekSelectorProps {
@@ -18,8 +19,6 @@ interface WeekSelectorProps {
   size: 'sm' | 'lg';
   themes?: Record<number, WeekTheme>;
 }
-
-const LONG_PRESS_MS = 500;
 
 function buildButtonTitle(week: SeasonWeek, theme: WeekTheme | undefined): string {
   if (!theme) return week.label;
@@ -68,9 +67,6 @@ export function WeekSelector({
     }
   }
 
-  const popoverIdx = popoverWeek !== null
-    ? seasonWeeks.findIndex(w => w.number === popoverWeek)
-    : -1;
   const popoverTheme = popoverWeek !== null ? themes?.[popoverWeek] : undefined;
 
   return (
@@ -150,7 +146,7 @@ export function WeekSelector({
           );
         })}
       </div>
-      {popoverWeek !== null && popoverTheme && popoverIdx >= 0 && createPortal(
+      {popoverWeek !== null && popoverTheme && createPortal(
         <div
           ref={popoverContentRef}
           className="fixed z-50"

--- a/frontend/src/components/filters/WeekSelector.tsx
+++ b/frontend/src/components/filters/WeekSelector.tsx
@@ -106,6 +106,15 @@ export function WeekSelector({
                   openPopoverIfThemed(week.number);
                 }
               }}
+              onKeyDown={(e) => {
+                // ContextMenu key (Windows menu key, Shift+F10) opens the
+                // theme popover, matching the right-click affordance. Native
+                // Enter/Space still trigger the button's onTap behavior.
+                if (hasTheme && (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10'))) {
+                  e.preventDefault();
+                  openPopoverIfThemed(week.number);
+                }
+              }}
               onTouchStart={(e) => {
                 longPressFiredRef.current = false;
                 if (hasTheme) {

--- a/frontend/src/components/filters/WeekSelector.tsx
+++ b/frontend/src/components/filters/WeekSelector.tsx
@@ -124,10 +124,8 @@ export function WeekSelector({
                     openPopoverIfThemed(week.number);
                   }, LONG_PRESS_MS);
                 }
-                if (!longPressFiredRef.current) {
-                  e.preventDefault();
-                  if (!hasTheme) onTap(week.number);
-                }
+                e.preventDefault();
+                if (!hasTheme) onTap(week.number);
               }}
               onTouchEnd={(e) => {
                 clearLongPress();

--- a/frontend/src/components/filters/WeekSelector.tsx
+++ b/frontend/src/components/filters/WeekSelector.tsx
@@ -1,5 +1,10 @@
+import { useLayoutEffect, useRef, useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import type { SeasonWeek } from '@/lib/types';
 import { isWeekInPast } from '@/lib/utils/dateHelpers';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
+import { useFloatingCoords } from '@/hooks/useViewportClamp';
+import { WeekThemePopover, formatThemeDateRange } from './WeekThemePopover';
 
 interface WeekSelectorProps {
   seasonWeeks: SeasonWeek[];
@@ -11,53 +16,154 @@ interface WeekSelectorProps {
   onMouseUp: (weekNum: number) => void;
   onTap: (weekNum: number) => void;
   size: 'sm' | 'lg';
+  themes?: Record<number, WeekTheme>;
+}
+
+const LONG_PRESS_MS = 500;
+
+function buildButtonTitle(week: SeasonWeek, theme: WeekTheme | undefined): string {
+  if (!theme) return week.label;
+  return `Week ${week.number} — "${theme.title}" (${formatThemeDateRange(theme)})`;
 }
 
 export function WeekSelector({
   seasonWeeks, selectedWeeks, isDragging, isWeekHighlighted,
-  onMouseDown, onMouseEnter, onMouseUp, onTap, size,
+  onMouseDown, onMouseEnter, onMouseUp, onTap, size, themes,
 }: WeekSelectorProps) {
   const cellSize = size === 'sm' ? 'w-6 h-6' : 'w-8 h-8';
+  const [popoverWeek, setPopoverWeek] = useState<number | null>(null);
+  const longPressTimer = useRef<number | null>(null);
+  const longPressFiredRef = useRef(false);
+  const buttonRefs = useRef<Map<number, HTMLButtonElement | null>>(new Map());
+  const activeAnchorRef = useRef<HTMLButtonElement | null>(null);
+  const popoverContentRef = useRef<HTMLDivElement | null>(null);
+  useLayoutEffect(() => {
+    activeAnchorRef.current = popoverWeek !== null
+      ? buttonRefs.current.get(popoverWeek) ?? null
+      : null;
+  }, [popoverWeek]);
+  const popoverCoords = useFloatingCoords(
+    popoverWeek !== null,
+    activeAnchorRef,
+    popoverContentRef,
+    { mode: 'center' },
+  );
+
+  useEffect(() => () => {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current);
+    }
+  }, []);
+
+  function openPopoverIfThemed(weekNum: number) {
+    if (themes && themes[weekNum]) {
+      setPopoverWeek(weekNum);
+    }
+  }
+
+  function clearLongPress() {
+    if (longPressTimer.current !== null) {
+      window.clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  }
+
+  const popoverIdx = popoverWeek !== null
+    ? seasonWeeks.findIndex(w => w.number === popoverWeek)
+    : -1;
+  const popoverTheme = popoverWeek !== null ? themes?.[popoverWeek] : undefined;
 
   return (
-    <div
-      className={`flex border border-gray-300 dark:border-gray-600 rounded-md overflow-hidden select-none ${
-        isDragging ? 'cursor-grabbing' : 'cursor-pointer'
-      }`}
-    >
-      {seasonWeeks.map((week) => {
-        const isPast = isWeekInPast(week.number, seasonWeeks);
-        const isSelected = selectedWeeks.includes(week.number);
-        const highlighted = isWeekHighlighted(week.number, isSelected);
+    <div className="relative inline-block">
+      <div
+        className={`flex border border-gray-300 dark:border-gray-600 rounded-md overflow-hidden select-none ${
+          isDragging ? 'cursor-grabbing' : 'cursor-pointer'
+        }`}
+      >
+        {seasonWeeks.map((week) => {
+          const isPast = isWeekInPast(week.number, seasonWeeks);
+          const isSelected = selectedWeeks.includes(week.number);
+          const highlighted = isWeekHighlighted(week.number, isSelected);
+          const theme = themes?.[week.number];
+          const hasTheme = !!theme;
 
-        return (
-          <button
-            type="button"
-            key={week.number}
-            className={`${cellSize} flex items-center justify-center cursor-pointer border-r border-gray-300 dark:border-gray-600 last:border-r-0 transition-all text-xs flex-shrink-0 ${
-              isPast
-                ? highlighted
-                  ? 'bg-gray-400 dark:bg-gray-500 text-white'
-                  : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
-                : highlighted
-                ? 'bg-blue-600 text-white'
-                : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700'
-            }`}
-            onMouseDown={(e) => onMouseDown(week.number, e)}
-            onMouseEnter={() => onMouseEnter(week.number)}
-            onMouseUp={() => onMouseUp(week.number)}
-            onTouchStart={(e) => {
-              e.preventDefault();
-              onTap(week.number);
-            }}
-            title={week.label}
-            aria-label={`Week ${week.number}`}
-            aria-pressed={isSelected}
-          >
-            {week.number}
-          </button>
-        );
-      })}
+          return (
+            <button
+              type="button"
+              key={week.number}
+              ref={(el) => { buttonRefs.current.set(week.number, el); }}
+              className={`${cellSize} flex items-center justify-center cursor-pointer border-r border-gray-300 dark:border-gray-600 last:border-r-0 transition-all text-xs flex-shrink-0 ${
+                isPast
+                  ? highlighted
+                    ? 'bg-gray-400 dark:bg-gray-500 text-white'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-600'
+                  : highlighted
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700'
+              }`}
+              onMouseDown={(e) => onMouseDown(week.number, e)}
+              onMouseEnter={() => onMouseEnter(week.number)}
+              onMouseUp={() => onMouseUp(week.number)}
+              onContextMenu={(e) => {
+                if (hasTheme) {
+                  e.preventDefault();
+                  openPopoverIfThemed(week.number);
+                }
+              }}
+              onTouchStart={(e) => {
+                longPressFiredRef.current = false;
+                if (hasTheme) {
+                  clearLongPress();
+                  longPressTimer.current = window.setTimeout(() => {
+                    longPressFiredRef.current = true;
+                    openPopoverIfThemed(week.number);
+                  }, LONG_PRESS_MS);
+                }
+                if (!longPressFiredRef.current) {
+                  e.preventDefault();
+                  if (!hasTheme) onTap(week.number);
+                }
+              }}
+              onTouchEnd={(e) => {
+                clearLongPress();
+                if (longPressFiredRef.current) {
+                  e.preventDefault();
+                  longPressFiredRef.current = false;
+                  return;
+                }
+                if (hasTheme) {
+                  e.preventDefault();
+                  onTap(week.number);
+                }
+              }}
+              onTouchMove={() => clearLongPress()}
+              onTouchCancel={() => {
+                clearLongPress();
+                longPressFiredRef.current = false;
+              }}
+              title={buildButtonTitle(week, theme)}
+              aria-label={`Week ${week.number}`}
+              aria-pressed={isSelected}
+            >
+              {week.number}
+            </button>
+          );
+        })}
+      </div>
+      {popoverWeek !== null && popoverTheme && popoverIdx >= 0 && createPortal(
+        <div
+          ref={popoverContentRef}
+          className="fixed z-50"
+          style={{
+            top: popoverCoords ? `${popoverCoords.top}px` : '-9999px',
+            left: popoverCoords ? `${popoverCoords.left}px` : '0px',
+            visibility: popoverCoords ? 'visible' : 'hidden',
+          }}
+        >
+          <WeekThemePopover themes={[popoverTheme]} onClose={() => setPopoverWeek(null)} />
+        </div>,
+        document.body,
+      )}
     </div>
   );
 }

--- a/frontend/src/components/filters/WeekSelector.tsx
+++ b/frontend/src/components/filters/WeekSelector.tsx
@@ -97,9 +97,17 @@ export function WeekSelector({
                   ? 'bg-blue-600 text-white'
                   : 'bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700'
               }`}
-              onMouseDown={(e) => onMouseDown(week.number, e)}
+              onMouseDown={(e) => {
+                // Skip non-primary buttons so right-click opens the theme
+                // popover without also triggering the drag/selection path.
+                if (e.button !== 0) return;
+                onMouseDown(week.number, e);
+              }}
               onMouseEnter={() => onMouseEnter(week.number)}
-              onMouseUp={() => onMouseUp(week.number)}
+              onMouseUp={(e) => {
+                if (e.button !== 0) return;
+                onMouseUp(week.number);
+              }}
               onContextMenu={(e) => {
                 if (hasTheme) {
                   e.preventDefault();
@@ -107,9 +115,10 @@ export function WeekSelector({
                 }
               }}
               onKeyDown={(e) => {
-                // ContextMenu key (Windows menu key, Shift+F10) opens the
-                // theme popover, matching the right-click affordance. Native
-                // Enter/Space still trigger the button's onTap behavior.
+                // ContextMenu key (Windows menu key) and Shift+F10 (the
+                // universal keyboard equivalent of right-click) open the
+                // theme popover. Selection itself is mouse/touch-only in
+                // this control — there is no onClick path.
                 if (hasTheme && (e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10'))) {
                   e.preventDefault();
                   openPopoverIfThemed(week.number);

--- a/frontend/src/components/filters/WeekThemePopover.tsx
+++ b/frontend/src/components/filters/WeekThemePopover.tsx
@@ -4,6 +4,13 @@ import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 interface WeekThemePopoverProps {
   themes: WeekTheme[];
   onClose: () => void;
+  /**
+   * The DOM element that triggered the popover. Clicks/touches inside this
+   * element are NOT treated as "outside" — that way a trigger that also
+   * handles click-to-toggle (e.g. WeekBadge) can close the popover via its
+   * own state instead of fighting the outside-click handler.
+   */
+  triggerRef?: { current: HTMLElement | null };
 }
 
 const MONTH_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -20,7 +27,7 @@ export function formatThemeDateRange(theme: WeekTheme): string {
   return `${formatIsoAsShort(theme.startDate)}–${formatIsoAsShort(theme.endDate)}`;
 }
 
-export function WeekThemePopover({ themes, onClose }: WeekThemePopoverProps) {
+export function WeekThemePopover({ themes, onClose, triggerRef }: WeekThemePopoverProps) {
   const ref = useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
@@ -31,9 +38,10 @@ export function WeekThemePopover({ themes, onClose }: WeekThemePopoverProps) {
       }
     }
     function onPointerDownOutside(e: Event) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose();
-      }
+      const target = e.target as Node;
+      if (ref.current && ref.current.contains(target)) return;
+      if (triggerRef?.current && triggerRef.current.contains(target)) return;
+      onClose();
     }
     document.addEventListener('keydown', onKey);
     document.addEventListener('mousedown', onPointerDownOutside);
@@ -43,7 +51,7 @@ export function WeekThemePopover({ themes, onClose }: WeekThemePopoverProps) {
       document.removeEventListener('mousedown', onPointerDownOutside);
       document.removeEventListener('touchstart', onPointerDownOutside);
     };
-  }, [onClose]);
+  }, [onClose, triggerRef]);
 
   if (themes.length === 0) return null;
 

--- a/frontend/src/components/filters/WeekThemePopover.tsx
+++ b/frontend/src/components/filters/WeekThemePopover.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef } from 'react';
+import type { WeekTheme } from '@/hooks/useWeeklyThemes';
+
+interface WeekThemePopoverProps {
+  themes: WeekTheme[];
+  onClose: () => void;
+}
+
+const MONTH_ABBR = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+function formatIsoAsShort(iso: string): string {
+  const m = iso.match(/^\d{4}-(\d{2})-(\d{2})$/);
+  if (!m) return iso;
+  const month = parseInt(m[1], 10);
+  const day = parseInt(m[2], 10);
+  return `${MONTH_ABBR[month - 1]} ${day}`;
+}
+
+export function formatThemeDateRange(theme: WeekTheme): string {
+  return `${formatIsoAsShort(theme.startDate)}–${formatIsoAsShort(theme.endDate)}`;
+}
+
+export function WeekThemePopover({ themes, onClose }: WeekThemePopoverProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        onClose();
+      }
+    }
+    function onPointerDownOutside(e: Event) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('mousedown', onPointerDownOutside);
+    document.addEventListener('touchstart', onPointerDownOutside);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('mousedown', onPointerDownOutside);
+      document.removeEventListener('touchstart', onPointerDownOutside);
+    };
+  }, [onClose]);
+
+  if (themes.length === 0) return null;
+
+  const ariaLabel = themes.length === 1
+    ? `Week ${themes[0].number} theme`
+    : `Themes for weeks ${themes.map(t => t.number).join(' and ')}`;
+
+  return (
+    <div
+      ref={ref}
+      role="dialog"
+      aria-label={ariaLabel}
+      className="w-72 max-w-[90vw] bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-md shadow-lg p-3 text-left"
+    >
+      {themes.map((theme, idx) => (
+        <div key={theme.number} className={idx > 0 ? 'mt-3 pt-3 border-t border-gray-200 dark:border-gray-700' : ''}>
+          <div className="text-xs uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Week {theme.number} · {formatThemeDateRange(theme)}
+          </div>
+          <div className="mt-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {theme.title}
+          </div>
+          {theme.description ? (
+            <div className="mt-2 text-xs text-gray-700 dark:text-gray-300">
+              {theme.description}
+            </div>
+          ) : null}
+        </div>
+      ))}
+      <div className="mt-2">
+        <a
+          href="https://www.chq.org/things-to-do/events/weekly-themes/"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-xs text-blue-600 dark:text-blue-400 underline"
+        >
+          View on chq.org
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useViewportClamp.ts
+++ b/frontend/src/hooks/useViewportClamp.ts
@@ -1,0 +1,68 @@
+import { useLayoutEffect, useState } from 'react';
+
+const DEFAULT_MARGIN_PX = 8;
+
+interface FloatingOptions {
+  /**
+   * How the anchor's horizontal position maps to the popover's natural one:
+   * - "left" (default): popover's left edge aligns with the anchor's left.
+   * - "center": popover is centered on the anchor's horizontal midpoint.
+   */
+  mode?: 'left' | 'center';
+  marginPx?: number;
+  /** Pixels of gap to leave below the anchor. */
+  gapPx?: number;
+}
+
+export interface FloatingCoords {
+  /** Viewport-relative top (for `position: fixed`). */
+  top: number;
+  /** Viewport-relative left (for `position: fixed`). */
+  left: number;
+}
+
+/**
+ * Returns viewport-relative coordinates for rendering a popover with
+ * `position: fixed` underneath `anchorRef`, clamped horizontally to stay
+ * within the viewport. Re-runs on open and on resize/scroll while open.
+ */
+export function useFloatingCoords(
+  enabled: boolean,
+  anchorRef: { current: HTMLElement | null },
+  popoverRef: { current: HTMLElement | null },
+  options: FloatingOptions = {},
+): FloatingCoords | null {
+  const { mode = 'left', marginPx = DEFAULT_MARGIN_PX, gapPx = 8 } = options;
+  const [coords, setCoords] = useState<FloatingCoords | null>(null);
+
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setCoords(null);
+      return;
+    }
+    function reposition() {
+      const anchor = anchorRef.current;
+      const pop = popoverRef.current;
+      if (!anchor || !pop) return;
+      const anchorRect = anchor.getBoundingClientRect();
+      const popRect = pop.getBoundingClientRect();
+      const naturalLeft = mode === 'center'
+        ? anchorRect.left + anchorRect.width / 2 - popRect.width / 2
+        : anchorRect.left;
+      const minLeft = marginPx;
+      const maxLeft = window.innerWidth - popRect.width - marginPx;
+      const left = Math.max(minLeft, Math.min(naturalLeft, maxLeft));
+      const top = anchorRect.bottom + gapPx;
+      setCoords({ top, left });
+    }
+    reposition();
+    window.addEventListener('resize', reposition);
+    window.addEventListener('scroll', reposition, true);
+    return () => {
+      window.removeEventListener('resize', reposition);
+      window.removeEventListener('scroll', reposition, true);
+    };
+  }, [enabled, anchorRef, popoverRef, mode, marginPx, gapPx]);
+
+  return coords;
+}

--- a/frontend/src/hooks/useWeeklyThemes.ts
+++ b/frontend/src/hooks/useWeeklyThemes.ts
@@ -20,36 +20,51 @@ export interface UseWeeklyThemesResult {
   loading: boolean;
 }
 
-const inflight = new Map<number, Promise<Record<number, WeekTheme>>>();
+interface LoadResult {
+  themes: Record<number, WeekTheme>;
+  /** When true the result is durable (200/404) and may be cached forever. */
+  cacheable: boolean;
+}
+
+const inflight = new Map<number, Promise<LoadResult>>();
 const resolved = new Map<number, Record<number, WeekTheme>>();
 
-async function loadThemes(year: number): Promise<Record<number, WeekTheme>> {
+async function loadThemes(year: number): Promise<LoadResult> {
   if (resolved.has(year)) {
-    return resolved.get(year)!;
+    return { themes: resolved.get(year)!, cacheable: true };
   }
   const existing = inflight.get(year);
   if (existing) return existing;
 
-  const promise = (async () => {
+  const promise = (async (): Promise<LoadResult> => {
     try {
       const res = await fetch(`/data/weekly-themes/${year}.json`);
-      if (!res.ok) return {};
+      if (res.status === 404) {
+        // No themes file for this year — durable empty result.
+        return { themes: {}, cacheable: true };
+      }
+      if (!res.ok) {
+        // Transient (5xx / 403 / network error). Don't poison the cache.
+        return { themes: {}, cacheable: false };
+      }
       const payload = (await res.json()) as WeeklyThemesFile;
       const themes: Record<number, WeekTheme> = {};
       for (const w of payload.weeks ?? []) {
         themes[w.number] = w;
       }
-      return themes;
+      return { themes, cacheable: true };
     } catch {
-      return {};
+      return { themes: {}, cacheable: false };
     }
   })();
 
   inflight.set(year, promise);
-  const themes = await promise;
-  resolved.set(year, themes);
+  const result = await promise;
+  if (result.cacheable) {
+    resolved.set(year, result.themes);
+  }
   inflight.delete(year);
-  return themes;
+  return result;
 }
 
 export function useWeeklyThemes(year: number): UseWeeklyThemesResult {
@@ -64,10 +79,13 @@ export function useWeeklyThemes(year: number): UseWeeklyThemesResult {
       setLoading(false);
       return;
     }
+    // Clear stale themes from the prior year before the new fetch resolves,
+    // so consumers don't briefly see the wrong year's data.
+    setThemes({});
     setLoading(true);
     loadThemes(year).then((result) => {
       if (cancelled) return;
-      setThemes(result);
+      setThemes(result.themes);
       setLoading(false);
     });
     return () => {

--- a/frontend/src/hooks/useWeeklyThemes.ts
+++ b/frontend/src/hooks/useWeeklyThemes.ts
@@ -78,7 +78,12 @@ export function useWeeklyThemes(year: number): UseWeeklyThemesResult {
   return { themes, loading };
 }
 
-/** Test-only: clear the module-level cache so each test starts fresh. */
+/**
+ * Test-only: clear the module-level cache so each test starts fresh.
+ * The `inflight` / `resolved` Maps are deliberately module-scoped so all
+ * consumers of `useWeeklyThemes` share one fetch — that's untestable across
+ * Vitest cases without a reset hook. Do NOT call this from production code.
+ */
 export function __resetWeeklyThemesCacheForTests(): void {
   inflight.clear();
   resolved.clear();

--- a/frontend/src/hooks/useWeeklyThemes.ts
+++ b/frontend/src/hooks/useWeeklyThemes.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from 'react';
+
+export interface WeekTheme {
+  number: number;
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+}
+
+interface WeeklyThemesFile {
+  year: number;
+  scrapedAt: string;
+  source: string;
+  weeks: WeekTheme[];
+}
+
+export interface UseWeeklyThemesResult {
+  themes: Record<number, WeekTheme>;
+  loading: boolean;
+}
+
+const inflight = new Map<number, Promise<Record<number, WeekTheme>>>();
+const resolved = new Map<number, Record<number, WeekTheme>>();
+
+async function loadThemes(year: number): Promise<Record<number, WeekTheme>> {
+  if (resolved.has(year)) {
+    return resolved.get(year)!;
+  }
+  const existing = inflight.get(year);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const res = await fetch(`/data/weekly-themes/${year}.json`);
+      if (!res.ok) return {};
+      const payload = (await res.json()) as WeeklyThemesFile;
+      const themes: Record<number, WeekTheme> = {};
+      for (const w of payload.weeks ?? []) {
+        themes[w.number] = w;
+      }
+      return themes;
+    } catch {
+      return {};
+    }
+  })();
+
+  inflight.set(year, promise);
+  const themes = await promise;
+  resolved.set(year, themes);
+  inflight.delete(year);
+  return themes;
+}
+
+export function useWeeklyThemes(year: number): UseWeeklyThemesResult {
+  const cached = resolved.get(year);
+  const [themes, setThemes] = useState<Record<number, WeekTheme>>(cached ?? {});
+  const [loading, setLoading] = useState<boolean>(!cached);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (resolved.has(year)) {
+      setThemes(resolved.get(year)!);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    loadThemes(year).then((result) => {
+      if (cancelled) return;
+      setThemes(result);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [year]);
+
+  return { themes, loading };
+}
+
+/** Test-only: clear the module-level cache so each test starts fresh. */
+export function __resetWeeklyThemesCacheForTests(): void {
+  inflight.clear();
+  resolved.clear();
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,5 +1,6 @@
 export const CACHE_EXPIRY_MS = 3600000; // 1 hour in milliseconds
 export const USER_STATE_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
+export const LONG_PRESS_MS = 500;
 export const YEARS_MANIFEST_PATH = '/cache/calendar-cache/years.json';
 /**
  * Compute the default season year based on October 1 turnover.

--- a/frontend/src/lib/utils/eventHelpers.ts
+++ b/frontend/src/lib/utils/eventHelpers.ts
@@ -1,5 +1,4 @@
 import type { Event, SeasonWeek } from '@/lib/types';
-import { getWeekNumberForDate } from './dateHelpers';
 
 // Lookup table for common HTML entities found in event data
 const HTML_ENTITY_MAP: Record<string, string> = {
@@ -82,44 +81,63 @@ export function decodeEventHtmlEntities(event: Event): Event {
   };
 }
 
-export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): Array<{ day: string; events: Event[] }> {
-  const grouped: { [key: string]: Event[] } = {};
+export interface DayGroup {
+  /** Stable key per calendar date (YYYY-MM-DD in local time). */
+  key: string;
+  /** Display label without the week part, e.g. "Saturday, July 4, 2026". */
+  baseLabel: string;
+  /** Season week numbers that span any portion of this calendar date (1-2 entries). */
+  weekNumbers: number[];
+  events: Event[];
+}
 
-  events.forEach(event => {
-    const eventDate = new Date(event.startDate);
-    const baseDayKey = eventDate.toLocaleDateString('en-US', {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric'
-    });
+function localDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
 
-    // Add week number to the day label
-    const weekNumber = getWeekNumberForDate(eventDate, seasonWeeks);
-    const dayKey = weekNumber
-      ? `${baseDayKey} - Week ${weekNumber}`
-      : baseDayKey;
-
-    if (!grouped[dayKey]) {
-      grouped[dayKey] = [];
+function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]): number[] {
+  const dayStart = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
+  const dayEnd = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
+  const numbers: number[] = [];
+  for (const w of seasonWeeks) {
+    if (w.start <= dayEnd && w.end > dayStart) {
+      numbers.push(w.number);
     }
-    grouped[dayKey].push(event);
-  });
+  }
+  return numbers;
+}
 
-  // Sort events within each day by start time
-  Object.keys(grouped).forEach(dayKey => {
-    grouped[dayKey].sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
-  });
+export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): DayGroup[] {
+  const grouped = new Map<string, DayGroup>();
 
-  // Return days sorted by date
-  const sortedDays = Object.keys(grouped).sort((a, b) => {
-    const dateA = new Date(grouped[a][0].startDate);
-    const dateB = new Date(grouped[b][0].startDate);
-    return dateA.getTime() - dateB.getTime();
-  });
+  for (const event of events) {
+    const eventDate = new Date(event.startDate);
+    const key = localDateKey(eventDate);
+    let group = grouped.get(key);
+    if (!group) {
+      const baseLabel = eventDate.toLocaleDateString('en-US', {
+        weekday: 'long',
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+      });
+      group = {
+        key,
+        baseLabel,
+        weekNumbers: weekNumbersForCalendarDate(eventDate, seasonWeeks),
+        events: [],
+      };
+      grouped.set(key, group);
+    }
+    group.events.push(event);
+  }
 
-  return sortedDays.map(dayKey => ({
-    day: dayKey,
-    events: grouped[dayKey]
-  }));
+  for (const group of grouped.values()) {
+    group.events.sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
 }


### PR DESCRIPTION
## Summary

Implements the [weekly themes plan](docs/plans/2026-05-17-weekly-themes-design.md): captures Chautauqua's weekly themes durably in the repo and surfaces them in the calendar UI without sending users to chq.org.

### Scraper + workflow
- `backend/src/services/weeklyThemesScraper.ts` parses chq.org's weekly-themes listing (cheerio) and validates exactly 9 sequential titled, dated weeks in the requested year.
- `backend/src/scripts/scrapeWeeklyThemes.ts` is a ts-node CLI (`--year`, `--out`, `--dry-run`).
- `.github/workflows/scrape-weekly-themes.yml` is a manual `workflow_dispatch` workflow that scrapes the year, commits to `chore/weekly-themes-$YEAR`, and opens a PR for human review.
- `frontend/public/data/weekly-themes/2026.json` is the scraped data for the current season (committed, gitignore whitelisted).

### Frontend
- New `useWeeklyThemes(year)` hook: fetches `/data/weekly-themes/<year>.json` with a module-level cache and a shared in-flight promise; 404 → `{}` so the UI quietly omits the theme affordance for years without data.
- `WeekSelector`: themed week buttons get an extended native `title` tooltip; right-click (desktop) and long-press (mobile) open a popover anchored under the button. Bare-look preserved — no dot indicators, no chip-label changes.
- `groupEventsByDay` restructured to return `{ key, baseLabel, weekNumbers, events }`. Saturday day groups now report both adjacent season weeks (e.g. `[1, 2]`) because the canonical Sat-noon → Sat-noon boundary splits the day.
- New `WeekBadge` in the day header renders `Week 4` or `Week 4/5`, with the same hover-tooltip and tap/right-click/long-press popover. For Saturdays the popover stacks both weeks' themes.
- `WeekThemePopover` now takes `themes: WeekTheme[]`. Both popovers portal to `document.body` and are positioned via a new `useFloatingCoords` hook (`getBoundingClientRect` + viewport clamping + scroll/resize reposition) so they sit above sticky day-header stacking contexts and stay on-screen on mobile.

## Test plan

- [x] `npm run build --workspace=frontend` (validate + vitest + bundle) — green
- [x] `npm run build --workspace=backend` (jest + esbuild) — green
- [x] New unit tests: `weeklyThemesScraper` (12), `useWeeklyThemes` (5), `WeekSelector` theme behavior (7), `WeekBadge` (7), `groupEventsByDay` shape change (5)
- [x] Dev-server smoke: themed-week hover, right-click and long-press popovers in the filter row, day-header `Week N` and `Week N/M` (Saturday) popovers all render correctly and stay above sticky day headers
- [ ] Manual workflow_dispatch run on `scrape-weekly-themes.yml` after merge to validate the CI path

🤖 Generated with [Claude Code](https://claude.com/claude-code)