### PR TITLE
docs(ios): record the on-device Shortcuts findings (#197)

### DIFF
--- a/ios/ChqCalendarTests/ChqShortcutsTests.swift
+++ b/ios/ChqCalendarTests/ChqShortcutsTests.swift
@@ -19,15 +19,38 @@ import Testing
 /// shortcut being added (or reordered) with a parameterized phrase first,
 /// which would silently leak a raw slot name into the Siri tip UI again.
 struct ChqShortcutsTests {
-    /// `ShowTimeIntent` is a deliberate, documented exception. All four of
-    /// its phrases are parameterized on `\(\.$slot)` — there is no plain
-    /// variant to promote, because its slot vocabulary is only two fixed
-    /// values ("evening show", "morning lecture") and inventing a plain
-    /// phrase would add an utterance nobody actually says. It is also not
-    /// bound to any `SiriTipView` — its only surface is the Shortcuts
-    /// gallery, where Apple may render parameter slots as tappable tokens
-    /// rather than literal text. That has not been verified on a device,
-    /// so this exclusion should be revisited after a device check.
+    /// `ShowTimeIntent` is a deliberate exception. All four of its phrases
+    /// are parameterized on `\(\.$slot)`; there is no plain variant to
+    /// promote, because its slot vocabulary is only two fixed values
+    /// ("evening show", "morning lecture") and inventing a plain phrase
+    /// would add an utterance nobody actually says.
+    ///
+    /// This comment previously deferred the question to "a device check."
+    /// That check was done on 2026-08-09, and it *confirmed* the exception
+    /// rather than closing it. Three things were established on hardware,
+    /// none of them observable from CI or the simulator:
+    ///
+    /// 1. The Shortcuts app **expands** a parameter slot into one concrete
+    ///    row per value — "lectures", "symphony concerts", one row per
+    ///    venue — rather than printing `${slot}` literally. So the leak
+    ///    this test guards against is specific to `SiriTipView`, which
+    ///    renders `phraseTemplates[0]` as flat static text and resolves
+    ///    `\(.applicationName)` but not parameter slots.
+    /// 2. `ShowTimeIntent` is bound to no `SiriTipView`, so it has no
+    ///    surface that can leak a raw slot name.
+    /// 3. It is not listed in the Shortcuts Library at all — nor are
+    ///    `OpenEventIntent` or `WhoIsSpeakingIntent` — yet all three route
+    ///    correctly by voice ("what time is the evening show in CHQ
+    ///    Calendar" works). The Library stops enumerating once the
+    ///    generated surface grows; ours expands to roughly 370 rows, about
+    ///    300 of them from `NextEventsIntent`'s 27 phrase templates alone.
+    ///    That is a discoverability trade-off, tracked in #197 — not a
+    ///    phrase-ordering defect, and not something this test should fail
+    ///    on.
+    ///
+    /// Do not "fix" `ShowTimeIntent` by adding a slot-free phrase. It
+    /// would buy nothing: the shortcut already works by voice, and it is
+    /// absent from the Library for a reason unrelated to its phrases.
     private static let exemptIntents: Set<String> = ["ShowTimeIntent"]
 
     @Test func firstPhraseOfEveryAppShortcutHasNoParameterSlot() throws {


### PR DESCRIPTION
Comment-only change to `ChqShortcutsTests`. Full suite green at 700.

The `ShowTimeIntent` exemption comment deferred its own justification to "a device check." That check happened — @bbernstein ran it on hardware — and it **confirmed** the exemption rather than closing it. The comment now records the finding instead of pointing at work that is already done, which is the same stale-doc failure this branch's parent PR fixed twice.

## What the device established

None of it is observable from CI or the simulator, because `SiriTipView` renders nothing at all in the simulator — it captures as an empty skeleton, which is why the App Store screenshot showed neither the bug nor the fix.

1. **The Shortcuts app expands parameter slots.** `\(\.$kind)` becomes one concrete row per value — "lectures", "symphony concerts", one row per venue — rather than printing `${kind}`. So the literal-slot leak is specific to `SiriTipView`, which renders `phraseTemplates[0]` as flat static text and resolves `\(.applicationName)` but not parameter slots.
2. **`ShowTimeIntent` is bound to no `SiriTipView`**, so it has no surface that can leak a raw slot name.
3. **It is absent from the Shortcuts Library entirely** — as are `OpenEventIntent` and `WhoIsSpeakingIntent` — yet all three route correctly by voice. "What time is the evening show in CHQ Calendar" works.

## Why `ShowTimeIntent` should not be "fixed"

The obvious-looking change is to give it a slot-free phrase so it matches the other six. That would add an utterance nobody says and fix nothing: the shortcut already works by voice, and its absence from the Library has a different cause. The comment now says so explicitly, because the next person to read that exemption will reach for exactly that change.

## The thing that is worth deciding

Measured from the compiled `Metadata.appintents`: 55 phrase templates expand to **~370 Library rows, ~300 of them from `NextEventsIntent` alone** (27 templates × 10 event kinds, plus one row per venue). Seven `AppShortcut` entries is under Apple's cap of 10, so the cap is not the constraint — the generated row count is, and it appears to crowd three shortcuts out of the Library.

Those 27 templates are what make "what movies are playing at the Amp" work by voice. Trimming the `${venue}` or `${kind}` families would likely surface the missing shortcuts at the cost of voice coverage. Tracked in #197 for an explicit decision before the 1.2 submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShDP9eGbxejZ58bt76vyjY