### PR TITLE
feat: Captions quick link (captions.chq.org) on web and iOS

### DIFF
--- a/docs/app-store/RELEASE_CHECKLIST.md
+++ b/docs/app-store/RELEASE_CHECKLIST.md
@@ -266,6 +266,9 @@ the next submission.
   range and a filter count — beside the search field, each opening a
   sheet. About a third more of the screen is now event list.
 
+- Captions: the More menu now links to Chautauqua's live captioning at
+  captions.chq.org, for attendees who are deaf or hard of hearing.
+
 **Pending, not yet shipped** (do not fold into `whatsNew` until the PR
 that makes this change actually lands):
 

--- a/docs/superpowers/plans/2026-08-12-captions-link.md
+++ b/docs/superpowers/plans/2026-08-12-captions-link.md
@@ -1,0 +1,339 @@
+# Captions Quick Link Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Chautauqua's live CART captioning site (`captions.chq.org`) as a seventh entry in the shared quick-links list, so it appears in both the web header and the iOS toolbar **More** menu.
+
+**Architecture:** No new mechanism. `shared/links.json` is the cross-platform source of truth; the web reads it directly through `frontend/src/lib/quickLinks.ts`, and iOS hand-mirrors it in `AboutInfo.quickLinks` with an ordered-array equality test pinning the two together. This change is two data edits plus one test.
+
+**Tech Stack:** JSON, TypeScript (Vitest), Swift (Swift Testing / `xcodebuild`)
+
+**Spec:** `docs/superpowers/specs/2026-08-12-captions-link-design.md`
+
+## Global Constraints
+
+- Branch is `feat/captions-link`, already created off `main`. Never commit to `main`.
+- The link's exact values, used identically in both files: id `captions`, title `Captions`, url `https://captions.chq.org/` — **with the trailing slash**.
+- Position: index 4 of 7, immediately after `questions` and immediately before `bus-tram-tracker`. Final order: `about, feedback, programs, questions, captions, bus-tram-tracker, chautauqua-fund`.
+- No `webPath` key on this entry. That field only exists to keep same-site links on localhost in dev; this destination is external.
+- The working tree carries an **unrelated, uncommitted** `MARKETING_VERSION = 1.1.2` change in `ios/ChqCalendar.xcodeproj/project.pbxproj`. It must never be staged by this plan. Every `git add` below names explicit paths — do not substitute `git add -A` or `git add .`.
+- `CODE_SIGNING_ALLOWED=NO` is required on every local `xcodebuild` invocation. It is not cosmetic: `AppGroupTests.containerURLIsNilInTheUnitTestHost` asserts there is *no* App Group entitlement, which is the condition this flag creates. A signed run turns a green tree red.
+
+---
+
+### Task 1: Add the Captions link to both platforms
+
+Web and iOS are one task, not two, because `AboutInfoTests.quickLinksMatchSharedLinksJson` reads `shared/links.json` off disk at test time and compares it to the Swift list as ordered arrays. Editing either file alone leaves the iOS suite red. There is no commit boundary between them that a reviewer could accept.
+
+The task runs two RED/GREEN cycles. The second one is not ceremony: it is the only evidence that the cross-platform pin actually fires. If step 7 shows the iOS suite still passing after `links.json` gained an entry the Swift file lacks, the pin is broken and that is a bigger finding than this feature.
+
+**Files:**
+- Modify: `shared/links.json:6-7` (insert a line between them)
+- Modify: `ios/ChqCalendar/Features/About/AboutInfo.swift:43-44` (insert a line between them)
+- Test: `frontend/src/lib/__tests__/quickLinks.test.ts` (add one case)
+- Test (existing, must keep passing): `ios/ChqCalendarTests/AboutInfoTests.swift:88`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks — this is the first task.
+- Produces: a quick link with id `captions` present in `quickLinks` (TypeScript, from `@/lib/quickLinks`) and in `AboutInfo.quickLinks` (Swift). Task 2 describes this addition in release notes but does not import from it.
+
+- [ ] **Step 1: Write the failing web test**
+
+Add this case to `frontend/src/lib/__tests__/quickLinks.test.ts`, directly after the existing `includes the Chautauqua Fund link` case (which it deliberately mirrors):
+
+```ts
+  it('includes the captions link', () => {
+    const captions = quickLinks.find((l) => l.id === 'captions');
+    expect(captions?.title).toBe('Captions');
+    expect(captions?.url).toBe('https://captions.chq.org/');
+  });
+```
+
+Why this test exists when both header render tests already iterate `quickLinks` via `it.each`: a data-driven test cannot fail on a *deleted* entry. Remove the link and `it.each` simply runs one fewer case, all green. This case is what turns a silent deletion into a red build.
+
+- [ ] **Step 2: Run the web test and verify it fails**
+
+Run:
+```bash
+cd frontend && npx vitest run src/lib/__tests__/quickLinks.test.ts
+```
+
+Expected: FAIL on `includes the captions link`. `find` returns `undefined`, so `captions?.title` is `undefined` and the first `expect` reports `expected undefined to be 'Captions'`.
+
+If it passes, stop — an entry with that id already exists and this plan's premise is wrong.
+
+- [ ] **Step 3: Establish the iOS baseline is green**
+
+Run the one Swift test this change can break, before changing anything:
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -only-testing:ChqCalendarTests/AboutInfoTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS.
+
+If that destination does not exist on this machine, list what does with `xcrun simctl list devices available` and substitute a name/OS from the output. Do not assume the README's `iPhone 17, OS=26.1` is installed — CI resolves a UDID at runtime precisely because pinned destinations are not portable between machines.
+
+- [ ] **Step 4: Add the entry to `shared/links.json`**
+
+Insert between the `questions` line and the `bus-tram-tracker` line, so the file reads:
+
+```json
+{
+  "quickLinks": [
+    { "id": "about", "title": "Guide", "url": "https://www.chqcal.org/about", "webPath": "/about" },
+    { "id": "feedback", "title": "Feedback", "url": "https://www.chqcal.org/feedback", "webPath": "/feedback" },
+    { "id": "programs", "title": "Programs", "url": "https://programs.chq.org/" },
+    { "id": "questions", "title": "Questions", "url": "https://questions.chq.org/" },
+    { "id": "captions", "title": "Captions", "url": "https://captions.chq.org/" },
+    { "id": "bus-tram-tracker", "title": "Bus Tracker", "url": "https://busandtramtracker.chq.org" },
+    { "id": "chautauqua-fund", "title": "CHQ Fund", "url": "https://giving.chq.org/" }
+  ]
+}
+```
+
+- [ ] **Step 5: Run the web test and verify it passes**
+
+Run:
+```bash
+cd frontend && npx vitest run src/lib/__tests__/quickLinks.test.ts
+```
+
+Expected: PASS, all cases.
+
+- [ ] **Step 6: Run the full frontend test suite**
+
+Run:
+```bash
+cd frontend && npm test
+```
+
+Expected: PASS. The two `it.each(quickLinks)` cases in `src/components/layout/__tests__/Header.test.tsx` now each run a seventh iteration — `desktop nav opens Captions from shared/links.json` and `mobile dropdown opens Captions from shared/links.json` — and both should be green without any edit to that file. Confirm those two case names appear in the output; that is the evidence the header picked the entry up.
+
+- [ ] **Step 7: Run the iOS test and verify it now FAILS**
+
+Same command as step 3:
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -only-testing:ChqCalendarTests/AboutInfoTests \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: FAIL on `quickLinksMatchSharedLinksJson`. The Swift list has 6 entries, the JSON now has 7, so all three array comparisons (ids, titles, urls) differ.
+
+**If this passes, do not continue.** It means the cross-platform pin is not actually reading `shared/links.json` — the `#filePath`-relative path in `AboutInfoTests.swift:98-102` has drifted, or the decode is silently failing. Report that instead of proceeding; it is a defect that predates this change and it makes the whole shared-links mechanism unenforced.
+
+- [ ] **Step 8: Add the mirrored entry to `AboutInfo.swift`**
+
+In `ios/ChqCalendar/Features/About/AboutInfo.swift`, insert between the `questions` line and the `bus-tram-tracker` line so `quickLinks` reads:
+
+```swift
+    static let quickLinks: [Link] = [
+        Link(id: "about", title: "Guide", url: URL(string: "https://www.chqcal.org/about")!),
+        Link(id: "feedback", title: "Feedback", url: URL(string: "https://www.chqcal.org/feedback")!),
+        Link(id: "programs", title: "Programs", url: URL(string: "https://programs.chq.org/")!),
+        Link(id: "questions", title: "Questions", url: URL(string: "https://questions.chq.org/")!),
+        Link(id: "captions", title: "Captions", url: URL(string: "https://captions.chq.org/")!),
+        Link(id: "bus-tram-tracker", title: "Bus Tracker", url: URL(string: "https://busandtramtracker.chq.org")!),
+        Link(id: "chautauqua-fund", title: "CHQ Fund", url: URL(string: "https://giving.chq.org/")!),
+    ]
+```
+
+Do not touch the doc comment above it — it already names `shared/links.json` as the source of truth and tells the next reader to change both. Nothing in it becomes untrue.
+
+- [ ] **Step 9: Run the iOS test and verify it passes**
+
+Same command as steps 3 and 7. Expected: PASS.
+
+- [ ] **Step 10: Run the full iOS suite**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS, 720 tests. `quickLinksAreDistinctFromTheAboutSheetLinks` also covers this entry now — `captions` must not collide with the About sheet's ids (`guide`, `privacy`, `support`, `chq`), and it does not.
+
+- [ ] **Step 11: Run the full frontend build**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: PASS. This runs `validate` (type-check + lint), then `test:ci` (Vitest with coverage), then `vite build`. Coverage is floored per `.coverage-floor.json`; a data-only addition to a file that is already fully covered will not move it down.
+
+- [ ] **Step 12: Commit**
+
+Stage only these three paths. The `project.pbxproj` change in the working tree is unrelated and must stay unstaged.
+
+```bash
+git add shared/links.json \
+        ios/ChqCalendar/Features/About/AboutInfo.swift \
+        frontend/src/lib/__tests__/quickLinks.test.ts
+git status --short
+```
+
+Confirm `git status --short` shows the three files staged (`M ` in the first column) and `ios/ChqCalendar.xcodeproj/project.pbxproj` still unstaged (` M`). Then:
+
+```bash
+git commit -m "feat: Captions quick link (captions.chq.org) on web and iOS
+
+Chautauqua runs live CART captioning at captions.chq.org for attendees
+who are deaf or hard of hearing. Nothing in the app pointed at it — a
+user in the Amphitheater had to already know the hostname.
+
+Added to shared/links.json between Questions and Bus Tracker, and
+mirrored in AboutInfo.quickLinks. Both neighbours are things you use in
+the room during a talk, which is where captions belong; the order is
+shared, so the iOS More menu reorders to match.
+
+The URL is a 301 CHQ re-points at whichever session is currently being
+captioned, so off-session it lands on a stopped-session page. Shown
+unconditionally anyway: gating would need a liveness signal only CHQ's
+DNS can provide, and a hidden accessibility affordance is worse than a
+visible one that is sometimes idle.
+
+One explicit test despite the header tests already iterating quickLinks
+with it.each — a data-driven test runs one fewer case on a deleted
+entry and stays green, so it cannot catch a silent deletion.
+
+Verified the cross-platform pin fires rather than assuming it: with
+links.json edited and AboutInfo.swift not yet,
+quickLinksMatchSharedLinksJson failed on all three array comparisons.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QavxQ1q5L5J5nwTwGeA1cG"
+```
+
+---
+
+### Task 2: Record the release note
+
+Separate from Task 1 because it is a release-process artifact on a different review axis — a reviewer can reasonably accept the feature and reword the user-facing sentence, or vice versa.
+
+**Files:**
+- Modify: `docs/app-store/RELEASE_CHECKLIST.md:265-267` (append a bullet after the existing one)
+
+**Interfaces:**
+- Consumes: the shipped link from Task 1. This bullet describes behavior that must already be on the branch — the section's own header says not to list unshipped changes above the "Pending" divider.
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Add the bullet**
+
+In `docs/app-store/RELEASE_CHECKLIST.md`, under `## Release notes for the next version`, append after the existing "Filtering moved to the bottom of the screen" bullet and **before** the `**Pending, not yet shipped**` divider:
+
+```markdown
+- Captions: the More menu now links to Chautauqua's live captioning at
+  captions.chq.org, for attendees who are deaf or hard of hearing.
+```
+
+It goes above the divider, not below it, because Task 1 already landed the change on this branch. The "Pending" section is only for changes a later PR will make.
+
+- [ ] **Step 2: Verify placement**
+
+```bash
+sed -n '259,280p' docs/app-store/RELEASE_CHECKLIST.md
+```
+
+Expected: the new bullet appears after the filtering bullet and before the line beginning `**Pending, not yet shipped**`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/app-store/RELEASE_CHECKLIST.md
+git commit -m "docs: release note for the Captions quick link
+
+Tracked above the 'Pending, not yet shipped' divider because the change
+is on this branch, not deferred to a later PR.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QavxQ1q5L5J5nwTwGeA1cG"
+```
+
+---
+
+### Task 3: Open the pull request
+
+The screenshot guard is why this is a task with explicit content rather than a throwaway final step. `.github/workflows/app-store-assets.yml` fires on any change under `ios/ChqCalendar/Features/**`, and Task 1 modified `AboutInfo.swift`. Without the opt-out string in the PR body, the guard fails the PR.
+
+**Files:**
+- None in the repo. The deliverable is the PR.
+
+**Interfaces:**
+- Consumes: commits from Tasks 1 and 2.
+- Produces: nothing.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/captions-link
+```
+
+- [ ] **Step 2: Open the PR with the screenshot opt-out**
+
+The opt-out is legitimate, not a dodge. No shot in `ios/Scripts/screenshot-plan.json` opens the toolbar **More** menu — the ten shots cover the season list, filters, search, detail, articles, add-to-calendar, My Day, map, reminders, and the widget. A full regeneration run would leave `screenshots.manifest.json` unchanged, and the guard checks whether that file changed since the merge-base.
+
+```bash
+gh pr create --title "feat: Captions quick link (captions.chq.org) on web and iOS" --body "$(cat <<'EOF'
+Adds Chautauqua's live CART captioning site to the shared quick-links list
+that drives the web header and the iOS More menu.
+
+Order is now: Guide · Feedback · Programs · Questions · **Captions** · Bus
+Tracker · CHQ Fund. Programs and Questions are both things you use in the
+room during a talk, so captions sits with them rather than next to the
+donate link. The order is shared between platforms, so the iOS More menu
+reorders to match — pinned by `AboutInfoTests.quickLinksMatchSharedLinksJson`,
+which compares the two lists as ordered arrays.
+
+## What the URL actually is
+
+`captions.chq.org` is a 301 that CHQ re-points at whichever session is
+currently being captioned. On 2026-08-12 it resolved to a 1CapApp CART page
+titled "57919 chautauqua: the rev. frank a. thomas || 9:00-10:00 am" and read
+"Session has been stopped".
+
+Shown unconditionally anyway. Gating on liveness would need a second source of
+truth we cannot populate — CHQ controls the redirect, not us — and a hidden
+accessibility affordance is worse than a visible one that is sometimes idle.
+Bus Tracker is equally idle in February and is also shown unconditionally.
+
+## Testing
+
+One new explicit case in `quickLinks.test.ts`, despite both header render
+tests already iterating `quickLinks` with `it.each`. A data-driven test cannot
+fail on a deleted entry — it just runs one fewer case, all green — so the
+explicit case is what catches a silent deletion.
+
+The cross-platform pin was verified to fire rather than assumed: with
+`links.json` edited and `AboutInfo.swift` not yet, `quickLinksMatchSharedLinksJson`
+failed on all three array comparisons.
+
+Full frontend build green; full iOS suite green at 720 tests.
+
+Design: `docs/superpowers/specs/2026-08-12-captions-link-design.md`
+
+[skip-screenshots: no covered shot renders the More menu]
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01QavxQ1q5L5J5nwTwGeA1cG
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm the guard accepted the opt-out**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: the app-store-assets check passes on the opt-out reason rather than demanding a manifest change. If it fails, the reason string is malformed — it must be a non-empty reason inside `[skip-screenshots: ...]`.

--- a/docs/superpowers/plans/2026-08-12-captions-link.md
+++ b/docs/superpowers/plans/2026-08-12-captions-link.md
@@ -297,9 +297,8 @@ which compares the two lists as ordered arrays.
 ## What the URL actually is
 
 `captions.chq.org` is a 301 that CHQ re-points at whichever session is
-currently being captioned. On 2026-08-12 it resolved to a 1CapApp CART page
-titled "57919 chautauqua: the rev. frank a. thomas || 9:00-10:00 am" and read
-"Session has been stopped".
+currently being captioned. On 2026-08-12 it resolved to a 1CapApp CART session
+page for Chautauqua that read "Session has been stopped".
 
 Shown unconditionally anyway. Gating on liveness would need a second source of
 truth we cannot populate — CHQ controls the redirect, not us — and a hidden

--- a/docs/superpowers/specs/2026-08-12-captions-link-design.md
+++ b/docs/superpowers/specs/2026-08-12-captions-link-design.md
@@ -1,0 +1,175 @@
+# Captions quick link — design
+
+**Status:** Approved, not yet implemented
+**Date:** 2026-08-12
+
+## Problem
+
+Chautauqua Institution runs live CART captioning for talks at
+`captions.chq.org`, for attendees who are deaf or hard of hearing. Nothing in
+CHQ Calendar points at it. A user sitting in the Amphitheater who wants
+captions has to already know the hostname.
+
+## Solution
+
+Add `captions.chq.org` as a seventh entry in the shared quick-links list, which
+already drives both the web header and the iOS toolbar **More** menu.
+
+## What the URL actually is
+
+`https://captions.chq.org` is a 301 redirect, not a page we control. On
+2026-08-12 it resolved to `https://2020archive.1capapp.com/event/chautauqua/`,
+a 1CapApp CART session titled *"57919 chautauqua: the rev. frank a. thomas ||
+9:00-10:00 am"*, and rendered "Session has been stopped".
+
+CHQ appears to re-point the hostname at whichever session is currently being
+captioned. Two consequences shape the design:
+
+1. The link is useful *during* a captioned talk and lands on a stopped-session
+   screen the rest of the time, including all off-season.
+2. We cannot know from our side whether a session is live. Only CHQ's DNS and
+   1CapApp know that.
+
+## Decisions
+
+### Plain, unconditional link
+
+Treated exactly like the other six. No season gating, no time-of-day gating, no
+health check on the redirect target.
+
+Rejected: conditional display. It would require a second source of truth about
+"is a session live" that we cannot actually populate — CHQ controls the
+redirect, we don't. And a hidden accessibility affordance is worse than a
+visible one that occasionally lands on a stopped session. Bus Tracker is
+equally useless in February and is shown unconditionally.
+
+Consequence accepted: off-session, the user sees CHQ's own "session stopped"
+page. That is CHQ's surface, not ours, and it is self-explanatory.
+
+### Label: `Captions`
+
+The header buttons are terse (`Guide`, `Feedback`, `Programs`, `Questions`,
+`Bus Tracker`, `CHQ Fund`) and the mobile dropdown is 160px wide, so two short
+words is the practical ceiling.
+
+`Captions` is shortest, unambiguous, and matches the hostname — a user who sees
+`captions.chq.org` in the address bar recognizes where they came from.
+
+Rejected: `Live Captions` (wider, and "Live" overpromises on a page that is
+frequently a stopped session); `CART Captions` (term of art — precise for
+people who already know it, opaque for everyone else).
+
+### Position: between `Questions` and `Bus Tracker`
+
+Final order, shared by web and iOS:
+
+```
+Guide · Feedback · Programs · Questions · Captions · Bus Tracker · CHQ Fund
+```
+
+Programs and Questions are both things you use *in the room during a talk*.
+Captions belongs with them rather than appended next to the donate link.
+
+The order is shared, so this also reorders the iOS **More** menu. That is
+intended.
+
+### URL written with a trailing slash
+
+`https://captions.chq.org/`. `programs.chq.org/`, `questions.chq.org/` and
+`giving.chq.org/` all carry it; `busandtramtracker.chq.org` does not. The slash
+matches the majority and avoids one redirect hop, since the host 301s
+regardless.
+
+## Changes
+
+### 1. `shared/links.json`
+
+Insert after the `questions` entry:
+
+```json
+{ "id": "captions", "title": "Captions", "url": "https://captions.chq.org/" }
+```
+
+No `webPath`. That field exists only to keep same-site links on localhost
+during development; this destination is external.
+
+### 2. `ios/ChqCalendar/Features/About/AboutInfo.swift`
+
+Mirror the entry in `AboutInfo.quickLinks`, in the same position:
+
+```swift
+Link(id: "captions", title: "Captions", url: URL(string: "https://captions.chq.org/")!),
+```
+
+`AboutInfoTests.quickLinksMatchSharedLinksJson` compares the two lists by id,
+title, and URL **as ordered arrays**. A mismatch in any of the three, including
+order, fails the iOS suite rather than shipping a divergence between platforms.
+
+### 3. `frontend/src/lib/__tests__/quickLinks.test.ts`
+
+Add one test naming the link explicitly, mirroring the existing
+`includes the Chautauqua Fund link` case:
+
+```ts
+it('includes the captions link', () => {
+  const captions = quickLinks.find((l) => l.id === 'captions');
+  expect(captions?.title).toBe('Captions');
+  expect(captions?.url).toBe('https://captions.chq.org/');
+});
+```
+
+This is the only new test required. The existing generic tests (id shape,
+absolute https URL, unique ids, webPath shape) and both data-driven header
+render tests (`it.each(quickLinks)`, desktop and mobile) pick the new entry up
+automatically. The explicit test exists to catch a *silent deletion*, which the
+data-driven tests by construction cannot: remove the entry and they simply run
+one fewer case, all green.
+
+## No other consumers
+
+`shared/links.json` is read by `frontend/src/lib/quickLinks.ts` and mirrored in
+`AboutInfo.swift`. Nothing else in the repo names these links — in particular
+the `/about` marketing and guide pages do not enumerate them, so they need no
+update.
+
+## Screenshot guard
+
+`.github/workflows/app-store-assets.yml` fires on any change under
+`ios/ChqCalendar/Features/**`, and `AboutInfo.swift` is in scope.
+
+No shot in `ios/Scripts/screenshot-plan.json` opens the toolbar **More** menu.
+The ten shots cover the season list, filters, search, detail, articles,
+add-to-calendar, My Day, map, reminders, and the widget. The manifest therefore
+will not change even after a full regeneration run.
+
+Use the documented opt-out rather than burning a simulator pass to prove a
+no-op:
+
+```
+[skip-screenshots: no covered shot renders the More menu]
+```
+
+CLAUDE.md explicitly blesses this case.
+
+## App Store listing
+
+No `listing-copy.md` or `listing-fields.json` claim is invalidated — neither
+enumerates the quick links. Add a release-note bullet under "Release notes for
+the next version" in `docs/app-store/RELEASE_CHECKLIST.md`, since this is a
+user-visible addition that should reach `whatsNew` at the next submission.
+
+## Verification
+
+- `cd frontend && npm run build` — runs validate (type-check + lint) and the
+  frontend test suite
+- iOS suite — machine-checked on the PR by the CI job added in #205/#207, so
+  the `quickLinksMatchSharedLinksJson` pin is enforced rather than relying on a
+  local run
+
+## Out of scope
+
+- The uncommitted `MARKETING_VERSION = 1.1.2` bump sitting in
+  `project.pbxproj`. It belongs in its own commit and must not ride along on
+  this branch.
+- Any change to how quick links are rendered, ordered at runtime, or
+  configured. This is a data addition on an existing mechanism.

--- a/docs/superpowers/specs/2026-08-12-captions-link-design.md
+++ b/docs/superpowers/specs/2026-08-12-captions-link-design.md
@@ -1,6 +1,6 @@
 # Captions quick link — design
 
-**Status:** Approved, not yet implemented
+**Status:** Implemented on branch `feat/captions-link`
 **Date:** 2026-08-12
 
 ## Problem
@@ -19,8 +19,8 @@ already drives both the web header and the iOS toolbar **More** menu.
 
 `https://captions.chq.org` is a 301 redirect, not a page we control. On
 2026-08-12 it resolved to `https://2020archive.1capapp.com/event/chautauqua/`,
-a 1CapApp CART session titled *"57919 chautauqua: the rev. frank a. thomas ||
-9:00-10:00 am"*, and rendered "Session has been stopped".
+a 1CapApp CART session page for Chautauqua, and rendered "Session has been
+stopped".
 
 CHQ appears to re-point the hostname at whichever session is currently being
 captioned. Two consequences shape the design:
@@ -77,8 +77,10 @@ intended.
 
 `https://captions.chq.org/`. `programs.chq.org/`, `questions.chq.org/` and
 `giving.chq.org/` all carry it; `busandtramtracker.chq.org` does not. The slash
-matches the majority and avoids one redirect hop, since the host 301s
-regardless.
+matches the majority.
+
+It buys nothing beyond that consistency: both forms return exactly one 301 to
+the same target, so the slash saves no redirect hop.
 
 ## Changes
 

--- a/frontend/src/lib/__tests__/quickLinks.test.ts
+++ b/frontend/src/lib/__tests__/quickLinks.test.ts
@@ -8,6 +8,12 @@ describe('quickLinks (shared/links.json)', () => {
     expect(fund?.url).toBe('https://giving.chq.org/');
   });
 
+  it('includes the captions link', () => {
+    const captions = quickLinks.find((l) => l.id === 'captions');
+    expect(captions?.title).toBe('Captions');
+    expect(captions?.url).toBe('https://captions.chq.org/');
+  });
+
   it('every link has a non-empty id, title, and absolute https url', () => {
     for (const link of quickLinks) {
       expect(link.id).toMatch(/^[a-z0-9-]+$/);

--- a/ios/ChqCalendar/Features/About/AboutInfo.swift
+++ b/ios/ChqCalendar/Features/About/AboutInfo.swift
@@ -41,6 +41,7 @@ enum AboutInfo {
         Link(id: "feedback", title: "Feedback", url: URL(string: "https://www.chqcal.org/feedback")!),
         Link(id: "programs", title: "Programs", url: URL(string: "https://programs.chq.org/")!),
         Link(id: "questions", title: "Questions", url: URL(string: "https://questions.chq.org/")!),
+        Link(id: "captions", title: "Captions", url: URL(string: "https://captions.chq.org/")!),
         Link(id: "bus-tram-tracker", title: "Bus Tracker", url: URL(string: "https://busandtramtracker.chq.org")!),
         Link(id: "chautauqua-fund", title: "CHQ Fund", url: URL(string: "https://giving.chq.org/")!),
     ]

--- a/ios/ChqCalendarTests/AboutInfoTests.swift
+++ b/ios/ChqCalendarTests/AboutInfoTests.swift
@@ -66,16 +66,17 @@ struct AboutInfoTests {
     // MARK: - quickLinks
 
     @Test func quickLinksMatchTheWebHeader() {
-        #expect(AboutInfo.quickLinks.map(\.id) == ["about", "feedback", "programs", "questions", "bus-tram-tracker", "chautauqua-fund"])
+        #expect(AboutInfo.quickLinks.map(\.id) == ["about", "feedback", "programs", "questions", "captions", "bus-tram-tracker", "chautauqua-fund"])
         // "Guide", not "About": the ellipsis menu renders these quick links
         // directly above an in-app "About" sheet button, and two items both
         // reading "About" made the menu ambiguous.
-        #expect(AboutInfo.quickLinks.map(\.title) == ["Guide", "Feedback", "Programs", "Questions", "Bus Tracker", "CHQ Fund"])
+        #expect(AboutInfo.quickLinks.map(\.title) == ["Guide", "Feedback", "Programs", "Questions", "Captions", "Bus Tracker", "CHQ Fund"])
         #expect(AboutInfo.quickLinks.map { $0.url.absoluteString } == [
             "https://www.chqcal.org/about",
             "https://www.chqcal.org/feedback",
             "https://programs.chq.org/",
             "https://questions.chq.org/",
+            "https://captions.chq.org/",
             "https://busandtramtracker.chq.org",
             "https://giving.chq.org/",
         ])

--- a/shared/links.json
+++ b/shared/links.json
@@ -4,6 +4,7 @@
     { "id": "feedback", "title": "Feedback", "url": "https://www.chqcal.org/feedback", "webPath": "/feedback" },
     { "id": "programs", "title": "Programs", "url": "https://programs.chq.org/" },
     { "id": "questions", "title": "Questions", "url": "https://questions.chq.org/" },
+    { "id": "captions", "title": "Captions", "url": "https://captions.chq.org/" },
     { "id": "bus-tram-tracker", "title": "Bus Tracker", "url": "https://busandtramtracker.chq.org" },
     { "id": "chautauqua-fund", "title": "CHQ Fund", "url": "https://giving.chq.org/" }
   ]


### PR DESCRIPTION
Adds Chautauqua's live CART captioning site to the shared quick-links list
that drives the web header and the iOS More menu.

Order is now: Guide · Feedback · Programs · Questions · **Captions** · Bus
Tracker · CHQ Fund. Programs and Questions are both things you use in the
room during a talk, so captions sits with them rather than next to the
donate link. The order is shared between platforms, so the iOS More menu
reorders to match.

## What the URL actually is

`captions.chq.org` is a 301 that CHQ re-points at whichever session is
currently being captioned. On 2026-08-12 it resolved to a 1CapApp CART session
page for Chautauqua that read "Session has been stopped".

Shown unconditionally anyway. Gating on liveness would need a second source of
truth we cannot populate — CHQ controls the redirect, not us — and a hidden
accessibility affordance is worse than a visible one that is sometimes idle.
Bus Tracker is equally idle in February and is also shown unconditionally.

The URL carries a trailing slash to match `programs.`/`questions.`/`giving.chq.org/`.
That is the whole reason — both forms return exactly one 301 to the same
target, so it saves no redirect hop.

## Two pins, not one

`AboutInfo.quickLinks` is pinned to `shared/links.json` twice, by independent
mechanisms: `quickLinksMatchSharedLinksJson` reads the JSON off disk, and
`quickLinksMatchTheWebHeader` hardcodes its own arrays. Both needed the new
entry. They are worth keeping separate — only the hardcoded one catches a
*symmetric* deletion from both files, which the comparison test cannot see.

## Testing

One new explicit case in `quickLinks.test.ts`, despite both header render
tests already iterating `quickLinks` with `it.each`. A data-driven test cannot
fail on a deleted entry — it just runs one fewer case, all green — so the
explicit case is what catches a silent deletion.

The cross-platform pin was verified to fire rather than assumed: with
`links.json` edited and `AboutInfo.swift` not yet, `quickLinksMatchSharedLinksJson`
failed on all three array comparisons.

Frontend 542 tests green; iOS 720 tests green across 52 suites.

Design: `docs/superpowers/specs/2026-08-12-captions-link-design.md`

[skip-screenshots: no covered shot renders the More menu]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QavxQ1q5L5J5nwTwGeA1cG