### PR TITLE
feat(analytics): CloudFront traffic analytics (Phase A) — logs → S3 → Athena

### DIFF
--- a/docs/runbooks/traffic-analytics.md
+++ b/docs/runbooks/traffic-analytics.md
@@ -69,6 +69,15 @@ the editor to exclude obvious crawlers before running.
 Logging is free; Parquet + partition projection keep Athena scans at ~$0 for this
 volume. Raw logs auto-expire after 90 days; Athena results after 30 days.
 
+The saved queries scan the full retention window (they don't filter on the
+`year`/`month`/`day` partition columns) — negligible at this volume. If the dataset
+ever grows enough to matter, narrow a query in the console by adding a partition
+predicate, which prunes via partition projection, e.g.:
+
+```sql
+... WHERE year = 2026 AND month = 7 AND <the query's existing filters>
+```
+
 ## Troubleshooting
 
 - **A query errors with `HIVE_BAD_DATA` (type incompatible with `string`):** a Glue

--- a/docs/runbooks/traffic-analytics.md
+++ b/docs/runbooks/traffic-analytics.md
@@ -1,0 +1,70 @@
+# Runbook: CloudFront Traffic Analytics
+
+How to read site traffic (unique/returning visitors, pageviews) for chqcal.org.
+Infrastructure: `infrastructure/traffic-analytics.tf`. Design:
+`docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md`.
+
+## What this measures
+
+CloudFront standard logs (v2) are delivered as Parquet to a private S3 bucket and
+queried in Athena. There is **no cookie and no client-side tracking** — counts come
+purely from CloudFront request logs.
+
+A **pageview** is a request for a content object: an HTML page **or** a
+`/cache/calendar-cache/*.json` data file (the hourly data pull, which is the best
+signal of a long-lived app actively fetching updates). Because the HTML and JSON are
+each cached ~1 hour, a browser produces at most ~1 request/hour for them.
+
+Two headline numbers:
+- **Pageviews (raw)** — every content request, split into page loads vs. data pulls.
+- **Active visits** — distinct (visitor, hour) pairs; dedupes the multiple JSON files
+  fetched per app-hour. This is the ≤1/hour/browser proxy.
+
+**Visitor** = `md5(client-IP + user-agent)`. **Returning** = a visitor seen on ≥2 days.
+
+## How to run a query
+
+1. Open the Athena console (the URL is in the Terraform output
+   `traffic_analytics_athena_url`), region **us-east-1**.
+2. In the workgroup selector (top right), choose **`chautauqua-calendar-traffic`**.
+3. Open the **Saved queries** tab. You'll see queries `01`–`12`.
+4. Click one to load it, then **Run**. Results appear below and are also written to
+   `s3://<log-bucket>/athena-results/` (auto-deleted after 30 days).
+
+Queries `01`–`12`:
+
+| # | Query | Answers |
+|---|-------|---------|
+| 01 | Pageviews by day (split) | Daily page loads vs. data pulls |
+| 02 | Pageviews by week (split) | Weekly page loads vs. data pulls |
+| 03 | Active visits by day | Daily ≤1/hr/browser visits |
+| 04 | Active visits by week | Weekly active visits |
+| 05 | Unique visitors by day | Distinct visitors/day |
+| 06 | Unique visitors by week | Distinct visitors/week |
+| 07 | Unique visitors season-to-date | One season total |
+| 08 | New vs returning by day | Daily new vs. returning split |
+| 09 | Top pages | Most-requested content objects |
+| 10 | Top referrers | Where visitors come from |
+| 11 | Visitors by country | Geographic breakdown |
+| 12 | Visitors by network/carrier (ASN) | How much "unique" is one carrier-NAT pool |
+
+Each query has a commented **optional bot filter** line near the top — uncomment it in
+the editor to exclude obvious crawlers before running.
+
+## How to read the numbers (important caveats)
+
+- **IP-based uniqueness is approximate.** Traffic is phone-heavy. Mobile **carrier NAT**
+  makes many people share one IP (deflates unique counts); **dynamic IPs** make one
+  person look like several across sessions (inflates unique counts, and breaks
+  "returning" detection). Read these as **trends**, not precise headcounts. Query 12
+  (ASN) helps gauge how much of a "unique" count is really one carrier pool.
+- **Logs lag minutes–hours.** Today's numbers fill in over the next few hours; don't
+  expect real-time.
+- **Cookies are empty.** The `cs_cookie` column exists but is blank — the app sets no
+  cookies. This is intentional forward-compat (see the design's Open Follow-ups for the
+  first-party visitor-ID next step that would make returning-visitor counts reliable).
+
+## Cost & retention
+
+Logging is free; Parquet + partition projection keep Athena scans at ~$0 for this
+volume. Raw logs auto-expire after 90 days; Athena results after 30 days.

--- a/docs/runbooks/traffic-analytics.md
+++ b/docs/runbooks/traffic-analytics.md
@@ -68,3 +68,13 @@ the editor to exclude obvious crawlers before running.
 
 Logging is free; Parquet + partition projection keep Athena scans at ~$0 for this
 volume. Raw logs auto-expire after 90 days; Athena results after 30 days.
+
+## Troubleshooting
+
+- **A query errors with `HIVE_BAD_DATA` (type incompatible with `string`):** a Glue
+  column type doesn't match the Parquet data — most likely `asn`. Change that column's
+  `type` in `infrastructure/traffic-analytics.tf` (`aws_glue_catalog_table.cf_logs`) and
+  re-apply. See the plan's Task 6 for detail.
+- **Queries return no rows and `aws s3 ls s3://<bucket>/cf/` is empty:** logs can lag
+  minutes–hours after first enabling; if still empty after a few hours, verify the S3
+  path matches the Glue table `location` (see plan Task 6, Step 4).

--- a/docs/superpowers/plans/2026-07-19-cloudfront-traffic-analytics.md
+++ b/docs/superpowers/plans/2026-07-19-cloudfront-traffic-analytics.md
@@ -1,0 +1,879 @@
+# CloudFront Traffic Analytics (Phase A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Capture cookieless CloudFront traffic (unique/returning visitors, pageviews) via standard logging v2 → S3 (Parquet, partitioned) → Athena saved queries, all defined in Terraform, plus a runbook.
+
+**Architecture:** CloudFront standard logging v2 delivers Parquet access logs to a private, ACL-disabled S3 bucket under Hive-partitioned paths. An AWS Glue table (partition projection) exposes them to Athena, where a set of named queries compute the metrics. Nothing is added to the app; no cookies are set (the cookie field is captured empty for forward-compat). Viewing is manual from the Athena console, documented in a runbook.
+
+**Tech Stack:** Terraform (AWS provider `~> 6.0`), AWS CloudWatch Logs vended-logs delivery, S3, AWS Glue Data Catalog, Amazon Athena. Region `us-east-1`.
+
+**Spec:** `docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md`
+
+**Terraform note (adapted test cycle):** This plan is Terraform-only; there is no unit-test framework in `infrastructure/`. Each task's "test" is `terraform fmt` + `terraform validate` (deterministic, no AWS credentials needed). The end-to-end integration test is Task 6 (`terraform plan`/`apply` + Athena smoke queries), which is **user-gated** because it mutates the production CloudFront distribution's logging and creates real AWS resources.
+
+## Global Constraints
+
+- **Terraform only.** No frontend/backend/app code changes. No unit tests. (Spec §11.)
+- **Never commit to `main`.** Work is on branch `feat/cloudfront-traffic-analytics` (already created). (CLAUDE.md.)
+- **Region is `us-east-1`.** CloudFront logging-v2 delivery resources must be created there. (Spec §2; AWS requirement.)
+- **All new resources live in one new file:** `infrastructure/traffic-analytics.tf`. Do **not** modify the `aws_cloudfront_distribution.frontend_distribution` block — logging v2 references its ARN externally.
+- **Naming:** prefix resources/names with `var.app_name` (`chautauqua-calendar`), mirroring existing files.
+- **`visitor_key` = `md5(c_ip ‖ '|' ‖ cs_user_agent)`.** `asn`/`c_country`/`ssl_*` are captured as reporting dimensions only — **never** folded into `visitor_key`. (Spec §6.)
+- **Raw-log retention = 90 days**; Athena results = 30 days. (Spec §4, §8.)
+- **Bucket is `BucketOwnerEnforced` (ACLs disabled)**, public access fully blocked; delivery authorized by bucket policy for `delivery.logs.amazonaws.com`. (Spec §4.)
+- **`cs(Cookie)` is selected but empty today.** Fully populating cookie *values* also needs `IncludeCookies` on the distribution — deferred until a real session cookie exists (Spec §8, Open Follow-ups). Do not enable legacy `logging_config` on the distribution to force it.
+- **Parquet column names are underscored** (`cs_user_agent`, `cs_cookie`, …) and typed **`string`**; the delivery `record_fields` use AWS API names (`cs(User-Agent)`, `cs(Cookie)`, …). (AWS Athena Parquet DDL reference.)
+
+---
+
+### Task 1: Secure log bucket (private, ACL-disabled, lifecycle) + delivery bucket policy
+
+**Files:**
+- Create: `infrastructure/traffic-analytics.tf`
+
+**Interfaces:**
+- Consumes: `var.app_name`, `var.aws_region` (existing vars in `infrastructure/main.tf`).
+- Produces: `aws_s3_bucket.cf_logs` (bucket for logs + Athena results), `data.aws_caller_identity.current`, `random_id.cf_logs_suffix`. Objects land under prefix `cf/`; Athena results under `athena-results/`.
+
+- [ ] **Step 1: Create `infrastructure/traffic-analytics.tf` with the bucket, security, lifecycle, and delivery policy**
+
+```hcl
+# infrastructure/traffic-analytics.tf
+#
+# CloudFront traffic analytics (Phase A): standard logging v2 -> S3 (Parquet,
+# partitioned) -> Glue table -> Athena named queries.
+# Design: docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+
+data "aws_caller_identity" "current" {}
+
+resource "random_id" "cf_logs_suffix" {
+  byte_length = 4
+}
+
+# Private, ACL-disabled bucket for raw CloudFront logs (prefix cf/) and Athena
+# query results (prefix athena-results/).
+resource "aws_s3_bucket" "cf_logs" {
+  bucket = "${var.app_name}-cf-logs-${random_id.cf_logs_suffix.hex}"
+}
+
+resource "aws_s3_bucket_public_access_block" "cf_logs" {
+  bucket                  = aws_s3_bucket.cf_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ACLs fully disabled. Logging v2 delivers via bucket policy, not ACL.
+resource "aws_s3_bucket_ownership_controls" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+
+  rule {
+    id     = "expire-raw-logs"
+    status = "Enabled"
+    filter {
+      prefix = "cf/"
+    }
+    expiration {
+      days = 90
+    }
+  }
+
+  rule {
+    id     = "expire-athena-results"
+    status = "Enabled"
+    filter {
+      prefix = "athena-results/"
+    }
+    expiration {
+      days = 30
+    }
+  }
+}
+
+# Allow the CloudWatch Logs vended-logs delivery service to write logs under cf/.
+# Scoped to this account + region delivery sources. The x-amz-acl condition is
+# what the delivery service sends and is permitted under BucketOwnerEnforced.
+resource "aws_s3_bucket_policy" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AWSLogsDeliveryWrite"
+        Effect    = "Allow"
+        Principal = { Service = "delivery.logs.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.cf_logs.arn}/cf/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl"      = "bucket-owner-full-control"
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:delivery-source:*"
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.cf_logs]
+}
+```
+
+- [ ] **Step 2: Format and validate**
+
+Run: `cd infrastructure && terraform fmt && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+(If `terraform validate` reports the providers are not initialized, run `terraform init` once first — no new providers are introduced, so init should be a no-op or fast.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infrastructure/traffic-analytics.tf
+git commit -m "feat(analytics): private ACL-disabled log bucket + delivery policy"
+```
+
+---
+
+### Task 2: CloudFront standard logging v2 delivery (source → destination → delivery)
+
+**Files:**
+- Modify: `infrastructure/traffic-analytics.tf` (append)
+
+**Interfaces:**
+- Consumes: `aws_s3_bucket.cf_logs`, `aws_s3_bucket_policy.cf_logs`, `aws_cloudfront_distribution.frontend_distribution` (existing, `infrastructure/main.tf:401`), `var.app_name`, `var.aws_region`.
+- Produces: Parquet logs written to `s3://<bucket>/cf/year=YYYY/month=MM/day=DD/` (Hive-compatible paths). Delivered `record_fields` become the Glue table columns in Task 3.
+
+- [ ] **Step 1: Append the delivery trio to `infrastructure/traffic-analytics.tf`**
+
+```hcl
+# --- CloudFront standard logging v2 (vended-logs delivery) ---------------------
+
+# One delivery source per distribution (CloudFront is global; managed in us-east-1).
+resource "aws_cloudwatch_log_delivery_source" "cf_access" {
+  name         = "${var.app_name}-cf-access-logs"
+  log_type     = "ACCESS_LOGS"
+  resource_arn = aws_cloudfront_distribution.frontend_distribution.arn
+}
+
+# Parquet output to the log bucket under the cf/ prefix. Using a prefix in the
+# destination ARN suppresses CloudFront's default AWSLogs/<acct>/CloudFront/ path,
+# giving the predictable base s3://<bucket>/cf/.
+resource "aws_cloudwatch_log_delivery_destination" "cf_access_s3" {
+  name          = "${var.app_name}-cf-access-logs-s3"
+  output_format = "parquet"
+
+  delivery_destination_configuration {
+    destination_resource_arn = "${aws_s3_bucket.cf_logs.arn}/cf"
+  }
+}
+
+# Field selection replaces legacy include_cookies. record_fields use AWS API field
+# names (parenthesized); the Parquet columns become underscored (Task 3).
+# cs(Cookie) is captured but empty today (no app cookies; IncludeCookies deferred).
+resource "aws_cloudwatch_log_delivery" "cf_access" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.cf_access.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cf_access_s3.arn
+
+  record_fields = [
+    "date",
+    "time",
+    "c-ip",
+    "cs-method",
+    "cs-uri-stem",
+    "sc-status",
+    "cs(Referer)",
+    "cs(User-Agent)",
+    "cs(Cookie)",
+    "x-edge-result-type",
+    "ssl-protocol",
+    "ssl-cipher",
+    "asn",
+    "c-country",
+  ]
+
+  s3_delivery_configuration {
+    suffix_path                 = "{yyyy}/{MM}/{dd}"
+    enable_hive_compatible_path = true
+  }
+
+  depends_on = [aws_s3_bucket_policy.cf_logs]
+}
+```
+
+- [ ] **Step 2: Format and validate**
+
+Run: `cd infrastructure && terraform fmt && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infrastructure/traffic-analytics.tf
+git commit -m "feat(analytics): enable CloudFront standard logging v2 to S3 (parquet)"
+```
+
+---
+
+### Task 3: Glue database + partitioned Parquet table (partition projection)
+
+**Files:**
+- Modify: `infrastructure/traffic-analytics.tf` (append)
+
+**Interfaces:**
+- Consumes: `aws_s3_bucket.cf_logs`, the log layout `cf/year=…/month=…/day=…` from Task 2.
+- Produces: Glue DB `chq_cloudfront_logs` and table `access_logs` with all-`string` columns and `year`/`month`/`day` projected partitions. Athena queries in Task 4 read `chq_cloudfront_logs.access_logs`.
+
+- [ ] **Step 1: Append the Glue database and table**
+
+Note: `$${year}` etc. escape Terraform interpolation so the literal `${year}` reaches Athena. All columns are `string` per the AWS Parquet DDL reference. Only the selected `record_fields` are declared (Athena matches Parquet columns by name).
+
+```hcl
+# --- Glue catalog: schema over the Parquet logs -------------------------------
+
+resource "aws_glue_catalog_database" "cf_logs" {
+  name = "chq_cloudfront_logs"
+}
+
+resource "aws_glue_catalog_table" "cf_logs" {
+  name          = "access_logs"
+  database_name = aws_glue_catalog_database.cf_logs.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL                    = "TRUE"
+    classification              = "parquet"
+    "projection.enabled"        = "true"
+    "projection.year.type"      = "integer"
+    "projection.year.range"     = "2026,2035"
+    "projection.month.type"     = "integer"
+    "projection.month.range"    = "1,12"
+    "projection.month.digits"   = "2"
+    "projection.day.type"       = "integer"
+    "projection.day.range"      = "1,31"
+    "projection.day.digits"     = "2"
+    "storage.location.template" = "s3://${aws_s3_bucket.cf_logs.bucket}/cf/year=$${year}/month=$${month}/day=$${day}"
+  }
+
+  partition_keys {
+    name = "year"
+    type = "int"
+  }
+  partition_keys {
+    name = "month"
+    type = "int"
+  }
+  partition_keys {
+    name = "day"
+    type = "int"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.cf_logs.bucket}/cf/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "date"
+      type = "string"
+    }
+    columns {
+      name = "time"
+      type = "string"
+    }
+    columns {
+      name = "c_ip"
+      type = "string"
+    }
+    columns {
+      name = "cs_method"
+      type = "string"
+    }
+    columns {
+      name = "cs_uri_stem"
+      type = "string"
+    }
+    columns {
+      name = "sc_status"
+      type = "string"
+    }
+    columns {
+      name = "cs_referer"
+      type = "string"
+    }
+    columns {
+      name = "cs_user_agent"
+      type = "string"
+    }
+    columns {
+      name = "cs_cookie"
+      type = "string"
+    }
+    columns {
+      name = "x_edge_result_type"
+      type = "string"
+    }
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+    columns {
+      name = "asn"
+      type = "string"
+    }
+    columns {
+      name = "c_country"
+      type = "string"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Format and validate**
+
+Run: `cd infrastructure && terraform fmt && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add infrastructure/traffic-analytics.tf
+git commit -m "feat(analytics): Glue database + partitioned parquet table for CF logs"
+```
+
+---
+
+### Task 4: Athena workgroup, named queries, and console-URL output
+
+**Files:**
+- Modify: `infrastructure/traffic-analytics.tf` (append)
+
+**Interfaces:**
+- Consumes: `aws_s3_bucket.cf_logs`, `aws_glue_catalog_database.cf_logs`, `var.app_name`, `var.aws_region`.
+- Produces: Athena workgroup `${var.app_name}-traffic`, 12 `aws_athena_named_query` resources, and output `traffic_analytics_athena_url`.
+
+**Metric definitions used by every query (Spec §6):**
+- Content-object predicate (page loads + data pulls, excluding admin/api/auth/assets):
+  ```
+  cs_method = 'GET'
+  AND sc_status IN ('200','304')
+  AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+       OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+  AND cs_uri_stem NOT LIKE '/admin%'
+  AND cs_uri_stem NOT LIKE '/api%'
+  AND cs_uri_stem NOT LIKE '/auth%'
+  ```
+- `visitor_key` = `lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))`.
+- Each query carries a commented optional bot-filter line the user can uncomment in the console.
+
+- [ ] **Step 1: Append the Athena workgroup and output**
+
+```hcl
+# --- Athena workgroup + saved queries -----------------------------------------
+
+resource "aws_athena_workgroup" "traffic" {
+  name          = "${var.app_name}-traffic"
+  force_destroy = true
+
+  configuration {
+    enforce_workgroup_configuration = true
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.cf_logs.bucket}/athena-results/"
+    }
+  }
+}
+
+output "traffic_analytics_athena_url" {
+  description = "Athena console query editor (select the ${var.app_name}-traffic workgroup)"
+  value       = "https://${var.aws_region}.console.aws.amazon.com/athena/home?region=${var.aws_region}#/query-editor"
+}
+```
+
+- [ ] **Step 2: Append the 12 named queries**
+
+```hcl
+# 01 — Pageviews by day, split into page loads vs. data pulls.
+resource "aws_athena_named_query" "pageviews_by_day" {
+  name      = "01 - Pageviews by day (split by object)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    -- Optional bot filter: add
+    --   AND NOT regexp_like(cs_user_agent, '(?i)bot|spider|crawl|slurp|preview|monitor')
+    SELECT
+      "date" AS day,
+      CASE WHEN cs_uri_stem LIKE '/cache/calendar-cache/%.json'
+           THEN 'data-pull' ELSE 'page-load' END AS object_class,
+      COUNT(*) AS pageviews
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1, 2
+    ORDER BY day DESC, object_class;
+  SQL
+}
+
+# 02 — Pageviews by ISO week, split by object class.
+resource "aws_athena_named_query" "pageviews_by_week" {
+  name      = "02 - Pageviews by week (split by object)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      date_trunc('week', date_parse("date", '%Y-%m-%d')) AS week_start,
+      CASE WHEN cs_uri_stem LIKE '/cache/calendar-cache/%.json'
+           THEN 'data-pull' ELSE 'page-load' END AS object_class,
+      COUNT(*) AS pageviews
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1, 2
+    ORDER BY week_start DESC, object_class;
+  SQL
+}
+
+# 03 — Active visits by day = distinct (visitor, hour) pairs. The <=1/hr/browser proxy.
+resource "aws_athena_named_query" "active_visits_by_day" {
+  name      = "03 - Active visits by day (visitor-hour)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      "date" AS day,
+      COUNT(DISTINCT
+        lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent)))) || '#' || substr("time",1,2)
+      ) AS active_visits
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY day DESC;
+  SQL
+}
+
+# 04 — Active visits by week = distinct (visitor, day, hour).
+resource "aws_athena_named_query" "active_visits_by_week" {
+  name      = "04 - Active visits by week (visitor-hour)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      date_trunc('week', date_parse("date", '%Y-%m-%d')) AS week_start,
+      COUNT(DISTINCT
+        lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent)))) || '#' || "date" || substr("time",1,2)
+      ) AS active_visits
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY week_start DESC;
+  SQL
+}
+
+# 05 — Unique visitors by day.
+resource "aws_athena_named_query" "unique_visitors_by_day" {
+  name      = "05 - Unique visitors by day"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      "date" AS day,
+      COUNT(DISTINCT lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY day DESC;
+  SQL
+}
+
+# 06 — Unique visitors by week.
+resource "aws_athena_named_query" "unique_visitors_by_week" {
+  name      = "06 - Unique visitors by week"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      date_trunc('week', date_parse("date", '%Y-%m-%d')) AS week_start,
+      COUNT(DISTINCT lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY week_start DESC;
+  SQL
+}
+
+# 07 — Unique visitors season-to-date (single number).
+resource "aws_athena_named_query" "unique_visitors_season" {
+  name      = "07 - Unique visitors season-to-date"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      COUNT(DISTINCT lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))) AS unique_visitors_season
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%';
+  SQL
+}
+
+# 08 — New vs returning by day (returning = visitor seen on an earlier date).
+resource "aws_athena_named_query" "new_vs_returning_by_day" {
+  name      = "08 - New vs returning by day"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    WITH visits AS (
+      SELECT DISTINCT
+        lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent)))) AS visitor_key,
+        "date" AS day
+      FROM chq_cloudfront_logs.access_logs
+      WHERE cs_method = 'GET'
+        AND sc_status IN ('200','304')
+        AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+             OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+        AND cs_uri_stem NOT LIKE '/admin%'
+        AND cs_uri_stem NOT LIKE '/api%'
+        AND cs_uri_stem NOT LIKE '/auth%'
+    ),
+    first_seen AS (
+      SELECT visitor_key, MIN(day) AS first_day FROM visits GROUP BY visitor_key
+    )
+    SELECT
+      v.day,
+      COUNT_IF(v.day = f.first_day) AS new_visitors,
+      COUNT_IF(v.day > f.first_day) AS returning_visitors
+    FROM visits v
+    JOIN first_seen f USING (visitor_key)
+    GROUP BY v.day
+    ORDER BY v.day DESC;
+  SQL
+}
+
+# 09 — Top pages by request count.
+resource "aws_athena_named_query" "top_pages" {
+  name      = "09 - Top pages"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT cs_uri_stem AS page, COUNT(*) AS requests
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY requests DESC
+    LIMIT 50;
+  SQL
+}
+
+# 10 — Top referrers ('-' means no referrer).
+resource "aws_athena_named_query" "top_referrers" {
+  name      = "10 - Top referrers"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT cs_referer AS referrer, COUNT(*) AS requests
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+      AND cs_referer <> '-'
+    GROUP BY 1
+    ORDER BY requests DESC
+    LIMIT 50;
+  SQL
+}
+
+# 11 — Unique visitors by country (segmentation dimension).
+resource "aws_athena_named_query" "visitors_by_country" {
+  name      = "11 - Visitors by country"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT c_country AS country,
+      COUNT(DISTINCT lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY unique_visitors DESC;
+  SQL
+}
+
+# 12 — Unique visitors by network/carrier (ASN). Reads how much of "unique" is one carrier-NAT pool.
+resource "aws_athena_named_query" "visitors_by_network" {
+  name      = "12 - Visitors by network/carrier (ASN)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT asn,
+      COUNT(DISTINCT lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+    GROUP BY 1
+    ORDER BY unique_visitors DESC
+    LIMIT 50;
+  SQL
+}
+```
+
+- [ ] **Step 3: Format and validate**
+
+Run: `cd infrastructure && terraform fmt && terraform validate`
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add infrastructure/traffic-analytics.tf
+git commit -m "feat(analytics): Athena workgroup, 12 named queries, console URL output"
+```
+
+---
+
+### Task 5: Runbook
+
+**Files:**
+- Create: `docs/runbooks/traffic-analytics.md`
+
+**Interfaces:**
+- Consumes: the Athena workgroup `${app_name}-traffic` and named queries from Task 4.
+- Produces: operator documentation. No code dependency.
+
+- [ ] **Step 1: Create `docs/runbooks/traffic-analytics.md` with this content**
+
+````markdown
+# Runbook: CloudFront Traffic Analytics
+
+How to read site traffic (unique/returning visitors, pageviews) for chqcal.org.
+Infrastructure: `infrastructure/traffic-analytics.tf`. Design:
+`docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md`.
+
+## What this measures
+
+CloudFront standard logs (v2) are delivered as Parquet to a private S3 bucket and
+queried in Athena. There is **no cookie and no client-side tracking** — counts come
+purely from CloudFront request logs.
+
+A **pageview** is a request for a content object: an HTML page **or** a
+`/cache/calendar-cache/*.json` data file (the hourly data pull, which is the best
+signal of a long-lived app actively fetching updates). Because the HTML and JSON are
+each cached ~1 hour, a browser produces at most ~1 request/hour for them.
+
+Two headline numbers:
+- **Pageviews (raw)** — every content request, split into page loads vs. data pulls.
+- **Active visits** — distinct (visitor, hour) pairs; dedupes the multiple JSON files
+  fetched per app-hour. This is the ≤1/hour/browser proxy.
+
+**Visitor** = `md5(client-IP + user-agent)`. **Returning** = a visitor seen on ≥2 days.
+
+## How to run a query
+
+1. Open the Athena console (the URL is in the Terraform output
+   `traffic_analytics_athena_url`), region **us-east-1**.
+2. In the workgroup selector (top right), choose **`chautauqua-calendar-traffic`**.
+3. Open the **Saved queries** tab. You'll see queries `01`–`12`.
+4. Click one to load it, then **Run**. Results appear below and are also written to
+   `s3://<log-bucket>/athena-results/` (auto-deleted after 30 days).
+
+Queries `01`–`12`:
+
+| # | Query | Answers |
+|---|-------|---------|
+| 01 | Pageviews by day (split) | Daily page loads vs. data pulls |
+| 02 | Pageviews by week (split) | Weekly page loads vs. data pulls |
+| 03 | Active visits by day | Daily ≤1/hr/browser visits |
+| 04 | Active visits by week | Weekly active visits |
+| 05 | Unique visitors by day | Distinct visitors/day |
+| 06 | Unique visitors by week | Distinct visitors/week |
+| 07 | Unique visitors season-to-date | One season total |
+| 08 | New vs returning by day | Daily new vs. returning split |
+| 09 | Top pages | Most-requested content objects |
+| 10 | Top referrers | Where visitors come from |
+| 11 | Visitors by country | Geographic breakdown |
+| 12 | Visitors by network/carrier (ASN) | How much "unique" is one carrier-NAT pool |
+
+Each query has a commented **optional bot filter** line near the top — uncomment it in
+the editor to exclude obvious crawlers before running.
+
+## How to read the numbers (important caveats)
+
+- **IP-based uniqueness is approximate.** Traffic is phone-heavy. Mobile **carrier NAT**
+  makes many people share one IP (deflates unique counts); **dynamic IPs** make one
+  person look like several across sessions (inflates unique counts, and breaks
+  "returning" detection). Read these as **trends**, not precise headcounts. Query 12
+  (ASN) helps gauge how much of a "unique" count is really one carrier pool.
+- **Logs lag minutes–hours.** Today's numbers fill in over the next few hours; don't
+  expect real-time.
+- **Cookies are empty.** The `cs_cookie` column exists but is blank — the app sets no
+  cookies. This is intentional forward-compat (see the design's Open Follow-ups for the
+  first-party visitor-ID next step that would make returning-visitor counts reliable).
+
+## Cost & retention
+
+Logging is free; Parquet + partition projection keep Athena scans at ~$0 for this
+volume. Raw logs auto-expire after 90 days; Athena results after 30 days.
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/runbooks/traffic-analytics.md
+git commit -m "docs(analytics): runbook for reading CloudFront traffic in Athena"
+```
+
+---
+
+### Task 6: Apply + end-to-end smoke verification (USER-GATED)
+
+**This task mutates production** (turns on logging for the live distribution and creates AWS resources). Do **not** run it autonomously — confirm with the user, then run it together or hand them the commands. Requires AWS credentials for the account holding this infrastructure.
+
+**Files:** none (apply + verification only).
+
+- [ ] **Step 1: Plan and review**
+
+Run: `cd infrastructure && terraform plan`
+Expected: a plan that **creates** ~20 resources (bucket, PAB, ownership, lifecycle, bucket policy, `random_id`, delivery source/destination/delivery, Glue DB + table, Athena workgroup, 12 named queries, 1 output) and **changes/destroys nothing** on the existing distribution or other resources. Confirm no `~`/`-` on `aws_cloudfront_distribution.frontend_distribution`.
+
+- [ ] **Step 2: Apply (with user confirmation)**
+
+Run: `terraform apply`
+Type `yes` only after the user approves the plan.
+
+Contingency: if apply errors specifically on the `cs(Cookie)` record field (some accounts reject selecting it while distribution-level `IncludeCookies` is off), remove `"cs(Cookie)",` from `record_fields` in Task 2, drop the `cs_cookie` column from Task 3, re-apply, and note that the cookie field re-enters when the deferred first-party-ID work turns on `IncludeCookies`. This does not affect any Phase-A metric (the field is empty today).
+
+- [ ] **Step 3: Confirm the bucket is locked down**
+
+Run:
+```bash
+BUCKET=$(cd infrastructure && terraform output -raw traffic_analytics_athena_url >/dev/null; \
+  aws s3api list-buckets --query "Buckets[?starts_with(Name,'chautauqua-calendar-cf-logs')].Name" --output text)
+aws s3api get-bucket-ownership-controls --bucket "$BUCKET" \
+  --query 'OwnershipControls.Rules[0].ObjectOwnership' --output text
+aws s3api get-public-access-block --bucket "$BUCKET" \
+  --query 'PublicAccessBlockConfiguration' --output json
+```
+Expected: ownership `BucketOwnerEnforced`; all four public-access-block flags `true`.
+
+- [ ] **Step 4: Wait for the first logs, then confirm the S3 path matches the Glue table**
+
+Logs appear within minutes–hours. Check:
+```bash
+aws s3 ls "s3://$BUCKET/cf/" --recursive | head
+```
+Expected: objects under `cf/year=YYYY/month=MM/day=DD/…parquet`.
+
+**If the path is NOT `cf/year=…/month=…/day=…`** (e.g. AWS injected an `AWSLogs/…` prefix despite the destination-ARN prefix), update `aws_glue_catalog_table.cf_logs` `storage_descriptor.location` and the `storage.location.template` parameter to match the actual prefix, then `terraform apply` again. This is the one path that depends on AWS's delivery behavior; everything else is deterministic.
+
+- [ ] **Step 5: Run the smoke queries in Athena**
+
+In the Athena console (workgroup `chautauqua-calendar-traffic`):
+1. Run `SELECT * FROM chq_cloudfront_logs.access_logs LIMIT 5;` — expect rows with populated `c_ip`, `cs_user_agent`, `cs_uri_stem`; `cs_cookie` = `-` (empty); `asn`/`c_country` populated.
+2. Run saved query **05 - Unique visitors by day** — expect ≥1 row with a plausible count.
+3. Run **03 - Active visits by day** — expect counts ≤ the raw pageviews for the same day.
+
+Expected: queries succeed (no column-not-found / type errors) and return sane, non-empty numbers.
+
+- [ ] **Step 6: Push the branch and open a PR (do not merge)**
+
+```bash
+git push -u origin feat/cloudfront-traffic-analytics
+gh pr create --fill --base main
+```
+Report the PR URL to the user. Per project rules, the user requests the merge.
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- §3 architecture (logs→S3→Glue→Athena): Tasks 1–4. ✓
+- §4 capture (BucketOwnerEnforced bucket, policy, lifecycle 90d, delivery trio, `include_cookies`→`cs(Cookie)` field, asn/country/ssl fields): Tasks 1–2. ✓
+- §5 query layer (Glue DB + partitioned Parquet table + projection, Athena workgroup, results location, named queries): Tasks 3–4. ✓
+- §6 metric definitions (content object incl. `/cache/*.json`, raw pageviews split, active visits visitor-hour dedup, unique, returning, `visitor_key`=md5(IP‖UA), admin excluded, optional bot filter, asn/country as dimensions): Task 4 queries + Global Constraints. ✓
+- §7 saved-query set (pageviews day/week, active visits, unique day/week/season, new-vs-returning, top pages, top referrers, by country, by network): Task 4 (queries 01–12). ✓
+- §8 privacy/retention (13→14 selected fields, cookie empty, 90d expiry, hashed aggregates, bucket private ACLs-off): Tasks 1–2, runbook. ✓
+- §9 cost: runbook + design; no build action. ✓
+- §10 usage (runbook + Athena console URL output): Tasks 4–5. ✓
+- §11 scope/verification (Terraform + runbook only; plan/apply + first-logs smoke): Task 6. ✓
+- Open Follow-ups (first-party ID as next step): out of scope by design; referenced in runbook. ✓
+
+**2. Placeholder scan:** No TBD/TODO. The one AWS-behavior-dependent value (S3 path prefix) is handled as an explicit Step-4 verification-and-correct, not a placeholder. Column names/types, SerDe, projection, and provider schemas are all pinned from AWS docs. ✓
+
+**3. Type/name consistency:** `record_fields` use AWS API names (`cs(User-Agent)`, `cs(Cookie)`); Glue columns and all SQL use underscored names (`cs_user_agent`, `cs_cookie`, `c_country`, `asn`). `visitor_key` expression is identical across all 12 queries. Database/table `chq_cloudfront_logs.access_logs` and workgroup `${app_name}-traffic` are referenced consistently. ✓

--- a/docs/superpowers/plans/2026-07-19-cloudfront-traffic-analytics.md
+++ b/docs/superpowers/plans/2026-07-19-cloudfront-traffic-analytics.md
@@ -850,6 +850,8 @@ In the Athena console (workgroup `chautauqua-calendar-traffic`):
 
 Expected: queries succeed (no column-not-found / type errors) and return sane, non-empty numbers.
 
+**If a query errors with `HIVE_BAD_DATA` / "... incompatible with type string":** a Parquet column's real type differs from the `string` declared in the Glue table. Most likely `asn` (used only by query 12) is emitted as `bigint`. Fix: change that column's `type` in `aws_glue_catalog_table.cf_logs` (e.g. `asn` → `bigint`), `terraform apply`, and if you changed `asn` adjust query 12 only if it compares `asn` as text (it currently just groups by it, so no change needed). The base fields (`sc_status`, etc.) are `string` per AWS's v2 Parquet DDL and should not need changes.
+
 - [ ] **Step 6: Push the branch and open a PR (do not merge)**
 
 ```bash

--- a/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
@@ -157,10 +157,12 @@ resource "aws_cloudwatch_log_delivery" "cf_access" {
   }
 
   # Field selection (v2 replaces legacy include_cookies): capture exactly what
-  # the metrics need, including cs-cookie for forward-compat.
+  # the metrics need, plus a few cheap identity/segmentation signals.
   record_fields = [
     "timestamp", "c-ip", "cs-method", "cs-uri-stem", "sc-status",
     "cs-user-agent", "cs-referer", "cs-cookie", "x-edge-result-type",
+    # Identity / segmentation signals (near-zero cost, captured now):
+    "asn", "c-country", "ssl-protocol", "ssl-cipher",
   ]
 }
 ```
@@ -172,6 +174,19 @@ so a *future* session-cookie iteration needs no delivery change. See Privacy (§
 why this is safe today. (Field selection is also a privacy win: we log only the fields
 listed above, nothing more.)
 
+**Extra identity/segmentation fields (folded in per design review):**
+
+- **`asn`** — viewer's network/carrier (autonomous system number). The most useful
+  extra signal for this phone-heavy traffic: it disambiguates many users behind one
+  carrier-NAT IP and enables carrier/network breakdowns. Captured as a **reporting
+  dimension**, *not* baked into `visitor_key` (see §6).
+- **`c-country`** — viewer country (IP geolocation). Free geographic segmentation.
+- **`ssl-protocol` / `ssl-cipher`** — coarse TLS-stack characteristics; captured now as
+  low-value tiebreaker entropy for a possible future keying experiment, unused by the
+  Phase-A metrics.
+
+These are all standard-logging-v2 selectable fields — no functions, no extra infra.
+
 ---
 
 ## 5. Query Layer (Terraform)
@@ -181,7 +196,8 @@ listed above, nothing more.)
   **Parquet SerDe** (`org.apache.hadoop.hive.ql.io.parquet.*`). Columns follow the v2
   Parquet field names for the selected `record_fields`: `timestamp`, `c_ip`,
   `cs_method`, `cs_uri_stem`, `sc_status`, `cs_user_agent`, `cs_referer`, `cs_cookie`,
-  `x_edge_result_type` (the plan pins the exact Parquet column names AWS emits).
+  `x_edge_result_type`, `asn`, `c_country`, `ssl_protocol`, `ssl_cipher` (the plan
+  pins the exact Parquet column names AWS emits).
 - **Partitioned with partition projection.** Because v2 writes Hive-compatible paths
   (`cf/year=…/month=…/day=…` via `enable_hive_compatible_path`), the table declares
   `year`/`month`/`day` partition keys and uses Athena **partition projection**
@@ -201,6 +217,15 @@ listed above, nothing more.)
 **`visitor_key`** = `lower(to_hex(md5(to_utf8(concat(c_ip, '|', cs_user_agent)))))`.
 Hashing means aggregate outputs never contain raw IPs. IP-only (`c_ip`) is a trivial
 variant if ever wanted.
+
+The key stays **IP + UA only.** `asn`, `c_country`, and the `ssl_*` fields are captured
+(§4) but are treated as **reporting dimensions** — you can group/segment by them (e.g.
+"unique visitors by carrier") — *not* folded into `visitor_key`. Rationale (§ design
+review): adding fingerprint entropy reduces NAT over-merging a little but makes the key
+more volatile across sessions, which worsens the dominant mobile error (IP churn
+over-splitting one user into many keys). The genuine fix for cross-session identity is
+a persistent client-side ID, which is the designated deferred next step (§ Open
+Follow-ups), not more passive entropy.
 
 **Content object** — the requests that represent real user activity:
 
@@ -258,6 +283,9 @@ All queries live in the `chq-traffic` workgroup against the Glue table. Shipped 
 6. **New vs returning by day** — first-seen-date self-comparison.
 7. **Top pages** — content object stems by request count.
 8. **Top referrers** — `cs_referer` by count.
+9. **Visitors by country** — unique visitors grouped by `c_country` (segmentation).
+10. **Visitors by network/carrier** — unique visitors grouped by `asn`; useful for
+    reading how much of the "unique" count is really one carrier-NAT pool on mobile.
 
 Each named query carries a comment header documenting its metric definition and the
 optional bot-filter line, so the runbook and the SQL stay in sync.
@@ -266,8 +294,10 @@ optional bot-filter line, so the runbook and the SQL stay in sync.
 
 ## 8. Privacy & Retention
 
-- **Only selected fields are logged.** v2 `record_fields` captures exactly the nine
-  fields the metrics need (§4) and nothing else.
+- **Only selected fields are logged.** v2 `record_fields` captures exactly the 13
+  fields listed in §4 (metrics + a few identity/segmentation signals) and nothing else.
+  `asn`/`c_country` are network- and country-level, not personally identifying beyond
+  the IP we already log.
 - **Cookies are captured but empty today.** `cs-cookie` is in `record_fields`, but the
   app sets no cookies and admin auth travels in the `Authorization` header (not among
   the selected fields, and not logged), so the cookie field is empty on every request.
@@ -342,6 +372,42 @@ Effectively free at this site's scale.
 
 ## Open Follow-ups (post-Phase-A)
 
-- Decide B vs C after reviewing a week of real data.
-- When a real session cookie is introduced, the cookie field is already captured;
-  add session-oriented queries then.
+### Designated next step — first-party visitor ID (cookie / localStorage)
+
+Passive IP+UA (even with `asn`) cannot reliably track a mobile user across sessions —
+IP churn splits one person into many keys. The **real fix, and the intended next step**,
+is a persistent first-party visitor ID. This design is deliberately built so we can
+switch to it **without re-architecting** the pipeline, *if and when the owner is
+comfortable setting a cookie on user browsers*:
+
+- **What gets added:** a small, random, non-PII visitor ID (e.g. a UUID) minted once
+  per browser and persisted. Two viable placements, decided at that time:
+  - a **first-party cookie** set by a viewer-response CloudFront Function (or by client
+    JS) — this is the primary planned approach; **the `cs-cookie` field is already in
+    `record_fields`, so it flows into the logs the moment the cookie exists, with no
+    delivery change**; or
+  - a **localStorage** ID echoed into a request (e.g. a query param on the
+    `/cache/*.json` fetch, or a `cf.logCustomData()` call) if we prefer to avoid
+    cookies entirely — captured via `viewer-request-log-data`, still no new infra.
+- **What changes downstream:** `visitor_key` switches from `md5(IP‖UA)` to the visitor
+  ID (falling back to `md5(IP‖UA)` when the ID is absent — e.g. first-ever request or
+  cookies disabled). Only the query definitions change; capture, bucket, table, and
+  workgroup are untouched. **Unique** and especially **returning** visitor counts
+  become reliable across IP changes.
+- **Privacy posture to settle then:** the ID is random and app-scoped (no cross-site
+  tracking); document it in a privacy note; the 90-day raw-log expiry still applies.
+
+This is why cookies are captured now (empty today) and why the visitor-key logic is
+isolated in the queries rather than the capture layer — the switch is a query change,
+not a migration.
+
+### Other deferred items
+
+- **Decide B vs C** (CloudWatch custom metrics vs admin-page dashboard) after reviewing
+  a week of real Phase-A data.
+- **Optional — JA3/TLS fingerprint experiment.** *Only if* Phase-A data shows NAT
+  over-merging is materially distorting unique counts, try logging a JA3 fingerprint
+  via a CloudFront Function + `cf.logCustomData()` → `viewer-request-log-data` (fits our
+  existing viewer-request functions; no Kinesis/Lambda@Edge). Note JA3 is a *group*
+  fingerprint (browser+OS+TLS stack), not per-user — a NAT-disambiguation booster, not
+  a substitute for the first-party ID above.

--- a/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
@@ -25,7 +25,7 @@ To get visitor-level numbers we must begin capturing a per-request signal (viewe
 IP + user-agent). This design does that with the lowest-effort, cookieless,
 fully-in-AWS approach:
 
-> **CloudFront standard access logs → S3 → Athena (saved queries run from the console).**
+> **CloudFront standard logging v2 → S3 (Parquet, partitioned) → Athena (saved queries run from the console).**
 
 This is **Phase A** of a staged plan. Phase A is a strict *subset* of the richer
 options, so nothing here is throwaway:
@@ -70,19 +70,21 @@ definitions are meaningful.
                  viewer request
                        │
                        ▼
-              ┌──────────────────┐
-              │    CloudFront    │  standard access logging enabled
-              │  (distribution)  │───────────────┐
-              └──────────────────┘               │ gzipped W3C logs
-                       │                          │ (minutes–hours delay)
-       serves HTML + /cache/*.json                ▼
-                       │                 ┌──────────────────┐
-                       ▼                 │  S3 log bucket    │  cf/ prefix
-                    browser              │  (private, 90-day │  lifecycle-expire
-                                         │   lifecycle)      │
+              ┌──────────────────┐        CloudWatch Logs vended-logs delivery
+              │    CloudFront    │  ┌──────────────────────────────────────┐
+              │  (distribution)  │──│ delivery source → destination →       │
+              └──────────────────┘  │ delivery  (log_type = ACCESS_LOGS)    │
+                       │            └──────────────────────────────────────┘
+       serves HTML + /cache/*.json               │ Parquet, hive-partitioned
+                       │                          │ cf/{yyyy}/{MM}/{dd}/  (min–hr delay)
+                       ▼                          ▼
+                    browser              ┌──────────────────┐
+                                         │  S3 log bucket    │  BucketOwnerEnforced
+                                         │  (private, no ACL │  (ACLs disabled),
+                                         │   90-day lifecycle)│  bucket-policy delivery
                                          └──────────────────┘
                                                   │
-                                    Glue catalog table over cf/ prefix
+                              Glue table (Parquet SerDe) + partition projection
                                                   │
                                                   ▼
                                          ┌──────────────────┐
@@ -97,9 +99,10 @@ definitions are meaningful.
 
 | Component | Purpose | Depends on |
 |-----------|---------|------------|
-| Log bucket | Durable, private store for raw CF logs; auto-expires after 90d | — |
-| `logging_config` on distribution | Turns on standard logging into the bucket | Log bucket |
-| Glue table | Schema over the raw logs so Athena can read them | Log bucket layout |
+| Log bucket | Durable, private (ACLs disabled) store for CF logs; auto-expires after 90d | — |
+| Bucket policy | Allows `delivery.logs.amazonaws.com` to write logs (no ACL) | Log bucket |
+| Log-delivery trio (source/destination/delivery) | Turns on logging v2 into the bucket, in Parquet + partitioned | Log bucket, bucket policy |
+| Glue table | Partitioned Parquet schema so Athena can read the logs | Log bucket layout |
 | Athena workgroup | Isolated query context + results location | Log bucket, Glue table |
 | Named queries | The metric definitions, one click each | Glue table |
 | Runbook | Human procedure + how to read the numbers | Athena workgroup |
@@ -110,32 +113,64 @@ Everything except the runbook is Terraform in `infrastructure/`.
 
 ## 4. Log Capture (Terraform)
 
+We use **CloudFront standard logging v2**, which delivers through the CloudWatch Logs
+"vended logs" delivery pipeline. Unlike legacy logging (ACL-based), v2 delivers via a
+**bucket policy**, so the bucket can disable ACLs entirely.
+
 **Log bucket** — new private bucket `chautauqua-calendar-cf-logs-<random>`:
 
 - `aws_s3_bucket_public_access_block` — all four blocks `true`.
-- **Object Ownership = `BucketOwnerPreferred`** (`aws_s3_bucket_ownership_controls`)
-  and an ACL granting the CloudFront log-delivery group `WRITE`/`READ_ACP`. Legacy
-  standard logging delivers via ACL, so the bucket must permit ACLs — it cannot be
-  `BucketOwnerEnforced`. This is the one place we deliberately keep ACLs on.
+- **Object Ownership = `BucketOwnerEnforced`** (`aws_s3_bucket_ownership_controls`) —
+  **ACLs fully disabled.** No ACL grants anywhere.
+- `aws_s3_bucket_policy` granting `delivery.logs.amazonaws.com` `s3:PutObject` into the
+  `cf/` prefix, conditioned on `aws:SourceAccount` (the account id) and the delivery
+  ARN (`aws:SourceArn`) to prevent cross-account log injection.
 - `aws_s3_bucket_lifecycle_configuration` — expire objects under `cf/` after
   **90 days** (raw IPs/cookies do not accumulate indefinitely). A second rule expires
   `athena-results/` after e.g. 30 days.
 
-**Distribution logging** — add to `frontend_distribution`:
+**Logging v2 delivery** — three CloudWatch Logs delivery resources (created in
+`us-east-1`, where the distribution's global logs are managed):
 
 ```hcl
-logging_config {
-  bucket          = aws_s3_bucket.cf_logs.bucket_domain_name
-  prefix          = "cf/"
-  include_cookies = true
+resource "aws_cloudwatch_log_delivery_source" "cf_access" {
+  name         = "chq-cf-access-logs"
+  resource_arn = aws_cloudfront_distribution.frontend_distribution.arn
+  log_type     = "ACCESS_LOGS"
+}
+
+resource "aws_cloudwatch_log_delivery_destination" "cf_access_s3" {
+  name          = "chq-cf-access-logs-s3"
+  output_format = "parquet"
+  delivery_destination_configuration {
+    destination_resource_arn = aws_s3_bucket.cf_logs.arn
+  }
+}
+
+resource "aws_cloudwatch_log_delivery" "cf_access" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.cf_access.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cf_access_s3.arn
+
+  s3_delivery_configuration {
+    suffix_path                = "cf/{yyyy}/{MM}/{dd}"
+    enable_hive_compatible_path = true
+  }
+
+  # Field selection (v2 replaces legacy include_cookies): capture exactly what
+  # the metrics need, including cs-cookie for forward-compat.
+  record_fields = [
+    "timestamp", "c-ip", "cs-method", "cs-uri-stem", "sc-status",
+    "cs-user-agent", "cs-referer", "cs-cookie", "x-edge-result-type",
+  ]
 }
 ```
 
-`include_cookies = true` is deliberate forward-compatibility: today the `cs(Cookie)`
-field will be empty on every request (the app sets no cookies), but the field is then
-already captured for a *future* iteration that introduces a session cookie — no
-Terraform change needed later. CloudFront logs cookies on all paths regardless of
-cache-behavior forwarding; see Privacy (§8) for why this is safe today.
+**Capturing cookies:** v2 replaces legacy's `include_cookies = true` with explicit
+field selection — including `cs-cookie` in `record_fields` is the equivalent. Today
+that field is empty on every request (the app sets no cookies), but it is captured now
+so a *future* session-cookie iteration needs no delivery change. See Privacy (§8) for
+why this is safe today. (Field selection is also a privacy win: we log only the fields
+listed above, nothing more.)
 
 ---
 
@@ -143,20 +178,21 @@ cache-behavior forwarding; see Privacy (§8) for why this is safe today.
 
 - **Glue database** (`aws_glue_catalog_database`) e.g. `chq_cloudfront_logs`.
 - **Glue table** (`aws_glue_catalog_table`) over `s3://<log-bucket>/cf/`, using the
-  AWS-published CloudFront standard-log DDL: `LazySimpleSerDe`, `field.delim = '\t'`,
-  `skip.header.line.count = '2'` (CloudFront prepends two `#Version`/`#Fields`
-  comment lines). Columns: `date`, `time`, `x_edge_location`, `sc_bytes`, `c_ip`,
-  `cs_method`, `cs_host`, `cs_uri_stem`, `sc_status`, `cs_referer`, `cs_user_agent`,
-  `cs_uri_query`, `cs_cookie`, `x_edge_result_type`, … (full 33-field W3C set).
+  **Parquet SerDe** (`org.apache.hadoop.hive.ql.io.parquet.*`). Columns follow the v2
+  Parquet field names for the selected `record_fields`: `timestamp`, `c_ip`,
+  `cs_method`, `cs_uri_stem`, `sc_status`, `cs_user_agent`, `cs_referer`, `cs_cookie`,
+  `x_edge_result_type` (the plan pins the exact Parquet column names AWS emits).
+- **Partitioned with partition projection.** Because v2 writes Hive-compatible paths
+  (`cf/year=…/month=…/day=…` via `enable_hive_compatible_path`), the table declares
+  `year`/`month`/`day` partition keys and uses Athena **partition projection**
+  (`projection.enabled = true`, date-range projection) — no crawler, no
+  `MSCK REPAIR`, and every query prunes to only the days it needs. This keeps scans
+  minimal as volume grows, so no future re-architecture is needed.
 - **Athena workgroup** (`aws_athena_workgroup`) e.g. `chq-traffic` with
   `result_configuration.output_location = s3://<log-bucket>/athena-results/`.
-- **Unpartitioned table.** Legacy standard logs encode the date in the *filename*,
-  not the S3 path, so Hive partition projection is awkward. At this site's volume
-  (a few MB/day) an unpartitioned full scan costs a fraction of a cent per query.
-  If volume ever makes scans costly, switch to standard-logging-v2 with Hive-
-  partitioned paths + partition projection. **YAGNI for Phase A.**
 - **Named queries** (`aws_athena_named_query`, one per §7 query) so each is one
-  click in the console.
+  click in the console. Time-windowed queries filter on the `year`/`month`/`day`
+  partition columns to stay cheap.
 
 ---
 
@@ -230,26 +266,32 @@ optional bot-filter line, so the runbook and the SQL stay in sync.
 
 ## 8. Privacy & Retention
 
-- **Cookies are indiscriminate but empty today.** `include_cookies = true` logs every
-  cookie on every path — but the app sets none and admin auth travels in the
-  `Authorization` header (not logged), so `cs(Cookie)` is `-` on every request. No
-  tokens leak. The field is captured now purely so future session-cookie work needs no
-  logging change.
+- **Only selected fields are logged.** v2 `record_fields` captures exactly the nine
+  fields the metrics need (§4) and nothing else.
+- **Cookies are captured but empty today.** `cs-cookie` is in `record_fields`, but the
+  app sets no cookies and admin auth travels in the `Authorization` header (not among
+  the selected fields, and not logged), so the cookie field is empty on every request.
+  No tokens leak. The field is captured now purely so future session-cookie work needs
+  no delivery change.
 - **Raw logs auto-expire after 90 days** (S3 lifecycle). Only whatever aggregates you
   choose to record persist longer.
 - **Aggregates are hashed** (`visitor_key` = md5 of IP+UA); we only ever look at
   counts, never export raw IPs.
-- **Log bucket is fully private** (public-access-block on; ACL grants only the
-  CloudFront log-delivery group + bucket owner).
+- **Log bucket is fully private with ACLs disabled** (`BucketOwnerEnforced`;
+  public-access-block on all four). Delivery is authorized by a scoped bucket policy
+  (`delivery.logs.amazonaws.com`, conditioned on source account + delivery ARN), not by
+  an ACL.
 
 ---
 
 ## 9. Cost
 
 - **Standard logging:** free (no per-request charge).
-- **S3 storage:** a few MB/day of gzipped logs → cents/month; capped by the 90-day
-  lifecycle.
-- **Athena:** $5/TB scanned. At MB-per-query this rounds to $0. Results bucket
+- **S3 storage:** a few MB/day of compressed Parquet → cents/month; capped by the
+  90-day lifecycle. (There is a small CloudWatch vended-logs delivery charge per GB
+  delivered — negligible at this volume.)
+- **Athena:** $5/TB scanned. Columnar Parquet + partition projection means queries
+  scan only the needed columns for the needed days, rounding to $0. Results bucket
   auto-expires.
 
 Effectively free at this site's scale.
@@ -272,9 +314,10 @@ Effectively free at this site's scale.
 
 **In scope (Phase A):**
 
-- Terraform in `infrastructure/`: log bucket (+ ownership/ACL, public-access-block,
-  lifecycle), `logging_config` on the distribution, Glue DB + table, Athena workgroup
-  + results location, named queries, Athena-console URL output.
+- Terraform in `infrastructure/`: log bucket (BucketOwnerEnforced, public-access-block,
+  bucket policy, lifecycle), the logging-v2 delivery trio
+  (source/destination/delivery), Glue DB + partitioned table, Athena workgroup +
+  results location, named queries, Athena-console URL output.
 - Runbook `docs/runbooks/traffic-analytics.md`.
 
 **Out of scope:**
@@ -288,16 +331,17 @@ Effectively free at this site's scale.
 
 1. `terraform validate` and `terraform plan` are clean.
 2. `terraform apply`.
-3. Wait for the first log files to appear under `s3://<log-bucket>/cf/` (minutes–hours).
-4. Run each named query in the Athena console; confirm sane, non-empty numbers.
-5. Confirm `cs_cookie` is `-` (as expected) and no `Authorization`/token data appears.
+3. Wait for the first Parquet files to appear under the partitioned
+   `s3://<log-bucket>/cf/…` path (minutes–hours).
+4. Run each named query in the Athena console; confirm sane, non-empty numbers and
+   that partition projection prunes correctly (query one day, check bytes scanned).
+5. Confirm `cs_cookie` is empty (as expected) and no `Authorization`/token data appears.
+6. Confirm the bucket has ACLs disabled (`BucketOwnerEnforced`) and is not public.
 
 ---
 
 ## Open Follow-ups (post-Phase-A)
 
 - Decide B vs C after reviewing a week of real data.
-- If log volume grows enough to matter, migrate to standard-logging-v2 with Hive
-  partitioning + Athena partition projection.
 - When a real session cookie is introduced, the cookie field is already captured;
   add session-oriented queries then.

--- a/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
@@ -1,0 +1,303 @@
+# CloudFront Traffic Analytics — Design (Approach A)
+
+**Status:** Approved design, ready for implementation plan
+**Date:** 2026-07-19
+**Author:** brainstormed with Claude
+**Scope:** Phase A only (log capture + Athena query layer + runbook). Phases B and C deferred.
+
+---
+
+## 1. Summary & Goal
+
+We want to see how much traffic the Chautauqua Calendar site receives — specifically
+**unique visitors, returning visitors, and pageviews** — for a static site served
+entirely from CloudFront, with no application server to record page views, and
+**without setting cookies** for tracking.
+
+Today **none of this data exists.** There is no CloudFront access logging of any
+kind, so there is no per-request record of client IPs, user-agents, or URLs. The
+only frontend observability is the aggregate `AWS/CloudFront` CloudWatch dashboard
+(`chautauqua-calendar-cloudfront-monitoring`), which reports total request counts
+but *cannot* distinguish unique from returning visitors — standard metrics carry no
+per-client identity.
+
+To get visitor-level numbers we must begin capturing a per-request signal (viewer
+IP + user-agent). This design does that with the lowest-effort, cookieless,
+fully-in-AWS approach:
+
+> **CloudFront standard access logs → S3 → Athena (saved queries run from the console).**
+
+This is **Phase A** of a staged plan. Phase A is a strict *subset* of the richer
+options, so nothing here is throwaway:
+
+- **Phase A (this doc):** capture logs + Athena named queries, run manually.
+- **Phase B (deferred):** scheduled Lambda computes rollups → CloudWatch custom
+  metrics → widgets on the existing dashboard.
+- **Phase C (deferred):** scheduled Athena rollups → DynamoDB → endpoint in
+  `adminHandler` → a dashboard page in the admin area.
+
+B and C are revisited only after a week of real Phase-A data confirms the metric
+definitions are meaningful.
+
+---
+
+## 2. Current State (verified 2026-07-19)
+
+- **CloudFront access logging is OFF.** `aws_cloudfront_distribution.frontend_distribution`
+  (`infrastructure/main.tf:401`) has no `logging_config` block, and there is no
+  `aws_cloudfront_realtime_log_config` anywhere. No log S3 bucket exists.
+- **Aggregate-only dashboard exists.** `aws_cloudwatch_dashboard.cloudfront_dashboard`
+  (`infrastructure/main.tf:693`) shows Requests / BytesDownloaded / error rates /
+  cache-hit rate from the `AWS/CloudFront` namespace. Useful for volume, useless for
+  uniqueness.
+- **CloudFront Functions already in use** (viewer-request): `api_rewrite` (strips
+  `/api`, `/admin/api`) and `www_redirect` (apex → www). Establishes the edge-code
+  pattern; not needed for Phase A.
+- **The app is cookieless.** Admin auth stores a JWT in `localStorage` and sends it
+  as an `Authorization: Bearer` header (`frontend/src/lib/auth.ts:12`); no
+  `credentials: 'include'`; no `document.cookie` writes. Standard logs do not record
+  the `Authorization` header.
+- **Region:** `us-east-1` (single region). Terraform AWS provider `~> 6.0`.
+- **Closest existing per-request data:** API Gateway access logs in CloudWatch
+  (include `sourceIp`) — but they cover *API calls*, not page/content views, so they
+  are not a substitute.
+
+---
+
+## 3. Architecture
+
+```
+                 viewer request
+                       │
+                       ▼
+              ┌──────────────────┐
+              │    CloudFront    │  standard access logging enabled
+              │  (distribution)  │───────────────┐
+              └──────────────────┘               │ gzipped W3C logs
+                       │                          │ (minutes–hours delay)
+       serves HTML + /cache/*.json                ▼
+                       │                 ┌──────────────────┐
+                       ▼                 │  S3 log bucket    │  cf/ prefix
+                    browser              │  (private, 90-day │  lifecycle-expire
+                                         │   lifecycle)      │
+                                         └──────────────────┘
+                                                  │
+                                    Glue catalog table over cf/ prefix
+                                                  │
+                                                  ▼
+                                         ┌──────────────────┐
+                                         │      Athena      │  named queries,
+                                         │   (workgroup)    │  run from console
+                                         └──────────────────┘
+                                                  │
+                                       results → athena-results/ prefix
+```
+
+**Component boundaries (each independently understandable/testable):**
+
+| Component | Purpose | Depends on |
+|-----------|---------|------------|
+| Log bucket | Durable, private store for raw CF logs; auto-expires after 90d | — |
+| `logging_config` on distribution | Turns on standard logging into the bucket | Log bucket |
+| Glue table | Schema over the raw logs so Athena can read them | Log bucket layout |
+| Athena workgroup | Isolated query context + results location | Log bucket, Glue table |
+| Named queries | The metric definitions, one click each | Glue table |
+| Runbook | Human procedure + how to read the numbers | Athena workgroup |
+
+Everything except the runbook is Terraform in `infrastructure/`.
+
+---
+
+## 4. Log Capture (Terraform)
+
+**Log bucket** — new private bucket `chautauqua-calendar-cf-logs-<random>`:
+
+- `aws_s3_bucket_public_access_block` — all four blocks `true`.
+- **Object Ownership = `BucketOwnerPreferred`** (`aws_s3_bucket_ownership_controls`)
+  and an ACL granting the CloudFront log-delivery group `WRITE`/`READ_ACP`. Legacy
+  standard logging delivers via ACL, so the bucket must permit ACLs — it cannot be
+  `BucketOwnerEnforced`. This is the one place we deliberately keep ACLs on.
+- `aws_s3_bucket_lifecycle_configuration` — expire objects under `cf/` after
+  **90 days** (raw IPs/cookies do not accumulate indefinitely). A second rule expires
+  `athena-results/` after e.g. 30 days.
+
+**Distribution logging** — add to `frontend_distribution`:
+
+```hcl
+logging_config {
+  bucket          = aws_s3_bucket.cf_logs.bucket_domain_name
+  prefix          = "cf/"
+  include_cookies = true
+}
+```
+
+`include_cookies = true` is deliberate forward-compatibility: today the `cs(Cookie)`
+field will be empty on every request (the app sets no cookies), but the field is then
+already captured for a *future* iteration that introduces a session cookie — no
+Terraform change needed later. CloudFront logs cookies on all paths regardless of
+cache-behavior forwarding; see Privacy (§8) for why this is safe today.
+
+---
+
+## 5. Query Layer (Terraform)
+
+- **Glue database** (`aws_glue_catalog_database`) e.g. `chq_cloudfront_logs`.
+- **Glue table** (`aws_glue_catalog_table`) over `s3://<log-bucket>/cf/`, using the
+  AWS-published CloudFront standard-log DDL: `LazySimpleSerDe`, `field.delim = '\t'`,
+  `skip.header.line.count = '2'` (CloudFront prepends two `#Version`/`#Fields`
+  comment lines). Columns: `date`, `time`, `x_edge_location`, `sc_bytes`, `c_ip`,
+  `cs_method`, `cs_host`, `cs_uri_stem`, `sc_status`, `cs_referer`, `cs_user_agent`,
+  `cs_uri_query`, `cs_cookie`, `x_edge_result_type`, … (full 33-field W3C set).
+- **Athena workgroup** (`aws_athena_workgroup`) e.g. `chq-traffic` with
+  `result_configuration.output_location = s3://<log-bucket>/athena-results/`.
+- **Unpartitioned table.** Legacy standard logs encode the date in the *filename*,
+  not the S3 path, so Hive partition projection is awkward. At this site's volume
+  (a few MB/day) an unpartitioned full scan costs a fraction of a cent per query.
+  If volume ever makes scans costly, switch to standard-logging-v2 with Hive-
+  partitioned paths + partition projection. **YAGNI for Phase A.**
+- **Named queries** (`aws_athena_named_query`, one per §7 query) so each is one
+  click in the console.
+
+---
+
+## 6. Metric Definitions
+
+**`visitor_key`** = `lower(to_hex(md5(to_utf8(concat(c_ip, '|', cs_user_agent)))))`.
+Hashing means aggregate outputs never contain raw IPs. IP-only (`c_ip`) is a trivial
+variant if ever wanted.
+
+**Content object** — the requests that represent real user activity:
+
+- an **HTML document**: `cs_uri_stem` ends in `/` or `.html`; **OR**
+- a **data pull**: `cs_uri_stem LIKE '/cache/calendar-cache/%.json'`
+  (covers `article-links-2026.json`, `years.json`, `publisher-events-2026.json`, and
+  any future year-versioned data files).
+
+In all cases: `cs_method = 'GET'`, `sc_status IN (200, 304)`, and **exclude**
+`/api*`, `/admin/api*`, `/auth*`, admin HTML (`/admin*`), and static assets
+(`.js/.css/.png/.svg/.ico/.woff*` etc.). Excluding `/admin*` keeps operator traffic
+(just the site owner) out of public numbers.
+
+Rationale for including data pulls: the site is a long-lived PWA. The HTML loads once
+(and is cached ~1 hr), but an open app keeps fetching `/cache/calendar-cache/*.json`
+every hour as the data refreshes. The JSON fetch is therefore the *truest* signal of
+"a real user is actively getting updates," and is just as cache-bounded (≤1/hr/browser)
+as the HTML.
+
+**The two headline numbers** (a single active app-hour fetches ~2–3 JSON files, so a
+raw per-request count inflates ~3× per browser-hour — hence two numbers, not one):
+
+- **Pageviews (raw)** — count of content-object GETs, **split by object type**
+  (HTML page load vs. each data file). This is literally "count the JSON fetches."
+  Shows dynamic data-pull volume.
+- **Active visits** — `COUNT(DISTINCT (visitor_key, date, hour))` over content
+  objects. Dedupes the multi-file-per-hour inflation; **this is the ≤1/hr/browser
+  proxy.** A phone left open pulling data for 6 hours = 6 active visits = "this user
+  got updates 6 times."
+
+**Visitor metrics:**
+
+- **Unique visitors (period)** = `COUNT(DISTINCT visitor_key)` over content objects
+  in a day / week / season-to-date window.
+- **Returning visitors (period)** = visitor_keys appearing on **≥2 distinct dates**.
+- **New vs returning (per day)** = for each day, split that day's visitor_keys by
+  whether the key was seen on any earlier date.
+
+**Optional bot filter:** a commented-out `AND NOT regexp_like(cs_user_agent,
+'(?i)bot|spider|crawl|slurp|preview|monitor')` clause is included in each query so
+obvious crawlers can be removed when reading the numbers.
+
+---
+
+## 7. Saved Query Set
+
+All queries live in the `chq-traffic` workgroup against the Glue table. Shipped as
+`aws_athena_named_query` resources:
+
+1. **Pageviews by day (split HTML vs data-pull)** — `date`, object class, count.
+2. **Pageviews by week (split)** — ISO week rollup.
+3. **Active visits by day** — distinct `(visitor_key, date, hour)` per day.
+4. **Active visits by week.**
+5. **Unique visitors by day / week / season-to-date** — distinct `visitor_key`.
+6. **New vs returning by day** — first-seen-date self-comparison.
+7. **Top pages** — content object stems by request count.
+8. **Top referrers** — `cs_referer` by count.
+
+Each named query carries a comment header documenting its metric definition and the
+optional bot-filter line, so the runbook and the SQL stay in sync.
+
+---
+
+## 8. Privacy & Retention
+
+- **Cookies are indiscriminate but empty today.** `include_cookies = true` logs every
+  cookie on every path — but the app sets none and admin auth travels in the
+  `Authorization` header (not logged), so `cs(Cookie)` is `-` on every request. No
+  tokens leak. The field is captured now purely so future session-cookie work needs no
+  logging change.
+- **Raw logs auto-expire after 90 days** (S3 lifecycle). Only whatever aggregates you
+  choose to record persist longer.
+- **Aggregates are hashed** (`visitor_key` = md5 of IP+UA); we only ever look at
+  counts, never export raw IPs.
+- **Log bucket is fully private** (public-access-block on; ACL grants only the
+  CloudFront log-delivery group + bucket owner).
+
+---
+
+## 9. Cost
+
+- **Standard logging:** free (no per-request charge).
+- **S3 storage:** a few MB/day of gzipped logs → cents/month; capped by the 90-day
+  lifecycle.
+- **Athena:** $5/TB scanned. At MB-per-query this rounds to $0. Results bucket
+  auto-expires.
+
+Effectively free at this site's scale.
+
+---
+
+## 10. How You'll Use It
+
+- **Runbook:** `docs/runbooks/traffic-analytics.md` — open Athena, select the
+  `chq-traffic` workgroup, run a named query, read the result. Includes a "how to read
+  these numbers" section restating the **IP-based-uniqueness-is-approximate** caveat:
+  mobile carrier NAT makes users share an IP (deflates unique counts) and dynamic IPs
+  make one user look like several (inflates). Good for trends, not precise headcounts.
+- **Terraform output:** a deep-link Athena console URL for the workgroup (mirrors the
+  existing `cloudfront_dashboard` URL output at `infrastructure/main.tf:1897`).
+
+---
+
+## 11. Scope & Verification
+
+**In scope (Phase A):**
+
+- Terraform in `infrastructure/`: log bucket (+ ownership/ACL, public-access-block,
+  lifecycle), `logging_config` on the distribution, Glue DB + table, Athena workgroup
+  + results location, named queries, Athena-console URL output.
+- Runbook `docs/runbooks/traffic-analytics.md`.
+
+**Out of scope:**
+
+- No frontend/backend/app code. No unit tests (Terraform-only change; validated via
+  `terraform plan`/`terraform validate`).
+- Phase B (CloudWatch custom metrics) and Phase C (admin-page dashboard) — deferred
+  until a week of Phase-A data is reviewed.
+
+**Verification:**
+
+1. `terraform validate` and `terraform plan` are clean.
+2. `terraform apply`.
+3. Wait for the first log files to appear under `s3://<log-bucket>/cf/` (minutes–hours).
+4. Run each named query in the Athena console; confirm sane, non-empty numbers.
+5. Confirm `cs_cookie` is `-` (as expected) and no `Authorization`/token data appears.
+
+---
+
+## Open Follow-ups (post-Phase-A)
+
+- Decide B vs C after reviewing a week of real data.
+- If log volume grows enough to matter, migrate to standard-logging-v2 with Hive
+  partitioning + Athena partition projection.
+- When a real session cookie is introduced, the cookie field is already captured;
+  add session-oriented queries then.

--- a/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
@@ -143,7 +143,9 @@ resource "aws_cloudwatch_log_delivery_destination" "cf_access_s3" {
   name          = "chq-cf-access-logs-s3"
   output_format = "parquet"
   delivery_destination_configuration {
-    destination_resource_arn = aws_s3_bucket.cf_logs.arn
+    # `/cf` prefix on the destination ARN suppresses CloudFront's default
+    # AWSLogs/<acct>/CloudFront/ path, giving the predictable base s3://<bucket>/cf/.
+    destination_resource_arn = "${aws_s3_bucket.cf_logs.arn}/cf"
   }
 }
 
@@ -152,15 +154,16 @@ resource "aws_cloudwatch_log_delivery" "cf_access" {
   delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cf_access_s3.arn
 
   s3_delivery_configuration {
-    suffix_path                = "cf/{yyyy}/{MM}/{dd}"
+    suffix_path                 = "{yyyy}/{MM}/{dd}"
     enable_hive_compatible_path = true
   }
 
   # Field selection (v2 replaces legacy include_cookies): capture exactly what
-  # the metrics need, plus a few cheap identity/segmentation signals.
+  # the metrics need, plus a few cheap identity/segmentation signals. Field names
+  # are the AWS API names — parenthesized fields log as underscored Parquet columns.
   record_fields = [
-    "timestamp", "c-ip", "cs-method", "cs-uri-stem", "sc-status",
-    "cs-user-agent", "cs-referer", "cs-cookie", "x-edge-result-type",
+    "date", "time", "c-ip", "cs-method", "cs-uri-stem", "sc-status",
+    "cs(Referer)", "cs(User-Agent)", "cs(Cookie)", "x-edge-result-type",
     # Identity / segmentation signals (near-zero cost, captured now):
     "asn", "c-country", "ssl-protocol", "ssl-cipher",
   ]
@@ -194,21 +197,27 @@ These are all standard-logging-v2 selectable fields — no functions, no extra i
 - **Glue database** (`aws_glue_catalog_database`) e.g. `chq_cloudfront_logs`.
 - **Glue table** (`aws_glue_catalog_table`) over `s3://<log-bucket>/cf/`, using the
   **Parquet SerDe** (`org.apache.hadoop.hive.ql.io.parquet.*`). Columns follow the v2
-  Parquet field names for the selected `record_fields`: `timestamp`, `c_ip`,
-  `cs_method`, `cs_uri_stem`, `sc_status`, `cs_user_agent`, `cs_referer`, `cs_cookie`,
-  `x_edge_result_type`, `asn`, `c_country`, `ssl_protocol`, `ssl_cipher` (the plan
-  pins the exact Parquet column names AWS emits).
+  Parquet field names for the selected `record_fields`: `date`, `time`, `c_ip`,
+  `cs_method`, `cs_uri_stem`, `sc_status`, `cs_referer`, `cs_user_agent`, `cs_cookie`,
+  `x_edge_result_type`, `asn`, `c_country`, `ssl_protocol`, `ssl_cipher` — all typed
+  `string`. The Parquet footer emits mixed-case names for the parenthesized fields
+  (`cs_Referer`, `cs_User_Agent`, `cs_Cookie`); the table sets
+  `parquet.column.index.access = "false"` so Athena matches columns by name
+  (case-insensitively) rather than by position.
 - **Partitioned with partition projection.** Because v2 writes Hive-compatible paths
   (`cf/year=…/month=…/day=…` via `enable_hive_compatible_path`), the table declares
   `year`/`month`/`day` partition keys and uses Athena **partition projection**
-  (`projection.enabled = true`, date-range projection) — no crawler, no
-  `MSCK REPAIR`, and every query prunes to only the days it needs. This keeps scans
-  minimal as volume grows, so no future re-architecture is needed.
+  (`projection.enabled = true`, date-range projection) — so partitions are
+  discovered with no crawler and no `MSCK REPAIR`. Adding a `year`/`month`/`day`
+  predicate to a query then prunes the scan, keeping cost controllable as volume
+  grows without any re-architecture.
 - **Athena workgroup** (`aws_athena_workgroup`) e.g. `chq-traffic` with
   `result_configuration.output_location = s3://<log-bucket>/athena-results/`.
 - **Named queries** (`aws_athena_named_query`, one per §7 query) so each is one
-  click in the console. Time-windowed queries filter on the `year`/`month`/`day`
-  partition columns to stay cheap.
+  click in the console. The Phase-A one-click queries do **not** filter on the
+  `year`/`month`/`day` partition columns — they scan the full retention window,
+  which is negligible at this volume. A partition predicate can be added in the
+  console to prune scans if the dataset grows (documented in the runbook).
 
 ---
 

--- a/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+++ b/docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
@@ -380,15 +380,30 @@ is a persistent first-party visitor ID. This design is deliberately built so we 
 switch to it **without re-architecting** the pipeline, *if and when the owner is
 comfortable setting a cookie on user browsers*:
 
+- **Invariant that must hold either way:** the hourly `/cache/calendar-cache/*.json`
+  files stay **byte-identical and user-agnostic** — shared public data, cached and
+  served the same to everyone. No visitor ID is *ever* injected into a response body,
+  and the "content requests don't touch an application" boundary is preserved. The ID
+  lives only on the *request* side and in the logs, never in shared content.
 - **What gets added:** a small, random, non-PII visitor ID (e.g. a UUID) minted once
-  per browser and persisted. Two viable placements, decided at that time:
-  - a **first-party cookie** set by a viewer-response CloudFront Function (or by client
-    JS) — this is the primary planned approach; **the `cs-cookie` field is already in
-    `record_fields`, so it flows into the logs the moment the cookie exists, with no
-    delivery change**; or
-  - a **localStorage** ID echoed into a request (e.g. a query param on the
-    `/cache/*.json` fetch, or a `cf.logCustomData()` call) if we prefer to avoid
-    cookies entirely — captured via `viewer-request-log-data`, still no new infra.
+  per browser and persisted. Two clean placements, decided at that time:
+  - **First-party cookie (primary planned approach).** Set once — by a viewer-response
+    CloudFront Function or by client JS — scoped to the site domain. The browser then
+    attaches it automatically to every same-origin request, so **it needs no change to
+    how content is fetched**, and **the `cs-cookie` field is already in `record_fields`,
+    so it flows into the logs the moment the cookie exists**. To keep the shared cache
+    intact, the cache behaviors are configured to **exclude the cookie from the cache
+    key** (do not vary on it) — CloudFront still *logs* the cookie while serving the
+    same cached object to all users. Clean: the ID rides the request header, never the
+    response.
+  - **localStorage + a dedicated beacon (cookieless variant).** If we want to avoid
+    cookies entirely, the client mints/reads a localStorage ID and sends it on its own
+    **purpose-built beacon request** — e.g. `GET /px?v=<id>`, handled by a viewer-request
+    CloudFront Function that returns `204` (no origin hit) and records the ID via
+    `cf.logCustomData()` → `viewer-request-log-data`. This keeps the content requests
+    pure and makes the tracking *explicit and separate* rather than piggybacked. The
+    honest tradeoff vs. the cookie: it adds a small client snippet plus one beacon
+    route/function — a bit more surface, but no cookie and no touching the JSON.
 - **What changes downstream:** `visitor_key` switches from `md5(IP‖UA)` to the visitor
   ID (falling back to `md5(IP‖UA)` when the ID is absent — e.g. first-ever request or
   cookies disabled). Only the query definitions change; capture, bucket, table, and

--- a/infrastructure/traffic-analytics.tf
+++ b/infrastructure/traffic-analytics.tf
@@ -77,7 +77,7 @@ resource "aws_s3_bucket_policy" "cf_logs" {
             "aws:SourceAccount" = data.aws_caller_identity.current.account_id
           }
           ArnLike = {
-            "aws:SourceArn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:delivery-source:*"
+            "aws:SourceArn" = aws_cloudwatch_log_delivery_source.cf_access.arn
           }
         }
       }

--- a/infrastructure/traffic-analytics.tf
+++ b/infrastructure/traffic-analytics.tf
@@ -1,0 +1,88 @@
+# infrastructure/traffic-analytics.tf
+#
+# CloudFront traffic analytics (Phase A): standard logging v2 -> S3 (Parquet,
+# partitioned) -> Glue table -> Athena named queries.
+# Design: docs/superpowers/specs/2026-07-19-cloudfront-traffic-analytics-design.md
+
+resource "random_id" "cf_logs_suffix" {
+  byte_length = 4
+}
+
+# Private, ACL-disabled bucket for raw CloudFront logs (prefix cf/) and Athena
+# query results (prefix athena-results/).
+resource "aws_s3_bucket" "cf_logs" {
+  bucket = "${var.app_name}-cf-logs-${random_id.cf_logs_suffix.hex}"
+}
+
+resource "aws_s3_bucket_public_access_block" "cf_logs" {
+  bucket                  = aws_s3_bucket.cf_logs.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ACLs fully disabled. Logging v2 delivers via bucket policy, not ACL.
+resource "aws_s3_bucket_ownership_controls" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+  rule {
+    object_ownership = "BucketOwnerEnforced"
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+
+  rule {
+    id     = "expire-raw-logs"
+    status = "Enabled"
+    filter {
+      prefix = "cf/"
+    }
+    expiration {
+      days = 90
+    }
+  }
+
+  rule {
+    id     = "expire-athena-results"
+    status = "Enabled"
+    filter {
+      prefix = "athena-results/"
+    }
+    expiration {
+      days = 30
+    }
+  }
+}
+
+# Allow the CloudWatch Logs vended-logs delivery service to write logs under cf/.
+# Scoped to this account + region delivery sources. The x-amz-acl condition is
+# what the delivery service sends and is permitted under BucketOwnerEnforced.
+resource "aws_s3_bucket_policy" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "AWSLogsDeliveryWrite"
+        Effect    = "Allow"
+        Principal = { Service = "delivery.logs.amazonaws.com" }
+        Action    = "s3:PutObject"
+        Resource  = "${aws_s3_bucket.cf_logs.arn}/cf/*"
+        Condition = {
+          StringEquals = {
+            "s3:x-amz-acl"      = "bucket-owner-full-control"
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+          ArnLike = {
+            "aws:SourceArn" = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:delivery-source:*"
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [aws_s3_bucket_public_access_block.cf_logs]
+}

--- a/infrastructure/traffic-analytics.tf
+++ b/infrastructure/traffic-analytics.tf
@@ -139,3 +139,110 @@ resource "aws_cloudwatch_log_delivery" "cf_access" {
 
   depends_on = [aws_s3_bucket_policy.cf_logs]
 }
+
+# --- Glue catalog: schema over the Parquet logs -------------------------------
+
+resource "aws_glue_catalog_database" "cf_logs" {
+  name = "chq_cloudfront_logs"
+}
+
+resource "aws_glue_catalog_table" "cf_logs" {
+  name          = "access_logs"
+  database_name = aws_glue_catalog_database.cf_logs.name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    EXTERNAL                    = "TRUE"
+    classification              = "parquet"
+    "projection.enabled"        = "true"
+    "projection.year.type"      = "integer"
+    "projection.year.range"     = "2026,2035"
+    "projection.month.type"     = "integer"
+    "projection.month.range"    = "1,12"
+    "projection.month.digits"   = "2"
+    "projection.day.type"       = "integer"
+    "projection.day.range"      = "1,31"
+    "projection.day.digits"     = "2"
+    "storage.location.template" = "s3://${aws_s3_bucket.cf_logs.bucket}/cf/year=$${year}/month=$${month}/day=$${day}"
+  }
+
+  partition_keys {
+    name = "year"
+    type = "int"
+  }
+  partition_keys {
+    name = "month"
+    type = "int"
+  }
+  partition_keys {
+    name = "day"
+    type = "int"
+  }
+
+  storage_descriptor {
+    location      = "s3://${aws_s3_bucket.cf_logs.bucket}/cf/"
+    input_format  = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+
+    columns {
+      name = "date"
+      type = "string"
+    }
+    columns {
+      name = "time"
+      type = "string"
+    }
+    columns {
+      name = "c_ip"
+      type = "string"
+    }
+    columns {
+      name = "cs_method"
+      type = "string"
+    }
+    columns {
+      name = "cs_uri_stem"
+      type = "string"
+    }
+    columns {
+      name = "sc_status"
+      type = "string"
+    }
+    columns {
+      name = "cs_referer"
+      type = "string"
+    }
+    columns {
+      name = "cs_user_agent"
+      type = "string"
+    }
+    columns {
+      name = "cs_cookie"
+      type = "string"
+    }
+    columns {
+      name = "x_edge_result_type"
+      type = "string"
+    }
+    columns {
+      name = "ssl_protocol"
+      type = "string"
+    }
+    columns {
+      name = "ssl_cipher"
+      type = "string"
+    }
+    columns {
+      name = "asn"
+      type = "string"
+    }
+    columns {
+      name = "c_country"
+      type = "string"
+    }
+  }
+}

--- a/infrastructure/traffic-analytics.tf
+++ b/infrastructure/traffic-analytics.tf
@@ -12,6 +12,28 @@ resource "random_id" "cf_logs_suffix" {
 # query results (prefix athena-results/).
 resource "aws_s3_bucket" "cf_logs" {
   bucket = "${var.app_name}-cf-logs-${random_id.cf_logs_suffix.hex}"
+
+  # AWS provider v6 regression: an untagged bucket returns NoSuchTagSet on the
+  # GetBucketTagging read, which the provider misreads as "bucket deleted" and
+  # then proposes recreating it. At least one tag keeps the tag set non-empty so
+  # the read succeeds. Mirrors the frontend/cache buckets in main.tf (see PR #94).
+  tags = {
+    Name        = "${var.app_name}-cf-logs"
+    Environment = var.environment
+  }
+}
+
+# Explicit SSE-S3, matching the cache bucket convention (main.tf). This bucket
+# holds raw client IPs + user-agents for 90 days, so encryption-at-rest is
+# declared here rather than relying on the account-level default.
+resource "aws_s3_bucket_server_side_encryption_configuration" "cf_logs" {
+  bucket = aws_s3_bucket.cf_logs.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
 }
 
 resource "aws_s3_bucket_public_access_block" "cf_logs" {
@@ -152,18 +174,24 @@ resource "aws_glue_catalog_table" "cf_logs" {
   table_type    = "EXTERNAL_TABLE"
 
   parameters = {
-    EXTERNAL                    = "TRUE"
-    classification              = "parquet"
-    "projection.enabled"        = "true"
-    "projection.year.type"      = "integer"
-    "projection.year.range"     = "2026,2035"
-    "projection.month.type"     = "integer"
-    "projection.month.range"    = "1,12"
-    "projection.month.digits"   = "2"
-    "projection.day.type"       = "integer"
-    "projection.day.range"      = "1,31"
-    "projection.day.digits"     = "2"
-    "storage.location.template" = "s3://${aws_s3_bucket.cf_logs.bucket}/cf/year=$${year}/month=$${month}/day=$${day}"
+    EXTERNAL       = "TRUE"
+    classification = "parquet"
+    # Match Parquet columns by NAME, not position, so the record_fields order
+    # (delivery) and this columns block can't silently misalign on a future edit.
+    # Athena's Parquet name-matching is case-insensitive, so our lowercase Glue
+    # names resolve the mixed-case Parquet names (cs_User_Agent, cs_Referer,
+    # cs_Cookie). Verified against live delivered data.
+    "parquet.column.index.access" = "false"
+    "projection.enabled"          = "true"
+    "projection.year.type"        = "integer"
+    "projection.year.range"       = "2026,2035"
+    "projection.month.type"       = "integer"
+    "projection.month.range"      = "1,12"
+    "projection.month.digits"     = "2"
+    "projection.day.type"         = "integer"
+    "projection.day.range"        = "1,31"
+    "projection.day.digits"       = "2"
+    "storage.location.template"   = "s3://${aws_s3_bucket.cf_logs.bucket}/cf/year=$${year}/month=$${month}/day=$${day}"
   }
 
   partition_keys {
@@ -291,6 +319,12 @@ output "traffic_analytics_athena_url" {
 }
 
 # 01 — Pageviews by day, split into page loads vs. data pulls.
+# COST NOTE: these one-click queries intentionally do NOT filter on the
+# year/month/day partition columns, so they scan the full retention window.
+# That is negligible at this volume, but to bound cost on a large/growing
+# dataset add a partition predicate in the console, e.g.:
+#   WHERE year = 2026 AND month = 7    -- prunes via partition projection
+# See docs/runbooks/traffic-analytics.md ("Cost & retention").
 resource "aws_athena_named_query" "pageviews_by_day" {
   name      = "01 - Pageviews by day (split by object)"
   database  = aws_glue_catalog_database.cf_logs.name

--- a/infrastructure/traffic-analytics.tf
+++ b/infrastructure/traffic-analytics.tf
@@ -246,3 +246,254 @@ resource "aws_glue_catalog_table" "cf_logs" {
     }
   }
 }
+
+# --- Shared SQL fragments (DRY'd across the 12 named queries below) -----------
+#
+# Optional bot filter: every content query below may have the following added
+# after its WHERE predicate (uncomment/paste in the Athena console):
+#   AND NOT regexp_like(cs_user_agent, '(?i)bot|spider|crawl|slurp|preview|monitor')
+locals {
+  # Boolean predicate placed after WHERE in every content query.
+  cf_content_predicate = <<-SQL
+    cs_method = 'GET'
+      AND sc_status IN ('200','304')
+      AND (cs_uri_stem LIKE '%/' OR cs_uri_stem LIKE '%.html'
+           OR cs_uri_stem LIKE '/cache/calendar-cache/%.json')
+      AND cs_uri_stem NOT LIKE '/admin%'
+      AND cs_uri_stem NOT LIKE '/api%'
+      AND cs_uri_stem NOT LIKE '/auth%'
+  SQL
+
+  # SQL expression: per-visitor hash key (client IP + user-agent).
+  cf_visitor_key = "lower(to_hex(md5(to_utf8(c_ip || '|' || cs_user_agent))))"
+}
+
+# --- Athena workgroup + saved queries -----------------------------------------
+
+resource "aws_athena_workgroup" "traffic" {
+  name          = "${var.app_name}-traffic"
+  force_destroy = true
+
+  configuration {
+    enforce_workgroup_configuration = true
+    result_configuration {
+      output_location = "s3://${aws_s3_bucket.cf_logs.bucket}/athena-results/"
+    }
+  }
+}
+
+output "traffic_analytics_athena_url" {
+  # NOTE: output "description" must be a compile-time literal (no var/resource
+  # interpolation allowed by Terraform) — select the workgroup named
+  # aws_athena_workgroup.traffic.name (i.e. "<app_name>-traffic") in the console.
+  description = "Athena console query editor. Select the \"<app_name>-traffic\" workgroup (aws_athena_workgroup.traffic.name) before running a named query."
+  value       = "https://${var.aws_region}.console.aws.amazon.com/athena/home?region=${var.aws_region}#/query-editor"
+}
+
+# 01 — Pageviews by day, split into page loads vs. data pulls.
+resource "aws_athena_named_query" "pageviews_by_day" {
+  name      = "01 - Pageviews by day (split by object)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    -- Optional bot filter: add
+    --   AND NOT regexp_like(cs_user_agent, '(?i)bot|spider|crawl|slurp|preview|monitor')
+    SELECT
+      "date" AS day,
+      CASE WHEN cs_uri_stem LIKE '/cache/calendar-cache/%.json'
+           THEN 'data-pull' ELSE 'page-load' END AS object_class,
+      COUNT(*) AS pageviews
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1, 2
+    ORDER BY day DESC, object_class;
+  SQL
+}
+
+# 02 — Pageviews by ISO week, split by object class.
+resource "aws_athena_named_query" "pageviews_by_week" {
+  name      = "02 - Pageviews by week (split by object)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      date_trunc('week', date_parse("date", '%Y-%m-%d')) AS week_start,
+      CASE WHEN cs_uri_stem LIKE '/cache/calendar-cache/%.json'
+           THEN 'data-pull' ELSE 'page-load' END AS object_class,
+      COUNT(*) AS pageviews
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1, 2
+    ORDER BY week_start DESC, object_class;
+  SQL
+}
+
+# 03 — Active visits by day = distinct (visitor, hour) pairs. The <=1/hr/browser proxy.
+resource "aws_athena_named_query" "active_visits_by_day" {
+  name      = "03 - Active visits by day (visitor-hour)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      "date" AS day,
+      COUNT(DISTINCT
+        ${local.cf_visitor_key} || '#' || substr("time",1,2)
+      ) AS active_visits
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY day DESC;
+  SQL
+}
+
+# 04 — Active visits by week = distinct (visitor, day, hour).
+resource "aws_athena_named_query" "active_visits_by_week" {
+  name      = "04 - Active visits by week (visitor-hour)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      date_trunc('week', date_parse("date", '%Y-%m-%d')) AS week_start,
+      COUNT(DISTINCT
+        ${local.cf_visitor_key} || '#' || "date" || substr("time",1,2)
+      ) AS active_visits
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY week_start DESC;
+  SQL
+}
+
+# 05 — Unique visitors by day.
+resource "aws_athena_named_query" "unique_visitors_by_day" {
+  name      = "05 - Unique visitors by day"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      "date" AS day,
+      COUNT(DISTINCT ${local.cf_visitor_key}) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY day DESC;
+  SQL
+}
+
+# 06 — Unique visitors by week.
+resource "aws_athena_named_query" "unique_visitors_by_week" {
+  name      = "06 - Unique visitors by week"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      date_trunc('week', date_parse("date", '%Y-%m-%d')) AS week_start,
+      COUNT(DISTINCT ${local.cf_visitor_key}) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY week_start DESC;
+  SQL
+}
+
+# 07 — Unique visitors season-to-date (single number).
+resource "aws_athena_named_query" "unique_visitors_season" {
+  name      = "07 - Unique visitors season-to-date"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT
+      COUNT(DISTINCT ${local.cf_visitor_key}) AS unique_visitors_season
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate};
+  SQL
+}
+
+# 08 — New vs returning by day (returning = visitor seen on an earlier date).
+resource "aws_athena_named_query" "new_vs_returning_by_day" {
+  name      = "08 - New vs returning by day"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    WITH visits AS (
+      SELECT DISTINCT
+        ${local.cf_visitor_key} AS visitor_key,
+        "date" AS day
+      FROM chq_cloudfront_logs.access_logs
+      WHERE ${local.cf_content_predicate}
+    ),
+    first_seen AS (
+      SELECT visitor_key, MIN(day) AS first_day FROM visits GROUP BY visitor_key
+    )
+    SELECT
+      v.day,
+      COUNT_IF(v.day = f.first_day) AS new_visitors,
+      COUNT_IF(v.day > f.first_day) AS returning_visitors
+    FROM visits v
+    JOIN first_seen f USING (visitor_key)
+    GROUP BY v.day
+    ORDER BY v.day DESC;
+  SQL
+}
+
+# 09 — Top pages by request count.
+resource "aws_athena_named_query" "top_pages" {
+  name      = "09 - Top pages"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT cs_uri_stem AS page, COUNT(*) AS requests
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY requests DESC
+    LIMIT 50;
+  SQL
+}
+
+# 10 — Top referrers ('-' means no referrer).
+resource "aws_athena_named_query" "top_referrers" {
+  name      = "10 - Top referrers"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT cs_referer AS referrer, COUNT(*) AS requests
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+      AND cs_referer <> '-'
+    GROUP BY 1
+    ORDER BY requests DESC
+    LIMIT 50;
+  SQL
+}
+
+# 11 — Unique visitors by country (segmentation dimension).
+resource "aws_athena_named_query" "visitors_by_country" {
+  name      = "11 - Visitors by country"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT c_country AS country,
+      COUNT(DISTINCT ${local.cf_visitor_key}) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY unique_visitors DESC;
+  SQL
+}
+
+# 12 — Unique visitors by network/carrier (ASN). Reads how much of "unique" is one carrier-NAT pool.
+resource "aws_athena_named_query" "visitors_by_network" {
+  name      = "12 - Visitors by network/carrier (ASN)"
+  database  = aws_glue_catalog_database.cf_logs.name
+  workgroup = aws_athena_workgroup.traffic.name
+  query     = <<-SQL
+    SELECT asn,
+      COUNT(DISTINCT ${local.cf_visitor_key}) AS unique_visitors
+    FROM chq_cloudfront_logs.access_logs
+    WHERE ${local.cf_content_predicate}
+    GROUP BY 1
+    ORDER BY unique_visitors DESC
+    LIMIT 50;
+  SQL
+}

--- a/infrastructure/traffic-analytics.tf
+++ b/infrastructure/traffic-analytics.tf
@@ -86,3 +86,56 @@ resource "aws_s3_bucket_policy" "cf_logs" {
 
   depends_on = [aws_s3_bucket_public_access_block.cf_logs]
 }
+
+# --- CloudFront standard logging v2 (vended-logs delivery) ---------------------
+
+# One delivery source per distribution (CloudFront is global; managed in us-east-1).
+resource "aws_cloudwatch_log_delivery_source" "cf_access" {
+  name         = "${var.app_name}-cf-access-logs"
+  log_type     = "ACCESS_LOGS"
+  resource_arn = aws_cloudfront_distribution.frontend_distribution.arn
+}
+
+# Parquet output to the log bucket under the cf/ prefix. Using a prefix in the
+# destination ARN suppresses CloudFront's default AWSLogs/<acct>/CloudFront/ path,
+# giving the predictable base s3://<bucket>/cf/.
+resource "aws_cloudwatch_log_delivery_destination" "cf_access_s3" {
+  name          = "${var.app_name}-cf-access-logs-s3"
+  output_format = "parquet"
+
+  delivery_destination_configuration {
+    destination_resource_arn = "${aws_s3_bucket.cf_logs.arn}/cf"
+  }
+}
+
+# Field selection replaces legacy include_cookies. record_fields use AWS API field
+# names (parenthesized); the Parquet columns become underscored (Task 3).
+# cs(Cookie) is captured but empty today (no app cookies; IncludeCookies deferred).
+resource "aws_cloudwatch_log_delivery" "cf_access" {
+  delivery_source_name     = aws_cloudwatch_log_delivery_source.cf_access.name
+  delivery_destination_arn = aws_cloudwatch_log_delivery_destination.cf_access_s3.arn
+
+  record_fields = [
+    "date",
+    "time",
+    "c-ip",
+    "cs-method",
+    "cs-uri-stem",
+    "sc-status",
+    "cs(Referer)",
+    "cs(User-Agent)",
+    "cs(Cookie)",
+    "x-edge-result-type",
+    "ssl-protocol",
+    "ssl-cipher",
+    "asn",
+    "c-country",
+  ]
+
+  s3_delivery_configuration {
+    suffix_path                 = "{yyyy}/{MM}/{dd}"
+    enable_hive_compatible_path = true
+  }
+
+  depends_on = [aws_s3_bucket_policy.cf_logs]
+}


### PR DESCRIPTION
## CloudFront Traffic Analytics — Phase A

Cookieless site-traffic analytics (unique/returning visitors, pageviews) for the CloudFront-served static site. No such data existed before — this captures a per-request signal and makes it queryable, with **no app changes and no cookies set**.

### What this does
CloudFront **standard logging v2** → private S3 bucket (Parquet, Hive-partitioned) → AWS Glue table (partition projection) → **Amazon Athena** named queries, all defined in Terraform, plus an operator runbook. Viewing is manual from the Athena console (Phase A).

### Included (Terraform + docs only)
- `infrastructure/traffic-analytics.tf`: private **`BucketOwnerEnforced`** log bucket (public access fully blocked, tagged, SSE-S3, 90-day raw / 30-day results lifecycle) + scoped delivery bucket policy; logging-v2 delivery trio (parquet, `cf/year=…/month=…/day=…`); Glue DB + partitioned table (14 `string` columns, **name-based** Parquet matching); Athena workgroup + **12 named queries** (DRY'd via `locals`) + console-URL output.
- `docs/runbooks/traffic-analytics.md`: how to run the queries + how to read them (IP-uniqueness caveats, retention, partition-cost lever) + troubleshooting.
- `docs/superpowers/specs/…` and `docs/superpowers/plans/…`: design + implementation plan.

### Metrics
Pageviews (HTML page loads **and** `/cache/calendar-cache/*.json` data pulls, split), **active visits** (distinct visitor-hour, the ≤1/hr/browser proxy), unique/returning visitors, plus country and network/ASN breakdowns. `visitor_key = md5(IP‖UA)`; `asn`/`c_country`/`ssl_*` are reporting dimensions, never keyed on. Cookie field captured but empty today (forward-compat for a future first-party-ID next step).

### Deployment status — applied & smoke-verified ✅
`terraform apply` has been run against production and the end-to-end smoke test **passed**: first logs delivered ~6 min post-apply at `cf/year=2026/month=07/day=19/*.parquet` (path matches the Glue table); all 14 columns read cleanly incl. `asn` (no type mismatch); `cs_cookie` empty as designed; the named queries return data. Bucket confirmed `BucketOwnerEnforced` with all public-access blocks on. **Note:** the tags/SSE/name-based-matching changes added during PR review are on the branch and validate clean; they take effect on the live infra at the next `terraform apply` (the currently-deployed table already works).

### Not in this PR (deferred by design)
CloudWatch-metrics dashboard (Phase B) / admin-page dashboard (Phase C); the first-party visitor-ID (cookie or localStorage) that would make cross-session returning-visitor counts reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpjX7DHTH43xHEMKzRUYk1
