### PR TITLE
feat(web): promote the iOS app to eligible visitors (#223)

### DIFF
--- a/frontend/src/app/about/aboutContent.ts
+++ b/frontend/src/app/about/aboutContent.ts
@@ -8,6 +8,8 @@
  * against.
  */
 
+import { APP_STORE_URL } from '@/lib/constants';
+
 export type Platform = 'ios' | 'web';
 
 /** Points at a prepared WebP pair in /public/about/ (420w/840w for iOS
@@ -56,13 +58,14 @@ export const DISCLAIMER =
   'publicly posted listings; chq.org remains the authoritative source.';
 
 /**
- * Public App Store URL. App Store Connect assigns the numeric Apple ID at
- * app-record creation, but the /app/id… URL only resolves once a version is
- * live. `PlatformCard` renders a "coming soon" state while this is empty, so
- * the site can ship before the app is approved; the iOS-app promo banner is
- * likewise gated on this being non-empty.
+ * Public App Store URL, defined in `@/lib/constants` so the calendar bundle can
+ * read it without importing this page's copy. App Store Connect assigns the
+ * numeric Apple ID at app-record creation, but the /app/id… URL only resolves
+ * once a version is live. `PlatformCard` renders a "coming soon" state while
+ * this is empty, so the site can ship before the app is approved; the iOS-app
+ * promo surfaces are likewise gated on it being non-empty.
  */
-export const APP_STORE_URL = 'https://apps.apple.com/us/app/chqcalendar/id6797027562';
+export { APP_STORE_URL };
 
 const IOS_SHOT = { width: 840, height: 1825 };   // iPhone 6.9 (1320×2868) scaled
 const WEB_SHOT = { width: 1280, height: 900 };

--- a/frontend/src/app/about/aboutContent.ts
+++ b/frontend/src/app/about/aboutContent.ts
@@ -56,13 +56,13 @@ export const DISCLAIMER =
   'publicly posted listings; chq.org remains the authoritative source.';
 
 /**
- * Public App Store URL. Empty until the app is released — App Store Connect
- * assigns the numeric Apple ID at app-record creation, but the /app/id… URL
- * only resolves once a version is live. `PlatformCard` renders a
- * "coming soon" state while this is empty, so shipping the site does not
- * depend on the app being approved first.
+ * Public App Store URL. App Store Connect assigns the numeric Apple ID at
+ * app-record creation, but the /app/id… URL only resolves once a version is
+ * live. `PlatformCard` renders a "coming soon" state while this is empty, so
+ * the site can ship before the app is approved; the iOS-app promo banner is
+ * likewise gated on this being non-empty.
  */
-export const APP_STORE_URL = '';
+export const APP_STORE_URL = 'https://apps.apple.com/us/app/chqcalendar/id6797027562';
 
 const IOS_SHOT = { width: 840, height: 1825 };   // iPhone 6.9 (1320×2868) scaled
 const WEB_SHOT = { width: 1280, height: 900 };

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -15,6 +15,7 @@ import { useProgramLinks } from '@/hooks/useProgramLinks';
 import { GlobalEventDataProvider, useGlobalEventData } from '@/components/providers/GlobalEventDataProvider';
 import { Header } from '@/components/layout/Header';
 import { CountdownBanner } from '@/components/layout/CountdownBanner';
+import { IosAppBanner } from '@/components/layout/IosAppBanner';
 import { LoadingSpinner } from '@/components/layout/LoadingSpinner';
 import { EmptyState } from '@/components/layout/EmptyState';
 import { SearchBar } from '@/components/filters/SearchBar';
@@ -129,6 +130,7 @@ function HomeContent() {
         defaultYear={defaultYear}
         onYearChange={setSelectedYear}
       />
+      <IosAppBanner />
       {selectedYear === defaultYear && <CountdownBanner seasonWeeks={seasonWeeks} />}
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 sm:py-8">
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow mb-4 sm:mb-6">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { YearSelector } from '@/components/layout/YearSelector';
 import { quickLinks } from '@/lib/quickLinks';
+import { isAppLaunchAvailable, launchApp, readDeviceInfo, resolveDeepLink } from '@/lib/iosPromo';
 
 interface HeaderProps {
   selectedYear: number;
@@ -11,7 +12,23 @@ interface HeaderProps {
 
 export function Header({ selectedYear, availableYears, defaultYear, onYearChange }: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
+  // Eligible iOS devices keep a persistent "Open in app" entry regardless of
+  // whether the promo banner was dismissed. Detected in an effect so the first
+  // paint is deterministic (and the button never flashes on desktop).
+  const [appAvailable, setAppAvailable] = useState(false);
+  const launchCleanupRef = useRef<(() => void) | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setAppAvailable(isAppLaunchAvailable(readDeviceInfo()));
+    return () => { launchCleanupRef.current?.(); };
+  }, []);
+
+  const openInApp = () => {
+    launchCleanupRef.current?.();
+    launchCleanupRef.current = launchApp({ deepLink: resolveDeepLink() });
+    setMenuOpen(false);
+  };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -51,6 +68,14 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
           </div>
           {/* Desktop */}
           <div className="hidden lg:flex items-center gap-2 flex-wrap justify-end">
+            {appAvailable && (
+              <button
+                onClick={openInApp}
+                className="px-3 py-1 text-sm bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors"
+              >
+                Open in app
+              </button>
+            )}
             {quickLinks.map((link) => (
               <button
                 key={link.id}
@@ -79,6 +104,14 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             </button>
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-md shadow-lg py-1 z-50">
+                {appAvailable && (
+                  <button
+                    onClick={openInApp}
+                    className="block w-full text-left px-4 py-2 text-sm font-medium text-green-700 dark:text-green-400 hover:bg-gray-100 dark:hover:bg-gray-600"
+                  >
+                    Open in app
+                  </button>
+                )}
                 {quickLinks.map((link) => (
                   <button
                     key={link.id}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from 'react';
 import { YearSelector } from '@/components/layout/YearSelector';
 import { quickLinks } from '@/lib/quickLinks';
-import { isAppLaunchAvailable, launchApp, readDeviceInfo, resolveDeepLink } from '@/lib/iosPromo';
+import { APP_STORE_URL } from '@/lib/constants';
+import { isAppPromoAvailable, readDeviceInfo } from '@/lib/iosPromo';
 
 interface HeaderProps {
   selectedYear: number;
@@ -12,23 +13,15 @@ interface HeaderProps {
 
 export function Header({ selectedYear, availableYears, defaultYear, onYearChange }: HeaderProps) {
   const [menuOpen, setMenuOpen] = useState(false);
-  // Eligible iOS devices keep a persistent "Open in app" entry regardless of
+  // Eligible iOS devices keep a persistent link to the app regardless of
   // whether the promo banner was dismissed. Detected in an effect so the first
-  // paint is deterministic (and the button never flashes on desktop).
+  // paint is deterministic (and the link never flashes on desktop).
   const [appAvailable, setAppAvailable] = useState(false);
-  const launchCleanupRef = useRef<(() => void) | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    setAppAvailable(isAppLaunchAvailable(readDeviceInfo()));
-    return () => { launchCleanupRef.current?.(); };
+    setAppAvailable(isAppPromoAvailable(readDeviceInfo()));
   }, []);
-
-  const openInApp = () => {
-    launchCleanupRef.current?.();
-    launchCleanupRef.current = launchApp({ deepLink: resolveDeepLink() });
-    setMenuOpen(false);
-  };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -69,12 +62,12 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
           {/* Desktop */}
           <div className="hidden lg:flex items-center gap-2 flex-wrap justify-end">
             {appAvailable && (
-              <button
-                onClick={openInApp}
+              <a
+                href={APP_STORE_URL}
                 className="px-3 py-1 text-sm bg-green-600 text-white rounded-md hover:bg-green-700 transition-colors"
               >
-                Open in app
-              </button>
+                Get the app
+              </a>
             )}
             {quickLinks.map((link) => (
               <button
@@ -104,13 +97,17 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             </button>
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-md shadow-lg py-1 z-50">
+                {/* No onClick close: unmounting this anchor (by collapsing the
+                    menu) from inside its own click handler can cancel the
+                    navigation. The outside-click handler closes the menu when
+                    the user comes back. */}
                 {appAvailable && (
-                  <button
-                    onClick={openInApp}
+                  <a
+                    href={APP_STORE_URL}
                     className="block w-full text-left px-4 py-2 text-sm font-medium text-green-700 dark:text-green-400 hover:bg-gray-100 dark:hover:bg-gray-600"
                   >
-                    Open in app
-                  </button>
+                    Get the app
+                  </a>
                 )}
                 {quickLinks.map((link) => (
                   <button

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -18,10 +18,20 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
   // paint is deterministic (and the link never flashes on desktop).
   const [appAvailable, setAppAvailable] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
+  const menuCloseTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setAppAvailable(isAppPromoAvailable(readDeviceInfo()));
+    return () => { if (menuCloseTimer.current) clearTimeout(menuCloseTimer.current); };
   }, []);
+
+  // Collapsing the menu synchronously would unmount the App Store anchor from
+  // inside its own click handler, which can cancel the navigation it just
+  // started — so the close waits for the next task. The quick links above use
+  // `window.open` from a button and have no such constraint.
+  const closeMenuAfterNavigating = () => {
+    menuCloseTimer.current = setTimeout(() => setMenuOpen(false), 0);
+  };
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -97,13 +107,10 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
             </button>
             {menuOpen && (
               <div className="absolute right-0 mt-2 w-40 bg-white dark:bg-gray-700 rounded-md shadow-lg py-1 z-50">
-                {/* No onClick close: unmounting this anchor (by collapsing the
-                    menu) from inside its own click handler can cancel the
-                    navigation. The outside-click handler closes the menu when
-                    the user comes back. */}
                 {appAvailable && (
                   <a
                     href={APP_STORE_URL}
+                    onClick={closeMenuAfterNavigating}
                     className="block w-full text-left px-4 py-2 text-sm font-medium text-green-700 dark:text-green-400 hover:bg-gray-100 dark:hover:bg-gray-600"
                   >
                     Get the app

--- a/frontend/src/components/layout/IosAppBanner.tsx
+++ b/frontend/src/components/layout/IosAppBanner.tsx
@@ -1,39 +1,31 @@
-import { useEffect, useRef, useState } from 'react';
-import { APP_STORE_URL } from '@/app/about/aboutContent';
-import {
-  launchApp,
-  readDeviceInfo,
-  resolveDeepLink,
-  shouldShowPromoBanner,
-  snoozePromo,
-} from '@/lib/iosPromo';
+import { useEffect, useState } from 'react';
+import { APP_STORE_URL } from '@/lib/constants';
+import { readDeviceInfo, shouldShowPromoBanner, snoozePromo } from '@/lib/iosPromo';
 
 /**
  * A dismissible strip shown to iPhone/iPad visitors (iOS >= 18) inviting them
- * into the native app: "Open in app" launches it (or falls back to the App
- * Store), while a plain App Store link is always offered. Dismissing snoozes
- * the banner for a few days. Renders nothing on ineligible devices, while
- * snoozed, or before the app is live (empty APP_STORE_URL). The eligibility
- * check runs in an effect so the server/first paint stays deterministic.
+ * into the native app via its App Store listing (see `iosPromo` for why we
+ * don't try the `chqcal://` scheme first). Dismissing snoozes the banner for a
+ * few days. Renders nothing on ineligible devices, while snoozed, or before the
+ * app is live (empty APP_STORE_URL). The eligibility check runs in an effect so
+ * the server/first paint stays deterministic.
  */
 export function IosAppBanner() {
   const [visible, setVisible] = useState(false);
-  const cleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     setVisible(shouldShowPromoBanner(readDeviceInfo(), Date.now()));
-    return () => { cleanupRef.current?.(); };
   }, []);
 
   if (!visible) return null;
 
   const handleOpen = () => {
-    cleanupRef.current?.();
-    // Opening the app counts as engagement — snooze so we don't re-nag someone
-    // who just chose to go to the app or the store.
+    // Heading to the store counts as engagement — snooze so we don't re-nag
+    // someone who just acted on the banner. Deliberately no `setVisible(false)`
+    // here: unmounting the anchor from inside its own click handler can cancel
+    // the navigation it was supposed to perform. The snooze hides the banner on
+    // the next load, which is when the user actually comes back to it.
     snoozePromo(Date.now());
-    cleanupRef.current = launchApp({ deepLink: resolveDeepLink() });
-    setVisible(false);
   };
 
   const handleDismiss = () => {
@@ -56,18 +48,12 @@ export function IosAppBanner() {
           <span className="font-medium">Get the CHQ Calendar app</span>
           <span className="hidden sm:inline"> — reminders, Home Screen widgets, and a map of the grounds.</span>
         </p>
-        <button
-          type="button"
+        <a
+          href={APP_STORE_URL}
           onClick={handleOpen}
           className="shrink-0 px-3 py-1 text-sm font-medium bg-white text-blue-700 rounded-md hover:bg-blue-50 transition-colors"
         >
-          Open in app
-        </button>
-        <a
-          href={APP_STORE_URL}
-          className="shrink-0 hidden sm:inline text-sm underline underline-offset-2 hover:text-blue-100"
-        >
-          App Store
+          Get the app
         </a>
         <button
           type="button"

--- a/frontend/src/components/layout/IosAppBanner.tsx
+++ b/frontend/src/components/layout/IosAppBanner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { APP_STORE_URL } from '@/lib/constants';
 import { readDeviceInfo, shouldShowPromoBanner, snoozePromo } from '@/lib/iosPromo';
 
@@ -12,20 +12,25 @@ import { readDeviceInfo, shouldShowPromoBanner, snoozePromo } from '@/lib/iosPro
  */
 export function IosAppBanner() {
   const [visible, setVisible] = useState(false);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     setVisible(shouldShowPromoBanner(readDeviceInfo(), Date.now()));
+    return () => { if (hideTimer.current) clearTimeout(hideTimer.current); };
   }, []);
 
   if (!visible) return null;
 
   const handleOpen = () => {
     // Heading to the store counts as engagement — snooze so we don't re-nag
-    // someone who just acted on the banner. Deliberately no `setVisible(false)`
-    // here: unmounting the anchor from inside its own click handler can cancel
-    // the navigation it was supposed to perform. The snooze hides the banner on
-    // the next load, which is when the user actually comes back to it.
+    // someone who just acted on the banner.
     snoozePromo(Date.now());
+    // Hide on the next task, never synchronously: unmounting the anchor from
+    // inside its own click handler can cancel the navigation it just started.
+    // Deferring still hides it in time, because iOS keeps this page loaded
+    // while the App Store is in the foreground — the user would otherwise
+    // swipe back to a banner they already acted on.
+    hideTimer.current = setTimeout(() => setVisible(false), 0);
   };
 
   const handleDismiss = () => {

--- a/frontend/src/components/layout/IosAppBanner.tsx
+++ b/frontend/src/components/layout/IosAppBanner.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useRef, useState } from 'react';
+import { APP_STORE_URL } from '@/app/about/aboutContent';
+import {
+  launchApp,
+  readDeviceInfo,
+  resolveDeepLink,
+  shouldShowPromoBanner,
+  snoozePromo,
+} from '@/lib/iosPromo';
+
+/**
+ * A dismissible strip shown to iPhone/iPad visitors (iOS >= 18) inviting them
+ * into the native app: "Open in app" launches it (or falls back to the App
+ * Store), while a plain App Store link is always offered. Dismissing snoozes
+ * the banner for a few days. Renders nothing on ineligible devices, while
+ * snoozed, or before the app is live (empty APP_STORE_URL). The eligibility
+ * check runs in an effect so the server/first paint stays deterministic.
+ */
+export function IosAppBanner() {
+  const [visible, setVisible] = useState(false);
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    setVisible(shouldShowPromoBanner(readDeviceInfo(), Date.now()));
+    return () => { cleanupRef.current?.(); };
+  }, []);
+
+  if (!visible) return null;
+
+  const handleOpen = () => {
+    cleanupRef.current?.();
+    // Opening the app counts as engagement — snooze so we don't re-nag someone
+    // who just chose to go to the app or the store.
+    snoozePromo(Date.now());
+    cleanupRef.current = launchApp({ deepLink: resolveDeepLink() });
+    setVisible(false);
+  };
+
+  const handleDismiss = () => {
+    snoozePromo(Date.now());
+    setVisible(false);
+  };
+
+  return (
+    <div className="bg-blue-600 text-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2 flex items-center gap-3">
+        <img
+          src="/chq-calendar-icon-256.svg"
+          alt=""
+          aria-hidden="true"
+          width={28}
+          height={28}
+          className="w-7 h-7 rounded-md bg-white/10 p-0.5 shrink-0"
+        />
+        <p className="text-sm leading-tight flex-1 min-w-0">
+          <span className="font-medium">Get the CHQ Calendar app</span>
+          <span className="hidden sm:inline"> — reminders, Home Screen widgets, and a map of the grounds.</span>
+        </p>
+        <button
+          type="button"
+          onClick={handleOpen}
+          className="shrink-0 px-3 py-1 text-sm font-medium bg-white text-blue-700 rounded-md hover:bg-blue-50 transition-colors"
+        >
+          Open in app
+        </button>
+        <a
+          href={APP_STORE_URL}
+          className="shrink-0 hidden sm:inline text-sm underline underline-offset-2 hover:text-blue-100"
+        >
+          App Store
+        </a>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss"
+          className="shrink-0 p-1 -mr-1 text-white/80 hover:text-white transition-colors"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
@@ -44,4 +44,17 @@ describe('Header "Get the app" affordance', () => {
     // One in the desktop nav, one in the now-open dropdown.
     expect(screen.getAllByRole('link', { name: 'Get the app' })).toHaveLength(2);
   });
+
+  // Collapsing the menu would unmount this anchor from inside its own click
+  // handler, which can cancel the navigation to the App Store — so unlike the
+  // quick links, this entry deliberately leaves the dropdown open.
+  it('leaves the mobile dropdown open when its link is clicked', () => {
+    available.mockReturnValue(true);
+    render(<Header {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /More/ }));
+    const inDropdown = screen.getAllByRole('link', { name: 'Get the app' })[1];
+    fireEvent.click(inDropdown);
+    // Still two: the dropdown never collapsed, so its copy survived the click.
+    expect(screen.getAllByRole('link', { name: 'Get the app' })).toHaveLength(2);
+  });
 });

--- a/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/preact';
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact';
 
 const { available } = vi.hoisted(() => ({
   available: vi.fn(),
@@ -45,16 +45,20 @@ describe('Header "Get the app" affordance', () => {
     expect(screen.getAllByRole('link', { name: 'Get the app' })).toHaveLength(2);
   });
 
-  // Collapsing the menu would unmount this anchor from inside its own click
-  // handler, which can cancel the navigation to the App Store — so unlike the
-  // quick links, this entry deliberately leaves the dropdown open.
-  it('leaves the mobile dropdown open when its link is clicked', () => {
+  // Collapsing the menu during the click would unmount this anchor from inside
+  // its own click handler, which can cancel the navigation to the App Store.
+  // Unlike the quick links, this entry closes on the next task instead.
+  it('keeps the dropdown open through the click, then closes it', async () => {
     available.mockReturnValue(true);
     render(<Header {...props} />);
     fireEvent.click(screen.getByRole('button', { name: /More/ }));
     const inDropdown = screen.getAllByRole('link', { name: 'Get the app' })[1];
     fireEvent.click(inDropdown);
-    // Still two: the dropdown never collapsed, so its copy survived the click.
+    // Still two: the dropdown had not collapsed by the time the click resolved.
     expect(screen.getAllByRole('link', { name: 'Get the app' })).toHaveLength(2);
+    // Only the desktop-nav copy survives once the deferred close runs.
+    await waitFor(() => {
+      expect(screen.getAllByRole('link', { name: 'Get the app' })).toHaveLength(1);
+    });
   });
 });

--- a/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/preact';
+
+const { available, launch } = vi.hoisted(() => ({
+  available: vi.fn(),
+  launch: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@/lib/iosPromo', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/iosPromo')>();
+  return { ...actual, isAppLaunchAvailable: available, launchApp: launch };
+});
+
+import { Header } from '../Header';
+
+const props = { selectedYear: 2026, availableYears: [2026], defaultYear: 2026, onYearChange: () => {} };
+
+beforeEach(() => {
+  available.mockReset();
+  launch.mockReset();
+  launch.mockReturnValue(vi.fn());
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('Header "Open in app" affordance', () => {
+  it('is absent on ineligible devices', () => {
+    available.mockReturnValue(false);
+    render(<Header {...props} />);
+    expect(screen.queryByRole('button', { name: 'Open in app' })).toBeNull();
+  });
+
+  it('appears in the desktop nav on eligible devices and launches the app', () => {
+    available.mockReturnValue(true);
+    render(<Header {...props} />);
+    // Desktop nav button (the mobile dropdown is collapsed until "More").
+    fireEvent.click(screen.getByRole('button', { name: 'Open in app' }));
+    expect(launch).toHaveBeenCalledTimes(1);
+  });
+
+  it('appears in the mobile dropdown on eligible devices', () => {
+    available.mockReturnValue(true);
+    render(<Header {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /More/ }));
+    // One in the desktop nav, one in the now-open dropdown.
+    expect(screen.getAllByRole('button', { name: 'Open in app' })).toHaveLength(2);
+  });
+});

--- a/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.iosPromo.test.tsx
@@ -1,41 +1,40 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/preact';
 
-const { available, launch } = vi.hoisted(() => ({
+const { available } = vi.hoisted(() => ({
   available: vi.fn(),
-  launch: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('@/lib/iosPromo', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/iosPromo')>();
-  return { ...actual, isAppLaunchAvailable: available, launchApp: launch };
+  return { ...actual, isAppPromoAvailable: available };
 });
 
 import { Header } from '../Header';
+import { APP_STORE_URL } from '@/lib/constants';
 
 const props = { selectedYear: 2026, availableYears: [2026], defaultYear: 2026, onYearChange: () => {} };
 
 beforeEach(() => {
   available.mockReset();
-  launch.mockReset();
-  launch.mockReturnValue(vi.fn());
 });
 
 afterEach(() => { vi.restoreAllMocks(); });
 
-describe('Header "Open in app" affordance', () => {
+describe('Header "Get the app" affordance', () => {
   it('is absent on ineligible devices', () => {
     available.mockReturnValue(false);
     render(<Header {...props} />);
-    expect(screen.queryByRole('button', { name: 'Open in app' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Get the app' })).toBeNull();
   });
 
-  it('appears in the desktop nav on eligible devices and launches the app', () => {
+  it('appears in the desktop nav on eligible devices, linking to the App Store', () => {
     available.mockReturnValue(true);
     render(<Header {...props} />);
-    // Desktop nav button (the mobile dropdown is collapsed until "More").
-    fireEvent.click(screen.getByRole('button', { name: 'Open in app' }));
-    expect(launch).toHaveBeenCalledTimes(1);
+    // Desktop nav link (the mobile dropdown is collapsed until "More").
+    const link = screen.getByRole('link', { name: 'Get the app' }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe(APP_STORE_URL);
+    expect(link.getAttribute('href')).not.toContain('chqcal://');
   });
 
   it('appears in the mobile dropdown on eligible devices', () => {
@@ -43,6 +42,6 @@ describe('Header "Open in app" affordance', () => {
     render(<Header {...props} />);
     fireEvent.click(screen.getByRole('button', { name: /More/ }));
     // One in the desktop nav, one in the now-open dropdown.
-    expect(screen.getAllByRole('button', { name: 'Open in app' })).toHaveLength(2);
+    expect(screen.getAllByRole('link', { name: 'Get the app' })).toHaveLength(2);
   });
 });

--- a/frontend/src/components/layout/__tests__/IosAppBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/IosAppBanner.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/preact';
+
+const { shouldShow, snooze, launch } = vi.hoisted(() => ({
+  shouldShow: vi.fn(),
+  snooze: vi.fn(),
+  launch: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('@/lib/iosPromo', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/iosPromo')>();
+  return { ...actual, shouldShowPromoBanner: shouldShow, snoozePromo: snooze, launchApp: launch };
+});
+
+import { IosAppBanner } from '../IosAppBanner';
+import { APP_STORE_URL } from '@/app/about/aboutContent';
+
+beforeEach(() => {
+  shouldShow.mockReset();
+  snooze.mockReset();
+  launch.mockReset();
+  launch.mockReturnValue(vi.fn());
+});
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('IosAppBanner', () => {
+  it('renders nothing when the promo should not show', () => {
+    shouldShow.mockReturnValue(false);
+    const { container } = render(<IosAppBanner />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the prompt and a live App Store link when eligible', () => {
+    shouldShow.mockReturnValue(true);
+    render(<IosAppBanner />);
+    expect(screen.getByText(/Get the CHQ Calendar app/)).toBeTruthy();
+    const link = screen.getByRole('link', { name: 'App Store' }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe(APP_STORE_URL);
+    expect(APP_STORE_URL).not.toBe('');
+  });
+
+  it('"Open in app" launches the app, snoozes, and hides the banner', () => {
+    shouldShow.mockReturnValue(true);
+    const { container } = render(<IosAppBanner />);
+    fireEvent.click(screen.getByRole('button', { name: 'Open in app' }));
+    expect(launch).toHaveBeenCalledTimes(1);
+    expect(snooze).toHaveBeenCalledTimes(1);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dismiss snoozes and hides without launching', () => {
+    shouldShow.mockReturnValue(true);
+    const { container } = render(<IosAppBanner />);
+    fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+    expect(snooze).toHaveBeenCalledTimes(1);
+    expect(launch).not.toHaveBeenCalled();
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/components/layout/__tests__/IosAppBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/IosAppBanner.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/preact';
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact';
 
 const { shouldShow, snooze } = vi.hoisted(() => ({
   shouldShow: vi.fn(),
@@ -48,14 +48,17 @@ describe('IosAppBanner', () => {
     expect(link.getAttribute('href')).not.toContain('chqcal://');
   });
 
-  // The CTA snoozes but must NOT unmount itself: removing the anchor from
-  // inside its own click handler can cancel the navigation to the App Store.
-  it('taking the CTA snoozes and leaves the link in place to navigate', () => {
+  // The CTA snoozes but must NOT unmount itself during the click: removing the
+  // anchor from inside its own click handler can cancel the navigation to the
+  // App Store. It hides on the next task instead, so a user returning from the
+  // App Store (iOS keeps this page loaded) doesn't see a banner they acted on.
+  it('taking the CTA snoozes, leaves the link to navigate, then hides', async () => {
     shouldShow.mockReturnValue(true);
-    render(<IosAppBanner />);
+    const { container } = render(<IosAppBanner />);
     fireEvent.click(screen.getByRole('link', { name: 'Get the app' }));
     expect(snooze).toHaveBeenCalledTimes(1);
     expect(screen.getByRole('link', { name: 'Get the app' })).toBeTruthy();
+    await waitFor(() => { expect(container.firstChild).toBeNull(); });
   });
 
   it('dismiss snoozes and hides the banner', () => {

--- a/frontend/src/components/layout/__tests__/IosAppBanner.test.tsx
+++ b/frontend/src/components/layout/__tests__/IosAppBanner.test.tsx
@@ -1,25 +1,22 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/preact';
 
-const { shouldShow, snooze, launch } = vi.hoisted(() => ({
+const { shouldShow, snooze } = vi.hoisted(() => ({
   shouldShow: vi.fn(),
   snooze: vi.fn(),
-  launch: vi.fn(() => vi.fn()),
 }));
 
 vi.mock('@/lib/iosPromo', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/iosPromo')>();
-  return { ...actual, shouldShowPromoBanner: shouldShow, snoozePromo: snooze, launchApp: launch };
+  return { ...actual, shouldShowPromoBanner: shouldShow, snoozePromo: snooze };
 });
 
 import { IosAppBanner } from '../IosAppBanner';
-import { APP_STORE_URL } from '@/app/about/aboutContent';
+import { APP_STORE_URL } from '@/lib/constants';
 
 beforeEach(() => {
   shouldShow.mockReset();
   snooze.mockReset();
-  launch.mockReset();
-  launch.mockReturnValue(vi.fn());
 });
 
 afterEach(() => { vi.restoreAllMocks(); });
@@ -35,26 +32,37 @@ describe('IosAppBanner', () => {
     shouldShow.mockReturnValue(true);
     render(<IosAppBanner />);
     expect(screen.getByText(/Get the CHQ Calendar app/)).toBeTruthy();
-    const link = screen.getByRole('link', { name: 'App Store' }) as HTMLAnchorElement;
+    const link = screen.getByRole('link', { name: 'Get the app' }) as HTMLAnchorElement;
     expect(link.getAttribute('href')).toBe(APP_STORE_URL);
     expect(APP_STORE_URL).not.toBe('');
   });
 
-  it('"Open in app" launches the app, snoozes, and hides the banner', () => {
+  // The CTA must stay a plain link: navigating to the app's chqcal:// scheme
+  // instead raises Safari's "the address is invalid" alert for every visitor
+  // who doesn't have the app — the banner's whole audience.
+  it('points the CTA straight at the App Store, not a custom scheme', () => {
     shouldShow.mockReturnValue(true);
-    const { container } = render(<IosAppBanner />);
-    fireEvent.click(screen.getByRole('button', { name: 'Open in app' }));
-    expect(launch).toHaveBeenCalledTimes(1);
-    expect(snooze).toHaveBeenCalledTimes(1);
-    expect(container.firstChild).toBeNull();
+    render(<IosAppBanner />);
+    const link = screen.getByRole('link', { name: 'Get the app' }) as HTMLAnchorElement;
+    expect(link.getAttribute('href')?.startsWith('https://apps.apple.com/')).toBe(true);
+    expect(link.getAttribute('href')).not.toContain('chqcal://');
   });
 
-  it('dismiss snoozes and hides without launching', () => {
+  // The CTA snoozes but must NOT unmount itself: removing the anchor from
+  // inside its own click handler can cancel the navigation to the App Store.
+  it('taking the CTA snoozes and leaves the link in place to navigate', () => {
+    shouldShow.mockReturnValue(true);
+    render(<IosAppBanner />);
+    fireEvent.click(screen.getByRole('link', { name: 'Get the app' }));
+    expect(snooze).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('link', { name: 'Get the app' })).toBeTruthy();
+  });
+
+  it('dismiss snoozes and hides the banner', () => {
     shouldShow.mockReturnValue(true);
     const { container } = render(<IosAppBanner />);
     fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
     expect(snooze).toHaveBeenCalledTimes(1);
-    expect(launch).not.toHaveBeenCalled();
     expect(container.firstChild).toBeNull();
   });
 });

--- a/frontend/src/lib/__tests__/iosPromo.test.ts
+++ b/frontend/src/lib/__tests__/iosPromo.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  detectIosEligibility,
+  isSnoozed,
+  snoozePromo,
+  shouldShowPromoBanner,
+  isAppLaunchAvailable,
+  resolveDeepLink,
+  launchApp,
+  readDeviceInfo,
+  IOS_PROMO_SNOOZE_KEY,
+  type DeviceInfo,
+} from '@/lib/iosPromo';
+import { IOS_PROMO_SNOOZE_MS } from '@/lib/constants';
+
+const IPHONE_18: DeviceInfo = {
+  userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Mobile/15E148 Safari/604.1',
+  platform: 'iPhone',
+  maxTouchPoints: 5,
+  standalone: false,
+};
+
+const IPHONE_17: DeviceInfo = {
+  ...IPHONE_18,
+  userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Version/17.5 Mobile/15E148 Safari/604.1',
+};
+
+const IPAD_DESKTOP: DeviceInfo = {
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+  platform: 'MacIntel',
+  maxTouchPoints: 5,
+  standalone: false,
+};
+
+const MAC_DESKTOP: DeviceInfo = {
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+  platform: 'MacIntel',
+  maxTouchPoints: 0,
+  standalone: false,
+};
+
+const ANDROID: DeviceInfo = {
+  userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Mobile Safari/537.36',
+  platform: 'Linux armv8l',
+  maxTouchPoints: 5,
+  standalone: false,
+};
+
+describe('detectIosEligibility', () => {
+  it('accepts an iPhone on iOS 18', () => {
+    const r = detectIosEligibility(IPHONE_18);
+    expect(r).toMatchObject({ isIos: true, version: 18, eligible: true });
+  });
+
+  it('rejects an iPhone on iOS 17', () => {
+    const r = detectIosEligibility(IPHONE_17);
+    expect(r).toMatchObject({ isIos: true, version: 17, eligible: false });
+  });
+
+  it('accepts iPadOS reporting itself as desktop Safari (version unknown)', () => {
+    const r = detectIosEligibility(IPAD_DESKTOP);
+    expect(r).toMatchObject({ isIos: true, version: null, eligible: true });
+  });
+
+  it('rejects a real Mac desktop (no touch)', () => {
+    expect(detectIosEligibility(MAC_DESKTOP).eligible).toBe(false);
+  });
+
+  it('rejects Android', () => {
+    expect(detectIosEligibility(ANDROID)).toMatchObject({ isIos: false, eligible: false });
+  });
+
+  it('rejects an eligible device already running as an installed app', () => {
+    expect(detectIosEligibility({ ...IPHONE_18, standalone: true }).eligible).toBe(false);
+  });
+});
+
+describe('snooze', () => {
+  let store: Record<string, string>;
+  const storage = {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+  };
+
+  beforeEach(() => { store = {}; });
+
+  it('is not snoozed with nothing stored', () => {
+    expect(isSnoozed(1000, storage)).toBe(false);
+  });
+
+  it('snoozePromo writes now + IOS_PROMO_SNOOZE_MS', () => {
+    snoozePromo(1000, storage);
+    expect(store[IOS_PROMO_SNOOZE_KEY]).toBe(String(1000 + IOS_PROMO_SNOOZE_MS));
+  });
+
+  it('is snoozed within the window and clears after it', () => {
+    snoozePromo(1000, storage);
+    expect(isSnoozed(1000 + IOS_PROMO_SNOOZE_MS - 1, storage)).toBe(true);
+    expect(isSnoozed(1000 + IOS_PROMO_SNOOZE_MS, storage)).toBe(false);
+    expect(isSnoozed(1000 + IOS_PROMO_SNOOZE_MS + 1, storage)).toBe(false);
+  });
+
+  it('ignores a corrupt stored value', () => {
+    store[IOS_PROMO_SNOOZE_KEY] = 'not-a-number';
+    expect(isSnoozed(1000, storage)).toBe(false);
+  });
+});
+
+describe('shouldShowPromoBanner / isAppLaunchAvailable', () => {
+  const storage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+
+  it('shows for an eligible device that has not snoozed', () => {
+    expect(shouldShowPromoBanner(IPHONE_18, 1000, storage)).toBe(true);
+  });
+
+  it('hides for an ineligible device', () => {
+    expect(shouldShowPromoBanner(ANDROID, 1000, storage)).toBe(false);
+    expect(isAppLaunchAvailable(ANDROID)).toBe(false);
+  });
+
+  it('hides the banner while snoozed but keeps launch available', () => {
+    const snoozed = {
+      getItem: () => String(2000 + IOS_PROMO_SNOOZE_MS),
+      setItem: () => {},
+      removeItem: () => {},
+    };
+    expect(shouldShowPromoBanner(IPHONE_18, 2000, snoozed)).toBe(false);
+    expect(isAppLaunchAvailable(IPHONE_18)).toBe(true);
+  });
+});
+
+describe('resolveDeepLink', () => {
+  it('defaults to my-day with no context', () => {
+    expect(resolveDeepLink()).toBe('chqcal://my-day');
+  });
+
+  it('targets an event when given an id', () => {
+    expect(resolveDeepLink({ eventId: '101037' })).toBe('chqcal://event/101037');
+  });
+
+  it('encodes an id and ignores an empty one', () => {
+    expect(resolveDeepLink({ eventId: 'a b' })).toBe('chqcal://event/a%20b');
+    expect(resolveDeepLink({ eventId: '' })).toBe('chqcal://my-day');
+  });
+});
+
+describe('launchApp', () => {
+  function makeDoc(visibilityState: DocumentVisibilityState) {
+    const listeners: Record<string, Array<() => void>> = {};
+    return {
+      visibilityState,
+      addEventListener: (t: string, fn: () => void) => {
+        (listeners[t] ??= []).push(fn);
+      },
+      removeEventListener: (t: string, fn: () => void) => {
+        listeners[t] = (listeners[t] ?? []).filter((f) => f !== fn);
+      },
+      fire: (t: string) => (listeners[t] ?? []).forEach((f) => f()),
+      count: (t: string) => (listeners[t] ?? []).length,
+    };
+  }
+
+  it('fires the deep link, then redirects to the App Store when still visible', () => {
+    const doc = makeDoc('visible');
+    const navigate = vi.fn();
+    let timerFn: (() => void) | null = null;
+    launchApp({
+      deepLink: 'chqcal://my-day',
+      appStoreUrl: 'https://apps.apple.com/app/id1',
+      doc,
+      navigate,
+      setTimer: (fn) => { timerFn = fn; return 1 as unknown as ReturnType<typeof setTimeout>; },
+      clearTimer: () => {},
+    });
+    expect(navigate).toHaveBeenNthCalledWith(1, 'chqcal://my-day');
+    timerFn!();
+    expect(navigate).toHaveBeenNthCalledWith(2, 'https://apps.apple.com/app/id1');
+  });
+
+  it('cancels the App Store fallback when the app takes over (page hidden)', () => {
+    const doc = makeDoc('visible');
+    const navigate = vi.fn();
+    const clearTimer = vi.fn();
+    launchApp({
+      deepLink: 'chqcal://my-day',
+      appStoreUrl: 'https://apps.apple.com/app/id1',
+      doc,
+      navigate,
+      setTimer: () => 1 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer,
+    });
+    doc.visibilityState = 'hidden';
+    doc.fire('visibilitychange');
+    expect(clearTimer).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledTimes(1); // only the deep link
+    expect(doc.count('visibilitychange')).toBe(0); // listener removed
+  });
+
+  it('cleanup cancels a pending fallback and detaches listeners', () => {
+    const doc = makeDoc('visible');
+    const clearTimer = vi.fn();
+    const cleanup = launchApp({
+      deepLink: 'chqcal://my-day',
+      doc,
+      navigate: vi.fn(),
+      setTimer: () => 7 as unknown as ReturnType<typeof setTimeout>,
+      clearTimer,
+    });
+    cleanup();
+    expect(clearTimer).toHaveBeenCalledWith(7);
+    expect(doc.count('visibilitychange')).toBe(0);
+    expect(doc.count('pagehide')).toBe(0);
+  });
+});
+
+describe('readDeviceInfo', () => {
+  it('reads the live navigator without throwing', () => {
+    const info = readDeviceInfo();
+    expect(typeof info.userAgent).toBe('string');
+    expect(typeof info.standalone).toBe('boolean');
+  });
+});

--- a/frontend/src/lib/__tests__/iosPromo.test.ts
+++ b/frontend/src/lib/__tests__/iosPromo.test.ts
@@ -1,12 +1,10 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import {
   detectIosEligibility,
   isSnoozed,
   snoozePromo,
   shouldShowPromoBanner,
-  isAppLaunchAvailable,
-  resolveDeepLink,
-  launchApp,
+  isAppPromoAvailable,
   readDeviceInfo,
   IOS_PROMO_SNOOZE_KEY,
   type DeviceInfo,
@@ -107,7 +105,7 @@ describe('snooze', () => {
   });
 });
 
-describe('shouldShowPromoBanner / isAppLaunchAvailable', () => {
+describe('shouldShowPromoBanner / isAppPromoAvailable', () => {
   const storage = {
     getItem: () => null,
     setItem: () => {},
@@ -120,101 +118,17 @@ describe('shouldShowPromoBanner / isAppLaunchAvailable', () => {
 
   it('hides for an ineligible device', () => {
     expect(shouldShowPromoBanner(ANDROID, 1000, storage)).toBe(false);
-    expect(isAppLaunchAvailable(ANDROID)).toBe(false);
+    expect(isAppPromoAvailable(ANDROID)).toBe(false);
   });
 
-  it('hides the banner while snoozed but keeps launch available', () => {
+  it('hides the banner while snoozed but keeps the header link available', () => {
     const snoozed = {
       getItem: () => String(2000 + IOS_PROMO_SNOOZE_MS),
       setItem: () => {},
       removeItem: () => {},
     };
     expect(shouldShowPromoBanner(IPHONE_18, 2000, snoozed)).toBe(false);
-    expect(isAppLaunchAvailable(IPHONE_18)).toBe(true);
-  });
-});
-
-describe('resolveDeepLink', () => {
-  it('defaults to my-day with no context', () => {
-    expect(resolveDeepLink()).toBe('chqcal://my-day');
-  });
-
-  it('targets an event when given an id', () => {
-    expect(resolveDeepLink({ eventId: '101037' })).toBe('chqcal://event/101037');
-  });
-
-  it('encodes an id and ignores an empty one', () => {
-    expect(resolveDeepLink({ eventId: 'a b' })).toBe('chqcal://event/a%20b');
-    expect(resolveDeepLink({ eventId: '' })).toBe('chqcal://my-day');
-  });
-});
-
-describe('launchApp', () => {
-  function makeDoc(visibilityState: DocumentVisibilityState) {
-    const listeners: Record<string, Array<() => void>> = {};
-    return {
-      visibilityState,
-      addEventListener: (t: string, fn: () => void) => {
-        (listeners[t] ??= []).push(fn);
-      },
-      removeEventListener: (t: string, fn: () => void) => {
-        listeners[t] = (listeners[t] ?? []).filter((f) => f !== fn);
-      },
-      fire: (t: string) => (listeners[t] ?? []).forEach((f) => f()),
-      count: (t: string) => (listeners[t] ?? []).length,
-    };
-  }
-
-  it('fires the deep link, then redirects to the App Store when still visible', () => {
-    const doc = makeDoc('visible');
-    const navigate = vi.fn();
-    let timerFn: (() => void) | null = null;
-    launchApp({
-      deepLink: 'chqcal://my-day',
-      appStoreUrl: 'https://apps.apple.com/app/id1',
-      doc,
-      navigate,
-      setTimer: (fn) => { timerFn = fn; return 1 as unknown as ReturnType<typeof setTimeout>; },
-      clearTimer: () => {},
-    });
-    expect(navigate).toHaveBeenNthCalledWith(1, 'chqcal://my-day');
-    timerFn!();
-    expect(navigate).toHaveBeenNthCalledWith(2, 'https://apps.apple.com/app/id1');
-  });
-
-  it('cancels the App Store fallback when the app takes over (page hidden)', () => {
-    const doc = makeDoc('visible');
-    const navigate = vi.fn();
-    const clearTimer = vi.fn();
-    launchApp({
-      deepLink: 'chqcal://my-day',
-      appStoreUrl: 'https://apps.apple.com/app/id1',
-      doc,
-      navigate,
-      setTimer: () => 1 as unknown as ReturnType<typeof setTimeout>,
-      clearTimer,
-    });
-    doc.visibilityState = 'hidden';
-    doc.fire('visibilitychange');
-    expect(clearTimer).toHaveBeenCalled();
-    expect(navigate).toHaveBeenCalledTimes(1); // only the deep link
-    expect(doc.count('visibilitychange')).toBe(0); // listener removed
-  });
-
-  it('cleanup cancels a pending fallback and detaches listeners', () => {
-    const doc = makeDoc('visible');
-    const clearTimer = vi.fn();
-    const cleanup = launchApp({
-      deepLink: 'chqcal://my-day',
-      doc,
-      navigate: vi.fn(),
-      setTimer: () => 7 as unknown as ReturnType<typeof setTimeout>,
-      clearTimer,
-    });
-    cleanup();
-    expect(clearTimer).toHaveBeenCalledWith(7);
-    expect(doc.count('visibilitychange')).toBe(0);
-    expect(doc.count('pagehide')).toBe(0);
+    expect(isAppPromoAvailable(IPHONE_18)).toBe(true);
   });
 });
 

--- a/frontend/src/lib/__tests__/iosPromo.test.ts
+++ b/frontend/src/lib/__tests__/iosPromo.test.ts
@@ -23,11 +23,23 @@ const IPHONE_17: DeviceInfo = {
   userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 Version/17.5 Mobile/15E148 Safari/604.1',
 };
 
+// iPadOS in desktop mode drops the `OS <major>_` token; Safari's own
+// `Version/<major>` is the stand-in, since it tracks the OS major.
 const IPAD_DESKTOP: DeviceInfo = {
-  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.0 Safari/605.1.15',
   platform: 'MacIntel',
   maxTouchPoints: 5,
   standalone: false,
+};
+
+const IPAD_DESKTOP_17: DeviceInfo = {
+  ...IPAD_DESKTOP,
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+};
+
+const IPAD_DESKTOP_NO_VERSION: DeviceInfo = {
+  ...IPAD_DESKTOP,
+  userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Safari/605.1.15',
 };
 
 const MAC_DESKTOP: DeviceInfo = {
@@ -55,9 +67,28 @@ describe('detectIosEligibility', () => {
     expect(r).toMatchObject({ isIos: true, version: 17, eligible: false });
   });
 
-  it('accepts iPadOS reporting itself as desktop Safari (version unknown)', () => {
+  it('accepts iPadOS reporting itself as desktop Safari, via Safari\'s version', () => {
     const r = detectIosEligibility(IPAD_DESKTOP);
+    expect(r).toMatchObject({ isIos: true, version: 18, eligible: true });
+  });
+
+  it('rejects a desktop-mode iPad whose Safari version is below the minimum', () => {
+    const r = detectIosEligibility(IPAD_DESKTOP_17);
+    expect(r).toMatchObject({ isIos: true, version: 17, eligible: false });
+  });
+
+  // Fail open: a store page saying "requires a newer OS" is cheaper than
+  // hiding the app from a modern iPad we simply couldn't version-check.
+  it('accepts a desktop-mode iPad with no version token at all', () => {
+    const r = detectIosEligibility(IPAD_DESKTOP_NO_VERSION);
     expect(r).toMatchObject({ isIos: true, version: null, eligible: true });
+  });
+
+  // The Version/ fallback must not leak to non-iPad UAs: a touchless Mac
+  // reporting Safari 18 must stay ineligible.
+  it('does not treat a touchless Mac on Safari 18 as an iPad', () => {
+    const r = detectIosEligibility({ ...MAC_DESKTOP, userAgent: MAC_DESKTOP.userAgent.replace('Version/17.0', 'Version/18.0') });
+    expect(r).toMatchObject({ isIos: false, eligible: false });
   });
 
   it('rejects a real Mac desktop (no touch)', () => {

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,6 +1,10 @@
 export const CACHE_EXPIRY_MS = 3600000; // 1 hour in milliseconds
 export const USER_STATE_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
 export const LONG_PRESS_MS = 500;
+/** How long the iOS-app promo banner stays hidden after the user dismisses it. */
+export const IOS_PROMO_SNOOZE_MS = 5 * 24 * 60 * 60 * 1000; // 5 days in milliseconds
+/** Minimum iOS/iPadOS major version the native app supports (deployment target). */
+export const IOS_MIN_VERSION = 18;
 export const YEARS_MANIFEST_PATH = '/cache/calendar-cache/years.json';
 /**
  * Compute the default season year based on October 1 turnover.

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -5,6 +5,13 @@ export const LONG_PRESS_MS = 500;
 export const IOS_PROMO_SNOOZE_MS = 5 * 24 * 60 * 60 * 1000; // 5 days in milliseconds
 /** Minimum iOS/iPadOS major version the native app supports (deployment target). */
 export const IOS_MIN_VERSION = 18;
+/**
+ * The native app's App Store listing. Every promo surface is gated on this
+ * being non-empty, so clearing it turns the whole feature off. It lives here
+ * rather than in the /about page content so the calendar bundle doesn't pull
+ * in that page's copy dataset just to read one URL.
+ */
+export const APP_STORE_URL = 'https://apps.apple.com/us/app/chqcalendar/id6797027562';
 export const YEARS_MANIFEST_PATH = '/cache/calendar-cache/years.json';
 /**
  * Compute the default season year based on October 1 turnover.

--- a/frontend/src/lib/iosPromo.ts
+++ b/frontend/src/lib/iosPromo.ts
@@ -3,29 +3,25 @@
  *
  * The web calendar runs in every browser, but iPhone/iPad visitors on a
  * device that can run our app (iOS >= 18, the app's deployment target) get a
- * nudge toward it: launch the app if it's installed, or send them to the App
- * Store if it isn't, remembering a dismissal for a few days.
+ * nudge toward its App Store listing, and a dismissal is remembered for a few
+ * days.
  *
- * There is no reliable browser API that answers "is this native app
- * installed?" for a custom URL scheme, so `launchApp` uses the classic
- * scheme-with-timeout trick: fire the `chqcal://` deep link and, if the page
- * is still visible a beat later (the app never came to the foreground),
- * fall back to the App Store. Phase 2 (Universal Links) will make the launch
- * silent and remove the guesswork; until then this is gated behind an
- * explicit user tap so Safari allows the scheme navigation.
- *
- * The pure helpers here (eligibility, snooze, deep-link resolution) are unit
- * tested; the DOM-heavy `launchApp` is a thin wrapper with injectable seams.
+ * Every promo surface links straight to the App Store rather than trying the
+ * app's `chqcal://` scheme first. There is no browser API that answers "is
+ * this app installed?", and the classic scheme-with-timeout trick fails loudly
+ * for anyone who doesn't have it: iOS Safari shows a modal "the address is
+ * invalid" alert for an unregistered scheme (confirmed on a simulator with the
+ * app absent), which is exactly the audience a promo banner is aimed at. The
+ * App Store listing costs an installed user one extra tap — the store shows
+ * "Open" — and costs everyone else nothing. Universal Links (silent launch
+ * when installed, App Store otherwise) are the real fix and are tracked as the
+ * Phase 2 follow-up; they need an `applinks` entitlement and an app release.
  */
 
-import { APP_STORE_URL } from '@/app/about/aboutContent';
-import { IOS_MIN_VERSION, IOS_PROMO_SNOOZE_MS } from '@/lib/constants';
+import { APP_STORE_URL, IOS_MIN_VERSION, IOS_PROMO_SNOOZE_MS } from '@/lib/constants';
 
 /** localStorage key holding the epoch-ms until which the banner stays hidden. */
-export const IOS_PROMO_SNOOZE_KEY = 'chq:iosPromoSnoozeUntil';
-
-/** The app's custom URL scheme (see ios/ChqCalendar/Info.plist). */
-const DEEP_LINK_SCHEME = 'chqcal://';
+export const IOS_PROMO_SNOOZE_KEY = 'chq-calendar-ios-promo-snooze';
 
 export interface DeviceInfo {
   userAgent: string;
@@ -144,90 +140,7 @@ export function shouldShowPromoBanner(
   return !isSnoozed(now, storage);
 }
 
-/** Whether the always-available "Open in app" affordance should render. */
-export function isAppLaunchAvailable(device: DeviceInfo): boolean {
+/** Whether the always-available header link to the app should render. */
+export function isAppPromoAvailable(device: DeviceInfo): boolean {
   return APP_STORE_URL.length > 0 && detectIosEligibility(device).eligible;
-}
-
-/**
- * Map a web context to the closest in-app screen. Today the scheme covers
- * events, My Day, and the map; an unknown context opens the app's default
- * screen. `eventId` is the only context the calendar surfaces so far.
- */
-export function resolveDeepLink(context?: { eventId?: string | number }): string {
-  if (context?.eventId != null && context.eventId !== '') {
-    return `${DEEP_LINK_SCHEME}event/${encodeURIComponent(String(context.eventId))}`;
-  }
-  return `${DEEP_LINK_SCHEME}my-day`;
-}
-
-/** The slice of `document` `launchApp` touches — kept minimal so tests can
- *  supply a lightweight fake without reconstructing the DOM's overloads. */
-export interface DocLike {
-  visibilityState: DocumentVisibilityState;
-  addEventListener: (type: string, listener: () => void) => void;
-  removeEventListener: (type: string, listener: () => void) => void;
-}
-
-export interface LaunchOptions {
-  deepLink?: string;
-  appStoreUrl?: string;
-  timeoutMs?: number;
-  /** Injectable seams for testing. */
-  now?: () => number;
-  navigate?: (url: string) => void;
-  doc?: DocLike;
-  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
-  clearTimer?: (id: ReturnType<typeof setTimeout>) => void;
-}
-
-/**
- * Attempt to open the app via its custom scheme, falling back to the App Store
- * if the app doesn't take over the page within `timeoutMs`. Must be called
- * from a user gesture (Safari blocks non-gesture scheme navigations).
- *
- * Returns a cleanup function that cancels the pending fallback, so a caller
- * unmounting mid-launch doesn't fire a late redirect.
- */
-export function launchApp(options: LaunchOptions = {}): () => void {
-  const deepLink = options.deepLink ?? resolveDeepLink();
-  const appStoreUrl = options.appStoreUrl ?? APP_STORE_URL;
-  const timeoutMs = options.timeoutMs ?? 1200;
-  const navigate = options.navigate ?? ((url: string) => { window.location.assign(url); });
-  const doc = options.doc ?? (typeof document !== 'undefined' ? document : undefined);
-  const setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
-  const clearTimer = options.clearTimer ?? ((id) => clearTimeout(id));
-
-  let done = false;
-  const finish = () => {
-    if (done) return;
-    done = true;
-    clearTimer(timer);
-    doc?.removeEventListener('visibilitychange', onHide);
-    doc?.removeEventListener('pagehide', onHide);
-  };
-  // The app coming to the foreground hides/hidden-pages the web page; that's
-  // our signal it was installed, so cancel the App Store fallback.
-  const onHide = () => {
-    if (!doc || doc.visibilityState === 'hidden') finish();
-  };
-
-  const timer = setTimer(() => {
-    if (done) return;
-    done = true;
-    doc?.removeEventListener('visibilitychange', onHide);
-    doc?.removeEventListener('pagehide', onHide);
-    // Still visible → app never opened → send to the App Store.
-    if (!doc || doc.visibilityState === 'visible') {
-      if (appStoreUrl) navigate(appStoreUrl);
-    }
-  }, timeoutMs);
-
-  doc?.addEventListener('visibilitychange', onHide);
-  doc?.addEventListener('pagehide', onHide);
-
-  // Fire the deep link last so the listeners/timer are already armed.
-  navigate(deepLink);
-
-  return finish;
 }

--- a/frontend/src/lib/iosPromo.ts
+++ b/frontend/src/lib/iosPromo.ts
@@ -1,0 +1,233 @@
+/**
+ * Logic for promoting the native iOS app to eligible web visitors.
+ *
+ * The web calendar runs in every browser, but iPhone/iPad visitors on a
+ * device that can run our app (iOS >= 18, the app's deployment target) get a
+ * nudge toward it: launch the app if it's installed, or send them to the App
+ * Store if it isn't, remembering a dismissal for a few days.
+ *
+ * There is no reliable browser API that answers "is this native app
+ * installed?" for a custom URL scheme, so `launchApp` uses the classic
+ * scheme-with-timeout trick: fire the `chqcal://` deep link and, if the page
+ * is still visible a beat later (the app never came to the foreground),
+ * fall back to the App Store. Phase 2 (Universal Links) will make the launch
+ * silent and remove the guesswork; until then this is gated behind an
+ * explicit user tap so Safari allows the scheme navigation.
+ *
+ * The pure helpers here (eligibility, snooze, deep-link resolution) are unit
+ * tested; the DOM-heavy `launchApp` is a thin wrapper with injectable seams.
+ */
+
+import { APP_STORE_URL } from '@/app/about/aboutContent';
+import { IOS_MIN_VERSION, IOS_PROMO_SNOOZE_MS } from '@/lib/constants';
+
+/** localStorage key holding the epoch-ms until which the banner stays hidden. */
+export const IOS_PROMO_SNOOZE_KEY = 'chq:iosPromoSnoozeUntil';
+
+/** The app's custom URL scheme (see ios/ChqCalendar/Info.plist). */
+const DEEP_LINK_SCHEME = 'chqcal://';
+
+export interface DeviceInfo {
+  userAgent: string;
+  platform: string;
+  maxTouchPoints: number;
+  /** navigator.standalone — true when running as an installed home-screen app. */
+  standalone: boolean;
+}
+
+export interface IosEligibility {
+  /** iPhone/iPad/iPod, including iPadOS reporting itself as desktop Safari. */
+  isIos: boolean;
+  /** Parsed major iOS version, or null when the UA doesn't expose it. */
+  version: number | null;
+  /** True when we should offer the app: iOS >= 18 and not already app-like. */
+  eligible: boolean;
+}
+
+/** Read the current device's traits, tolerating a non-browser (SSR/test) env. */
+export function readDeviceInfo(): DeviceInfo {
+  if (typeof navigator === 'undefined') {
+    return { userAgent: '', platform: '', maxTouchPoints: 0, standalone: false };
+  }
+  return {
+    userAgent: navigator.userAgent ?? '',
+    platform: navigator.platform ?? '',
+    maxTouchPoints: navigator.maxTouchPoints ?? 0,
+    // `standalone` is a non-standard Safari-only flag; guard the access.
+    standalone: (navigator as unknown as { standalone?: boolean }).standalone === true,
+  };
+}
+
+/**
+ * Decide whether to promote the app to this device.
+ *
+ * iPadOS 13+ masquerades as desktop Safari ("MacIntel" + touch), which hides
+ * the version string. Such a device is a modern iPad, so we treat the unknown
+ * version as eligible: the worst case is a tap that lands on an App Store page
+ * telling the user the app needs a newer OS — no error dialog, no data cost.
+ * A UA that names iOS but carries no parseable version is treated as
+ * ineligible rather than guessed.
+ */
+export function detectIosEligibility(device: DeviceInfo): IosEligibility {
+  const { userAgent, platform, maxTouchPoints, standalone } = device;
+
+  const uaIsIos = /iPhone|iPod|iPad/.test(userAgent);
+  const ipadAsDesktop = platform === 'MacIntel' && maxTouchPoints > 1;
+  const isIos = uaIsIos || ipadAsDesktop;
+
+  const match = userAgent.match(/OS (\d+)_/);
+  const version = match ? parseInt(match[1], 10) : null;
+
+  let versionOk: boolean;
+  if (version !== null) {
+    versionOk = version >= IOS_MIN_VERSION;
+  } else {
+    // No version string: eligible only for iPad-as-desktop (a modern iPad).
+    versionOk = ipadAsDesktop;
+  }
+
+  const eligible = isIos && versionOk && !standalone;
+  return { isIos, version, eligible };
+}
+
+type MinimalStorage = Pick<Storage, 'getItem' | 'setItem' | 'removeItem'>;
+
+function safeStorage(storage?: MinimalStorage): MinimalStorage | null {
+  if (storage) return storage;
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    // Access can throw in private mode / sandboxed iframes.
+    return null;
+  }
+}
+
+/** True when the user dismissed the banner recently and it should stay hidden. */
+export function isSnoozed(now: number, storage?: MinimalStorage): boolean {
+  const store = safeStorage(storage);
+  if (!store) return false;
+  try {
+    const raw = store.getItem(IOS_PROMO_SNOOZE_KEY);
+    if (!raw) return false;
+    const until = Number(raw);
+    if (!Number.isFinite(until)) return false;
+    return now < until;
+  } catch {
+    return false;
+  }
+}
+
+/** Record a dismissal: hide the banner until `now + IOS_PROMO_SNOOZE_MS`. */
+export function snoozePromo(now: number, storage?: MinimalStorage): void {
+  const store = safeStorage(storage);
+  if (!store) return;
+  try {
+    store.setItem(IOS_PROMO_SNOOZE_KEY, String(now + IOS_PROMO_SNOOZE_MS));
+  } catch {
+    // Best-effort; a failed write just means the banner may reappear sooner.
+  }
+}
+
+/**
+ * Whether the promo banner should render right now: the app is live (App Store
+ * URL wired up), the device is eligible, and the user hasn't snoozed it.
+ * The persistent header affordance uses only the eligibility half of this.
+ */
+export function shouldShowPromoBanner(
+  device: DeviceInfo,
+  now: number,
+  storage?: MinimalStorage,
+): boolean {
+  if (!APP_STORE_URL) return false;
+  if (!detectIosEligibility(device).eligible) return false;
+  return !isSnoozed(now, storage);
+}
+
+/** Whether the always-available "Open in app" affordance should render. */
+export function isAppLaunchAvailable(device: DeviceInfo): boolean {
+  return APP_STORE_URL.length > 0 && detectIosEligibility(device).eligible;
+}
+
+/**
+ * Map a web context to the closest in-app screen. Today the scheme covers
+ * events, My Day, and the map; an unknown context opens the app's default
+ * screen. `eventId` is the only context the calendar surfaces so far.
+ */
+export function resolveDeepLink(context?: { eventId?: string | number }): string {
+  if (context?.eventId != null && context.eventId !== '') {
+    return `${DEEP_LINK_SCHEME}event/${encodeURIComponent(String(context.eventId))}`;
+  }
+  return `${DEEP_LINK_SCHEME}my-day`;
+}
+
+/** The slice of `document` `launchApp` touches — kept minimal so tests can
+ *  supply a lightweight fake without reconstructing the DOM's overloads. */
+export interface DocLike {
+  visibilityState: DocumentVisibilityState;
+  addEventListener: (type: string, listener: () => void) => void;
+  removeEventListener: (type: string, listener: () => void) => void;
+}
+
+export interface LaunchOptions {
+  deepLink?: string;
+  appStoreUrl?: string;
+  timeoutMs?: number;
+  /** Injectable seams for testing. */
+  now?: () => number;
+  navigate?: (url: string) => void;
+  doc?: DocLike;
+  setTimer?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimer?: (id: ReturnType<typeof setTimeout>) => void;
+}
+
+/**
+ * Attempt to open the app via its custom scheme, falling back to the App Store
+ * if the app doesn't take over the page within `timeoutMs`. Must be called
+ * from a user gesture (Safari blocks non-gesture scheme navigations).
+ *
+ * Returns a cleanup function that cancels the pending fallback, so a caller
+ * unmounting mid-launch doesn't fire a late redirect.
+ */
+export function launchApp(options: LaunchOptions = {}): () => void {
+  const deepLink = options.deepLink ?? resolveDeepLink();
+  const appStoreUrl = options.appStoreUrl ?? APP_STORE_URL;
+  const timeoutMs = options.timeoutMs ?? 1200;
+  const navigate = options.navigate ?? ((url: string) => { window.location.assign(url); });
+  const doc = options.doc ?? (typeof document !== 'undefined' ? document : undefined);
+  const setTimer = options.setTimer ?? ((fn, ms) => setTimeout(fn, ms));
+  const clearTimer = options.clearTimer ?? ((id) => clearTimeout(id));
+
+  let done = false;
+  const finish = () => {
+    if (done) return;
+    done = true;
+    clearTimer(timer);
+    doc?.removeEventListener('visibilitychange', onHide);
+    doc?.removeEventListener('pagehide', onHide);
+  };
+  // The app coming to the foreground hides/hidden-pages the web page; that's
+  // our signal it was installed, so cancel the App Store fallback.
+  const onHide = () => {
+    if (!doc || doc.visibilityState === 'hidden') finish();
+  };
+
+  const timer = setTimer(() => {
+    if (done) return;
+    done = true;
+    doc?.removeEventListener('visibilitychange', onHide);
+    doc?.removeEventListener('pagehide', onHide);
+    // Still visible → app never opened → send to the App Store.
+    if (!doc || doc.visibilityState === 'visible') {
+      if (appStoreUrl) navigate(appStoreUrl);
+    }
+  }, timeoutMs);
+
+  doc?.addEventListener('visibilitychange', onHide);
+  doc?.addEventListener('pagehide', onHide);
+
+  // Fire the deep link last so the listeners/timer are already armed.
+  navigate(deepLink);
+
+  return finish;
+}

--- a/frontend/src/lib/iosPromo.ts
+++ b/frontend/src/lib/iosPromo.ts
@@ -34,7 +34,8 @@ export interface DeviceInfo {
 export interface IosEligibility {
   /** iPhone/iPad/iPod, including iPadOS reporting itself as desktop Safari. */
   isIos: boolean;
-  /** Parsed major iOS version, or null when the UA doesn't expose it. */
+  /** Parsed major iOS version, or null when the UA doesn't expose it. For an
+   *  iPad in desktop mode this is Safari's major, which tracks the OS major. */
   version: number | null;
   /** True when we should offer the app: iOS >= 18 and not already app-like. */
   eligible: boolean;
@@ -57,12 +58,17 @@ export function readDeviceInfo(): DeviceInfo {
 /**
  * Decide whether to promote the app to this device.
  *
- * iPadOS 13+ masquerades as desktop Safari ("MacIntel" + touch), which hides
- * the version string. Such a device is a modern iPad, so we treat the unknown
- * version as eligible: the worst case is a tap that lands on an App Store page
- * telling the user the app needs a newer OS — no error dialog, no data cost.
- * A UA that names iOS but carries no parseable version is treated as
- * ineligible rather than guessed.
+ * iPadOS 13+ masquerades as desktop Safari ("MacIntel" + touch), which drops
+ * the `OS <major>_` token. Safari still reports its own `Version/<major>`
+ * there, and Safari's major version has tracked the OS major since iOS 15, so
+ * that stands in as the version signal for this case.
+ *
+ * When neither token parses we stay eligible for iPad-as-desktop and fall back
+ * to ineligible everywhere else. That asymmetry is deliberate: showing the
+ * promo to an iPad we couldn't version-check costs one tap onto a store page
+ * that says the app needs a newer OS, while hiding it from a modern iPad costs
+ * an install we never hear about. A UA that names iOS but carries no version
+ * is a narrower, weirder case, so it stays ineligible rather than guessed.
  */
 export function detectIosEligibility(device: DeviceInfo): IosEligibility {
   const { userAgent, platform, maxTouchPoints, standalone } = device;
@@ -71,14 +77,16 @@ export function detectIosEligibility(device: DeviceInfo): IosEligibility {
   const ipadAsDesktop = platform === 'MacIntel' && maxTouchPoints > 1;
   const isIos = uaIsIos || ipadAsDesktop;
 
-  const match = userAgent.match(/OS (\d+)_/);
-  const version = match ? parseInt(match[1], 10) : null;
+  const osMatch = userAgent.match(/OS (\d+)_/);
+  const safariMatch = ipadAsDesktop ? userAgent.match(/Version\/(\d+)/) : null;
+  const versionMatch = osMatch ?? safariMatch;
+  const version = versionMatch ? parseInt(versionMatch[1], 10) : null;
 
   let versionOk: boolean;
   if (version !== null) {
     versionOk = version >= IOS_MIN_VERSION;
   } else {
-    // No version string: eligible only for iPad-as-desktop (a modern iPad).
+    // Nothing to check: eligible only for iPad-as-desktop (see above).
     versionOk = ipadAsDesktop;
   }
 


### PR DESCRIPTION
iPhone/iPad visitors on iOS 18+ (the app's deployment target) now see a
dismissible banner inviting them into the native app, alongside a persistent
"Get the app" entry in the header for eligible devices that survives a
dismissal. Both link straight to the App Store listing. Dismissing snoozes the
banner for a few days.

- `iosPromo.ts`: pure eligibility detection (UA + iPadOS-as-desktop, version
  gate), snooze read/write, and the two render gates.
- `IosAppBanner` mounted on the calendar page; `Header` gains the always-on
  affordance for eligible devices.
- Wire the now-live `APP_STORE_URL` (in `lib/constants`), which the whole
  feature is gated on.

### Why not the `chqcal://` deep link

The first pass fired the app's custom scheme and fell back to the App Store
1200 ms later if the page was still visible. On-device testing killed it: iOS
Safari answers an unregistered scheme with a modal *"Safari cannot open the
page because the address is invalid"* alert, and the modal swallows the pending
fallback. That hits everyone who doesn't already have the app — the entire
audience the banner exists for.

Linking to the App Store costs an installed user one extra tap (the store shows
"Open") and costs everyone else nothing. Universal Links are the real fix and
stay the Phase 2 follow-up; they need an `applinks` entitlement and an app
release, so they can't fix this today.

Phase 1 of #223.