### PR TITLE
feat: Chautauqua Fund link on web + iOS, driven by shared links.json (#169)

### DIFF
--- a/docs/plans/2026-08-05-shared-links-plan.md
+++ b/docs/plans/2026-08-05-shared-links-plan.md
@@ -1,0 +1,257 @@
+# Shared Links Source of Truth + Chautauqua Fund Link (Issue #169) — Design & Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Status:** Approved 2026-08-05 (design decisions confirmed by user: shared JSON + iOS consistency test; link title "Chautauqua Fund").
+
+**Goal:** Add a "Chautauqua Fund" link (https://giving.chq.org/) to the web header and iOS More menu, and refactor so both platforms' quick links come from one shared file that cannot silently drift.
+
+**Architecture:** A new `shared/links.json` at the repo root is the single source of truth. The web imports it at build time and renders the header link buttons by mapping over it. iOS keeps its typed `AboutInfo.quickLinks` (SwiftUI wants `URL`s; bundling repo-root files into the app target is not worth the xcodeproj complexity), but a unit test reads the shared JSON via `#filePath` and asserts the Swift list matches exactly — the same pattern the repo already uses for the About disclaimer (`appStoreListing.test.ts` vs `listing-fields.json`).
+
+**Tech Stack:** Vite/Preact/TypeScript (web), Swift 6 / Swift Testing (iOS), vitest.
+
+## Global Constraints
+
+- Never commit to `main`; work on `feature/169-shared-links`.
+- Frontend verification: `cd frontend && npm run build` (runs validate + tests).
+- iOS verification: `cd ios && xcodebuild test -scheme ChqCalendar -destination 'platform=iOS Simulator,name=iPhone 17 Pro Max'` (or the simulator available locally).
+- New link: id `chautauqua-fund`, title `Chautauqua Fund`, url `https://giving.chq.org/`.
+- The web's Feedback link must keep opening the relative path `/feedback` (so local dev stays on localhost); iOS keeps the absolute URL. The JSON carries an optional `webPath` override for this.
+- iOS More-menu change is user-visible, but `ios/Scripts/screenshot-plan.json` has no shot covering the More menu, so the PR opts out with `[skip-screenshots: shot plan does not cover the More menu; no covered shot changes]`.
+
+## File Structure
+
+- Create: `shared/links.json` — single source of truth (`quickLinks` array of `{id, title, url, webPath?}`).
+- Create: `frontend/src/lib/quickLinks.ts` — typed re-export of the JSON for web consumers.
+- Create: `frontend/src/lib/__tests__/quickLinks.test.ts` — shape/content tests.
+- Modify: `frontend/vite.config.ts`, `frontend/vitest.config.ts`, `frontend/tsconfig.json` — add `@shared` alias → `../shared`.
+- Modify: `frontend/src/components/layout/Header.tsx` — map over `quickLinks` in desktop + mobile nav.
+- Modify: `frontend/src/components/layout/__tests__/Header.test.tsx` — data-driven assertions incl. Chautauqua Fund.
+- Modify: `ios/ChqCalendar/Features/About/AboutInfo.swift` — add Chautauqua Fund to `quickLinks`.
+- Modify: `ios/ChqCalendarTests/AboutInfoTests.swift` — update hardcoded expectations; add JSON consistency test.
+
+---
+
+### Task 1: `shared/links.json` + web typed accessor
+
+**Files:**
+- Create: `shared/links.json`
+- Create: `frontend/src/lib/quickLinks.ts`
+- Test: `frontend/src/lib/__tests__/quickLinks.test.ts`
+- Modify: `frontend/vite.config.ts` (resolve.alias), `frontend/vitest.config.ts` (resolve.alias), `frontend/tsconfig.json` (paths)
+
+**Interfaces:**
+- Produces: `quickLinks: QuickLink[]` from `@/lib/quickLinks`, where `interface QuickLink { id: string; title: string; url: string; webPath?: string }`. Order in the JSON is display order.
+
+- [ ] **Step 1: Create the shared JSON**
+
+```json
+{
+  "quickLinks": [
+    { "id": "feedback", "title": "Feedback", "url": "https://www.chqcal.org/feedback", "webPath": "/feedback" },
+    { "id": "programs", "title": "Programs", "url": "https://programs.chq.org/" },
+    { "id": "questions", "title": "Questions", "url": "https://questions.chq.org/" },
+    { "id": "bus-tram-tracker", "title": "Bus & Tram Tracker", "url": "https://busandtramtracker.chq.org" },
+    { "id": "chautauqua-fund", "title": "Chautauqua Fund", "url": "https://giving.chq.org/" }
+  ]
+}
+```
+
+- [ ] **Step 2: Add the `@shared` alias to all three configs**
+
+`frontend/vite.config.ts` and `frontend/vitest.config.ts`, inside the existing `resolve.alias` object:
+
+```ts
+'@shared': resolve(__dirname, '../shared'),
+```
+
+`frontend/tsconfig.json`, inside `compilerOptions.paths`:
+
+```json
+"@shared/*": ["../shared/*"]
+```
+
+- [ ] **Step 3: Write the failing test**
+
+`frontend/src/lib/__tests__/quickLinks.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { quickLinks } from '@/lib/quickLinks';
+
+describe('quickLinks (shared/links.json)', () => {
+  it('includes the Chautauqua Fund link', () => {
+    const fund = quickLinks.find((l) => l.id === 'chautauqua-fund');
+    expect(fund?.title).toBe('Chautauqua Fund');
+    expect(fund?.url).toBe('https://giving.chq.org/');
+  });
+
+  it('every link has a non-empty id, title, and absolute https url', () => {
+    for (const link of quickLinks) {
+      expect(link.id).toMatch(/^[a-z0-9-]+$/);
+      expect(link.title.trim().length).toBeGreaterThan(0);
+      expect(link.url).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('feedback keeps its relative webPath for same-site navigation', () => {
+    expect(quickLinks.find((l) => l.id === 'feedback')?.webPath).toBe('/feedback');
+  });
+
+  it('ids are unique', () => {
+    expect(new Set(quickLinks.map((l) => l.id)).size).toBe(quickLinks.length);
+  });
+});
+```
+
+- [ ] **Step 4: Run it — expect FAIL (module not found)**
+
+Run: `cd frontend && npx vitest run src/lib/__tests__/quickLinks.test.ts`
+
+- [ ] **Step 5: Implement `frontend/src/lib/quickLinks.ts`**
+
+```ts
+import linksJson from '@shared/links.json';
+
+export interface QuickLink {
+  id: string;
+  title: string;
+  url: string;
+  /** Relative path the web app opens instead of `url` (keeps local dev on localhost). */
+  webPath?: string;
+}
+
+export const quickLinks: QuickLink[] = linksJson.quickLinks;
+```
+
+- [ ] **Step 6: Run test — expect PASS**, then `npm run type-check`
+
+- [ ] **Step 7: Commit** — `feat(web): shared links.json as single source for header quick links`
+
+---
+
+### Task 2: Header renders from the shared list
+
+**Files:**
+- Modify: `frontend/src/components/layout/Header.tsx`
+- Test: `frontend/src/components/layout/__tests__/Header.test.tsx`
+
+**Interfaces:**
+- Consumes: `quickLinks`, `QuickLink` from `@/lib/quickLinks` (Task 1).
+
+- [ ] **Step 1: Extend Header tests to be data-driven**
+
+Keep the existing behavioral tests (they pin Questions and Bus & Tram Tracker via `window.open` spies). Add:
+
+```tsx
+import { quickLinks } from '@/lib/quickLinks';
+
+it.each(quickLinks)('desktop nav opens $title from shared links.json', (link) => {
+  const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  render(<Header selectedYear={2026} availableYears={[2026]} defaultYear={2026} onYearChange={() => {}} />);
+  fireEvent.click(screen.getAllByText(link.title)[0]);
+  expect(openSpy).toHaveBeenCalledWith(link.webPath ?? link.url, '_blank', 'noopener,noreferrer');
+});
+
+it('mobile More menu opens the Chautauqua Fund link', () => {
+  const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+  render(<Header selectedYear={2026} availableYears={[2026]} defaultYear={2026} onYearChange={() => {}} />);
+  fireEvent.click(screen.getByText('More'));
+  fireEvent.click(screen.getByText('Chautauqua Fund'));
+  expect(openSpy).toHaveBeenCalledWith('https://giving.chq.org/', '_blank', 'noopener,noreferrer');
+});
+```
+
+(Adapt imports/render helpers to match the existing test file's conventions — read it first.)
+
+- [ ] **Step 2: Run — expect FAIL** (Chautauqua Fund not rendered yet)
+
+- [ ] **Step 3: Refactor Header.tsx**
+
+Replace the four hardcoded desktop `<button>`s with:
+
+```tsx
+{quickLinks.map((link) => (
+  <button
+    key={link.id}
+    onClick={() => window.open(link.webPath ?? link.url, '_blank', 'noopener,noreferrer')}
+    className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+  >
+    {link.title}
+  </button>
+))}
+```
+
+And the four mobile menu `<button>`s with the same map using the mobile classes and `setMenuOpen(false)` after opening. Import `quickLinks` from `@/lib/quickLinks`.
+
+- [ ] **Step 4: Run all Header + quickLinks tests — expect PASS**
+
+- [ ] **Step 5: Full frontend verification** — `cd frontend && npm run build`
+
+- [ ] **Step 6: Commit** — `feat(web): Chautauqua Fund header link; header driven by shared links.json (#169)`
+
+---
+
+### Task 3: iOS — add the link + consistency test against shared JSON
+
+**Files:**
+- Modify: `ios/ChqCalendar/Features/About/AboutInfo.swift`
+- Test: `ios/ChqCalendarTests/AboutInfoTests.swift`
+
+**Interfaces:**
+- Consumes: `shared/links.json` (Task 1) read from the repo checkout via `#filePath`.
+
+- [ ] **Step 1: Update the hardcoded expectations and add the consistency test**
+
+In `AboutInfoTests.swift`, extend `quickLinksMatchTheWebHeader` arrays with `"chautauqua-fund"` / `"Chautauqua Fund"` / `"https://giving.chq.org/"`, and add:
+
+```swift
+/// The cross-platform source of truth is shared/links.json (also consumed
+/// by the web header). This test reads it from the repo checkout so any
+/// drift between the Swift list and the JSON fails CI on either side.
+@Test func quickLinksMatchSharedLinksJson() throws {
+    struct SharedLinksFile: Decodable {
+        struct SharedLink: Decodable {
+            let id: String
+            let title: String
+            let url: String
+        }
+        let quickLinks: [SharedLink]
+    }
+
+    let repoRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent() // AboutInfoTests.swift
+        .deletingLastPathComponent() // ChqCalendarTests
+        .deletingLastPathComponent() // ios
+    let jsonURL = repoRoot.appendingPathComponent("shared/links.json")
+    let data = try Data(contentsOf: jsonURL)
+    let shared = try JSONDecoder().decode(SharedLinksFile.self, from: data)
+
+    #expect(AboutInfo.quickLinks.map(\.id) == shared.quickLinks.map(\.id))
+    #expect(AboutInfo.quickLinks.map(\.title) == shared.quickLinks.map(\.title))
+    #expect(AboutInfo.quickLinks.map { $0.url.absoluteString } == shared.quickLinks.map(\.url))
+}
+```
+
+- [ ] **Step 2: Run iOS tests — expect the new test and the updated hardcoded test to FAIL** (Swift list lacks the fund link)
+
+- [ ] **Step 3: Add the link to `AboutInfo.quickLinks`**
+
+```swift
+Link(id: "chautauqua-fund", title: "Chautauqua Fund", url: URL(string: "https://giving.chq.org/")!),
+```
+
+Also update the doc comment on `quickLinks` to name `shared/links.json` as the source of truth.
+
+- [ ] **Step 4: Run iOS tests — expect PASS**
+
+- [ ] **Step 5: Commit** — `feat(ios): Chautauqua Fund quick link + consistency test vs shared/links.json (#169)`
+
+---
+
+### Task 4: Verification + PR
+
+- [ ] Frontend: `cd frontend && npm run build` — green.
+- [ ] Backend untouched, but run `cd backend && npm run validate` per repo checklist.
+- [ ] iOS: full test suite via xcodebuild — green.
+- [ ] Push branch, open PR referencing #169 with `[skip-screenshots: shot plan does not cover the More menu; no covered shot changes]` and the standard footer.

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { YearSelector } from '@/components/layout/YearSelector';
+import { quickLinks } from '@/lib/quickLinks';
 
 interface HeaderProps {
   selectedYear: number;
@@ -50,30 +51,15 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
           </div>
           {/* Desktop */}
           <div className="hidden md:flex items-center gap-2">
-            <button
-              onClick={() => window.open('/feedback', '_blank', 'noopener,noreferrer')}
-              className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Feedback
-            </button>
-            <button
-              onClick={() => window.open('https://programs.chq.org/', '_blank', 'noopener,noreferrer')}
-              className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Programs
-            </button>
-            <button
-              onClick={() => window.open('https://questions.chq.org/', '_blank', 'noopener,noreferrer')}
-              className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Questions
-            </button>
-            <button
-              onClick={() => window.open('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer')}
-              className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-            >
-              Bus & Tram Tracker
-            </button>
+            {quickLinks.map((link) => (
+              <button
+                key={link.id}
+                onClick={() => window.open(link.webPath ?? link.url, '_blank', 'noopener,noreferrer')}
+                className="px-3 py-1 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+              >
+                {link.title}
+              </button>
+            ))}
           </div>
           {/* Mobile */}
           <div className="md:hidden relative" ref={menuRef}>
@@ -93,30 +79,15 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             </button>
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-md shadow-lg py-1 z-50">
-                <button
-                  onClick={() => { window.open('/feedback', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
-                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                >
-                  Feedback
-                </button>
-                <button
-                  onClick={() => { window.open('https://programs.chq.org/', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
-                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                >
-                  Programs
-                </button>
-                <button
-                  onClick={() => { window.open('https://questions.chq.org/', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
-                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                >
-                  Questions
-                </button>
-                <button
-                  onClick={() => { window.open('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
-                  className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
-                >
-                  Bus & Tram Tracker
-                </button>
+                {quickLinks.map((link) => (
+                  <button
+                    key={link.id}
+                    onClick={() => { window.open(link.webPath ?? link.url, '_blank', 'noopener,noreferrer'); setMenuOpen(false); }}
+                    className="block w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-600"
+                  >
+                    {link.title}
+                  </button>
+                ))}
               </div>
             )}
           </div>

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/preact';
 import { Header } from '../Header';
+import { quickLinks } from '@/lib/quickLinks';
 
 // Global cleanup runs from frontend/src/__tests__/setup.ts (afterEach hook).
 
@@ -60,5 +61,38 @@ describe('Header navigation', () => {
 
     fireEvent.click(trackers[1]);
     expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer');
+  });
+
+  // The header is driven by shared/links.json (also consumed by the iOS
+  // app), so every entry must appear in both the desktop nav and the
+  // mobile dropdown, opening its webPath when one is set (Feedback stays
+  // a same-site relative link) and its absolute url otherwise.
+  it.each(quickLinks)('desktop nav opens $title from shared/links.json', (link) => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: link.title }));
+    expect(openSpy).toHaveBeenCalledWith(link.webPath ?? link.url, '_blank', 'noopener,noreferrer');
+  });
+
+  it.each(quickLinks)('mobile dropdown opens $title from shared/links.json', (link) => {
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /More/ }));
+    const buttons = screen.getAllByRole('button', { name: link.title });
+    expect(buttons).toHaveLength(2);
+
+    fireEvent.click(buttons[1]);
+    expect(openSpy).toHaveBeenCalledWith(link.webPath ?? link.url, '_blank', 'noopener,noreferrer');
+  });
+
+  it('closes the mobile dropdown after a link is opened', () => {
+    vi.spyOn(window, 'open').mockImplementation(() => null);
+    render(<Header {...defaultProps} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /More/ }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Chautauqua Fund' })[1]);
+    expect(screen.getAllByRole('button', { name: 'Chautauqua Fund' })).toHaveLength(1);
   });
 });

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -17,52 +17,6 @@ afterEach(() => {
 });
 
 describe('Header navigation', () => {
-  it('renders the Questions button in the desktop nav linking to questions.chq.org', () => {
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-    render(<Header {...defaultProps} />);
-
-    // Only the desktop nav is rendered up front; the mobile dropdown is
-    // gated behind the "More" toggle, so exactly one Questions button exists.
-    const questions = screen.getByRole('button', { name: 'Questions' });
-    fireEvent.click(questions);
-    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank', 'noopener,noreferrer');
-  });
-
-  it('renders the Questions button in the mobile dropdown', () => {
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-    render(<Header {...defaultProps} />);
-
-    // Open the mobile "More" dropdown to reveal its copy of the links.
-    fireEvent.click(screen.getByRole('button', { name: /More/ }));
-    const questions = screen.getAllByRole('button', { name: 'Questions' });
-    // Desktop + mobile copies are both present once the dropdown is open.
-    expect(questions).toHaveLength(2);
-
-    fireEvent.click(questions[1]);
-    expect(openSpy).toHaveBeenCalledWith('https://questions.chq.org/', '_blank', 'noopener,noreferrer');
-  });
-
-  it('renders the Bus & Tram Tracker button in the desktop nav', () => {
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-    render(<Header {...defaultProps} />);
-
-    const tracker = screen.getByRole('button', { name: 'Bus & Tram Tracker' });
-    fireEvent.click(tracker);
-    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer');
-  });
-
-  it('renders the Bus & Tram Tracker button in the mobile dropdown', () => {
-    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
-    render(<Header {...defaultProps} />);
-
-    fireEvent.click(screen.getByRole('button', { name: /More/ }));
-    const trackers = screen.getAllByRole('button', { name: 'Bus & Tram Tracker' });
-    expect(trackers).toHaveLength(2);
-
-    fireEvent.click(trackers[1]);
-    expect(openSpy).toHaveBeenCalledWith('https://busandtramtracker.chq.org', '_blank', 'noopener,noreferrer');
-  });
-
   // The header is driven by shared/links.json (also consumed by the iOS
   // app), so every entry must appear in both the desktop nav and the
   // mobile dropdown, opening its webPath when one is set (Feedback stays
@@ -71,6 +25,8 @@ describe('Header navigation', () => {
     const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
     render(<Header {...defaultProps} />);
 
+    // Only the desktop nav is rendered up front; the mobile dropdown is
+    // gated behind the "More" toggle, so exactly one button exists here.
     fireEvent.click(screen.getByRole('button', { name: link.title }));
     expect(openSpy).toHaveBeenCalledWith(link.webPath ?? link.url, '_blank', 'noopener,noreferrer');
   });

--- a/frontend/src/lib/__tests__/quickLinks.test.ts
+++ b/frontend/src/lib/__tests__/quickLinks.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { quickLinks } from '@/lib/quickLinks';
+
+describe('quickLinks (shared/links.json)', () => {
+  it('includes the Chautauqua Fund link', () => {
+    const fund = quickLinks.find((l) => l.id === 'chautauqua-fund');
+    expect(fund?.title).toBe('Chautauqua Fund');
+    expect(fund?.url).toBe('https://giving.chq.org/');
+  });
+
+  it('every link has a non-empty id, title, and absolute https url', () => {
+    for (const link of quickLinks) {
+      expect(link.id).toMatch(/^[a-z0-9-]+$/);
+      expect(link.title.trim().length).toBeGreaterThan(0);
+      expect(link.url).toMatch(/^https:\/\//);
+    }
+  });
+
+  it('feedback keeps its relative webPath for same-site navigation', () => {
+    expect(quickLinks.find((l) => l.id === 'feedback')?.webPath).toBe('/feedback');
+  });
+
+  it('ids are unique', () => {
+    expect(new Set(quickLinks.map((l) => l.id)).size).toBe(quickLinks.length);
+  });
+});

--- a/frontend/src/lib/__tests__/quickLinks.test.ts
+++ b/frontend/src/lib/__tests__/quickLinks.test.ts
@@ -20,6 +20,16 @@ describe('quickLinks (shared/links.json)', () => {
     expect(quickLinks.find((l) => l.id === 'feedback')?.webPath).toBe('/feedback');
   });
 
+  it('any webPath present is a non-empty root-relative path', () => {
+    // The header opens webPath verbatim when set, so an empty or
+    // non-relative value would silently break that link.
+    for (const link of quickLinks) {
+      if (link.webPath !== undefined) {
+        expect(link.webPath).toMatch(/^\/\S*$/);
+      }
+    }
+  });
+
   it('ids are unique', () => {
     expect(new Set(quickLinks.map((l) => l.id)).size).toBe(quickLinks.length);
   });

--- a/frontend/src/lib/quickLinks.ts
+++ b/frontend/src/lib/quickLinks.ts
@@ -1,0 +1,11 @@
+import linksJson from '@shared/links.json';
+
+export interface QuickLink {
+  id: string;
+  title: string;
+  url: string;
+  /** Relative path the web app opens instead of `url` (keeps local dev on localhost). */
+  webPath?: string;
+}
+
+export const quickLinks: QuickLink[] = linksJson.quickLinks;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -14,7 +14,8 @@
     "jsx": "react-jsx",
     "incremental": true,
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@shared/*": ["../shared/*"]
     },
     "types": ["vite/client", "vitest/globals", "node"]
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -129,6 +129,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@shared': resolve(__dirname, '../shared'),
     },
   },
   build: {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@shared': resolve(__dirname, '../shared'),
       'react': 'preact/compat',
       'react-dom': 'preact/compat',
     },

--- a/ios/ChqCalendar/Features/About/AboutInfo.swift
+++ b/ios/ChqCalendar/Features/About/AboutInfo.swift
@@ -30,11 +30,17 @@ enum AboutInfo {
     /// the web header's buttons (frontend/src/components/layout/Header.tsx).
     /// Kept separate from `links`, which are the About sheet's legal and
     /// attribution links.
+    ///
+    /// The cross-platform source of truth is `shared/links.json` at the
+    /// repo root — the web header renders directly from it, and
+    /// `AboutInfoTests.quickLinksMatchSharedLinksJson` asserts this list
+    /// matches it. If you change one, change the other.
     static let quickLinks: [Link] = [
         Link(id: "feedback", title: "Feedback", url: URL(string: "https://www.chqcal.org/feedback")!),
         Link(id: "programs", title: "Programs", url: URL(string: "https://programs.chq.org/")!),
         Link(id: "questions", title: "Questions", url: URL(string: "https://questions.chq.org/")!),
         Link(id: "bus-tram-tracker", title: "Bus & Tram Tracker", url: URL(string: "https://busandtramtracker.chq.org")!),
+        Link(id: "chautauqua-fund", title: "Chautauqua Fund", url: URL(string: "https://giving.chq.org/")!),
     ]
 
     /// Formats the marketing version and build number for display.

--- a/ios/ChqCalendarTests/AboutInfoTests.swift
+++ b/ios/ChqCalendarTests/AboutInfoTests.swift
@@ -56,14 +56,42 @@ struct AboutInfoTests {
     // MARK: - quickLinks
 
     @Test func quickLinksMatchTheWebHeader() {
-        #expect(AboutInfo.quickLinks.map(\.id) == ["feedback", "programs", "questions", "bus-tram-tracker"])
-        #expect(AboutInfo.quickLinks.map(\.title) == ["Feedback", "Programs", "Questions", "Bus & Tram Tracker"])
+        #expect(AboutInfo.quickLinks.map(\.id) == ["feedback", "programs", "questions", "bus-tram-tracker", "chautauqua-fund"])
+        #expect(AboutInfo.quickLinks.map(\.title) == ["Feedback", "Programs", "Questions", "Bus & Tram Tracker", "Chautauqua Fund"])
         #expect(AboutInfo.quickLinks.map { $0.url.absoluteString } == [
             "https://www.chqcal.org/feedback",
             "https://programs.chq.org/",
             "https://questions.chq.org/",
             "https://busandtramtracker.chq.org",
+            "https://giving.chq.org/",
         ])
+    }
+
+    /// The cross-platform source of truth is shared/links.json (also
+    /// consumed by the web header via frontend/src/lib/quickLinks.ts).
+    /// This test reads it from the repo checkout so any drift between the
+    /// Swift list and the JSON fails CI on either side.
+    @Test func quickLinksMatchSharedLinksJson() throws {
+        struct SharedLinksFile: Decodable {
+            struct SharedLink: Decodable {
+                let id: String
+                let title: String
+                let url: String
+            }
+            let quickLinks: [SharedLink]
+        }
+
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // AboutInfoTests.swift
+            .deletingLastPathComponent() // ChqCalendarTests
+            .deletingLastPathComponent() // ios
+        let jsonURL = repoRoot.appendingPathComponent("shared/links.json")
+        let data = try Data(contentsOf: jsonURL)
+        let shared = try JSONDecoder().decode(SharedLinksFile.self, from: data)
+
+        #expect(AboutInfo.quickLinks.map(\.id) == shared.quickLinks.map(\.id))
+        #expect(AboutInfo.quickLinks.map(\.title) == shared.quickLinks.map(\.title))
+        #expect(AboutInfo.quickLinks.map { $0.url.absoluteString } == shared.quickLinks.map(\.url))
     }
 
     @Test func quickLinksAreDistinctFromTheAboutSheetLinks() {

--- a/shared/links.json
+++ b/shared/links.json
@@ -1,0 +1,9 @@
+{
+  "quickLinks": [
+    { "id": "feedback", "title": "Feedback", "url": "https://www.chqcal.org/feedback", "webPath": "/feedback" },
+    { "id": "programs", "title": "Programs", "url": "https://programs.chq.org/" },
+    { "id": "questions", "title": "Questions", "url": "https://questions.chq.org/" },
+    { "id": "bus-tram-tracker", "title": "Bus & Tram Tracker", "url": "https://busandtramtracker.chq.org" },
+    { "id": "chautauqua-fund", "title": "Chautauqua Fund", "url": "https://giving.chq.org/" }
+  ]
+}


### PR DESCRIPTION
Closes #169.

## What changed

- **New \`shared/links.json\`** at the repo root — single source of truth for the quick links shown in the web header and the iOS More menu. Adding/changing a link is now a one-file edit.
- **New link: Chautauqua Fund** → https://giving.chq.org/ (web desktop nav, web mobile More menu, iOS More menu).
- **Web**: \`Header.tsx\` maps over the shared list instead of hardcoding each button twice (desktop + mobile). Feedback keeps opening the relative \`/feedback\` path via a \`webPath\` override so local dev stays on localhost. New \`@shared\` alias in vite/vitest/tsconfig; typed accessor at \`frontend/src/lib/quickLinks.ts\`.
- **iOS**: \`AboutInfo.quickLinks\` stays typed Swift (SwiftUI wants \`URL\`s), but a new test \`quickLinksMatchSharedLinksJson\` decodes \`shared/links.json\` from the repo checkout via \`#filePath\` and asserts the Swift list matches it exactly — same consistency-test pattern already used for the About disclaimer. Drift on either platform now fails CI.

## Testing

- Frontend: \`npm run build\` green — 495 tests across 55 files (includes new data-driven Header tests asserting every shared link renders and opens in both navs).
- iOS: full suite green — 281 tests in 20 suites (red→green TDD on the new consistency test).
- Backend: \`npm run validate\` clean (no backend changes).

Design/plan doc: \`docs/plans/2026-08-05-shared-links-plan.md\`.

[skip-screenshots: ios/Scripts/screenshot-plan.json has no shot covering the More menu, so no covered shot changes]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLbHofu9P9xZ3XfP15DRsG