### PR TITLE
fix: repair the local Docker dev setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+backend/node_modules
+frontend/node_modules
+tools/publisher-format/node_modules
+.git
+docs
+infrastructure

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,37 @@
+# The Docker build context is the repo root (npm workspaces keeps a single
+# lockfile there), so everything the dev images do not need is excluded here.
+# Without this the context is ~1.9 GB, almost all of it Terraform providers
+# and iOS assets.
+#
+# NOTE: .dockerignore applies to the build context only — it has no effect on
+# the bind mounts in docker-compose.yml. Those are scoped explicitly instead.
+
+# Dependencies — reinstalled inside the image from the lockfile
 node_modules
-backend/node_modules
-frontend/node_modules
-tools/publisher-format/node_modules
+**/node_modules
+
+# Build output
+frontend/out
+backend/dist
+tools/publisher-format/dist
+**/coverage
+
+# Not needed by the frontend or backend dev images.
+#
+# docs/ is deliberately NOT excluded: tools/publisher-format's build reads
+# docs/publisher/{categories,venues}.json into dist/refs and writes
+# docs/publisher/feed.schema.json back out. The backend container runs that
+# build at start, so it needs its own copy in the image — and because docs/ is
+# not bind-mounted, those writes stay inside the container instead of landing
+# on the host as root. It is only ~5 MB.
 .git
-docs
+.github
+.worktrees
 infrastructure
+ios
+
+# Local noise
+*.log
+.DS_Store
+.env
+.env.*

--- a/README.md
+++ b/README.md
@@ -161,6 +161,8 @@ docker compose restart
 # Rebuild and restart (--renew-anon-volumes: see the note under Running Locally)
 docker compose up -d --build --renew-anon-volumes
 
-# Remove all data (reset database)
+# Stop and remove containers plus their volumes. This clears each container's
+# cached node_modules; it does not "reset the database", since DynamoDB Local
+# runs -inMemory and keeps nothing between restarts anyway.
 docker compose down -v
 ```

--- a/README.md
+++ b/README.md
@@ -112,8 +112,17 @@ The application can run completely locally using Docker:
 ./scripts/setup-local.sh
 
 # Or manual setup
-docker compose up -d --build
+docker compose up -d --build --renew-anon-volumes
 ```
+
+> **After changing `package.json` or `package-lock.json`, rebuild with
+> `--renew-anon-volumes`.** Each container's `node_modules` lives in an
+> anonymous volume so the host's copy doesn't shadow it, and those volumes
+> survive a plain `docker compose up --build` — the new image is built
+> correctly and then masked by the previous run's dependency tree. Symptoms are
+> confusing: a package you just pinned stays at the old version, or a newly
+> added dependency is missing entirely. `./scripts/setup-local.sh` passes the
+> flag for you.
 
 ### Local Services
 - **Frontend**: http://localhost:3000 (Vite dev server with HMR)

--- a/README.md
+++ b/README.md
@@ -102,7 +102,9 @@ cd backend && npm run deploy
 
 ### Prerequisites
 - Docker with the Compose plugin (Docker Compose v2)
-- Node.js 24+ (for development outside Docker; see `.nvmrc`)
+- Node.js 24+ (see `.nvmrc`) — required by `./scripts/setup-local.sh`, which
+  installs the workspace tree on the host as well as building the containers,
+  and for any development outside Docker
 
 ### Running Locally
 The application can run completely locally using Docker:
@@ -135,7 +137,7 @@ docker compose up -d --build --renew-anon-volumes
 
 ### Local Development Features
 - Hot reloading for frontend with instant filter updates
-- Local DynamoDB with persistent data storage
+- Local DynamoDB (runs `-inMemory`, so its data resets on container restart)
 - DynamoDB Admin UI for database management
 - Development mode authentication bypass for admin features
 - State persistence in localStorage with cache versioning

--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ docker compose down
 # Restart services
 docker compose restart
 
-# Rebuild and restart
-docker compose up -d --build
+# Rebuild and restart (--renew-anon-volumes: see the note under Running Locally)
+docker compose up -d --build --renew-anon-volumes
 
 # Remove all data (reset database)
 docker compose down -v

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd backend && npm run deploy
 
 ### Prerequisites
 - Docker with the Compose plugin (Docker Compose v2)
-- Node.js 22+ (minimum 20.19, for development outside Docker)
+- Node.js 24+ (for development outside Docker; see `.nvmrc`)
 
 ### Running Locally
 The application can run completely locally using Docker:

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -22,5 +22,9 @@ EXPOSE 3001
 
 # publisher-format ships no prebuilt dist (gitignored), and the bind-mounted
 # source in docker-compose.yml shadows anything built at image-build time,
-# so build it as part of container start.
-CMD ["sh", "-c", "cd /app && npm run build --workspace=tools/publisher-format && cd /app/backend && npm run dev"]
+# so build it as part of container start. The container runs as root, and
+# tools/publisher-format is bind-mounted from the host, so the build output
+# would otherwise land on the host owned by root; chown it back to whatever
+# user already owns the bind-mounted source so host-side npm installs can
+# still touch it afterwards.
+CMD ["sh", "-c", "cd /app && npm run build --workspace=tools/publisher-format && chown -R $(stat -c '%u:%g' tools/publisher-format) tools/publisher-format/dist && cd /app/backend && npm run dev"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -2,8 +2,12 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Copy workspace manifests (root + backend + the local publisher-format
+# dependency) so `npm install` resolves @chq-calendar/publisher-format via
+# npm workspaces instead of trying to fetch it from the registry.
 COPY package*.json ./
+COPY backend/package.json backend/package.json
+COPY tools/publisher-format/package.json tools/publisher-format/package.json
 
 # Install dependencies
 RUN npm install
@@ -11,8 +15,12 @@ RUN npm install
 # Copy source code
 COPY . .
 
+WORKDIR /app/backend
+
 # Expose port
 EXPOSE 3001
 
-# Development command
-CMD ["npm", "run", "dev"]
+# publisher-format ships no prebuilt dist (gitignored), and the bind-mounted
+# source in docker-compose.yml shadows anything built at image-build time,
+# so build it as part of container start.
+CMD ["sh", "-c", "cd /app && npm run build --workspace=tools/publisher-format && cd /app/backend && npm run dev"]

--- a/backend/Dockerfile.dev
+++ b/backend/Dockerfile.dev
@@ -2,15 +2,23 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy workspace manifests (root + backend + the local publisher-format
-# dependency) so `npm install` resolves @chq-calendar/publisher-format via
-# npm workspaces instead of trying to fetch it from the registry.
-COPY package*.json ./
-COPY backend/package.json backend/package.json
-COPY tools/publisher-format/package.json tools/publisher-format/package.json
+# This monorepo keeps a single lockfile at the repo root, so the build context
+# is the repo root (see docker-compose.yml). Copy the root manifests plus every
+# workspace manifest the lockfile references — `npm ci` refuses to run against a
+# tree whose declared workspaces are missing, and it is `npm ci` we want: plain
+# `npm install` could not resolve @chq-calendar/publisher-format (a local
+# workspace package that is never published) and 404'd fetching it from the
+# registry.
+COPY package.json package-lock.json ./
+COPY backend/package.json backend/
+COPY frontend/package.json frontend/
+COPY tools/publisher-format/package.json tools/publisher-format/
 
-# Install dependencies
-RUN npm install
+# Scoped to the workspaces this image runs: the backend itself, plus
+# publisher-format, whose dist/refs the backend imports and which is built at
+# container start. --include-workspace-root brings in the root devDependencies
+# (typescript) that build needs.
+RUN npm ci -w backend -w tools/publisher-format --include-workspace-root
 
 # Copy source code
 COPY . .
@@ -20,11 +28,9 @@ WORKDIR /app/backend
 # Expose port
 EXPOSE 3001
 
-# publisher-format ships no prebuilt dist (gitignored), and the bind-mounted
-# source in docker-compose.yml shadows anything built at image-build time,
-# so build it as part of container start. The container runs as root, and
-# tools/publisher-format is bind-mounted from the host, so the build output
-# would otherwise land on the host owned by root; chown it back to whatever
-# user already owns the bind-mounted source so host-side npm installs can
-# still touch it afterwards.
-CMD ["sh", "-c", "cd /app && npm run build --workspace=tools/publisher-format && chown -R $(stat -c '%u:%g' tools/publisher-format) tools/publisher-format/dist && cd /app/backend && npm run dev"]
+# publisher-format ships no prebuilt dist (it is gitignored) and the backend
+# imports its refs, so build it at container start. docker-compose.yml mounts
+# an anonymous volume over tools/publisher-format/dist so this output stays
+# inside the container: writing it into the bind-mounted host tree as root is
+# what left host-side `npm install` failing with EPERM.
+CMD ["sh", "-c", "cd /app && npm run build --workspace=tools/publisher-format && cd /app/backend && npm run dev"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
   # Backend (Express server for local development)
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile.dev
+      context: .
+      dockerfile: backend/Dockerfile.dev
     container_name: chq-calendar-backend
     ports:
       - "3001:3001"
@@ -36,19 +36,20 @@ services:
       - DATA_SOURCES_TABLE_NAME=chautauqua-calendar-data-sources  
       - FEEDBACK_TABLE_NAME=chautauqua-calendar-feedback
     volumes:
-      - ./backend:/app
+      - .:/app
       - /app/node_modules
+      - /app/backend/node_modules
+      - /app/tools/publisher-format/node_modules
     depends_on:
       - dynamodb
     networks:
       - chq-calendar-network
-    command: npm run dev
 
   # Frontend (Vite + Preact)
   frontend:
     build:
-      context: ./frontend
-      dockerfile: Dockerfile.dev
+      context: .
+      dockerfile: frontend/Dockerfile.dev
     container_name: chq-calendar-frontend
     ports:
       - "3000:3000"
@@ -57,8 +58,9 @@ services:
       # Points browser directly to backend (Docker proxy can't reach localhost:3001)
       - VITE_API_URL=http://localhost:3001
     volumes:
-      - ./frontend:/app
+      - .:/app
       - /app/node_modules
+      - /app/frontend/node_modules
     depends_on:
       - dynamodb
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   # DynamoDB Local
   dynamodb:
@@ -36,10 +34,24 @@ services:
       - DATA_SOURCES_TABLE_NAME=chautauqua-calendar-data-sources  
       - FEEDBACK_TABLE_NAME=chautauqua-calendar-feedback
     volumes:
-      - .:/app
-      - /app/node_modules
+      # Scoped mounts: only the workspaces this container runs, plus the root
+      # manifests npm needs to resolve them. Mounting the repo root instead
+      # would put infrastructure/ (Terraform state), .git, ios/ and any .env
+      # inside the container — .dockerignore does not apply to bind mounts.
+      # The root manifests are read-only so the container can never rewrite
+      # the host's lockfile.
+      - ./backend:/app/backend
+      - ./tools/publisher-format:/app/tools/publisher-format
+      - ./package.json:/app/package.json:ro
+      - ./package-lock.json:/app/package-lock.json:ro
+      # Anonymous volumes keep the image's installed node_modules (and the
+      # dist built at container start) instead of letting the host's shadow
+      # them. NOTE: these survive `up --build`, so after a lockfile change run
+      # `docker compose up -d --build --renew-anon-volumes` or the container
+      # keeps the old dependency tree. scripts/setup-local.sh does this for you.
       - /app/backend/node_modules
       - /app/tools/publisher-format/node_modules
+      - /app/tools/publisher-format/dist
     depends_on:
       - dynamodb
     networks:
@@ -58,14 +70,17 @@ services:
       # Points browser directly to backend (Docker proxy can't reach localhost:3001)
       - VITE_API_URL=http://localhost:3001
     volumes:
-      - .:/app
-      - /app/node_modules
+      # Scoped mounts — see the backend service above for the rationale.
+      - ./frontend:/app/frontend
+      - ./package.json:/app/package.json:ro
+      - ./package-lock.json:/app/package-lock.json:ro
+      # See the note on the backend service: rebuild with --renew-anon-volumes
+      # after a lockfile change.
       - /app/frontend/node_modules
     depends_on:
       - dynamodb
     networks:
       - chq-calendar-network
-    command: npx vite --host
 
   # LocalStack — S3-compatible endpoint for local integration testing of the
   # article-links pipeline (EventSnapshotLoader / ArticleLinksPublisher run the

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -54,8 +54,10 @@ npm run deploy
 # Start all services with Docker
 ./scripts/setup-local.sh
 
-# Or manually
-docker compose up -d --build
+# Or manually. --renew-anon-volumes discards each container's cached
+# node_modules volume, which otherwise survives --build and masks the rebuilt
+# image — see the note in README.md under Running Locally.
+docker compose up -d --build --renew-anon-volumes
 ```
 
 ### Local Services

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -36,10 +36,11 @@ terraform apply
 
 ### Backend Only
 ```bash
-cd backend
-npm install
-npm run build
-npm run deploy
+# From the repo root — see Manual Local Setup below for why the install is not
+# run from inside backend/
+npm ci
+npm run build --workspace=backend
+npm run deploy --workspace=backend
 ```
 
 ### Frontend Only
@@ -68,16 +69,24 @@ docker compose up -d --build --renew-anon-volumes
 - **Backend**: Uses production AWS Lambda endpoints
 
 ### Manual Local Setup
+All commands run from the repo root. This is an npm workspaces monorepo with a
+single root lockfile, so dependencies install once at the root — `npm install`
+from inside `backend/` cannot resolve `@chq-calendar/publisher-format` (a local
+workspace package that is never published) and 404s against the registry.
+
 ```bash
+# Install every workspace at the locked versions
+npm ci
+
+# The backend imports publisher-format's generated refs, which are gitignored
+# and so must be built before the server will start
+npm run build --workspace=tools/publisher-format
+
 # Backend
-cd backend
-npm install
-npm run dev
+npm run dev --workspace=backend
 
 # Frontend (in another terminal)
-cd frontend
-npm install
-npm run dev
+npm run dev --workspace=frontend
 ```
 
 ## 📁 Script Reference

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -120,7 +120,9 @@ npm run dev --workspace=frontend
 
 ### For Local Development
 - [Docker](https://docker.com) and Docker Compose
-- [Node.js](https://nodejs.org) >= 18 (optional for running outside Docker)
+- [Node.js](https://nodejs.org) 24+ (see `.nvmrc`) — required by
+  `./scripts/setup-local.sh` and by the manual setup above, both of which
+  install the workspace tree on the host
 - Access to production AWS endpoints (no local backend server)
 
 ## 🔍 Health Checks

--- a/docs/DEVELOPMENT_WORKFLOW.md
+++ b/docs/DEVELOPMENT_WORKFLOW.md
@@ -45,8 +45,10 @@ cd chq-calendar
 # Start all services (frontend + local DynamoDB)
 ./scripts/start-local.sh
 
-# Or manually with Docker Compose
-docker compose up -d --build
+# Or manually with Docker Compose. --renew-anon-volumes discards each
+# container's cached node_modules volume, which otherwise survives --build and
+# masks the rebuilt image — see the note in README.md under Running Locally.
+docker compose up -d --build --renew-anon-volumes
 
 # Check service status
 docker compose ps

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,14 +2,20 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy package files
+# Copy the workspace root manifest + lockfile (this monorepo has a single
+# lockfile at the repo root, not one per workspace) so npm resolves the
+# exact locked versions instead of re-resolving semver ranges against the
+# registry — the frontend does not need the other workspaces' manifests.
 COPY package*.json ./
+COPY frontend/package.json frontend/package.json
 
 # Install dependencies
 RUN npm install
 
 # Copy source code
 COPY . .
+
+WORKDIR /app/frontend
 
 # Expose port
 EXPOSE 3000

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -2,15 +2,25 @@ FROM node:24-alpine
 
 WORKDIR /app
 
-# Copy the workspace root manifest + lockfile (this monorepo has a single
-# lockfile at the repo root, not one per workspace) so npm resolves the
-# exact locked versions instead of re-resolving semver ranges against the
-# registry — the frontend does not need the other workspaces' manifests.
-COPY package*.json ./
-COPY frontend/package.json frontend/package.json
+# This monorepo keeps a single lockfile at the repo root, so the build context
+# is the repo root (see docker-compose.yml). Copy the root manifests plus every
+# workspace manifest the lockfile references — `npm ci` refuses to run against a
+# tree whose declared workspaces are missing, and it is `npm ci` we want: plain
+# `npm install` re-resolves semver ranges instead of installing the locked
+# versions. That drift is the original bug, which installed
+# @preact/preset-vite 2.10.5 over the pinned 2.10.3; 2.10.5 pulls in the
+# ESM-only zimmerframe, breaking its hook-name transform and blanking the page.
+COPY package.json package-lock.json ./
+COPY frontend/package.json frontend/
+COPY backend/package.json backend/
+COPY tools/publisher-format/package.json tools/publisher-format/
 
-# Install dependencies
-RUN npm install
+# Scoped to this workspace: an unscoped `npm ci` installs all three workspaces
+# (1139 packages) into an image that only needs 407. All four manifests are
+# still copied above — dropping the unused ones changes resolution slightly
+# (405 packages instead of 407), and matching the lockfile exactly is the whole
+# point of using `npm ci` here.
+RUN npm ci -w frontend --include-workspace-root
 
 # Copy source code
 COPY . .
@@ -20,5 +30,8 @@ WORKDIR /app/frontend
 # Expose port
 EXPOSE 3000
 
-# Start development server
-CMD ["npm", "run", "dev"]
+# Start development server. --host is required for the port publish to work:
+# Vite binds 127.0.0.1 by default, which is unreachable from outside the
+# container. Kept here rather than in docker-compose.yml so `docker run` on
+# this image behaves the same as `docker compose up`.
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -4,9 +4,15 @@ A Vite + Preact static site for the Chautauqua Institution event calendar.
 
 ## Development
 
+Run these from the **repo root**, not from this directory. The project is an
+npm workspaces monorepo with a single root lockfile; `npm install` in here
+resolves against `frontend/package.json`'s semver ranges instead of that
+lockfile, which is how an unpinned `@preact/preset-vite` gets installed and
+serves a blank page.
+
 ```bash
-npm install
-npm run dev
+npm ci
+npm run dev --workspace=frontend
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to view the app.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "deploy:infra": "cd infrastructure && terraform apply",
     "deploy:backend": "cd backend && npm run deploy",
     "deploy:frontend": "cd frontend && npm run build && npm run deploy",
-    "setup": "./scripts/setup.sh",
+    "setup": "./scripts/setup-local.sh",
     "test:integration": "node integration-test.js",
     "smoke:publisher": "jest --config=scripts/smoke/jest.smoke.config.js"
   },

--- a/package.json
+++ b/package.json
@@ -25,5 +25,11 @@
     "@types/node": "^24.0.0",
     "typescript": "^5.0.0",
     "node-fetch": "^2.7.0"
+  },
+  "allowScripts": {
+    "@tailwindcss/oxide@4.1.11": true,
+    "aws-sdk@2.1692.0": true,
+    "esbuild@0.25.6": true,
+    "esbuild@0.27.3": true
   }
 }

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -18,10 +18,24 @@ if ! docker compose version &> /dev/null; then
     exit 1
 fi
 
-# Function to check if port is available
+# Function to check if port is available. Uses a raw TCP connect instead of
+# lsof/ss process inspection: Docker's port-forwarding sockets are owned by
+# root, so a non-root lsof silently fails to see them as in-use, letting a
+# real conflict slip through unnoticed.
+port_in_use() {
+    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3>&- 3<&-; return 0; } || return 1
+}
+
 check_port() {
     local port=$1
-    if lsof -Pi :$port -sTCP:LISTEN -t >/dev/null 2>&1; then
+    if port_in_use "$port"; then
+        # If this project's own containers are already up, docker compose up
+        # below will just reuse/recreate them — not a real conflict, and
+        # re-running this script against an already-running stack should
+        # succeed rather than bailing out.
+        if docker compose ps --status running --format '{{.Names}}' 2>/dev/null | grep -q '^chq-calendar-'; then
+            return 0
+        fi
         echo "❌ Port $port is already in use. Please stop the service using this port."
         exit 1
     fi

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -89,11 +89,12 @@ check_port 8000
 check_port 8001
 
 # No manual `docker network create` here: docker-compose.yml declares the
-# network without a `name:`, so Compose creates and owns its own
-# project-prefixed one (docker-dev_chq-calendar-network). A hand-made
-# `chq-calendar-network` is attached to nothing, survives `docker compose
-# down -v`, and just accumulates on developer machines as a decoy when
-# debugging connectivity.
+# network without a `name:`, so Compose creates and owns its own network named
+# <project>_chq-calendar-network — where <project> is COMPOSE_PROJECT_NAME, or
+# the directory name if that is unset. A hand-made `chq-calendar-network` is
+# attached to nothing, survives `docker compose down -v`, and just accumulates
+# on developer machines as a decoy when debugging connectivity.
+# `docker compose config` prints the resolved name if you need it.
 
 # Install host-side dependencies. This is an npm workspaces monorepo with a
 # single root lockfile; installing per-workspace builds nested trees that fight

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -22,6 +22,15 @@ if ! docker compose version &> /dev/null; then
     exit 1
 fi
 
+# npm is required even though the services themselves run in Docker: this
+# script installs the workspace tree on the host too, so editors, type-checking
+# and host-run tests work. Checked up front rather than letting `npm ci` below
+# fail with a bare "command not found".
+if ! command -v npm &> /dev/null; then
+    echo "❌ npm is not installed. Node.js 24+ is required (see .nvmrc)."
+    exit 1
+fi
+
 # Is anything listening on this port? Uses a raw TCP connect rather than
 # lsof/ss process inspection: Docker's port-forwarding sockets are owned by
 # root, so a non-root lsof cannot see them and a real conflict slips through
@@ -152,7 +161,8 @@ echo "                       package.json / package-lock.json change)"
 echo ""
 echo "🗄️  Database:"
 echo "   • DynamoDB tables will be created automatically"
-echo "   • Data persists in Docker volume 'dynamodb_data'"
+echo "   • DynamoDB Local runs with -inMemory: data is discarded whenever"
+echo "     the container restarts"
 echo "   • Use DynamoDB Admin UI to view/edit data"
 echo ""
 echo "Happy coding! 🚀"

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -27,8 +27,12 @@ fi
 # root, so a non-root lsof cannot see them and a real conflict slips through
 # unnoticed. /dev/tcp is a bash builtin — this is why the shebang above is
 # bash and not sh; do not "portability-fix" it.
+# Both loopbacks are probed: Docker's published ports bind dual-stack, but a
+# stray host process bound only to ::1 would otherwise slip through a v4-only
+# check and fail confusingly later.
 port_in_use() {
-    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && return 0
+    (exec 3<>"/dev/tcp/::1/$1") 2>/dev/null
 }
 
 # The container that legitimately owns each port when this project's stack is
@@ -95,39 +99,38 @@ npm ci
 echo "🚀 Building and starting services..."
 docker compose up -d --build --renew-anon-volumes
 
-# Wait for services to be ready
-echo "⏳ Waiting for services to start..."
-sleep 10
+# Poll for readiness rather than sleeping a fixed interval and hoping. The
+# backend container compiles tools/publisher-format with tsc before it starts
+# the dev server, and the --renew-anon-volumes above discards that build on
+# every run — so a cold start routinely takes longer than the 10s this used to
+# sleep, and a fixed wait reports "failed to start" for a container that is
+# merely still compiling. That false negative is exactly the kind of first-run
+# confusion this script exists to prevent.
+wait_for() {
+    local label=$1 port=$2 url=$3 tries=${4:-90}
+    local i
+    for ((i = 1; i <= tries; i++)); do
+        if curl -s -o /dev/null --max-time 3 "$url"; then
+            echo "✅ $label is running on port $port"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "❌ $label failed to start (no response from $url after ${tries}s)"
+    return 1
+}
 
-# Check if services are running
-echo "🔍 Checking service health..."
+echo "⏳ Waiting for services to become ready..."
+all_ready=true
+wait_for "DynamoDB Local" 8000 http://localhost:8000        || all_ready=false
+wait_for "Backend API"    3001 http://localhost:3001/health || all_ready=false
+wait_for "Frontend"       3000 http://localhost:3000        || all_ready=false
+wait_for "DynamoDB Admin" 8001 http://localhost:8001        || all_ready=false
 
-# Check DynamoDB
-if curl -s http://localhost:8000 > /dev/null; then
-    echo "✅ DynamoDB Local is running on port 8000"
-else
-    echo "❌ DynamoDB Local failed to start"
-fi
-
-# Check Backend API
-if curl -s http://localhost:3001/health > /dev/null; then
-    echo "✅ Backend API is running on port 3001"
-else
-    echo "❌ Backend API failed to start"
-fi
-
-# Check Frontend
-if curl -s http://localhost:3000 > /dev/null; then
-    echo "✅ Frontend is running on port 3000"
-else
-    echo "❌ Frontend failed to start"
-fi
-
-# Check DynamoDB Admin
-if curl -s http://localhost:8001 > /dev/null; then
-    echo "✅ DynamoDB Admin is running on port 8001"
-else
-    echo "❌ DynamoDB Admin failed to start"
+if [ "$all_ready" != true ]; then
+    echo ""
+    echo "⚠️  Some services did not come up. Check their logs with:"
+    echo "     docker compose logs -f"
 fi
 
 echo ""

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -4,6 +4,10 @@
 
 set -e
 
+# Run from the repo root no matter where this was invoked from: every
+# `docker compose` call below resolves docker-compose.yml relative to cwd.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
 echo "🎪 Setting up Chautauqua Calendar for local development..."
 
 # Check if Docker is installed
@@ -18,27 +22,50 @@ if ! docker compose version &> /dev/null; then
     exit 1
 fi
 
-# Function to check if port is available. Uses a raw TCP connect instead of
+# Is anything listening on this port? Uses a raw TCP connect rather than
 # lsof/ss process inspection: Docker's port-forwarding sockets are owned by
-# root, so a non-root lsof silently fails to see them as in-use, letting a
-# real conflict slip through unnoticed.
+# root, so a non-root lsof cannot see them and a real conflict slips through
+# unnoticed. /dev/tcp is a bash builtin — this is why the shebang above is
+# bash and not sh; do not "portability-fix" it.
 port_in_use() {
-    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null && { exec 3>&- 3<&-; return 0; } || return 1
+    (exec 3<>"/dev/tcp/127.0.0.1/$1") 2>/dev/null
+}
+
+# The container that legitimately owns each port when this project's stack is
+# already up. Re-running setup against a live stack should be a no-op rather
+# than a hard exit, but only this project's own container earns that pass —
+# anything else on the port is a genuine conflict.
+port_owner() {
+    case "$1" in
+        3000) echo "chq-calendar-frontend" ;;
+        3001) echo "chq-calendar-backend" ;;
+        8000) echo "chq-calendar-dynamodb" ;;
+        8001) echo "chq-calendar-dynamodb-admin" ;;
+        *)    echo "" ;;
+    esac
+}
+
+# `docker ps` rather than `docker compose ps`: it does not depend on cwd or on
+# the Compose version supporting Go-template --format.
+container_running() {
+    [ -n "$1" ] || return 1
+    docker ps --filter "name=^${1}$" --filter status=running --format '{{.Names}}' 2>/dev/null \
+        | grep -qx "$1"
 }
 
 check_port() {
     local port=$1
-    if port_in_use "$port"; then
-        # If this project's own containers are already up, docker compose up
-        # below will just reuse/recreate them — not a real conflict, and
-        # re-running this script against an already-running stack should
-        # succeed rather than bailing out.
-        if docker compose ps --status running --format '{{.Names}}' 2>/dev/null | grep -q '^chq-calendar-'; then
-            return 0
-        fi
-        echo "❌ Port $port is already in use. Please stop the service using this port."
-        exit 1
+    local owner
+    port_in_use "$port" || return 0
+
+    owner=$(port_owner "$port")
+    if container_running "$owner"; then
+        echo "ℹ️  Port $port is held by $owner — reusing the running stack."
+        return 0
     fi
+
+    echo "❌ Port $port is already in use. Please stop the service using this port."
+    exit 1
 }
 
 # Check required ports
@@ -52,21 +79,21 @@ check_port 8001
 echo "🌐 Creating Docker network..."
 docker network create chq-calendar-network 2>/dev/null || echo "Network already exists"
 
-# Install backend dependencies
-echo "📦 Installing backend dependencies..."
-cd backend
-npm install
-cd ..
+# Install host-side dependencies. This is an npm workspaces monorepo with a
+# single root lockfile; installing per-workspace builds nested trees that fight
+# it. One root `npm ci` installs every workspace at exactly the locked versions.
+echo "📦 Installing dependencies (all workspaces)..."
+npm ci
 
-# Install frontend dependencies
-echo "📦 Installing frontend dependencies..."
-cd frontend
-npm install
-cd ..
-
-# Build and start services
+# Build and start services.
+#
+# --renew-anon-volumes is load-bearing: the anonymous volumes that hold each
+# container's node_modules survive `up --build`, so without it a rebuilt image
+# is masked by the previous run's dependency tree and a lockfile change never
+# takes effect. That silent staleness is the same class of bug this setup
+# exists to fix, so pay the reinstall rather than risk it.
 echo "🚀 Building and starting services..."
-docker compose up -d --build
+docker compose up -d --build --renew-anon-volumes
 
 # Wait for services to be ready
 echo "⏳ Waiting for services to start..."
@@ -116,7 +143,9 @@ echo "🔧 Useful commands:"
 echo "   • View logs:       docker compose logs -f"
 echo "   • Stop services:   docker compose down"
 echo "   • Restart:         docker compose restart"
-echo "   • Rebuild:         docker compose up -d --build"
+echo "   • Rebuild:         docker compose up -d --build --renew-anon-volumes"
+echo "                      (--renew-anon-volumes is required after any"
+echo "                       package.json / package-lock.json change)"
 echo ""
 echo "🗄️  Database:"
 echo "   • DynamoDB tables will be created automatically"

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -139,10 +139,19 @@ wait_for "Backend API"    3001 http://localhost:3001/health || all_ready=false
 wait_for "Frontend"       3000 http://localhost:3000        || all_ready=false
 wait_for "DynamoDB Admin" 8001 http://localhost:8001        || all_ready=false
 
+# Fail loudly rather than printing the success banner over a broken stack.
+# `npm run setup` runs this script, so a zero exit here is a health claim that
+# automation and humans both act on — announcing "ready" when a service never
+# answered is worse than no message at all. The containers are deliberately
+# left running so the logs are still there to read.
 if [ "$all_ready" != true ]; then
     echo ""
-    echo "⚠️  Some services did not come up. Check their logs with:"
+    echo "❌ Some services never became ready. Inspect them with:"
     echo "     docker compose logs -f"
+    echo ""
+    echo "   The stack is still running. Fix the problem and re-run this"
+    echo "   script, or tear it down with: docker compose down"
+    exit 1
 fi
 
 echo ""

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -88,9 +88,12 @@ check_port 3001
 check_port 8000
 check_port 8001
 
-# Create Docker network if it doesn't exist
-echo "🌐 Creating Docker network..."
-docker network create chq-calendar-network 2>/dev/null || echo "Network already exists"
+# No manual `docker network create` here: docker-compose.yml declares the
+# network without a `name:`, so Compose creates and owns its own
+# project-prefixed one (docker-dev_chq-calendar-network). A hand-made
+# `chq-calendar-network` is attached to nothing, survives `docker compose
+# down -v`, and just accumulates on developer machines as a decoy when
+# debugging connectivity.
 
 # Install host-side dependencies. This is an npm workspaces monorepo with a
 # single root lockfile; installing per-workspace builds nested trees that fight


### PR DESCRIPTION
Split out of #210, which is closed in favour of this PR and #213. The first three commits are @Woodwell's, unchanged; the fourth addresses review findings on them.

Cloning this repo fresh and running the documented local dev setup did not work on either macOS or Linux. This makes it work.

## @Woodwell's commits

**1. Workspace lockfile resolution.** Both `Dockerfile.dev` files built with a workspace-scoped context, cut off from the repo-root `package-lock.json` this npm-workspaces monorepo relies on:

- backend: `npm install` could not resolve `@chq-calendar/publisher-format` — a local workspace package that is never published — and 404'd fetching it from the registry.
- frontend: with no lockfile in context, npm re-resolved semver ranges fresh and landed on `@preact/preset-vite@2.10.5` instead of the pinned `2.10.3`. 2.10.5 pulls in the ESM-only `zimmerframe`, which breaks its hook-name transform plugin and serves a blank page.

Both now build from the repo root with the real lockfile, plus a `.dockerignore` and an `allowScripts` stanza covering the four postinstalls npm's allow-scripts policy flags.

**2. Idempotent, runnable setup script.** `check_port()` used `lsof -sTCP:LISTEN`, which cannot see Docker's root-owned port-forwarding sockets from a non-root shell, so real conflicts passed silently. `package.json`'s `setup` script pointed at `scripts/setup.sh`, which does not exist — only `setup-local.sh` does, so `npm run setup` failed immediately.

**3. Stale Node prereq.** README said "Node.js 22+ (minimum 20.19)"; `.nvmrc` pins 24 and every workspace's `engines.node` is `>=24.0.0`.

## Review follow-ups (4th commit)

**`npm ci`, scoped per workspace.** Building from the root with the real lockfile fixed resolution, but `npm install` still re-resolves semver ranges rather than installing the locked tree — a weaker guarantee than this bug demands, given that installing an unpinned `@preact/preset-vite` is what blanked the page. Both images now copy all four workspace manifests and run `npm ci -w <workspace> --include-workspace-root`. Scoping matters: unscoped, both images install all 1139 packages; the frontend needs 407. Dropping the unused manifests instead of scoping resolves to 405 packages rather than 407, so the manifests stay and the install is scoped.

**Scoped bind mounts.** `.dockerignore` does not apply to bind mounts, so `.:/app` put `infrastructure/` (1.4 GB locally, including any local tfstate), `.git`, `ios/` and any `.env` inside both dev containers. Each service now mounts only the workspaces it runs plus the root manifests, and the manifests are `:ro` so a container can never rewrite the host's lockfile.

**Anonymous volumes survive `up --build`.** The volumes masking each container's `node_modules` are not renewed when a container is recreated, so a rebuilt image is silently masked by the previous run's dependency tree and a lockfile change never takes effect — the same class of bug this setup exists to fix, and one that would have hidden the original 2.10.5 problem indefinitely. `setup-local.sh` now passes `--renew-anon-volumes`, and the README documents the symptoms.

**publisher-format no longer writes to the host.** Its `build` script also runs `cp src/feed.schema.json ../../docs/publisher/feed.schema.json`, so with the repo root mounted it overwrote a *tracked host file* as root — the `chown` of `tools/publisher-format/dist` covered only half the problem. `docs/` is now deliberately kept in the build context and left unmounted, so the container writes to its own copy. The `chown` is gone rather than extended.

**Port check.** Narrowed the already-running-stack escape hatch to the specific container that owns each port; previously any running `chq-calendar-*` container suppressed the conflict check for *every* port, so an unrelated process on 3000 slipped through to a confusing failure later. Switched to `docker ps --filter`, which depends on neither cwd nor Compose's Go-template `--format` support, and added a `cd` to the repo root. Replaced the per-workspace `npm install` calls with one root `npm ci` — installing workspaces individually builds nested trees that fight the single root lockfile.

**Left as-is:** the `allowScripts` stanza is correct and complete. `npm install-scripts ls` reports exactly the four packages it approves; the extra `fsevents` entries visible in `npm ci --dry-run` output are optional darwin-only packages npm's policy tool does not require. Worth knowing that on npm 11.x this is a *warning* — unreviewed install scripts still run, and only an explicit `false` skips them — so the stanza silences noise rather than unblocking the build.

Also drops the obsolete compose `version:` key, which Compose v2+ warns on.

## Verification

Run against a real Docker daemon, not just config parsing:

- [x] `docker compose build` — both images build clean (frontend 407 packages / 442 MB, backend 954 / 733 MB)
- [x] **The regression itself:** `@preact/preset-vite` inside the built frontend image is **2.10.3**, the pinned version — vite 7.3.1
- [x] `docker compose up -d --renew-anon-volumes` — all five containers up; frontend `200`, backend `/health` `200` (`{"status":"ok"}`), dynamodb-admin `200`
- [x] **Not a blank page:** `/src/entries/main.tsx` is served transformed through preset-vite into Preact `render` + `jsx-dev-runtime` calls
- [x] **No host writes from the container:** after a full run, host `git status` is clean, host `tools/publisher-format/dist` is empty and `bernard`-owned, and host `docs/publisher/feed.schema.json` is unmodified — while the container has its own built copies
- [x] Port-check helpers unit-tested in isolation (7 assertions: owner mapping, free vs listening detection, empty/bogus container names, and a *foreign* process on 3000 still being rejected)
- [x] `bash -n` and `shellcheck` clean on `scripts/setup-local.sh`
- [x] `docker compose config` parses; resolved mounts confirmed read-only where intended
- [N/A] `npm run validate --workspace=backend` — no backend source changed
- [N/A] `cd ios && xcodebuild test ...` — no iOS changes

## App Store listing

[skip-screenshots: local dev tooling, README and Docker config only — no iOS or user-visible app change]

- [x] Not applicable — no visual change

## Known follow-ups (not in this PR)

- No CI job exercises the Docker dev setup, which is why it rotted in the first place. A `docker compose build` smoke job on PRs touching these files would be cheap insurance.
- The port-check helpers were verified with an ad-hoc harness; the repo has no shell-test framework, so nothing permanent was added. Happy to land one if you want that story.
