### PR TITLE
ci: skip Claude Code Review on fork PRs (#211)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,6 +7,25 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    # Fork PRs cannot run this job, and no `permissions:` block or repo setting
+    # can change that. GitHub withholds all three things the job needs from a
+    # `pull_request` run whose head is a fork. Run 31428615838 (PR #210, #211)
+    # shows each one:
+    #   1. Repository secrets  — logged `Secret source: None` and
+    #      `CLAUDE_CODE_OAUTH_TOKEN: ""`, so there are no Anthropic credentials
+    #      to review with.
+    #   2. A writable GITHUB_TOKEN — the run was granted `PullRequests: read`
+    #      despite the `pull-requests: write` declared below, so Claude could
+    #      not post a review even if it authenticated.
+    #   3. An OIDC token — which is what actually errored and got reported.
+    # Passing `github_token: ${{ secrets.GITHUB_TOKEN }}` (the fix suggested in
+    # #211) addresses only 3; the job would then fail on 1 instead. Switching to
+    # `pull_request_target` would supply all three, but it checks out untrusted
+    # fork code and hands it to an agent with Bash — not a trade worth making to
+    # get a code review. Skipping is the only correct option, and a skipped job
+    # is neutral where the old behaviour was a permanently-red, unactionable
+    # check on every external contribution.
+    if: github.event.pull_request.head.repo.fork != true
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Closes #211.

## The reported problem

`Claude Code Review` fails on every PR opened from a fork, leaving a permanently-red, unactionable check on each external contribution:

```
Error message: Unable to get ACTIONS_ID_TOKEN_REQUEST_URL env variable
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

The job already declares `id-token: write`, so the permissions block was never the problem — GitHub disables OIDC issuance for `pull_request` runs whose head is a fork, as a platform boundary.

## Why the fix suggested in the issue would not have worked

#211 proposed passing `github_token: ${{ secrets.GITHUB_TOKEN }}` to short-circuit the OIDC exchange. Reading the full log for the failing run (31428615838, PR #210) shows the OIDC failure is only the first of **three** independent blockers — it's just the one the action hits first:

| # | Blocker | Evidence in the run log |
|---|---------|--------------------------|
| 1 | No Anthropic credentials | `Secret source: None`, `CLAUDE_CODE_OAUTH_TOKEN:` (empty), `"claude_code_oauth_token": ""` |
| 2 | Read-only `GITHUB_TOKEN` | `GITHUB_TOKEN Permissions: Contents: read, Issues: read, Metadata: read, PullRequests: read` — despite the job requesting `pull-requests: write` |
| 3 | No OIDC token | the error above |

Passing `github_token` clears **3**, and the job then fails on **1** with empty credentials. Even given credentials, the read-only token from **2** could not post a review. GitHub withholds repository secrets and downgrades `GITHUB_TOKEN` to read-only for fork `pull_request` runs regardless of what the workflow asks for.

`pull_request_target` would supply all three — and check out untrusted fork code and hand it to an agent with `Bash`. Not a trade worth making to obtain a code review.

## The fix

Skip the job on fork PRs. A skipped job is neutral; the previous behaviour was a red X that neither the contributor nor a maintainer could act on.

```yaml
if: github.event.pull_request.head.repo.fork != true
```

This mirrors the existing fork idiom already used in `build-and-test.yml` and `ios.yml`. The rationale is recorded as a comment in the workflow itself, because the OIDC error message actively suggests the wrong fix and will otherwise invite the same wrong change again.

## Verification

- Confirmed `bbernstein/chq-calendar` is **not** itself a fork (`.fork == false`), so same-repo PRs have `head.repo.fork == false` and still run. A guard like this silently disables the workflow entirely if the base repo is a fork.
- Confirmed the payload field on both PR shapes: #210 (external) → `head.repo.fork == true` (skips); #209 (same-repo) → `false` (runs).
- Workflow YAML parses; `if`, `permissions`, and both steps intact.
- `npm run build` (frontend, incl. validate + tests) and `npm run validate` + `npm run build` (backend) both pass — no application code changed.

This PR is same-repo, so the check it modifies runs on it.

## Note on scope

I deliberately did **not** also add `github_token:` to the action. Same-repo PRs authenticate via OIDC successfully today (every recent run is green), and passing `GITHUB_TOKEN` would change review comments from the Claude GitHub App identity to `github-actions[bot]`. That's a separate, unforced change.

[skip-screenshots: CI workflow only, no iOS or user-visible code touched]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fja3KPmA7kiDrYjoXd3dTo