### PR TITLE
feat(header): add Questions nav link to questions.chq.org

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -62,6 +62,12 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             >
               Programs
             </button>
+            <button
+              onClick={() => window.open('https://questions.chq.org/', '_blank')}
+              className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+            >
+              Questions
+            </button>
           </div>
           {/* Mobile */}
           <div className="md:hidden relative" ref={menuRef}>
@@ -92,6 +98,12 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
                 >
                   Programs
+                </button>
+                <button
+                  onClick={() => { window.open('https://questions.chq.org/', '_blank'); setMenuOpen(false); }}
+                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                >
+                  Questions
                 </button>
               </div>
             )}

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/preact';
+import { Header } from '../Header';
+
+// Global cleanup runs from frontend/src/__tests__/setup.ts (afterEach hook).
+
+const defaultProps = {
+  selectedYear: 2026,
+  availableYears: [2026],
+  defaultYear: 2026,
+  onYearChange: () => {},
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('Header navigation', () => {
+  it('renders the Questions button in the desktop nav linking to questions.chq.org', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    // Only the desktop nav is rendered up front; the mobile dropdown is
+    // gated behind the "More" toggle, so exactly one Questions button exists.
+    const questions = screen.getByRole('button', { name: 'Questions' });
+    fireEvent.click(questions);
+    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank');
+  });
+
+  it('renders the Questions button in the mobile dropdown', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    // Open the mobile "More" dropdown to reveal its copy of the links.
+    fireEvent.click(screen.getByRole('button', { name: /More/ }));
+    const questions = screen.getAllByRole('button', { name: 'Questions' });
+    // Desktop + mobile copies are both present once the dropdown is open.
+    expect(questions).toHaveLength(2);
+
+    fireEvent.click(questions[1]);
+    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank');
+  });
+});


### PR DESCRIPTION
## Summary
Adds a **Questions** menu item to the site header, alongside the existing Feedback and Programs links. It links to https://questions.chq.org/ and opens in a new tab, matching the existing external Programs link.

The header nav renders in two places, both updated:
- Desktop nav (`hidden md:flex`)
- Mobile "More" dropdown

## Order
Feedback · Programs · **Questions**

## Tests
Adds `Header.test.tsx` (the header nav previously had no test coverage) verifying the Questions button appears and opens the correct URL in both the desktop nav and the mobile dropdown.

## Verification
- `npm run build` (validate + type-check + lint + tests) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)