### PR TITLE
fix: local Docker dev setup — workspace lockfile resolution

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+backend/node_modules
+frontend/node_modules
+tools/publisher-format/node_modules
+.git
+docs
+infrastructure

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -2,8 +2,12 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Copy workspace manifests (root + backend + the local publisher-format
+# dependency) so `npm install` resolves @chq-calendar/publisher-format via
+# npm workspaces instead of trying to fetch it from the registry.
 COPY package*.json ./
+COPY backend/package.json backend/package.json
+COPY tools/publisher-format/package.json tools/publisher-format/package.json
 
 # Install dependencies
 RUN npm install
@@ -11,8 +15,12 @@ RUN npm install
 # Copy source code
 COPY . .
 
+WORKDIR /app/backend
+
 # Expose port
 EXPOSE 3001
 
-# Development command
-CMD ["npm", "run", "dev"]
+# publisher-format ships no prebuilt dist (gitignored), and the bind-mounted
+# source in docker-compose.yml shadows anything built at image-build time,
+# so build it as part of container start.
+CMD ["sh", "-c", "cd /app && npm run build --workspace=tools/publisher-format && cd /app/backend && npm run dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
   # Backend (Express server for local development)
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile.dev
+      context: .
+      dockerfile: backend/Dockerfile.dev
     container_name: chq-calendar-backend
     ports:
       - "3001:3001"
@@ -36,19 +36,20 @@ services:
       - DATA_SOURCES_TABLE_NAME=chautauqua-calendar-data-sources  
       - FEEDBACK_TABLE_NAME=chautauqua-calendar-feedback
     volumes:
-      - ./backend:/app
+      - .:/app
       - /app/node_modules
+      - /app/backend/node_modules
+      - /app/tools/publisher-format/node_modules
     depends_on:
       - dynamodb
     networks:
       - chq-calendar-network
-    command: npm run dev
 
   # Frontend (Vite + Preact)
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile.dev
+      context: .
+      dockerfile: frontend/Dockerfile.dev
     container_name: chq-calendar-frontend
     ports:
       - "3000:3000"
@@ -57,8 +58,9 @@ services:
       # Points browser directly to backend (Docker proxy can't reach localhost:3001)
       - VITE_API_URL=http://localhost:3001
     volumes:
-      - ./frontend:/app
+      - .:/app
       - /app/node_modules
+      - /app/frontend/node_modules
     depends_on:
       - dynamodb
     networks:

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,14 +2,20 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Copy the workspace root manifest + lockfile (this monorepo has a single
+# lockfile at the repo root, not one per workspace) so npm resolves the
+# exact locked versions instead of re-resolving semver ranges against the
+# registry — the frontend does not need the other workspaces' manifests.
 COPY package*.json ./
+COPY frontend/package.json frontend/package.json
 
 # Install dependencies
 RUN npm install
 
 # Copy source code
 COPY . .
+
+WORKDIR /app/frontend
 
 # Expose port
 EXPOSE 3000

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "@types/node": "^24.0.0",
     "typescript": "^5.0.0",
     "node-fetch": "^2.7.0"
+  },
+  "allowScripts": {
+    "@tailwindcss/oxide@4.1.11": true,
+    "aws-sdk@2.1692.0": true,
+    "esbuild@0.25.6": true,
+    "esbuild@0.27.3": true
   }
 }


### PR DESCRIPTION

## What changed

Both backend and frontend Dockerfile.dev built with a workspace-scoped context, isolated from the repo-root package-lock.json this npm workspaces monorepo relies on:

- backend: npm install couldn't resolve @chq-calendar/publisher-format (a local workspace package, never published) and 404'd trying to fetch it from the registry.
- frontend: with no lockfile in context, npm re-resolved semver ranges fresh, landing on @preact/preset-vite@2.10.5 instead of the pinned 2.10.3 — 2.10.5 pulls in the ESM-only zimmerframe, which breaks its hook-name transform plugin and blanks the page.

Both Dockerfiles now build from the repo root with the real lockfile, and docker-compose.yml mounts the whole repo with anonymous volumes protecting each container's own installed node_modules. Also approved the four postinstall scripts (esbuild, @tailwindcss/oxide, aws-sdk) npm's allowScripts policy was blocking, and added a .dockerignore so the root build context skips node_modules/.git.

Verified with `docker compose up -d --build`: all four services healthy, backend /health OK, frontend renders the calendar UI in-browser.

Important note - this is 99% claude code :)

## Why

I was unable to build from the repo (mac or linux) before these changes. 

## Verification

<!-- Commands run and their result. Paste output for anything non-obvious. -->

- [X ] `npm run build --workspace=frontend`
- [N/A ] `npm run validate --workspace=backend` (if backend changed)
- [ N/A] `cd ios && xcodebuild test ...` (if iOS changed)

## App Store listing

<!-- Only applies to PRs touching ios/ChqCalendar/Features, /App, or Assets.xcassets. -->

- [ N/A] Screenshots regenerated (`ios/Scripts/capture-screenshots.sh` + `compose-screenshots.py`) and the manifest committed
- [ N/A] `docs/app-store/listing-copy.md` re-read for claims this change invalidates
- [N/A ] Not applicable — no visual change (add `[skip-screenshots: reason]` above to satisfy CI)
