### PR TITLE
fix(matcher): corroboration bonus + diacritics (#138) + space-separated startDate (#140)

### DIFF
--- a/backend/src/__tests__/articleMatcher.test.ts
+++ b/backend/src/__tests__/articleMatcher.test.ts
@@ -43,6 +43,7 @@ describe('formatEventTimeAsPrinted', () => {
     ['2026-07-15T20:15:00', '8:15 p.m.'],
     ['2026-07-15T12:00:00', '12 p.m.'],
     ['2026-07-15T00:30:00', '12:30 a.m.'],
+    ['2026-07-15 14:00:00', '2 p.m.'], // space separator — the production event format (issue #140)
   ])('%s → %s', (iso, printed) => {
     expect(formatEventTimeAsPrinted(iso)).toBe(printed);
   });
@@ -249,6 +250,47 @@ describe('scorePair', () => {
     // Wrong day: venue matches but no person, no same-day time → below threshold
     expect(wrong).toBeNull();
     expect(right!.score).toBeGreaterThan(MATCH_THRESHOLD);
+  });
+
+  test('accented article name matches an ASCII presenter surname (issue #138)', () => {
+    // The event feed spells the presenter ASCII ("Grgic"); the Daily writes it
+    // accented ("Grgić"). Before diacritic folding these normalized to
+    // different tokens (grgic vs grgi), so the surname match silently failed.
+    const a = article({
+      title: 'Grgić dazzles',
+      tags: [],
+      categories: ['Amphitheater'],
+      excerptText: '',
+      bodyText: 'A wonderful recital.',
+      pubDate: '2026-07-15T09:00:00',
+    });
+    const e = event({
+      title: 'An Evening Recital', // shares no distinctive tokens with the article title
+      startDate: '2026-07-15T14:00:00',
+      venue: { name: 'Amphitheater' },
+      category: undefined,
+      presenter: 'Mak Grgic',
+    });
+    const r = scorePair(a, e);
+    expect(r).not.toBeNull();
+    expect(r!.reasons).toContain('people'); // fires only via the surname match
+  });
+
+  test('time-of-day fires when the event startDate uses a space separator (issue #140)', () => {
+    // Production events store startDate as "YYYY-MM-DD HH:MM:SS" (space), not
+    // "…T…". The printed-time signal must still fire.
+    const r = scorePair(article(), event({ startDate: '2026-07-15 14:00:00' }));
+    expect(r).not.toBeNull();
+    expect(r!.reasons).toContain('time-of-day');
+  });
+
+  test('same-day morning preview is not mislabeled a recap with a space-separated startDate (issue #140)', () => {
+    // Article at 6:30 a.m., event at 2 p.m. the same day. The recap check must
+    // compare the T-form pubDate and space-form startDate on a normalized
+    // separator, or 'T' > ' ' would flag every same-day article a recap.
+    const r = scorePair(article(), event({ startDate: '2026-07-15 14:00:00' }));
+    expect(r).not.toBeNull();
+    expect(r!.kind).toBe('preview');
   });
 
   test('recap: "Lecture Recap" tag or post-event pubDate classifies as recap', () => {

--- a/backend/src/__tests__/articleMatcher.test.ts
+++ b/backend/src/__tests__/articleMatcher.test.ts
@@ -134,15 +134,76 @@ describe('scorePair', () => {
     expect(r!.reasons).not.toContain('category-concept');
     expect(r!.reasons).not.toContain('category-token');
 
-    // Prove the body tier applied HALF credit, not full: the same pair with the
-    // program as a structured tag fires the concept tier (full 0.15) instead of
-    // the body tier (half 0.075), with every other signal identical. The score
-    // delta therefore equals exactly half the category weight. ('cso' is 3 chars,
-    // so adding it as a tag does not affect the people/title-token signal.)
-    const conceptSibling = scorePair({ ...a, tags: ['cso'] }, e);
-    expect(conceptSibling).not.toBeNull();
-    expect(conceptSibling!.reasons).toContain('category-concept');
-    expect(conceptSibling!.score - r!.score).toBeCloseTo(0.075, 4);
+    // Prove the body tier applied HALF credit, not full: the same pair with a
+    // program TOKEN in a structured category ("Classical" shares the token
+    // "classical" with the event's "…/Classical Concerts") fires the token tier
+    // (full 0.15) instead of the body tier (half 0.075), with every other signal
+    // identical. The score delta therefore equals exactly half the category
+    // weight. A token — not concept — sibling is used deliberately so the
+    // people+concept corroboration bonus doesn't perturb the delta (both this
+    // sibling and `r` have people but neither has category-concept).
+    const tokenSibling = scorePair({ ...a, categories: [...a.categories, 'Classical'] }, e);
+    expect(tokenSibling).not.toBeNull();
+    expect(tokenSibling!.reasons).toContain('category-token');
+    expect(tokenSibling!.reasons).not.toContain('category-concept');
+    expect(tokenSibling!.score - r!.score).toBeCloseTo(0.075, 4);
+  });
+
+  test('people + concept corroboration rescues a venue-changed event (Grgić/CSO regression)', () => {
+    // Real case: the CSO concert moved Amphitheater→Norton Hall after the
+    // Daily's preview ran, so the article still names the old venue and the
+    // venue signal (0.30) is gone. It is also a day-ahead preview (local
+    // pubDate the evening before), so time-of-day can't fire either. A
+    // performer/title match plus an exact-program (concept) match must still
+    // identify it: 0.35 people + 0.15 concept + 0.05 bonus + ~0.086 proximity.
+    const a = article({
+      title: 'Uplifting the Spirit: Grgic to perform guitar concerto with CSO',
+      categories: ['Chautauqua Symphony Orchestra', 'Amphitheater'],
+      tags: ['cso'],
+      pubDate: '2026-07-15T20:40:03',
+      excerptText: 'Mak Grgic takes the stage beside the Chautauqua Symphony Orchestra.',
+      bodyText: 'Together they perform a guitar concerto.',
+    });
+    const e = event({
+      id: '98400',
+      title: 'Chautauqua Symphony Orchestra with Mak Grgic, guitar',
+      startDate: '2026-07-16 20:00:00',
+      venue: { name: 'Norton Hall' },
+      category: 'Chautauqua Symphony Orchestra/Classical Concerts',
+      categories: undefined,
+      presenter: undefined,
+    });
+    const r = scorePair(a, e);
+    expect(r).not.toBeNull();
+    expect(r!.reasons).toEqual(
+      expect.arrayContaining(['people', 'category-concept', 'people-concept-corroboration']),
+    );
+    expect(r!.reasons).not.toContain('venue-category');
+    expect(r!.reasons).not.toContain('venue-body');
+  });
+
+  test('concept match without a people match does NOT trigger the corroboration bonus', () => {
+    // Only venue + concept + proximity, no performer/title overlap. Must stay
+    // below threshold (0.30 + 0.15 + 0.10 = 0.55): the bonus requires BOTH
+    // people and concept, so it must not leak in on a concept-only match.
+    const a = article({
+      title: 'Season concert series announced',
+      categories: ['Chautauqua Symphony Orchestra', 'Amphitheater'],
+      tags: ['cso'],
+      excerptText: '',
+      bodyText: 'The orchestra returns this week.',
+      pubDate: '2026-07-16T06:00:00',
+    });
+    const e = event({
+      id: 'cso-noppl',
+      title: 'Toward a New World',
+      startDate: '2026-07-16T20:00:00',
+      venue: { name: 'Amphitheater' },
+      category: 'Chautauqua Symphony Orchestra/Classical Concerts',
+      categories: undefined,
+      presenter: undefined,
+    });
+    expect(scorePair(a, e)).toBeNull();
   });
 
   test('no category signal when taxonomies and body share no concept or token', () => {

--- a/backend/src/__tests__/textNormalize.test.ts
+++ b/backend/src/__tests__/textNormalize.test.ts
@@ -1,0 +1,15 @@
+import { normalize } from '../services/textNormalize';
+
+describe('normalize', () => {
+  test('folds diacritics to their ASCII base letters (issue #138)', () => {
+    expect(normalize('Grgić')).toBe('grgic');
+    expect(normalize('Dvořák')).toBe('dvorak');
+    expect(normalize('Peña')).toBe('pena');
+    expect(normalize('Antonín Dvořák')).toBe('antonin dvorak');
+  });
+
+  test('still lowercases, strips punctuation to spaces, and collapses whitespace', () => {
+    expect(normalize('  Hello,   World!  ')).toBe('hello world');
+    expect(normalize('CSO/Classical Concerts')).toBe('cso classical concerts');
+  });
+});

--- a/backend/src/services/articleMatcher.ts
+++ b/backend/src/services/articleMatcher.ts
@@ -15,7 +15,7 @@ import { conceptsFor, conceptsInBody } from './chqConcepts';
  * Bump when weights, threshold, aliases, or signal logic change — forces a
  * one-time full recompute so scoring improvements apply retroactively.
  */
-export const MATCHER_VERSION = 4;
+export const MATCHER_VERSION = 5;
 export const MATCH_THRESHOLD = 0.6;
 export const MAX_LINKS_PER_EVENT = 4;
 
@@ -25,6 +25,9 @@ const WEIGHTS = {
   timeOfDay: 0.4,
   category: 0.15,
   proximityMax: 0.1,
+  // Bonus when a performer/title match AND an exact-program (concept) match
+  // co-fire — a strong joint identifier that survives a venue change.
+  peopleConceptBonus: 0.05,
 } as const;
 
 /** Event date must fall within [pubDate - RECAP_DAYS, pubDate + PREVIEW_DAYS]. */
@@ -186,6 +189,17 @@ export function scorePair(article: StoredArticle, event: CalendarEventLite): Pai
         reasons.push('category-body');
       }
     }
+  }
+
+  // Corroboration bonus: a performer/title match AND an exact-program (concept)
+  // match together identify an event with high confidence even when the venue
+  // disagrees — e.g. a concert moved indoors after the Daily's preview ran, so
+  // the article still names the old venue. Gated on BOTH signals, so it never
+  // rescues a weak single match: venue + concept without people is still
+  // 0.30 + 0.15 + 0.10 = 0.55 < 0.60.
+  if (reasons.includes('people') && reasons.includes('category-concept')) {
+    score += WEIGHTS.peopleConceptBonus;
+    reasons.push('people-concept-corroboration');
   }
 
   // Date proximity (tiebreaker between recurring events)

--- a/backend/src/services/articleMatcher.ts
+++ b/backend/src/services/articleMatcher.ts
@@ -69,10 +69,11 @@ function dayDiff(dateA: string, dateB: string): number {
 /**
  * Render an event start time the way the Daily prints it: "10:45 a.m.",
  * "2 p.m.", "12 p.m." (noon). Returns null when startDate has no parseable
- * HH:MM component.
+ * HH:MM component. Accepts either date/time separator — production events use
+ * a space ("2026-07-16 20:00:00"), not "T" (issue #140).
  */
 export function formatEventTimeAsPrinted(startDate: string): string | null {
-  const m = startDate.match(/T(\d{2}):(\d{2})/);
+  const m = startDate.match(/[T ](\d{2}):(\d{2})/);
   if (!m) return null;
   const hour24 = Number(m[1]);
   const minute = Number(m[2]);
@@ -214,11 +215,13 @@ export function scorePair(article: StoredArticle, event: CalendarEventLite): Pai
   // A recap is either explicitly tagged, or published after the event started.
   // Compare full site-local ISO timestamps (not just calendar dates) so an
   // evening recap of a morning/afternoon event is classified correctly instead
-  // of slipping through as a same-day "preview". Both strings are local
-  // wall-clock with no offset, so a lexicographic comparison is timezone-safe —
-  // unlike new Date(), which parses date-only vs date-time strings in different
-  // zones.
-  const publishedAfterEventStart = article.pubDate > event.startDate;
+  // of slipping through as a same-day "preview". Both are local wall-clock with
+  // no offset, so a lexicographic comparison is timezone-safe — but the WP
+  // pubDate uses a "T" separator while event startDate uses a space, and 'T' >
+  // ' ' would flag every same-day article a recap. Normalize the separator
+  // first (issue #140).
+  const publishedAfterEventStart =
+    article.pubDate.replace(' ', 'T') > event.startDate.replace(' ', 'T');
   const kind: ArticleLinkKind = isRecapTagged || publishedAfterEventStart ? 'recap' : 'preview';
   return { score: finalScore, reasons, kind };
 }

--- a/backend/src/services/textNormalize.ts
+++ b/backend/src/services/textNormalize.ts
@@ -1,8 +1,20 @@
 /**
- * Lowercase, strip punctuation/symbols to spaces, and collapse whitespace.
- * Shared by the matcher and the concept normalizer so both compare text the
- * same way. NOTE: this intentionally does NOT fold diacritics — see issue #138.
+ * Lowercase, fold diacritics to ASCII base letters, strip punctuation/symbols
+ * to spaces, and collapse whitespace. Shared by the matcher and the concept
+ * normalizer so both compare text the same way.
+ *
+ * Diacritic folding (NFD decomposition + stripping the resulting combining
+ * marks) runs BEFORE the character-class replace so an accented letter becomes
+ * its base letter ("Grgić" → "grgic", "Dvořák" → "dvorak") instead of splitting
+ * the word on the accent ("dvor a k"). Without it, a Daily byline spelled with
+ * accents never matched the ASCII presenter name in the event feed (issue #138).
  */
 export function normalize(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+  return s
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/\p{M}/gu, '') // strip combining marks left by NFD decomposition
+    .replace(/[^a-z0-9\s]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
 }


### PR DESCRIPTION
Three matcher fixes, all shipping under one `MATCHER_VERSION 4 → 5` recompute.

---

## 1. Corroboration bonus — rescues venue-changed events (Grgić/CSO)

After PR #139 deployed, the event **"CSO with Mak Grgić"** (id `98400`) lost its Daily link. Root-caused against live data: the event's venue changed **Amphitheater → Norton Hall** after the preview ran (article still says Amphitheater), removing the 0.30 venue signal; and the article's *local* pubDate is the evening before (a day-ahead preview), so no time-of-day either. Remaining `people (0.35) + category-concept (0.15) + proximity (~0.086) = 0.586`, just under 0.60. **Not a #139 regression** — with the old Amphitheater venue the same article still scores 0.886.

**Fix:** add a `0.05` bonus when **both** `people` and `category-concept` fire — a performer + exact-program match is a strong joint identifier that survives a venue change (→ ~0.636). Gated on both signals, so the safety invariant holds: venue+concept without people is still `0.55 < 0.60` (tested). Proximity-bounded — can't rescue a distant article.

## 2. Diacritic folding (#138)

`normalize()` didn't fold diacritics, so a Daily byline spelled with accents ("Grgić") normalized to different tokens than the ASCII presenter name in the event feed ("Grgic" → `grgic` vs `grgi`), silently failing the surname match. Now NFD-decomposes and strips combining marks before the character-class replace, so accented letters fold to their base (`Grgić → grgic`, `Dvořák → dvorak`) rather than splitting the word on the accent.

## 3. Space-separated startDate (#140)

Production events store `startDate` as `"YYYY-MM-DD HH:MM:SS"` (space), not `"…T…"`. Two silent effects, both confirmed on live data:
- `formatEventTimeAsPrinted`'s `/T(\d{2}):(\d{2})/` never matched → the **time-of-day signal (weight 0.40, the highest) was dead in production**.
- The recap/preview check compared a `T`-form pubDate against a space-form startDate lexicographically; `'T' > ' '` **mislabeled every same-day article a recap**.

Fix: accept either separator in the time regex, and normalize the separator before the recap comparison.

---

## Tests

- Corroboration: real Grgić/CSO regression (now matches with `people-concept-corroboration`); concept-only pair (no people) stays `null` (safety invariant).
- #138: `normalize` diacritic folding; `scorePair` surname match on an accented name.
- #140: `formatEventTimeAsPrinted` space case; time-of-day fires with a space-separated startDate; same-day morning preview no longer mislabeled a recap.
- Existing half-credit magnitude test adjusted to a token sibling so the new bonus doesn't perturb its delta.
- Full backend suite **864/864**, `npm run validate` clean, `npm run build` succeeds.

## Rollout

Merge → `deploy-production.yml` auto-deploys + invokes the Lambda; `matcherVersion 4→5` forces a full recompute + republish. Verify:
```
curl -s https://www.chqcal.org/cache/calendar-cache/article-links-2026.json \
  | jq '{matcherVersion, has98400: (.links|has("98400"))}'
```
→ expect `matcherVersion: 5`, `has98400: true`.

Note: fixing #140 revives the time-of-day signal (0.40) for real same-day articles, so the `v5` recompute will legitimately shift some matches/classifications — expected, and the reason it rides the version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EZ5Pts5eyp7eJUaXvYANz
