### PR TITLE
chore(ios): put every target on 1.1.2, app and widgets stay at build 5

### DIFF
--- a/ios/ChqCalendar.xcodeproj/project.pbxproj
+++ b/ios/ChqCalendar.xcodeproj/project.pbxproj
@@ -321,7 +321,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.chqcal.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -355,7 +355,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.chqcal.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -372,7 +372,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RX6EGLMU69;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.chqcal.calendarTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -390,7 +390,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = RX6EGLMU69;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.chqcal.calendarTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
@@ -473,7 +473,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.chqcal.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1.1;
+				MARKETING_VERSION = 1.1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = org.chqcal.app.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;


### PR DESCRIPTION
Marketing version **1.1.2** across the app, the widgets extension and the test
bundle. App and widgets keep **build 5**; the test bundle stays at build 1,
which `RELEASE_CHECKLIST.md` versions independently since it is never uploaded.

## Why build 5 is not incremented

Build 5 was never uploaded. The 1.1.1 build that reached TestFlight is
**1.1.1(1)**, archived from `080973c` — the first commit of #202, before review
corrected build 1 to build 5. So 1.1.1(5) only ever existed in the project
file, and 5 remains a number this app has never shipped, satisfying the
never-reused rule.

## What was incomplete

App and widgets had already been moved to 1.1.2 in the working tree, but
`org.chqcal.calendarTests` was left on 1.1.1. That diverges from the shape #202
deliberately established — every target on one marketing version, with only the
build number differing. This PR finishes it.

## Verification

Against built products, not the project file, because the `.pbxproj` alone
cannot show what `CFBundleVersion` resolves to (`GENERATE_INFOPLIST_FILE` is
YES for all six configurations, so the setting is the only source):

```
ChqCalendar.app          short=1.1.2  build=5
ChqCalendarWidgets.appex short=1.1.2  build=5
```

An embedded extension's `CFBundleVersion` must match its containing app; that
mismatch is rejected at upload, before App Review, and cost a round trip on 1.1.

## What 1.1.2(5) carries over TestFlight's 1.1.1(1)

- **#203** — stale scope-local date state leaking across scope switches (#156);
  the date pill rendering "Week 6" over a day-filtered list; a My Day chip
  silently dropped on nil.
- **#209** — one star tap cost 2 × N full JSON decodes of the largest payload
  the app reads; now memoized.
- **#218** — the Captions quick link.

It is also the first iOS archive whose Swift was checked by CI (#207);
1.1.1(1) predates that job.

## Still open before submitting to App Review

Not blockers for this PR, but they gate the submission itself:

- `whatsNew` in `listing-fields.json` still describes 1.1 and mentions neither
  the expanded Siri surface nor My Day.
- `APP_STORE_URL` is still unset.
- The on-device Siri pass — bare-"Chautauqua" routing and the Shortcuts
  gallery's parameter-slot rendering are unverifiable in CI and the simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QavxQ1q5L5J5nwTwGeA1cG