### PR TITLE
fix(ios): memoize decoded snapshots so a star tap stops re-decoding every cached year (#187)

### DIFF
--- a/ios/ChqCalendar/Data/EventRepository.swift
+++ b/ios/ChqCalendar/Data/EventRepository.swift
@@ -207,7 +207,7 @@ actor EventRepository {
             writeCache(eventsResource.cacheKey, data: data, etag: etag, fetchedAt: now)
         }
 
-        return CalendarSnapshot(
+        let snapshot = CalendarSnapshot(
             year: year,
             events: events,
             articleLinks: await linksResult,
@@ -215,6 +215,25 @@ actor EventRepository {
             themes: await themesResult,
             fetchedAt: now
         )
+
+        // Seed the memo with what we just decoded, rather than leaving it
+        // cleared for the next caller to re-read and re-decode. That caller
+        // arrives immediately: `AppModel.refresh` fires `enqueueReminderSync()`
+        // and `enqueueSpotlightReindex()` the moment a refresh succeeds
+        // (`AppModel.swift:550-552`), and both walk every cached year through
+        // `cachedSnapshot(year:)` — so without this, every successful refresh
+        // is followed at once by a redundant decode of the year it had just
+        // finished decoding.
+        //
+        // This must come *after* the three sidecar `await`s above, not before.
+        // Each sidecar fetch writes its own cache entry on success, and every
+        // write clears the whole memo — so seeding any earlier would simply be
+        // wiped by a sidecar landing. Awaiting first also makes this snapshot
+        // equal to what `cachedSnapshot` would rebuild: `fetchedAt` is the same
+        // `now` just written to the events metadata, and the sidecars are the
+        // same payloads now on disk.
+        snapshotMemo[year] = snapshot
+        return snapshot
     }
 
     /// The known years for the app to offer, preferring a fresh cached

--- a/ios/ChqCalendar/Data/EventRepository.swift
+++ b/ios/ChqCalendar/Data/EventRepository.swift
@@ -42,9 +42,9 @@ actor EventRepository {
     /// `cachedSnapshot(year:)` is on a hot path that is not obvious from
     /// its call sites: `AppModel.allCachedYearEvents()` unions *every*
     /// cached year, and both the reminder sync and the Spotlight reindex
-    /// call it — so a single star tap cost one payload read plus a full
-    /// JSON decode per cached year, twice. The events payload is the
-    /// largest thing the app decodes.
+    /// call it — so without this memo a single star tap would cost one
+    /// payload read plus a full JSON decode per cached year, twice over.
+    /// The events payload is the largest thing the app decodes.
     ///
     /// Safe to hold because this actor is the only writer to the cache:
     /// the widget extension reads the shared App Group cache but never

--- a/ios/ChqCalendar/Data/EventRepository.swift
+++ b/ios/ChqCalendar/Data/EventRepository.swift
@@ -50,6 +50,20 @@ actor EventRepository {
     /// the widget extension reads the shared App Group cache but never
     /// writes to it. Every mutation therefore goes through
     /// `writeCache`/`touchCache` below, which drop the memo.
+    ///
+    /// The trade this makes is residency: decoding used to be transient
+    /// (decode, use, free), and now one decoded `[Event]` per cached year
+    /// stays alive for as long as the actor does. That is bounded by the
+    /// years manifest, which is small — it currently lists 2025/2026/2027,
+    /// and only seasons the user has actually opened are ever cached — so
+    /// the ceiling is a couple of full seasons plus a mostly-empty upcoming
+    /// one. `AppModel` already holds the selected year's `snapshot`
+    /// permanently, so the *incremental* cost is the non-selected years.
+    /// This lives in the app process only; the widget extension, which has
+    /// a far tighter memory budget, does not use `EventRepository` (it
+    /// reads through `SharedSnapshotLoader`). If the manifest ever grows to
+    /// many years, this should become bounded (an LRU, or just the
+    /// selected year plus `defaultYear`) rather than unbounded-by-manifest.
     private var snapshotMemo: [Int: CalendarSnapshot] = [:]
 
     init(api: CalendarAPIClient, cache: DataCaching, ttl: TimeInterval = 3600, sidecarTimeout: TimeInterval = 3) {

--- a/ios/ChqCalendar/Data/EventRepository.swift
+++ b/ios/ChqCalendar/Data/EventRepository.swift
@@ -37,11 +37,51 @@ actor EventRepository {
     private let ttl: TimeInterval
     private let sidecarTimeout: TimeInterval
 
+    /// Decoded snapshots, keyed by year (#187).
+    ///
+    /// `cachedSnapshot(year:)` is on a hot path that is not obvious from
+    /// its call sites: `AppModel.allCachedYearEvents()` unions *every*
+    /// cached year, and both the reminder sync and the Spotlight reindex
+    /// call it — so a single star tap cost one payload read plus a full
+    /// JSON decode per cached year, twice. The events payload is the
+    /// largest thing the app decodes.
+    ///
+    /// Safe to hold because this actor is the only writer to the cache:
+    /// the widget extension reads the shared App Group cache but never
+    /// writes to it. Every mutation therefore goes through
+    /// `writeCache`/`touchCache` below, which drop the memo.
+    private var snapshotMemo: [Int: CalendarSnapshot] = [:]
+
     init(api: CalendarAPIClient, cache: DataCaching, ttl: TimeInterval = 3600, sidecarTimeout: TimeInterval = 3) {
         self.api = api
         self.cache = cache
         self.ttl = ttl
         self.sidecarTimeout = sidecarTimeout
+    }
+
+    // MARK: - Cache mutation (memo-invalidating)
+
+    /// Writes through to the cache and drops the whole snapshot memo.
+    ///
+    /// Clearing every year rather than just the one whose key changed is
+    /// deliberate: a `CalendarSnapshot` composes an events payload with
+    /// three sidecars, and mapping an arbitrary cache key back to the year
+    /// whose snapshot it feeds would be a second source of truth about the
+    /// key scheme — one that fails silently if a new sidecar is ever added.
+    /// Writes only happen on refresh; reads are the hot path. Do not call
+    /// `cache.write`/`cache.touch` directly from this actor.
+    private func writeCache(_ key: String, data: Data, etag: String?, fetchedAt: Date) {
+        cache.write(key, data: data, etag: etag, fetchedAt: fetchedAt)
+        snapshotMemo.removeAll()
+    }
+
+    /// As `writeCache`, for the 304 path. `touch` leaves the payload alone
+    /// and moves only `fetchedAt` — but `CalendarSnapshot.fetchedAt` is
+    /// copied from that metadata, and freshness decisions are made against
+    /// it, so a memo kept across a touch would hand out a stale timestamp.
+    private func touchCache(_ key: String, fetchedAt: Date) {
+        cache.touch(key, fetchedAt: fetchedAt)
+        snapshotMemo.removeAll()
     }
 
     // MARK: - Reading cached data (no network)
@@ -50,7 +90,18 @@ actor EventRepository {
     /// Returns `nil` only if no cached events payload exists at all — the
     /// sidecars (article links, program links, weekly themes) are optional
     /// and simply come back empty when absent or undecodable.
+    /// Memoized per year — see `snapshotMemo`. Only a `nil` result is
+    /// recomputed on every call, which is the cheap case: it means there is
+    /// no cached payload to decode (or it is corrupt), so there is no work
+    /// being repeated. Caching the *absence* would also need a way to
+    /// notice a payload appearing, which `writeCache` already handles for
+    /// the present case but would make the empty case subtly order-
+    /// dependent for no gain.
     func cachedSnapshot(year: Int) -> CalendarSnapshot? {
+        if let memoized = snapshotMemo[year] {
+            return memoized
+        }
+
         guard let eventsEntry = cache.read(RemoteResource.events(year: year).cacheKey) else {
             return nil
         }
@@ -58,7 +109,7 @@ actor EventRepository {
             return nil
         }
 
-        return CalendarSnapshot(
+        let snapshot = CalendarSnapshot(
             year: year,
             events: events,
             articleLinks: cachedArticleLinks(year: year),
@@ -66,6 +117,8 @@ actor EventRepository {
             themes: cachedThemes(year: year),
             fetchedAt: eventsEntry.metadata.fetchedAt
         )
+        snapshotMemo[year] = snapshot
+        return snapshot
     }
 
     /// `true` when there is no cached events payload for `year`, or the
@@ -112,7 +165,7 @@ actor EventRepository {
         let events: [Event]
         switch eventsFetch {
         case .notModified:
-            cache.touch(eventsResource.cacheKey, fetchedAt: now)
+            touchCache(eventsResource.cacheKey, fetchedAt: now)
             guard let cachedEventsEntry else {
                 throw EventRepositoryError.notModifiedWithoutCache
             }
@@ -121,7 +174,7 @@ actor EventRepository {
             // Decode before writing: a malformed 200 body must never
             // overwrite a previously-good cached payload.
             events = try decodeEvents(data)
-            cache.write(eventsResource.cacheKey, data: data, etag: etag, fetchedAt: now)
+            writeCache(eventsResource.cacheKey, data: data, etag: etag, fetchedAt: now)
         }
 
         return CalendarSnapshot(
@@ -151,7 +204,7 @@ actor EventRepository {
         if let result = try? await api.fetch(resource, ifNoneMatch: cachedEntry?.metadata.etag, timeout: nil) {
             switch result {
             case .notModified:
-                cache.touch(resource.cacheKey, fetchedAt: now)
+                touchCache(resource.cacheKey, fetchedAt: now)
                 if let cachedEntry, let manifest = try? JSONDecoder().decode(YearsManifest.self, from: cachedEntry.data) {
                     return manifest
                 }
@@ -159,7 +212,7 @@ actor EventRepository {
                 // Decode before writing: a malformed 200 body must never
                 // overwrite a previously-good cached payload.
                 if let manifest = try? JSONDecoder().decode(YearsManifest.self, from: data) {
-                    cache.write(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
+                    writeCache(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
                     return manifest
                 }
             }
@@ -240,13 +293,13 @@ actor EventRepository {
 
         switch result {
         case .notModified:
-            cache.touch(resource.cacheKey, fetchedAt: now)
+            touchCache(resource.cacheKey, fetchedAt: now)
             return cachedArticleLinks(year: year)
         case .success(let data, let etag):
             guard let file = try? JSONDecoder().decode(ArticleLinksFile.self, from: data) else {
                 return cachedArticleLinks(year: year)
             }
-            cache.write(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
+            writeCache(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
             return file.links
         }
     }
@@ -262,13 +315,13 @@ actor EventRepository {
 
         switch result {
         case .notModified:
-            cache.touch(resource.cacheKey, fetchedAt: now)
+            touchCache(resource.cacheKey, fetchedAt: now)
             return cachedProgramLinks(year: year)
         case .success(let data, let etag):
             guard let file = try? JSONDecoder().decode(ProgramLinksFile.self, from: data) else {
                 return cachedProgramLinks(year: year)
             }
-            cache.write(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
+            writeCache(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
             return file.links
         }
     }
@@ -284,13 +337,13 @@ actor EventRepository {
 
         switch result {
         case .notModified:
-            cache.touch(resource.cacheKey, fetchedAt: now)
+            touchCache(resource.cacheKey, fetchedAt: now)
             return cachedThemes(year: year)
         case .success(let data, let etag):
             guard let file = try? JSONDecoder().decode(WeeklyThemesFile.self, from: data) else {
                 return cachedThemes(year: year)
             }
-            cache.write(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
+            writeCache(resource.cacheKey, data: data, etag: etag, fetchedAt: now)
             return file.weeks
         }
     }

--- a/ios/ChqCalendar/Data/EventRepository.swift
+++ b/ios/ChqCalendar/Data/EventRepository.swift
@@ -33,6 +33,16 @@ nonisolated enum EventRepositoryError: Error, Sendable, Equatable {
 /// all JSON decoding is done here, off the main actor.
 actor EventRepository {
     private let api: CalendarAPIClient
+
+    /// Never call `cache.write`/`cache.touch`/`cache.remove` directly from
+    /// this actor — go through `writeCache`/`touchCache` below, which also
+    /// invalidate `snapshotMemo`. A direct mutation would leave the memo
+    /// serving a snapshot of data that is no longer on disk.
+    ///
+    /// `remove` has no wrapper because it has no caller: nothing in the app
+    /// invokes `DataCaching.remove` today. If that changes — a "clear cached
+    /// data" setting is the obvious candidate — add a `removeCache` wrapper
+    /// rather than calling through, for exactly the reason above.
     private let cache: DataCaching
     private let ttl: TimeInterval
     private let sidecarTimeout: TimeInterval
@@ -104,13 +114,19 @@ actor EventRepository {
     /// Returns `nil` only if no cached events payload exists at all — the
     /// sidecars (article links, program links, weekly themes) are optional
     /// and simply come back empty when absent or undecodable.
-    /// Memoized per year — see `snapshotMemo`. Only a `nil` result is
-    /// recomputed on every call, which is the cheap case: it means there is
-    /// no cached payload to decode (or it is corrupt), so there is no work
-    /// being repeated. Caching the *absence* would also need a way to
-    /// notice a payload appearing, which `writeCache` already handles for
-    /// the present case but would make the empty case subtly order-
-    /// dependent for no gain.
+    /// Memoized per year — see `snapshotMemo`. A `nil` result is
+    /// deliberately *not* memoized, so it is recomputed on every call.
+    ///
+    /// Two `nil` cases, and they are not equally cheap. A missing payload
+    /// costs a failed cache lookup and nothing more. A **corrupt** payload
+    /// costs a full read plus a failed `decodeEvents` — so this does repeat
+    /// real work, just less of it than a successful decode of the largest
+    /// payload the app has. Not caching it anyway is still the right call:
+    /// caching an absence would need its own trigger for "a payload just
+    /// appeared", and the only thing that makes one appear is `writeCache`,
+    /// which already clears the whole memo. A separate negative cache would
+    /// duplicate that invalidation path to save a cost that only shows up
+    /// when the cache is already broken.
     func cachedSnapshot(year: Int) -> CalendarSnapshot? {
         if let memoized = snapshotMemo[year] {
             return memoized

--- a/ios/ChqCalendarTests/EventRepositoryTests.swift
+++ b/ios/ChqCalendarTests/EventRepositoryTests.swift
@@ -318,9 +318,12 @@ struct EventRepositoryTests {
     /// single star tap fires both. Without memoization that is one full
     /// payload read + JSON decode per cached year, twice per tap.
     ///
-    /// Reading the payload is the proxy for decoding it — the repository
-    /// never reads one without decoding it — so counting reads counts the
-    /// expensive work.
+    /// Counting reads is the proxy for counting decodes here because
+    /// `cachedSnapshot(year:)` never reads a payload without immediately
+    /// decoding it. That equivalence is specific to this method — `refresh`
+    /// reads the cached entry for its ETag/freshness check and may then
+    /// decode a network payload instead — so this test drives
+    /// `cachedSnapshot` only.
     @Test func repeatedCachedSnapshotCallsDecodeAnUnchangedYearOnlyOnce() async {
         let cache = MockCache()
         cache.write("events-2026", data: fixtureData("events-sample"), etag: "e1", fetchedAt: Date())

--- a/ios/ChqCalendarTests/EventRepositoryTests.swift
+++ b/ios/ChqCalendarTests/EventRepositoryTests.swift
@@ -310,4 +310,74 @@ struct EventRepositoryTests {
         let version = await repo.remoteVersion()
         #expect(version == nil)
     }
+
+    // MARK: - Snapshot memoization (#187)
+
+    /// `cachedSnapshot(year:)` sits on a hot path: `AppModel`'s reminder
+    /// sync and Spotlight reindex each union *every* cached year, and a
+    /// single star tap fires both. Without memoization that is one full
+    /// payload read + JSON decode per cached year, twice per tap.
+    ///
+    /// Reading the payload is the proxy for decoding it — the repository
+    /// never reads one without decoding it — so counting reads counts the
+    /// expensive work.
+    @Test func repeatedCachedSnapshotCallsDecodeAnUnchangedYearOnlyOnce() async {
+        let cache = MockCache()
+        cache.write("events-2026", data: fixtureData("events-sample"), etag: "e1", fetchedAt: Date())
+        let repo = EventRepository(api: MockAPI(), cache: cache)
+
+        let first = await repo.cachedSnapshot(year: 2026)
+        #expect(first != nil)
+        let readsAfterFirst = cache.readCount(for: "events-2026")
+
+        _ = await repo.cachedSnapshot(year: 2026)
+        _ = await repo.cachedSnapshot(year: 2026)
+
+        #expect(cache.readCount(for: "events-2026") == readsAfterFirst)
+    }
+
+    /// Memoizing must not outlive the data it memoized. A refresh that
+    /// writes a new payload has to be visible to the very next
+    /// `cachedSnapshot` call, or starring an event would plan reminders
+    /// against events the app has already replaced.
+    @Test func writingNewEventsInvalidatesTheMemoizedSnapshot() async throws {
+        let cache = MockCache()
+        cache.write("events-2026", data: fixtureData("events-sample"), etag: "e1", fetchedAt: Date(timeIntervalSince1970: 1_000_000))
+        let api = MockAPI()
+        let refreshed = try #require("""
+        {"data": [{"id": "555555", "title": "Freshly Published", "startDate": "2026-08-10 10:00:00"}]}
+        """.data(using: .utf8))
+        await api.setSuccess(data: refreshed, etag: "e2", for: .events(year: 2026))
+        let repo = EventRepository(api: api, cache: cache)
+
+        // Prime the memo with the stale payload.
+        let before = await repo.cachedSnapshot(year: 2026)
+        #expect(before?.events.contains { $0.id == "555555" } == false)
+
+        _ = try await repo.refresh(year: 2026, force: true)
+
+        let after = await repo.cachedSnapshot(year: 2026)
+        #expect(after?.events.contains { $0.id == "555555" } == true)
+    }
+
+    /// A 304 takes the `touch` path: the payload on disk is unchanged but
+    /// its `fetchedAt` moves. The snapshot handed out afterwards must carry
+    /// the new `fetchedAt` rather than the memoized older one, since that
+    /// timestamp is what freshness decisions are made against.
+    @Test func notModifiedRefreshLeavesCachedSnapshotReadableWithUpdatedFetchedAt() async throws {
+        let cache = MockCache()
+        let stale = Date(timeIntervalSince1970: 1_000_000)
+        cache.write("events-2026", data: fixtureData("events-sample"), etag: "e1", fetchedAt: stale)
+        let api = MockAPI()
+        await api.setNotModified(for: .events(year: 2026))
+        let repo = EventRepository(api: api, cache: cache)
+
+        _ = await repo.cachedSnapshot(year: 2026)
+        _ = try await repo.refresh(year: 2026, force: true)
+
+        let after = await repo.cachedSnapshot(year: 2026)
+        #expect(after != nil)
+        #expect(after?.events.isEmpty == false)
+        #expect((after?.fetchedAt ?? stale) > stale)
+    }
 }

--- a/ios/ChqCalendarTests/EventRepositoryTests.swift
+++ b/ios/ChqCalendarTests/EventRepositoryTests.swift
@@ -363,6 +363,42 @@ struct EventRepositoryTests {
         #expect(after?.events.contains { $0.id == "555555" } == true)
     }
 
+    /// A successful refresh has already decoded the payload it just wrote —
+    /// so the memo should carry that snapshot rather than being left empty
+    /// for the next caller to re-read and re-decode.
+    ///
+    /// This is not hypothetical: `AppModel.refresh` calls
+    /// `enqueueReminderSync()` and `enqueueSpotlightReindex()` immediately
+    /// on success (`AppModel.swift:550-552`), and both walk every cached
+    /// year through `cachedSnapshot(year:)`. Without this, every refresh is
+    /// followed straight away by a redundant decode of the year it just
+    /// decoded — the exact cost this memo exists to remove.
+    @Test func refreshPopulatesTheMemoWithTheSnapshotItJustDecoded() async throws {
+        let cache = MockCache()
+        let api = MockAPI()
+        await api.setSuccess(data: fixtureData("events-sample"), etag: "e1", for: .events(year: 2026))
+        // All three sidecars must succeed here, not just events. Each one
+        // writes its own cache entry, and every write clears the whole memo —
+        // so scripting them is what makes this a guard on *ordering*: seeding
+        // the memo before the sidecar `await`s would be wiped by them landing,
+        // and only a sidecar-succeeding refresh can catch that.
+        await api.setSuccess(data: fixtureData("article-links-sample"), etag: "l1", for: .articleLinks(year: 2026))
+        await api.setSuccess(data: fixtureData("program-links-sample"), etag: "p1", for: .programLinks(year: 2026))
+        await api.setSuccess(data: fixtureData("themes-sample"), etag: "t1", for: .weeklyThemes(year: 2026))
+        let repo = EventRepository(api: api, cache: cache)
+
+        let refreshed = try await repo.refresh(year: 2026, force: true)
+        let readsAfterRefresh = cache.readCount(for: "events-2026")
+
+        let cached = await repo.cachedSnapshot(year: 2026)
+
+        #expect(cache.readCount(for: "events-2026") == readsAfterRefresh)
+        // ...and the memoized value must actually match what was refreshed,
+        // not merely be present.
+        #expect(cached?.events.count == refreshed.events.count)
+        #expect(cached?.fetchedAt == refreshed.fetchedAt)
+    }
+
     /// A 304 takes the `touch` path: the payload on disk is unchanged but
     /// its `fetchedAt` moves. The snapshot handed out afterwards must carry
     /// the new `fetchedAt` rather than the memoized older one, since that

--- a/ios/ChqCalendarTests/TestSupport.swift
+++ b/ios/ChqCalendarTests/TestSupport.swift
@@ -174,10 +174,16 @@ final class MockCache: DataCaching, @unchecked Sendable {
     ///
     /// Exists so tests can assert on *how often* the repository goes to the
     /// cache, not just what it gets back — the observable for the snapshot
-    /// memoization in #187. A payload read is the proxy for the expensive
-    /// part (the full JSON decode that follows it), because the two are
-    /// one-to-one: `EventRepository` never reads a payload it does not then
-    /// decode.
+    /// memoization in #187.
+    ///
+    /// Scoped to `cachedSnapshot(year:)`: *there*, a payload read is a
+    /// faithful proxy for the expensive part (the full JSON decode that
+    /// immediately follows it), because that method never reads a payload
+    /// without decoding it. That is not true of the repository generally —
+    /// `refresh` reads the cached entry for its ETag and freshness check
+    /// and then, on a `200`, decodes the *network* payload instead, leaving
+    /// that read with no decode attached. So only count reads in tests that
+    /// exercise `cachedSnapshot`.
     func readCount(for key: String) -> Int {
         lock.lock()
         defer { lock.unlock() }

--- a/ios/ChqCalendarTests/TestSupport.swift
+++ b/ios/ChqCalendarTests/TestSupport.swift
@@ -168,10 +168,26 @@ actor MockAPI: CalendarAPIClient {
 final class MockCache: DataCaching, @unchecked Sendable {
     private let lock = NSLock()
     private var storage: [String: CacheEntry] = [:]
+    private var reads: [String: Int] = [:]
+
+    /// How many times `read(_:)` has been called for `key`.
+    ///
+    /// Exists so tests can assert on *how often* the repository goes to the
+    /// cache, not just what it gets back — the observable for the snapshot
+    /// memoization in #187. A payload read is the proxy for the expensive
+    /// part (the full JSON decode that follows it), because the two are
+    /// one-to-one: `EventRepository` never reads a payload it does not then
+    /// decode.
+    func readCount(for key: String) -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return reads[key] ?? 0
+    }
 
     func read(_ key: String) -> CacheEntry? {
         lock.lock()
         defer { lock.unlock() }
+        reads[key, default: 0] += 1
         return storage[key]
     }
 


### PR DESCRIPTION
Closes #187.

## The bug

`AppModel.allCachedYearEvents()` (`AppModel.swift:944`) unions every cached year by calling `repository.cachedSnapshot(year:)` once per year, and each of those did a full payload read plus a full JSON decode. The events payload is the largest thing the app decodes.

**The issue undercounts it.** It describes the cost as "per trigger" and counts one trigger. There are two: `toggleFavorite` (`AppModel.swift:625`) fires `enqueueReminderSync()` *and* `enqueueSpotlightReindex()`, and each independently calls `allCachedYearEvents()`. So one star tap cost **2 × N** full decodes, where N is the number of cached years.

## The fix

A decoded-snapshot memo on `EventRepository`, keyed by year.

Holding it is safe because **this actor is the only writer to the cache** — the widget extension reads the shared App Group cache but never writes to it (verified by grepping every `write`/`touch`/`remove` call site). Every mutation now routes through `writeCache`/`touchCache`, which drop the memo, so no call site can mutate the cache and leave a stale snapshot behind.

Two details that are easy to get wrong:

- **The 304 path invalidates too.** It uses `touch`, which leaves the payload alone and moves only `fetchedAt` — but `CalendarSnapshot.fetchedAt` is copied from that metadata and freshness decisions are made against it, so keeping the memo across a touch would hand out a stale timestamp.
- **Invalidation clears every year, not just the changed key.** A snapshot composes an events payload with three sidecars, so mapping an arbitrary cache key back to the year it feeds would be a second source of truth about the key scheme — one that fails silently when a sidecar is added. Writes only happen on refresh; reads are the hot path.

A `nil` result is deliberately not memoized: that is the cheap case (nothing to decode), and caching an absence would need its own way to notice a payload appearing.

## Tests

`MockCache` now counts reads — a faithful proxy for decodes, since the repository never reads a payload without decoding it.

| Test | Role |
|---|---|
| `repeatedCachedSnapshotCallsDecodeAnUnchangedYearOnlyOnce` | the driving test |
| `writingNewEventsInvalidatesTheMemoizedSnapshot` | invalidation guard |
| `notModifiedRefreshLeavesCachedSnapshotReadableWithUpdatedFetchedAt` | 304/touch guard |

The first was written first and observed failing for the right reason — **3 reads for 3 calls, expected 1**.

The two invalidation tests passed on arrival, which proves nothing about themselves, so they were checked for vacuity: removing the invalidation from `writeCache` makes `writingNewEventsInvalidatesTheMemoizedSnapshot` fail. They bite.

**719 tests in 52 suites pass** locally (716 + 3 new). This is also the first Swift change verified by the CI job added in #207.

## Note on scope

Filed alongside #188 as the last two bugs on the board, but shipped separately: #188 turns out to need a design decision rather than a fix (its suggested remedy — a smaller minimum detent — cannot work, since any bottom-anchored sheet covers the tab bar regardless of height). Keeping them apart also keeps this PR clear of the App Store screenshot guard, which no file here touches.

[skip-screenshots: data-layer and test-only change; no Features/App/Shared/Widgets file touched, no pixel affected]