### PR TITLE
fix(pwa): auto-update installed home-screen users on every release

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -410,20 +410,37 @@ jobs:
       - name: Deploy frontend to S3 and CloudFront
         working-directory: ./frontend
         run: |
-          # Sync to S3 bucket
-          aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
+          BUCKET="${{ secrets.S3_BUCKET_NAME }}"
+
+          # Pass 1 — content-hashed, immutable assets. Exclude the files that must always
+          # revalidate so they never get the year-long immutable header. --delete removes
+          # stale hashed bundles; excluded files are neither uploaded nor deleted here.
+          aws s3 sync out/ "s3://$BUCKET/" \
             --delete \
             --exclude "*.map" \
             --exclude "cache/*" \
-            --cache-control "public, max-age=31536000, immutable" \
-            --metadata-directive REPLACE
+            --exclude "*.html" \
+            --exclude "manifest.json" \
+            --exclude "version.json" \
+            --cache-control "public, max-age=31536000, immutable"
 
-          # Update HTML files with shorter cache
-          aws s3 sync out/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
+          # Pass 2 — always-revalidate files. `cp` re-uploads unconditionally (unlike
+          # `sync`, which skips unchanged files and was the cause of the stale-shell bug),
+          # so the no-cache header is applied every time.
+          aws s3 cp out/ "s3://$BUCKET/" \
+            --recursive \
             --exclude "*" \
             --include "*.html" \
-            --cache-control "public, max-age=3600" \
-            --metadata-directive REPLACE
+            --content-type "text/html" \
+            --cache-control "no-cache"
+
+          aws s3 cp out/manifest.json "s3://$BUCKET/manifest.json" \
+            --content-type "application/json" \
+            --cache-control "no-cache"
+
+          aws s3 cp out/version.json "s3://$BUCKET/version.json" \
+            --content-type "application/json" \
+            --cache-control "no-cache"
 
           # Invalidate CloudFront cache
           aws cloudfront create-invalidation \

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -422,6 +422,7 @@ jobs:
             --exclude "*.html" \
             --exclude "manifest.json" \
             --exclude "version.json" \
+            --exclude "sw.js" \
             --cache-control "public, max-age=31536000, immutable"
 
           # Pass 2 — always-revalidate files. `cp` re-uploads unconditionally (unlike
@@ -440,6 +441,10 @@ jobs:
 
           aws s3 cp out/version.json "s3://$BUCKET/version.json" \
             --content-type "application/json" \
+            --cache-control "no-cache"
+
+          aws s3 cp out/sw.js "s3://$BUCKET/sw.js" \
+            --content-type "text/javascript" \
             --cache-control "no-cache"
 
           # Invalidate CloudFront cache

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -423,6 +423,7 @@ jobs:
             --exclude "manifest.json" \
             --exclude "version.json" \
             --exclude "sw.js" \
+            --exclude "data/weekly-themes/*" \
             --cache-control "public, max-age=31536000, immutable"
 
           # Pass 2 — always-revalidate files. `cp` re-uploads unconditionally (unlike
@@ -445,6 +446,15 @@ jobs:
 
           aws s3 cp out/sw.js "s3://$BUCKET/sw.js" \
             --content-type "text/javascript" \
+            --cache-control "no-cache"
+
+          # weekly-themes JSON is fetched directly from /data/ in production
+          # (useWeeklyThemes has no dev/prod split) and is NOT content-hashed,
+          # so it must revalidate — otherwise a content edit under the same
+          # filename would never reach users (the same bug this deploy fixes).
+          aws s3 cp out/data/weekly-themes/ "s3://$BUCKET/data/weekly-themes/" \
+            --recursive \
+            --content-type "application/json" \
             --cache-control "no-cache"
 
           # Invalidate CloudFront cache

--- a/docs/superpowers/plans/2026-07-15-pwa-auto-update.md
+++ b/docs/superpowers/plans/2026-07-15-pwa-auto-update.md
@@ -1,0 +1,539 @@
+# PWA Auto-Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make installed iPhone home-screen users receive new frontend releases automatically, and guarantee it for every future release.
+
+**Architecture:** Fix the deploy so the HTML shell / `manifest.json` / `version.json` are served `no-cache` (root cause: a year-long `immutable` header applied by an `aws s3 sync` two-pass skip bug). Bake a build version (`VITE_APP_VERSION`) into the bundle, emit a matching `version.json`, and add a small client module that fetches `version.json` on load and on app-reopen and silently reloads when the deployed version differs. No service worker.
+
+**Tech Stack:** Vite 7, Preact 10, TypeScript 5, Vitest, AWS CLI (S3 + CloudFront) in GitHub Actions.
+
+## Global Constraints
+
+- Node.js `>=24.0.0`; do not use APIs unavailable in Node 24.
+- Preact, not React. `@preact/preset-vite` aliases `react`→`preact/compat`. JSX-rendering files import hooks/types from `'react'`; pure `.ts` files need no `'react'` import. `versionCheck.ts` is pure `.ts` (no JSX) — import nothing from react/preact.
+- Tests are colocated and matched by `src/**/*.test.{ts,tsx}` (vitest include). Coverage floor enforced via `.coverage-floor.json` — new module must be covered.
+- `npm run build` (in `frontend/`) runs `validate` (type-check + lint) then `vitest run --coverage` then `vite build`. It must stay green.
+- Production build substitutes `import.meta.env.VITE_APP_VERSION` at compile time via Vite `define`. Production code MUST reference that env var with the **exact** literal expression `import.meta.env.VITE_APP_VERSION` (no `as any` wrapping of `import.meta`) or the substitution will not fire.
+- Never commit to `main`. Work on branch `fix/pwa-auto-update` (already created).
+
+## File Structure
+
+- `frontend/src/lib/versionCheck.ts` — **new.** Pure update-decision logic + fetch/reload orchestration + a `visibilitychange` watcher. Dependency-injected (fetch, storage, reload) for testability.
+- `frontend/src/lib/versionCheck.test.ts` — **new.** Vitest unit tests.
+- `frontend/src/vite-env.d.ts` — **modify.** Add `VITE_APP_VERSION` to `ImportMetaEnv`.
+- `frontend/vite.config.ts` — **modify.** Compute app version from git, inject via `define`, and emit `version.json` into the build via a small plugin.
+- `frontend/src/entries/main.tsx` — **modify.** Start the version watcher after render.
+- `.github/workflows/deploy-production.yml` — **modify.** Restructure the frontend S3 upload so revalidate-always files get `no-cache` unconditionally.
+- `scripts/deploy-frontend.sh` — **modify.** Mirror the same header fix for local/manual deploys.
+
+---
+
+### Task 1: `versionCheck.ts` — update-decision logic and orchestration
+
+**Files:**
+- Create: `frontend/src/lib/versionCheck.ts`
+- Test: `frontend/src/lib/versionCheck.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces:
+  - `shouldReload(current: string | undefined, fetched: unknown, alreadyTargeted: string | null): boolean`
+  - `checkForUpdate(opts?: CheckOptions): Promise<void>` where
+    `CheckOptions = { current?: string; storage?: Pick<Storage,'getItem'|'setItem'>; reload?: () => void; fetchImpl?: typeof fetch }`
+  - `startVersionWatch(opts?: CheckOptions): void`
+  - Constants `VERSION_URL = '/version.json'`, `STORAGE_KEY = 'chq:reloadedForVersion'` (exported for tests).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `frontend/src/lib/versionCheck.test.ts`:
+
+```ts
+/// <reference types="vitest/globals" />
+import {
+  shouldReload,
+  checkForUpdate,
+  startVersionWatch,
+  VERSION_URL,
+  STORAGE_KEY,
+} from '@/lib/versionCheck';
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+function okJson(body: unknown) {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+describe('shouldReload', () => {
+  it('reloads when fetched differs from current and is not the guarded target', () => {
+    expect(shouldReload('abc', 'def', null)).toBe(true);
+  });
+  it('does not reload when versions match', () => {
+    expect(shouldReload('abc', 'abc', null)).toBe(false);
+  });
+  it('does not reload when fetched is missing/blank', () => {
+    expect(shouldReload('abc', undefined, null)).toBe(false);
+    expect(shouldReload('abc', '', null)).toBe(false);
+  });
+  it('does not reload twice for the same target (loop guard)', () => {
+    expect(shouldReload('abc', 'def', 'def')).toBe(false);
+  });
+});
+
+describe('checkForUpdate', () => {
+  it('reloads and records the target when a newer version is deployed', async () => {
+    const reload = vi.fn();
+    const storage = fakeStorage();
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'def' }));
+    await checkForUpdate({ current: 'abc', storage, reload, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledWith(VERSION_URL, { cache: 'no-store' });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(STORAGE_KEY)).toBe('def');
+  });
+  it('does not reload when versions match', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'abc' }));
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('does not reload again for a version already targeted (loop guard)', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'def' }));
+    await checkForUpdate({
+      current: 'abc',
+      storage: fakeStorage({ [STORAGE_KEY]: 'def' }),
+      reload,
+      fetchImpl,
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('swallows fetch rejection and does not reload', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('offline'));
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('does nothing on a non-OK response', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false } as Response);
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('swallows malformed JSON and does not reload', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => { throw new Error('bad json'); },
+    } as unknown as Response);
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('startVersionWatch', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('checks once immediately and again when the app becomes visible', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'abc' }));
+    const opts = { current: 'abc', storage: fakeStorage(), reload: vi.fn(), fetchImpl };
+    startVersionWatch(opts);
+    // initial check
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // simulate reopening the home-screen app
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/lib/versionCheck.test.ts`
+Expected: FAIL — cannot resolve module `@/lib/versionCheck`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `frontend/src/lib/versionCheck.ts`:
+
+```ts
+// Detects when a newer frontend build has been deployed and silently reloads
+// so installed (home-screen) users pick it up. See
+// docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md.
+
+export const VERSION_URL = '/version.json';
+export const STORAGE_KEY = 'chq:reloadedForVersion';
+
+type MinimalStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+export interface CheckOptions {
+  current?: string;
+  storage?: MinimalStorage;
+  reload?: () => void;
+  fetchImpl?: typeof fetch;
+}
+
+// Pure decision: reload only when we have a fetched version that differs from
+// what is running AND we have not already reloaded targeting that same version.
+export function shouldReload(
+  current: string | undefined,
+  fetched: unknown,
+  alreadyTargeted: string | null,
+): boolean {
+  if (typeof fetched !== 'string' || fetched.length === 0) return false;
+  if (fetched === current) return false;
+  if (fetched === alreadyTargeted) return false;
+  return true;
+}
+
+export async function checkForUpdate(opts: CheckOptions = {}): Promise<void> {
+  const {
+    current = import.meta.env.VITE_APP_VERSION,
+    storage = window.sessionStorage,
+    reload = () => window.location.reload(),
+    fetchImpl = fetch,
+  } = opts;
+
+  try {
+    const res = await fetchImpl(VERSION_URL, { cache: 'no-store' });
+    if (!res.ok) return;
+    const data = (await res.json()) as { version?: unknown };
+    const fetched = data?.version;
+    const alreadyTargeted = storage.getItem(STORAGE_KEY);
+    if (shouldReload(current, fetched, alreadyTargeted)) {
+      storage.setItem(STORAGE_KEY, fetched as string);
+      reload();
+    }
+  } catch {
+    // Offline, non-OK, or malformed response — keep running the current version.
+  }
+}
+
+// Checks now and every time the app regains visibility (iOS fires
+// visibilitychange when a home-screen app is reopened).
+export function startVersionWatch(opts: CheckOptions = {}): void {
+  void checkForUpdate(opts);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') void checkForUpdate(opts);
+  });
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/lib/versionCheck.test.ts`
+Expected: PASS (all suites).
+
+- [ ] **Step 5: Type-check and lint**
+
+Run: `cd frontend && npm run validate`
+Expected: no errors. (`import.meta.env.VITE_APP_VERSION` is typed in Task 2; if Task 1 is executed first and tsc flags it, do Task 2 Step 1 first — adding the env type — then re-run.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/lib/versionCheck.ts frontend/src/lib/versionCheck.test.ts
+git commit -m "feat(pwa): version-check module with silent auto-reload"
+```
+
+---
+
+### Task 2: Bake `VITE_APP_VERSION` into the build and emit `version.json`
+
+**Files:**
+- Modify: `frontend/src/vite-env.d.ts`
+- Modify: `frontend/vite.config.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a built `out/version.json` of shape `{ "version": string }`, and a compile-time value for `import.meta.env.VITE_APP_VERSION` equal to that same string. Task 1's `checkForUpdate` default and Task 3's wiring both rely on these.
+
+- [ ] **Step 1: Add the env type**
+
+Edit `frontend/src/vite-env.d.ts` — add one line inside `interface ImportMetaEnv`:
+
+```ts
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+  readonly VITE_RECAPTCHA_SITE_KEY: string;
+  readonly VITE_ENABLE_PUBLISHER_FEEDS: string;
+  readonly VITE_APP_VERSION: string;
+}
+```
+
+- [ ] **Step 2: Compute the version and wire `define` + the emit plugin in `vite.config.ts`**
+
+At the top of `frontend/vite.config.ts`, add to the existing imports:
+
+```ts
+import { execSync } from 'child_process';
+```
+
+Add these helpers below the imports (before `devServerMiddleware`):
+
+```ts
+// Build version stamp: short git SHA of the deployed commit, or a timestamp
+// fallback for environments without git. Baked into the bundle via `define`
+// and emitted as version.json so the client can detect new deploys.
+function resolveAppVersion(): string {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return `build-${Date.now()}`;
+  }
+}
+
+// Emits out/version.json at build time with the same value baked into the bundle.
+function emitVersionJson(version: string): PluginOption {
+  return {
+    name: 'emit-version-json',
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify({ version }),
+      });
+    },
+  };
+}
+
+const APP_VERSION = resolveAppVersion();
+```
+
+In the `defineConfig({ ... })` object, add `emitVersionJson` to `plugins` and add a `define` block. Change:
+
+```ts
+  plugins: [devServerMiddleware(), preact()],
+  resolve: {
+```
+
+to:
+
+```ts
+  plugins: [devServerMiddleware(), preact(), emitVersionJson(APP_VERSION)],
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(APP_VERSION),
+  },
+  resolve: {
+```
+
+- [ ] **Step 3: Build and verify the outputs**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds.
+
+Run: `cat frontend/out/version.json`
+Expected: `{"version":"<short-sha-or-build-timestamp>"}`
+
+Run: `grep -roh "$(node -e "process.stdout.write(require('./out/version.json').version)" 2>/dev/null || echo __none__)" frontend/out/assets/*.js | head -1`
+Expected: prints the same version string (proves `import.meta.env.VITE_APP_VERSION` was substituted into the bundle). If empty, the `define` expression does not match the code's literal — re-check the exact `import.meta.env.VITE_APP_VERSION` spelling in `versionCheck.ts`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/vite.config.ts frontend/src/vite-env.d.ts
+git commit -m "feat(pwa): bake VITE_APP_VERSION and emit version.json at build"
+```
+
+---
+
+### Task 3: Start the version watcher in the main entry
+
+**Files:**
+- Modify: `frontend/src/entries/main.tsx`
+
+**Interfaces:**
+- Consumes: `startVersionWatch` (Task 1), `import.meta.env.VITE_APP_VERSION` / `version.json` (Task 2).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Wire it up**
+
+Replace the entire contents of `frontend/src/entries/main.tsx` with:
+
+```tsx
+import { render } from 'preact';
+import '@/app/globals.css';
+import Home from '@/app/page';
+import { startVersionWatch } from '@/lib/versionCheck';
+
+render(<Home />, document.getElementById('root')!);
+
+// Auto-reload installed/home-screen users onto new deploys.
+startVersionWatch();
+```
+
+- [ ] **Step 2: Build to verify wiring compiles and bundles**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds (validate + tests + vite build all green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/entries/main.tsx
+git commit -m "feat(pwa): start version watcher on the main calendar entry"
+```
+
+---
+
+### Task 4: Fix cache headers in the CI deploy (`deploy-production.yml`)
+
+**Files:**
+- Modify: `.github/workflows/deploy-production.yml:410-431` (the "Deploy frontend to S3 and CloudFront" step).
+
+**Interfaces:**
+- Consumes: `out/version.json` and `out/manifest.json` produced by the build (Task 2 emits `version.json`; `manifest.json` already ships from `public/`).
+- Produces: correct production cache headers.
+
+- [ ] **Step 1: Replace the upload commands**
+
+In `.github/workflows/deploy-production.yml`, replace the body of the `run: |` block under `- name: Deploy frontend to S3 and CloudFront` (currently the two `aws s3 sync` calls + the invalidation, lines ~413-431) with:
+
+```bash
+BUCKET="${{ secrets.S3_BUCKET_NAME }}"
+
+# Pass 1 — content-hashed, immutable assets. Exclude the files that must always
+# revalidate so they never get the year-long immutable header. --delete removes
+# stale hashed bundles; excluded files are neither uploaded nor deleted here.
+aws s3 sync out/ "s3://$BUCKET/" \
+  --delete \
+  --exclude "*.map" \
+  --exclude "cache/*" \
+  --exclude "*.html" \
+  --exclude "manifest.json" \
+  --exclude "version.json" \
+  --cache-control "public, max-age=31536000, immutable"
+
+# Pass 2 — always-revalidate files. `cp` re-uploads unconditionally (unlike
+# `sync`, which skips unchanged files and was the cause of the stale-shell bug),
+# so the no-cache header is applied every time.
+aws s3 cp out/ "s3://$BUCKET/" \
+  --recursive \
+  --exclude "*" \
+  --include "*.html" \
+  --content-type "text/html" \
+  --cache-control "no-cache"
+
+aws s3 cp out/manifest.json "s3://$BUCKET/manifest.json" \
+  --content-type "application/json" \
+  --cache-control "no-cache"
+
+aws s3 cp out/version.json "s3://$BUCKET/version.json" \
+  --content-type "application/json" \
+  --cache-control "no-cache"
+
+# Invalidate CloudFront cache
+aws cloudfront create-invalidation \
+  --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+  --paths "/*"
+```
+
+- [ ] **Step 2: Lint the workflow YAML**
+
+Run: `cd /Users/bernard/src/chq/chq-calendar && python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/deploy-production.yml')); print('YAML OK')"`
+Expected: `YAML OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/deploy-production.yml
+git commit -m "fix(ci): serve HTML/manifest/version.json as no-cache (stop stale PWA shell)"
+```
+
+> **Post-deploy verification (run after this reaches production, not part of the plan's local run):**
+> ```bash
+> curl -sI https://www.chqcal.org/            | grep -i cache-control   # -> no-cache, NOT immutable
+> curl -sI https://www.chqcal.org/manifest.json | grep -i cache-control # -> no-cache
+> curl -sI https://www.chqcal.org/version.json  | grep -i cache-control # -> no-cache
+> curl -sI "https://www.chqcal.org/$(curl -s https://www.chqcal.org/ | grep -oE 'assets/[^"]+\.js' | head -1)" | grep -i cache-control  # -> max-age=31536000, immutable
+> ```
+
+---
+
+### Task 5: Mirror the header fix in `scripts/deploy-frontend.sh`
+
+**Files:**
+- Modify: `scripts/deploy-frontend.sh:90-127` (the S3 upload / content-type section).
+
+**Interfaces:**
+- Consumes: `out/version.json`, `out/manifest.json`, `out/*.html`.
+- Produces: identical header behavior for local/manual deploys.
+
+- [ ] **Step 1: Replace the upload block**
+
+In `scripts/deploy-frontend.sh`, replace everything from the `# Sync files to S3` comment (line ~90) through the `error.html` content-type `aws s3 cp` (line ~127) — i.e. the four upload/content-type blocks — with:
+
+```bash
+# Sync files to S3
+# Pass 1 — content-hashed, immutable assets. Exclude always-revalidate files.
+echo "☁️  Uploading immutable assets to S3..."
+aws s3 sync "$BUILD_DIR/" "s3://$S3_BUCKET/" \
+    --delete \
+    --exclude "*.map" \
+    --exclude "cache/*" \
+    --exclude "*.html" \
+    --exclude "manifest.json" \
+    --exclude "version.json" \
+    --cache-control "public, max-age=31536000, immutable"
+
+# Pass 2 — always-revalidate files. `cp` applies the header unconditionally
+# (`sync` skips unchanged files, leaving stale headers behind).
+echo "📄 Uploading HTML with no-cache..."
+aws s3 cp "$BUILD_DIR/" "s3://$S3_BUCKET/" \
+    --recursive \
+    --exclude "*" \
+    --include "*.html" \
+    --content-type "text/html" \
+    --cache-control "no-cache"
+
+if [ -f "$BUILD_DIR/manifest.json" ]; then
+    aws s3 cp "$BUILD_DIR/manifest.json" "s3://$S3_BUCKET/manifest.json" \
+        --content-type "application/json" \
+        --cache-control "no-cache"
+fi
+
+if [ -f "$BUILD_DIR/version.json" ]; then
+    aws s3 cp "$BUILD_DIR/version.json" "s3://$S3_BUCKET/version.json" \
+        --content-type "application/json" \
+        --cache-control "no-cache"
+fi
+```
+
+Leave the CloudFront invalidation block (lines ~129-138) unchanged.
+
+- [ ] **Step 2: Shellcheck / syntax check**
+
+Run: `bash -n scripts/deploy-frontend.sh`
+Expected: no output (syntax OK).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/deploy-frontend.sh
+git commit -m "fix(deploy): mirror no-cache header fix in manual deploy script"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Part 1 (header fix) → Tasks 4 (CI) + 5 (shell script). ✓
+- Part 2 (version stamp + `version.json`) → Task 2. ✓
+- Part 3 (client check, silent reload on reopen, loop guard, swallow failures) → Task 1 + wiring in Task 3. ✓
+- Testing (versionCheck unit tests; post-deploy curl assertions) → Task 1 tests; Task 4 post-deploy verification block. ✓
+- Non-goals (no service worker; main entry only) → respected; only `main.tsx` wired. ✓
+
+**Placeholder scan:** No TBD/TODO/"handle edge cases"; all code shown in full. ✓
+
+**Type consistency:** `shouldReload`, `checkForUpdate`, `startVersionWatch`, `CheckOptions`, `VERSION_URL`, `STORAGE_KEY` are used identically in the module, its tests, and the wiring. `version.json` shape `{ version: string }` matches between `emitVersionJson` (Task 2) and `checkForUpdate`'s parse (Task 1). `import.meta.env.VITE_APP_VERSION` literal matches the `define` key (Task 2) and the module default (Task 1). ✓

--- a/docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md
+++ b/docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md
@@ -108,11 +108,12 @@ Restructure the S3 upload in **both** `.github/workflows/deploy-production.yml`
   a one-year immutable TTL is correct. Continue to exclude `cache/*` and `*.map`
   as today.
 - **Pass 2 — always-revalidate files:** upload `*.html`, `manifest.json`, and
-  `version.json` with `cache-control: no-cache` using
-  `aws s3 cp --metadata-directive REPLACE` (explicit `cp`, **not** a second
-  `sync`) so the header is applied unconditionally and the sync-skip bug cannot
-  recur. `no-cache` means the browser revalidates via ETag on every load; an
-  unchanged file returns a near-free `304`.
+  `version.json` with `cache-control: no-cache` using `aws s3 cp` (explicit
+  `cp`, **not** a second `sync`) so the header is applied unconditionally and
+  the sync-skip bug cannot recur. (`--metadata-directive REPLACE` is not used —
+  it applies only to S3→S3 copies; a local→S3 `cp` takes its metadata directly
+  from the flags.) `no-cache` means the browser revalidates via ETag on every
+  load; an unchanged file returns a near-free `304`.
 - CloudFront full invalidation (`/*`) stays as-is.
 
 ### Part 2 — Version stamp

--- a/docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md
+++ b/docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md
@@ -1,0 +1,162 @@
+# PWA Auto-Update — Design
+
+**Date:** 2026-07-15
+**Status:** Approved (design). Next: implementation plan.
+**Topic:** Ensure installed home-screen ("PWA") users receive new frontend
+releases automatically, and guarantee the same for every future release.
+
+## Problem
+
+Users who installed `https://www.chqcal.org` to their iPhone home screen never
+receive new versions after a deploy. The app stays frozen on whatever version it
+first cached.
+
+### Root cause
+
+The live app shell is served with a **year-long immutable** cache header:
+
+```
+GET https://www.chqcal.org/
+cache-control: public, max-age=31536000, immutable
+```
+
+`immutable` + `max-age=31536000` tells every browser and every iOS home-screen
+web clip that `index.html` never changes for a year, so the device never
+re-requests it. New deploys land on S3 and CloudFront is invalidated, but the
+**device's own cache never asks the origin**, so it keeps serving the old shell,
+which references the old content-hashed JS/CSS bundles. `manifest.json` has the
+same header and the same problem.
+
+This is caused by an `aws s3 sync` two-pass bug in the deploy
+(`.github/workflows/deploy-production.yml:414-426`, mirrored in
+`scripts/deploy-frontend.sh`):
+
+1. Pass 1 uploads **everything** — including `*.html` — with
+   `max-age=31536000, immutable`.
+2. Pass 2 tries to re-upload the HTML with a shorter TTL, but `aws s3 sync`
+   skips files whose content is unchanged. The HTML was just uploaded seconds
+   earlier with identical content, so pass 2 uploads **nothing** and the
+   immutable header from pass 1 stays in place.
+
+The intended second-pass header (`max-age=3600`) was also weaker than an app
+shell warrants.
+
+### Honest constraint on already-installed users
+
+There is **no HTTP mechanism that instantly reaches a device which already
+believes `index.html` is immutable for a year** — such a device will not contact
+the origin until iOS evicts that cache entry on its own (iOS does this fairly
+regularly for web-clip caches, but not on a schedule we control). Therefore:
+
+- **Currently-trapped devices** recover the first time iOS revalidates their
+  cached shell after this fix ships. From that point on they are on the
+  self-updating path.
+- **Every future release** updates automatically once the header is corrected.
+
+No approach can change the reality for already-trapped devices; this is the same
+for every option considered. The chosen design makes updates deterministic and
+automatic from the corrected baseline onward.
+
+## Chosen approach
+
+**Header fix + client-side version check with silent auto-reload on reopen.**
+
+- Fixing the cache headers is the necessary root-cause fix: every future launch
+  revalidates the shell and picks up new bundles.
+- A lightweight version check makes the update happen *while the app is
+  open/reopened* — deterministic, with no service-worker complexity or its
+  associated stale-cache failure modes.
+
+Rejected alternatives:
+
+- **Header fix only** — correct but doesn't refresh an already-open/reopened
+  session; relies solely on the browser's revalidation timing.
+- **Full service worker (vite-plugin-pwa/Workbox)** — enables true offline and
+  deterministic updates, but adds real complexity and its own (harder to debug)
+  stale-cache failure mode, plus iOS SW quirks. Overkill for a static site that
+  does not need offline.
+
+## Design
+
+### Part 1 — Fix the cache headers (root cause)
+
+Restructure the S3 upload in **both** `.github/workflows/deploy-production.yml`
+(the real deploy path) and `scripts/deploy-frontend.sh` (kept consistent) so the
+"revalidate-always" files are never uploaded with the immutable header first:
+
+- **Pass 1 — immutable, content-hashed assets:** sync everything *except*
+  `*.html`, `manifest.json`, and `version.json` with
+  `public, max-age=31536000, immutable`. Vite content-hashes these filenames, so
+  a one-year immutable TTL is correct. Continue to exclude `cache/*` and `*.map`
+  as today.
+- **Pass 2 — always-revalidate files:** upload `*.html`, `manifest.json`, and
+  `version.json` with `cache-control: no-cache` using
+  `aws s3 cp --metadata-directive REPLACE` (explicit `cp`, **not** a second
+  `sync`) so the header is applied unconditionally and the sync-skip bug cannot
+  recur. `no-cache` means the browser revalidates via ETag on every load; an
+  unchanged file returns a near-free `304`.
+- CloudFront full invalidation (`/*`) stays as-is.
+
+### Part 2 — Version stamp
+
+- At build time, bake the version into the bundle as `VITE_APP_VERSION` — the
+  short git SHA, falling back to a build timestamp when a SHA is unavailable
+  (e.g. local builds outside CI).
+- Emit a tiny `version.json` at build time containing the **same** value:
+  `{ "version": "<sha-or-timestamp>" }`. It is uploaded to S3 and served
+  `no-cache` per Part 1.
+
+Both the running app and the served `version.json` carry the identical value, so
+a mismatch unambiguously means "a newer deploy exists."
+
+### Part 3 — Client version check
+
+New module `versionCheck.ts` (in `frontend/src/lib/`), wired into the main
+calendar entry only (the installed PWA surface). Admin and publisher pages are
+out of scope.
+
+Behavior:
+
+- On initial load, and on `visibilitychange` → document becomes visible (iOS
+  fires this when the home-screen app is reopened), fetch `/version.json` with
+  `cache: 'no-store'`.
+- If `fetched.version !== VITE_APP_VERSION`, call `location.reload()`.
+- **Loop guard:** before reloading, record the target version in
+  `sessionStorage`; never reload twice for the same target value. This protects
+  against a CloudFront propagation race where `version.json` updates a moment
+  before the new bundle is fetchable.
+- **Failure handling:** any fetch error (offline, non-OK status, malformed JSON)
+  is swallowed — no reload; the app continues on its current version.
+
+### Testing
+
+- **Header logic (CI/shell):** validated by review of the commands plus a
+  post-deploy live check. Assertions:
+  - `curl -sI https://www.chqcal.org/ | grep -i cache-control` →
+    contains `no-cache` (and NOT `immutable`).
+  - Same assertion for `/manifest.json` and `/version.json`.
+  - A hashed asset (e.g. `/assets/*.js`) still returns
+    `max-age=31536000, immutable`.
+- **`versionCheck.ts` (Vitest unit tests):** `fetch` and `location.reload`
+  mocked.
+  - Reloads when fetched version ≠ running version.
+  - No-op when versions match.
+  - No-op on fetch failure (rejection, non-OK, malformed JSON).
+  - Loop guard: does not reload twice for the same target version.
+  - Triggers a check on `visibilitychange` → visible.
+
+## Non-goals
+
+- No service worker / offline support.
+- No mechanism to instantly reach devices already trapped on the year-long
+  immutable copy — they recover automatically on the next iOS revalidation and
+  are self-updating thereafter.
+- No change to admin/publisher pages.
+
+## Affected files (anticipated)
+
+- `.github/workflows/deploy-production.yml` — restructure the frontend S3 upload.
+- `scripts/deploy-frontend.sh` — mirror the same header fix.
+- `frontend/vite.config.ts` — inject `VITE_APP_VERSION`, emit `version.json`.
+- `frontend/src/lib/versionCheck.ts` — new module (+ test).
+- `frontend/src/entries/main.tsx` — wire the check into the main entry.

--- a/docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md
+++ b/docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md
@@ -41,6 +41,23 @@ This is caused by an `aws s3 sync` two-pass bug in the deploy
 The intended second-pass header (`max-age=3600`) was also weaker than an app
 shell warrants.
 
+### Existing service worker
+
+Production already registers a hand-written service worker,
+`frontend/public/sw.js` (cache `chqcal-v4`), registered inline in
+`index.html`. It uses network-first for HTML navigations and — because
+`.json` is not in its static-asset list — network-first for `version.json`
+too, and it already calls `skipWaiting()` + `clients.claim()` on
+install/activate. The immutable-header bug above also defeated the SW's
+network-first path: `fetch()` inside the SW still honors the browser's HTTP
+cache, so a network-first request for the shell was quietly served the
+year-long-cached copy instead of hitting the origin. Fixing the headers
+therefore repairs the SW's own update path, not just the no-SW case; the
+`version.json` + auto-reload mechanism below adds the deterministic
+in-session reload that the SW alone does not perform. This task also serves
+`sw.js` itself with `no-cache` (previously it fell into the immutable pass
+too) so future changes to the SW script propagate promptly.
+
 ### Honest constraint on already-installed users
 
 There is **no HTTP mechanism that instantly reaches a device which already
@@ -64,8 +81,9 @@ automatic from the corrected baseline onward.
 - Fixing the cache headers is the necessary root-cause fix: every future launch
   revalidates the shell and picks up new bundles.
 - A lightweight version check makes the update happen *while the app is
-  open/reopened* — deterministic, with no service-worker complexity or its
-  associated stale-cache failure modes.
+  open/reopened* — deterministic, without adding new service-worker
+  complexity or its associated stale-cache failure modes on top of the
+  existing `sw.js`.
 
 Rejected alternatives:
 
@@ -147,7 +165,9 @@ Behavior:
 
 ## Non-goals
 
-- No service worker / offline support.
+- No new/Workbox-managed service worker. The existing hand-written
+  `frontend/public/sw.js` stays as-is and is not restructured — this task
+  only fixes its cache header (Part 1) and does not change its behavior.
 - No mechanism to instantly reach devices already trapped on the year-long
   immutable copy — they recover automatically on the next iOS revalidation and
   are self-updating thereafter.

--- a/frontend/src/entries/main.tsx
+++ b/frontend/src/entries/main.tsx
@@ -1,5 +1,9 @@
 import { render } from 'preact';
 import '@/app/globals.css';
 import Home from '@/app/page';
+import { startVersionWatch } from '@/lib/versionCheck';
 
 render(<Home />, document.getElementById('root')!);
+
+// Auto-reload installed/home-screen users onto new deploys.
+startVersionWatch();

--- a/frontend/src/lib/versionCheck.test.ts
+++ b/frontend/src/lib/versionCheck.test.ts
@@ -1,0 +1,105 @@
+/// <reference types="vitest/globals" />
+import {
+  shouldReload,
+  checkForUpdate,
+  startVersionWatch,
+  VERSION_URL,
+  STORAGE_KEY,
+} from '@/lib/versionCheck';
+
+function fakeStorage(initial: Record<string, string> = {}) {
+  const map = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    _map: map,
+  };
+}
+
+function okJson(body: unknown) {
+  return { ok: true, json: async () => body } as unknown as Response;
+}
+
+describe('shouldReload', () => {
+  it('reloads when fetched differs from current and is not the guarded target', () => {
+    expect(shouldReload('abc', 'def', null)).toBe(true);
+  });
+  it('does not reload when versions match', () => {
+    expect(shouldReload('abc', 'abc', null)).toBe(false);
+  });
+  it('does not reload when fetched is missing/blank', () => {
+    expect(shouldReload('abc', undefined, null)).toBe(false);
+    expect(shouldReload('abc', '', null)).toBe(false);
+  });
+  it('does not reload twice for the same target (loop guard)', () => {
+    expect(shouldReload('abc', 'def', 'def')).toBe(false);
+  });
+});
+
+describe('checkForUpdate', () => {
+  it('reloads and records the target when a newer version is deployed', async () => {
+    const reload = vi.fn();
+    const storage = fakeStorage();
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'def' }));
+    await checkForUpdate({ current: 'abc', storage, reload, fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledWith(VERSION_URL, { cache: 'no-store' });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(storage.getItem(STORAGE_KEY)).toBe('def');
+  });
+  it('does not reload when versions match', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'abc' }));
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('does not reload again for a version already targeted (loop guard)', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'def' }));
+    await checkForUpdate({
+      current: 'abc',
+      storage: fakeStorage({ [STORAGE_KEY]: 'def' }),
+      reload,
+      fetchImpl,
+    });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('swallows fetch rejection and does not reload', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockRejectedValue(new Error('offline'));
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('does nothing on a non-OK response', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false } as Response);
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+  it('swallows malformed JSON and does not reload', async () => {
+    const reload = vi.fn();
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => { throw new Error('bad json'); },
+    } as unknown as Response);
+    await checkForUpdate({ current: 'abc', storage: fakeStorage(), reload, fetchImpl });
+    expect(reload).not.toHaveBeenCalled();
+  });
+});
+
+describe('startVersionWatch', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('checks once immediately and again when the app becomes visible', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(okJson({ version: 'abc' }));
+    const opts = { current: 'abc', storage: fakeStorage(), reload: vi.fn(), fetchImpl };
+    startVersionWatch(opts);
+    // initial check
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    // simulate reopening the home-screen app
+    Object.defineProperty(document, 'visibilityState', { value: 'visible', configurable: true });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await Promise.resolve();
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/lib/versionCheck.ts
+++ b/frontend/src/lib/versionCheck.ts
@@ -1,0 +1,60 @@
+// Detects when a newer frontend build has been deployed and silently reloads
+// so installed (home-screen) users pick it up. See
+// docs/superpowers/specs/2026-07-15-pwa-auto-update-design.md.
+
+export const VERSION_URL = '/version.json';
+export const STORAGE_KEY = 'chq:reloadedForVersion';
+
+type MinimalStorage = Pick<Storage, 'getItem' | 'setItem'>;
+
+export interface CheckOptions {
+  current?: string;
+  storage?: MinimalStorage;
+  reload?: () => void;
+  fetchImpl?: typeof fetch;
+}
+
+// Pure decision: reload only when we have a fetched version that differs from
+// what is running AND we have not already reloaded targeting that same version.
+export function shouldReload(
+  current: string | undefined,
+  fetched: unknown,
+  alreadyTargeted: string | null,
+): boolean {
+  if (typeof fetched !== 'string' || fetched.length === 0) return false;
+  if (fetched === current) return false;
+  if (fetched === alreadyTargeted) return false;
+  return true;
+}
+
+export async function checkForUpdate(opts: CheckOptions = {}): Promise<void> {
+  const {
+    current = import.meta.env.VITE_APP_VERSION,
+    storage = window.sessionStorage,
+    reload = () => window.location.reload(),
+    fetchImpl = fetch,
+  } = opts;
+
+  try {
+    const res = await fetchImpl(VERSION_URL, { cache: 'no-store' });
+    if (!res.ok) return;
+    const data = (await res.json()) as { version?: unknown };
+    const fetched = data?.version;
+    const alreadyTargeted = storage.getItem(STORAGE_KEY);
+    if (shouldReload(current, fetched, alreadyTargeted)) {
+      storage.setItem(STORAGE_KEY, fetched as string);
+      reload();
+    }
+  } catch {
+    // Offline, non-OK, or malformed response — keep running the current version.
+  }
+}
+
+// Checks now and every time the app regains visibility (iOS fires
+// visibilitychange when a home-screen app is reopened).
+export function startVersionWatch(opts: CheckOptions = {}): void {
+  void checkForUpdate(opts);
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') void checkForUpdate(opts);
+  });
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -4,6 +4,7 @@ interface ImportMetaEnv {
   readonly VITE_API_URL: string;
   readonly VITE_RECAPTCHA_SITE_KEY: string;
   readonly VITE_ENABLE_PUBLISHER_FEEDS: string;
+  readonly VITE_APP_VERSION: string;
 }
 
 interface ImportMeta {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, PluginOption } from 'vite';
 import preact from '@preact/preset-vite';
 import { resolve } from 'path';
 import { existsSync } from 'fs';
+import { execSync } from 'child_process';
 
 // In MPA mode, Vite doesn't resolve bare paths like /feedback to /feedback/index.html.
 // This plugin adds that behavior so dev matches production (S3/CloudFront).
@@ -50,6 +51,34 @@ function devServerMiddleware(): PluginOption {
   };
 }
 
+// Build version stamp: short git SHA of the deployed commit, or a timestamp
+// fallback for environments without git. Baked into the bundle via `define`
+// and emitted as version.json so the client can detect new deploys.
+function resolveAppVersion(): string {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return `build-${Date.now()}`;
+  }
+}
+
+// Emits out/version.json at build time with the same value baked into the bundle.
+function emitVersionJson(version: string): PluginOption {
+  return {
+    name: 'emit-version-json',
+    apply: 'build',
+    generateBundle() {
+      this.emitFile({
+        type: 'asset',
+        fileName: 'version.json',
+        source: JSON.stringify({ version }),
+      });
+    },
+  };
+}
+
+const APP_VERSION = resolveAppVersion();
+
 // Proxy config shared between dev server and preview server.
 // Routes API/auth requests to the local backend (port 3001) and
 // cache requests to the production CDN.
@@ -77,7 +106,10 @@ const backendProxy = {
 
 export default defineConfig({
   appType: 'mpa',
-  plugins: [devServerMiddleware(), preact()],
+  plugins: [devServerMiddleware(), preact(), emitVersionJson(APP_VERSION)],
+  define: {
+    'import.meta.env.VITE_APP_VERSION': JSON.stringify(APP_VERSION),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -97,6 +97,7 @@ aws s3 sync "$BUILD_DIR/" "s3://$S3_BUCKET/" \
     --exclude "*.html" \
     --exclude "manifest.json" \
     --exclude "version.json" \
+    --exclude "sw.js" \
     --cache-control "public, max-age=31536000, immutable"
 
 # Pass 2 — always-revalidate files. `cp` applies the header unconditionally
@@ -118,6 +119,12 @@ fi
 if [ -f "$BUILD_DIR/version.json" ]; then
     aws s3 cp "$BUILD_DIR/version.json" "s3://$S3_BUCKET/version.json" \
         --content-type "application/json" \
+        --cache-control "no-cache"
+fi
+
+if [ -f "$BUILD_DIR/sw.js" ]; then
+    aws s3 cp "$BUILD_DIR/sw.js" "s3://$S3_BUCKET/sw.js" \
+        --content-type "text/javascript" \
         --cache-control "no-cache"
 fi
 

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -88,43 +88,38 @@ EOF
 fi
 
 # Sync files to S3
-echo "☁️  Uploading files to S3..."
+# Pass 1 — content-hashed, immutable assets. Exclude always-revalidate files.
+echo "☁️  Uploading immutable assets to S3..."
 aws s3 sync "$BUILD_DIR/" "s3://$S3_BUCKET/" \
     --delete \
-    --cache-control "public, max-age=31536000" \
+    --exclude "*.map" \
+    --exclude "cache/*" \
     --exclude "*.html" \
-    --exclude "*.xml" \
-    --exclude "*.txt"
+    --exclude "manifest.json" \
+    --exclude "version.json" \
+    --cache-control "public, max-age=31536000, immutable"
 
-# Upload HTML files with different cache control
-echo "📄 Uploading HTML files..."
-aws s3 sync "$BUILD_DIR/" "s3://$S3_BUCKET/" \
-    --delete \
-    --cache-control "public, max-age=0, must-revalidate" \
+# Pass 2 — always-revalidate files. `cp` applies the header unconditionally
+# (`sync` skips unchanged files, leaving stale headers behind).
+echo "📄 Uploading HTML with no-cache..."
+aws s3 cp "$BUILD_DIR/" "s3://$S3_BUCKET/" \
+    --recursive \
+    --exclude "*" \
+    --include "*.html" \
     --content-type "text/html" \
-    --include "*.html"
+    --cache-control "no-cache"
 
-# Upload other text files
-echo "📄 Uploading text files..."
-find "$BUILD_DIR" -name "*.xml" -o -name "*.txt" -o -name "*.json" | while read file; do
-    if [ -f "$file" ]; then
-        relative_path=${file#$BUILD_DIR/}
-        aws s3 cp "$file" "s3://$S3_BUCKET/$relative_path" \
-            --cache-control "public, max-age=3600"
-    fi
-done
+if [ -f "$BUILD_DIR/manifest.json" ]; then
+    aws s3 cp "$BUILD_DIR/manifest.json" "s3://$S3_BUCKET/manifest.json" \
+        --content-type "application/json" \
+        --cache-control "no-cache"
+fi
 
-# Set proper content types for specific files
-echo "🔧 Setting content types..."
-aws s3 cp "s3://$S3_BUCKET/index.html" "s3://$S3_BUCKET/index.html" \
-    --metadata-directive REPLACE \
-    --content-type "text/html" \
-    --cache-control "public, max-age=0, must-revalidate" || true
-
-aws s3 cp "s3://$S3_BUCKET/error.html" "s3://$S3_BUCKET/error.html" \
-    --metadata-directive REPLACE \
-    --content-type "text/html" \
-    --cache-control "public, max-age=0, must-revalidate" || true
+if [ -f "$BUILD_DIR/version.json" ]; then
+    aws s3 cp "$BUILD_DIR/version.json" "s3://$S3_BUCKET/version.json" \
+        --content-type "application/json" \
+        --cache-control "no-cache"
+fi
 
 # Invalidate CloudFront cache
 if [ ! -z "$CLOUDFRONT_DISTRIBUTION_ID" ] && [ "$CLOUDFRONT_DISTRIBUTION_ID" != "null" ]; then

--- a/scripts/deploy-frontend.sh
+++ b/scripts/deploy-frontend.sh
@@ -98,6 +98,7 @@ aws s3 sync "$BUILD_DIR/" "s3://$S3_BUCKET/" \
     --exclude "manifest.json" \
     --exclude "version.json" \
     --exclude "sw.js" \
+    --exclude "data/weekly-themes/*" \
     --cache-control "public, max-age=31536000, immutable"
 
 # Pass 2 — always-revalidate files. `cp` applies the header unconditionally
@@ -125,6 +126,17 @@ fi
 if [ -f "$BUILD_DIR/sw.js" ]; then
     aws s3 cp "$BUILD_DIR/sw.js" "s3://$S3_BUCKET/sw.js" \
         --content-type "text/javascript" \
+        --cache-control "no-cache"
+fi
+
+# weekly-themes JSON is fetched directly from /data/ in production
+# (useWeeklyThemes has no dev/prod split) and is NOT content-hashed, so it must
+# revalidate — otherwise a content edit under the same filename would never
+# reach users (the same bug this deploy fixes).
+if [ -d "$BUILD_DIR/data/weekly-themes" ]; then
+    aws s3 cp "$BUILD_DIR/data/weekly-themes/" "s3://$S3_BUCKET/data/weekly-themes/" \
+        --recursive \
+        --content-type "application/json" \
         --cache-control "no-cache"
 fi
 


### PR DESCRIPTION
## Problem

Users who installed **chqcal.org** to their iPhone home screen never received new releases — the app stayed frozen on whatever version it first cached.

**Root cause:** the live app shell was served with a year-long immutable cache header:

```
GET https://www.chqcal.org/
cache-control: public, max-age=31536000, immutable
```

That tells every browser (and every iOS home-screen web clip) *"this file never changes for a year — don't re-check."* New deploys landed on S3 and CloudFront was invalidated, but the **device's own cache never asked origin**, so it kept serving the old shell pointing at old hashed bundles.

The bug was an `aws s3 sync` two-pass pitfall in the deploy: pass 1 uploaded HTML with the immutable header, and pass 2's *second* `sync` skipped the byte-identical HTML (sync skips unchanged files), so the intended short-TTL header was never applied.

This also silently defeated the existing hand-written service worker (`public/sw.js`): its network-first `fetch()` for the shell still honored the HTTP cache and got the year-long-cached copy instead of hitting origin.

## What this PR does

1. **Fixes the cache headers (root cause)** in `deploy-production.yml` (CI, the real deploy path) and `scripts/deploy-frontend.sh`. HTML / `manifest.json` / `version.json` / `sw.js` / `data/weekly-themes/*` are now served `no-cache` via `aws s3 cp` (unconditional, unlike the skip-prone `sync`); content-hashed assets stay `immutable`. Because Pass 1 (all hashed bundles) completes fully before Pass 2, and `index.html` is uploaded before `version.json` within Pass 2, a client that observes the new `version.json` is guaranteed the new shell and its referenced bundles are already on origin.
2. **Adds a client version check** (`frontend/src/lib/versionCheck.ts`) — fetches `/version.json` on load and on app-reopen (`visibilitychange`→visible) and **silently reloads** when the deployed version differs. Includes a `sessionStorage` loop-guard (protects against a CloudFront propagation race) and swallows all fetch failures.
3. **Stamps the build version** — bakes `VITE_APP_VERSION` (git short SHA) into the bundle via Vite `define` and emits a matching `version.json` at build time.
4. **Wires the watcher** into the main calendar entry only (`main.tsx`).
5. **Corrects the design doc** — it had wrongly claimed no service worker exists; documents the existing `sw.js` and how the fix repairs its update path too.

## Honest limitation

There's **no HTTP mechanism that instantly reaches a device already trapped** on the year-long immutable copy — it won't phone home until iOS evicts that cache entry on its own (which iOS does regularly, but not on a schedule we control). Those devices recover the first time they revalidate after this ships, and are self-updating from then on. **Every future release updates automatically.**

## Testing

- New module: 11 unit tests (decision matrix, loop guard, all fetch-failure modes, visibility re-check).
- Full frontend suite green: **407 tests** passing.
- Deploy files are CI/AWS-only — verified by YAML parse + `bash -n` + review of AWS CLI semantics.

**Post-deploy verification** (run once live):
```bash
curl -sI https://www.chqcal.org/            | grep -i cache-control   # -> no-cache, NOT immutable
curl -sI https://www.chqcal.org/version.json | grep -i cache-control  # -> no-cache
```

## Review process

Built via brainstorm → spec → plan → subagent-driven execution (6 tasks, each with an independent spec+quality review) → final whole-branch review (verdict: ready to merge). Design + plan committed under `docs/superpowers/`.

## Deferred non-blocking follow-ups

- Retired HTML pages are no longer auto-pruned from the bucket (excluded from the `--delete` pass; orphaned-but-harmless, served `no-cache`).
- `reload()` sits inside the fetch try/catch (only affects injected test doubles; production `location.reload` never throws).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZFzBKLppwMXAu8xvfYQvJ
