### PR TITLE
ci: skip the production deploy job on forks

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -14,6 +14,12 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: production
+    # Guards against forks: this job deploys straight to chqcal.org on push
+    # to main with static AWS keys and no branch-protection gate. A fork
+    # would otherwise red-X on every push (no secrets configured) or, worse,
+    # actually deploy over production if someone ever added real creds to
+    # the fork's secrets.
+    if: github.repository == 'bbernstein/chq-calendar'
     # Serialize deploys: two concurrent runs would interleave the
     # ci-e2e-test publisher's enable/disable toggles and corrupt the
     # post-deploy retraction assertion. cancel-in-progress=false so an


### PR DESCRIPTION
Split out of #210 (originally authored by @Woodwell) so it can land independently of the Docker dev-setup work.

## What changed

`deploy-production.yml` triggers on push to `main` and deploys straight to chqcal.org using static AWS keys, with no branch-protection gate on the `environment: production` target. Adds `if: github.repository == 'bbernstein/chq-calendar'` to the `deploy` job.

## Why

On a fork the job red-X's every push to `main`, since no secrets are configured — noisy but harmless *today*. The real risk is the next step: if a fork owner ever added real deploy credentials to their fork's secrets (say, to exercise the deploy pipeline), the very next push to their fork's `main` would deploy over the live production site. There is no repository check and no environment protection rule standing in the way.

The job-level `if` covers both triggers (`push` and `workflow_dispatch`), and skips cleanly rather than failing.

## Scope check

I checked every other workflow for the same exposure — this is the only one that needs the guard:

| Workflow | Triggers | Verdict |
|---|---|---|
| `deploy-production.yml` | push to `main`, `workflow_dispatch` | **Needs it** — static AWS keys, deploys to prod |
| `build-and-test.yml` | push to `main`, PR | Safe — only `RECAPTCHA_SITE_KEY`, with a `ci-placeholder-key` fallback |
| `scrape-weekly-themes.yml` | `workflow_dispatch` only | Safe — never fires on a fork push; uses only `GITHUB_TOKEN` |
| `ios.yml` | push to `main`, PR | Safe — no secrets |
| `validate-publisher-examples.yml` | push to `main`, PR | Safe — no secrets |
| `app-store-assets.yml` | PR | Safe — no secrets |

Complements #212, which fixed the fork failure for the Claude review workflow.

## Verification

- [x] `deploy-production.yml` parses as valid YAML with the `if` attached to the `deploy` job
- [x] Confirmed the job shows as skipped (not failed) on a push to a fork's `main` (@Woodwell, on #210)
- [ ] Confirm the job still runs normally on push to `bbernstein/chq-calendar:main` — only observable post-merge

## App Store listing

[skip-screenshots: CI workflow change only, no iOS or user-visible change]

- [x] Not applicable — no visual change
