### PR TITLE
feat: Bus & Tram Tracker link in iOS More menu + web header (#158)

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -68,6 +68,12 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             >
               Questions
             </button>
+            <button
+              onClick={() => window.open('https://busandtramtracker.chq.org', '_blank')}
+              className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+            >
+              Bus & Tram Tracker
+            </button>
           </div>
           {/* Mobile */}
           <div className="md:hidden relative" ref={menuRef}>
@@ -104,6 +110,12 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
                 >
                   Questions
+                </button>
+                <button
+                  onClick={() => { window.open('https://busandtramtracker.chq.org', '_blank'); setMenuOpen(false); }}
+                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                >
+                  Bus & Tram Tracker
                 </button>
               </div>
             )}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -51,25 +51,25 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
           {/* Desktop */}
           <div className="hidden md:flex items-center gap-2">
             <button
-              onClick={() => window.open('/feedback', '_blank')}
+              onClick={() => window.open('/feedback', '_blank', 'noopener,noreferrer')}
               className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
             >
               Feedback
             </button>
             <button
-              onClick={() => window.open('https://programs.chq.org/', '_blank')}
+              onClick={() => window.open('https://programs.chq.org/', '_blank', 'noopener,noreferrer')}
               className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
             >
               Programs
             </button>
             <button
-              onClick={() => window.open('https://questions.chq.org/', '_blank')}
+              onClick={() => window.open('https://questions.chq.org/', '_blank', 'noopener,noreferrer')}
               className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
             >
               Questions
             </button>
             <button
-              onClick={() => window.open('https://busandtramtracker.chq.org', '_blank')}
+              onClick={() => window.open('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer')}
               className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
             >
               Bus & Tram Tracker
@@ -94,25 +94,25 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-md shadow-lg py-1 z-50">
                 <button
-                  onClick={() => { window.open('/feedback', '_blank'); setMenuOpen(false); }}
+                  onClick={() => { window.open('/feedback', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
                 >
                   Feedback
                 </button>
                 <button
-                  onClick={() => { window.open('https://programs.chq.org/', '_blank'); setMenuOpen(false); }}
+                  onClick={() => { window.open('https://programs.chq.org/', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
                 >
                   Programs
                 </button>
                 <button
-                  onClick={() => { window.open('https://questions.chq.org/', '_blank'); setMenuOpen(false); }}
+                  onClick={() => { window.open('https://questions.chq.org/', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
                 >
                   Questions
                 </button>
                 <button
-                  onClick={() => { window.open('https://busandtramtracker.chq.org', '_blank'); setMenuOpen(false); }}
+                  onClick={() => { window.open('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
                   className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
                 >
                   Bus & Tram Tracker

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -24,7 +24,7 @@ describe('Header navigation', () => {
     // gated behind the "More" toggle, so exactly one Questions button exists.
     const questions = screen.getByRole('button', { name: 'Questions' });
     fireEvent.click(questions);
-    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank');
+    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank', 'noopener,noreferrer');
   });
 
   it('renders the Questions button in the mobile dropdown', () => {
@@ -38,7 +38,7 @@ describe('Header navigation', () => {
     expect(questions).toHaveLength(2);
 
     fireEvent.click(questions[1]);
-    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank');
+    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank', 'noopener,noreferrer');
   });
 
   it('renders the Bus & Tram Tracker button in the desktop nav', () => {
@@ -47,7 +47,7 @@ describe('Header navigation', () => {
 
     const tracker = screen.getByRole('button', { name: 'Bus & Tram Tracker' });
     fireEvent.click(tracker);
-    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank');
+    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer');
   });
 
   it('renders the Bus & Tram Tracker button in the mobile dropdown', () => {
@@ -59,6 +59,6 @@ describe('Header navigation', () => {
     expect(trackers).toHaveLength(2);
 
     fireEvent.click(trackers[1]);
-    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank');
+    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer');
   });
 });

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -40,4 +40,25 @@ describe('Header navigation', () => {
     fireEvent.click(questions[1]);
     expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank');
   });
+
+  it('renders the Bus & Tram Tracker button in the desktop nav', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    const tracker = screen.getByRole('button', { name: 'Bus & Tram Tracker' });
+    fireEvent.click(tracker);
+    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank');
+  });
+
+  it('renders the Bus & Tram Tracker button in the mobile dropdown', () => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /More/ }));
+    const trackers = screen.getAllByRole('button', { name: 'Bus & Tram Tracker' });
+    expect(trackers).toHaveLength(2);
+
+    fireEvent.click(trackers[1]);
+    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank');
+  });
 });

--- a/ios/ChqCalendar/Features/About/AboutInfo.swift
+++ b/ios/ChqCalendar/Features/About/AboutInfo.swift
@@ -34,6 +34,7 @@ enum AboutInfo {
         Link(id: "feedback", title: "Feedback", url: URL(string: "https://www.chqcal.org/feedback")!),
         Link(id: "programs", title: "Programs", url: URL(string: "https://programs.chq.org/")!),
         Link(id: "questions", title: "Questions", url: URL(string: "https://questions.chq.org/")!),
+        Link(id: "bus-tram-tracker", title: "Bus & Tram Tracker", url: URL(string: "https://busandtramtracker.chq.org")!),
     ]
 
     /// Formats the marketing version and build number for display.

--- a/ios/ChqCalendarTests/AboutInfoTests.swift
+++ b/ios/ChqCalendarTests/AboutInfoTests.swift
@@ -56,12 +56,13 @@ struct AboutInfoTests {
     // MARK: - quickLinks
 
     @Test func quickLinksMatchTheWebHeader() {
-        #expect(AboutInfo.quickLinks.map(\.id) == ["feedback", "programs", "questions"])
-        #expect(AboutInfo.quickLinks.map(\.title) == ["Feedback", "Programs", "Questions"])
+        #expect(AboutInfo.quickLinks.map(\.id) == ["feedback", "programs", "questions", "bus-tram-tracker"])
+        #expect(AboutInfo.quickLinks.map(\.title) == ["Feedback", "Programs", "Questions", "Bus & Tram Tracker"])
         #expect(AboutInfo.quickLinks.map { $0.url.absoluteString } == [
             "https://www.chqcal.org/feedback",
             "https://programs.chq.org/",
             "https://questions.chq.org/",
+            "https://busandtramtracker.chq.org",
         ])
     }
 


### PR DESCRIPTION
Closes #158.

Adds the Bus & Tram Tracker (https://busandtramtracker.chq.org) after Questions in:
- iOS toolbar More menu (`AboutInfo.quickLinks` — rendered via existing ForEach)
- Web header, desktop row + mobile More dropdown (`Header.tsx`)

Tests updated: `AboutInfoTests.quickLinksMatchTheWebHeader` (pins all 4 links), two new `Header.test.tsx` cases (desktop + mobile).

iOS suite run locally (CI has no macOS runner): all tests pass.

[skip-screenshots: link added inside the closed More menu; no shot in screenshot-plan.json opens that menu]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012mchpBcoJsknvac53PhHBQ