### PR TITLE
fix(ci): deploy-start timestamp fallback for manual (workflow_dispatch) deploys

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -26,6 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Record deploy start time
+        id: deploy_start
+        # Captured before any Lambda deploys so the publisher E2E test can
+        # assert each function's LastModified is newer than this deploy. Used as
+        # the workflow_dispatch fallback for DEPLOY_START_RAW: github.run_started_at
+        # is not a real github-context field and resolves to '' on manual runs,
+        # which made the downstream datetime.fromisoformat('') throw.
+        run: echo "ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
       - name: Use Node.js 24
         uses: actions/setup-node@v4
         with:
@@ -473,9 +482,11 @@ jobs:
         # ci-e2e-test publisher row + static feed exist.
         shell: bash
         env:
-          # github.event.head_commit.timestamp is only set on push; fall back
-          # to the run start time for workflow_dispatch.
-          DEPLOY_START_RAW: ${{ github.event.head_commit.timestamp || github.run_started_at }}
+          # github.event.head_commit.timestamp is only set on push; fall back to
+          # the timestamp captured by the "Record deploy start time" step for
+          # workflow_dispatch (github.run_started_at is not a real context field
+          # and resolves to '' on manual runs).
+          DEPLOY_START_RAW: ${{ github.event.head_commit.timestamp || steps.deploy_start.outputs.ts }}
           S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -482,10 +482,8 @@ jobs:
         # ci-e2e-test publisher row + static feed exist.
         shell: bash
         env:
-          # github.event.head_commit.timestamp is only set on push; fall back to
-          # the timestamp captured by the "Record deploy start time" step for
-          # workflow_dispatch (github.run_started_at is not a real context field
-          # and resolves to '' on manual runs).
+          # head_commit.timestamp is set only on push; on workflow_dispatch fall
+          # back to the "Record deploy start time" step (see its comment for why).
           DEPLOY_START_RAW: ${{ github.event.head_commit.timestamp || steps.deploy_start.outputs.ts }}
           S3_BUCKET: ${{ secrets.S3_BUCKET_NAME }}
         run: |


### PR DESCRIPTION
## Problem

A manual deploy (`gh workflow run deploy-production.yml` / Actions → Run workflow) fails in the **Publisher disable→retract end-to-end test** with:

```
ValueError: Invalid isoformat string: ''
```

That step asserts each Lambda's `LastModified` is newer than the deploy start, deriving the start from:

```
${{ github.event.head_commit.timestamp || github.run_started_at }}
```

On a `workflow_dispatch` run there is no head commit, and `github.run_started_at` is **not a real field** in the `github` context, so the fallback resolves to `''` and `datetime.fromisoformat('')` throws. Push-triggered deploys set `head_commit.timestamp` and were never affected.

## Fix

Capture the deploy start time in a new early step (`date -u`, before any Lambda deploys) and use its output as the `workflow_dispatch` fallback:

```
DEPLOY_START_RAW: ${{ github.event.head_commit.timestamp || steps.deploy_start.outputs.ts }}
```

Push behavior is unchanged (still uses `head_commit.timestamp`); manual deploys now get a real timestamp.

## Verification

- YAML parses; the new "Record deploy start time" step is second, right after checkout and before all Lambda deploys.
- Reproduced the exact failure (`fromisoformat('')` → `ValueError`) and confirmed the captured `2026-...T...Z` timestamp parses correctly, as does the existing push `head_commit.timestamp` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)