### PR TITLE
refactor(web): derive one date window instead of four date predicates

### DIFF
--- a/docs/superpowers/plans/2026-08-15-date-navigation-phase-1b-ios-window-model.md
+++ b/docs/superpowers/plans/2026-08-15-date-navigation-phase-1b-ios-window-model.md
@@ -946,6 +946,13 @@ nonisolated struct ViewWindow: Equatable, Sendable {
     /// end keeps the base window's exact instant: that is what preserves
     /// `.next`'s one-hour grace and `.thisWeek`'s noon boundaries until the
     /// user actually navigates past them.
+    ///
+    /// `bounds` clamps the *expansion inputs*, before they are merged with
+    /// `base` — never the merged result. The bounds limit how far navigation
+    /// can reach; they say nothing about a scope the user hasn't navigated,
+    /// and `base` can legitimately sit outside them (off-season `.today`,
+    /// most of the year). Clamping the merged result instead of the inputs
+    /// would invert the window (`startDay > endDay`) whenever that happens.
     static func make(
         selection: FilterSelection,
         events: [Event],
@@ -959,12 +966,19 @@ nonisolated struct ViewWindow: Equatable, Sendable {
             year: year, isCurrentYear: isCurrentYear, bounds: bounds)
         else { return nil }
 
+        var expandedStartDayKey = selection.windowStartDayKey
+        if let expanded = expandedStartDayKey, expanded < bounds.lowerBound {
+            expandedStartDayKey = bounds.lowerBound
+        }
+        var expandedEndDayKey = selection.windowEndDayKey
+        if let expanded = expandedEndDayKey, expanded > bounds.upperBound {
+            expandedEndDayKey = bounds.upperBound
+        }
+
         var startDay = base.startDay
         var endDay = base.endDay
-        if let expanded = selection.windowStartDayKey, expanded < startDay { startDay = expanded }
-        if let expanded = selection.windowEndDayKey, expanded > endDay { endDay = expanded }
-        if startDay < bounds.lowerBound { startDay = bounds.lowerBound }
-        if endDay > bounds.upperBound { endDay = bounds.upperBound }
+        if let expanded = expandedStartDayKey, expanded < startDay { startDay = expanded }
+        if let expanded = expandedEndDayKey, expanded > endDay { endDay = expanded }
 
         let start: Date
         if startDay == base.startDay {
@@ -979,7 +993,10 @@ nonisolated struct ViewWindow: Equatable, Sendable {
             ? base.endExclusive
             : (dayAfter(endDay) ?? base.endExclusive)
 
-        guard start < endExclusive else { return nil }
+        // No `guard start < endExclusive` here: unlike the clamp-after-merge
+        // form this replaced, expansion only ever widens outward from a
+        // `base` that is already a valid (non-empty) range, so `start` can
+        // never cross `endExclusive`.
         return ViewWindow(startDay: startDay, endDay: endDay, range: start..<endExclusive)
     }
 

--- a/docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md
+++ b/docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md
@@ -136,20 +136,24 @@ Base window, by scope:
 | weeks *n…m* | week *n* start → week *m* end |
 | `day` (iOS only) | that day → that day |
 
-Then:
+Then, clamp the *expansion inputs* — not the merged result — to
+**navigable bounds** = the season, widened to contain every day that has
+an event (web) and every starred day (iOS —
+`DayWindow.bounds(year:starredDays:)` already does exactly this widening):
 
 ```
+expandedStart = clamp(expandedStart, to: navigableBounds)
+expandedEnd   = clamp(expandedEnd,   to: navigableBounds)
+
 start = min(base.start, expandedStart)
 end   = max(base.end,   expandedEnd)
 ```
 
-clamped to **navigable bounds** = the season, widened to contain every day
-that has an event (web) and every starred day (iOS —
-`DayWindow.bounds(year:starredDays:)` already does exactly this widening).
-
-Because those bounds contain every event day by construction, the clamp is
-a no-op for `all` and a real constraint only for the scopes that can be
-expanded past a season edge.
+The clamp has to land before the merge: the bounds limit how far
+*navigation* can reach, and say nothing about a scope the user hasn't
+navigated. Clamping the merged result instead inverts the window
+(`start > end`) whenever the base window itself sits outside the bounds —
+which off-season `now`/`today` does for most of the year.
 
 **The list renders exactly the events inside this window. Nothing else.**
 

--- a/frontend/src/__tests__/hooks/useFilterState.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterState.test.ts
@@ -193,15 +193,16 @@ describe('useFilterState', () => {
       expect(result.current.selectedLocations).toEqual(['Hall A']);
     });
 
-    it('clears extraDays on reconciliation', () => {
+    it('clears the date window on reconciliation', () => {
       const { result } = renderHook(() => useFilterState());
-      act(() => { result.current.addExtraDay(); });
-      act(() => { result.current.addExtraDay(); });
+      act(() => { result.current.expandWindowEnd('2026-07-16'); });
+      act(() => { result.current.expandWindowStart('2026-07-13'); });
 
       act(() => {
         result.current.reconcileFilters([], [], true);
       });
-      expect(result.current.extraDays).toBe(0);
+      expect(result.current.windowEndDay).toBeNull();
+      expect(result.current.windowStartDay).toBeNull();
     });
 
     it('preserves searchTerm on reconciliation', () => {

--- a/frontend/src/__tests__/hooks/useFilterState.window.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterState.window.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useFilterState } from '@/hooks/useFilterState';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useFilterState window bounds', () => {
+  it('starts with no expansion', () => {
+    const { result } = renderHook(() => useFilterState());
+    expect(result.current.windowStartDay).toBeNull();
+    expect(result.current.windowEndDay).toBeNull();
+  });
+
+  it('records an expanded end', () => {
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    expect(result.current.windowEndDay).toBe('2026-07-17');
+  });
+
+  it('records an expanded start', () => {
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowStart('2026-07-13'));
+    expect(result.current.windowStartDay).toBe('2026-07-13');
+  });
+
+  it('clears both bounds when the date filter changes', () => {
+    // Replaces the old "reset extraDays on dateFilter change" effect.
+    // Without this, widening the window twice, switching scope, and
+    // switching back returns a window wider than a fresh selection with
+    // nothing on screen explaining why (#156 on iOS, same shape here).
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    act(() => result.current.setDateFilter('today'));
+    expect(result.current.windowEndDay).toBeNull();
+    expect(result.current.windowStartDay).toBeNull();
+  });
+
+  it('clears both bounds on resetWindow', () => {
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    act(() => result.current.expandWindowStart('2026-07-13'));
+    act(() => result.current.resetWindow());
+    expect(result.current.windowEndDay).toBeNull();
+    expect(result.current.windowStartDay).toBeNull();
+  });
+
+  it('clears both bounds on clearFilters', () => {
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    act(() => result.current.clearFilters());
+    expect(result.current.windowEndDay).toBeNull();
+  });
+
+  it('clears both bounds on reconcileFilters', () => {
+    // Year switching. A day key from 2026 means nothing in 2025.
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    act(() => result.current.reconcileFilters([], [], false));
+    expect(result.current.windowEndDay).toBeNull();
+  });
+
+  it('never persists the window to localStorage', () => {
+    // Session-only, matching iOS's selectedDayKey and extraDays. A date
+    // pinned days ago and silently restored on launch would be worse than
+    // no restore at all.
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    const saved = JSON.parse(localStorage.getItem('chq-calendar-user-state')!);
+    expect(saved).not.toHaveProperty('windowEndDay');
+    expect(saved).not.toHaveProperty('windowStartDay');
+    expect(saved).not.toHaveProperty('extraDays');
+  });
+});

--- a/frontend/src/__tests__/hooks/useFilterState.window.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterState.window.test.ts
@@ -37,6 +37,21 @@ describe('useFilterState window bounds', () => {
     expect(result.current.windowStartDay).toBeNull();
   });
 
+  it('keeps the window when the same date filter is dispatched again', () => {
+    // useScrollState dispatches setDateFilter('all') unconditionally from
+    // several handlers (mouse-down/drag/tap on the week strip), so a
+    // same-value dispatch is a real occurrence, not a hypothetical one.
+    // The reducer case fires on every dispatch (unlike the effect it
+    // replaced, which only fired on an actual change), so it must guard
+    // on the value being unchanged or it will silently discard the
+    // window the user just expanded.
+    const { result } = renderHook(() => useFilterState());
+    act(() => result.current.setDateFilter('all'));
+    act(() => result.current.expandWindowEnd('2026-07-17'));
+    act(() => result.current.setDateFilter('all'));
+    expect(result.current.windowEndDay).toBe('2026-07-17');
+  });
+
   it('clears both bounds on resetWindow', () => {
     const { result } = renderHook(() => useFilterState());
     act(() => result.current.expandWindowEnd('2026-07-17'));

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -9,8 +9,9 @@ import {
   navigableBounds,
   baseWindow,
   viewWindow,
+  windowContains,
 } from '@/lib/utils/dayWindow';
-import { getChautauquaSeasonWeeks, getCurrentWeekNumber } from '@/lib/utils/dateHelpers';
+import { getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
 import type { Event } from '@/lib/types';
 
 const seasonWeeks = getChautauquaSeasonWeeks(2026);
@@ -96,6 +97,44 @@ describe('navigableBounds', () => {
     const bounds = navigableBounds(seasonWeeks, []);
     expect(bounds.startDay).toBe(dayKeyOf(seasonWeeks[0].start));
     expect(bounds.endDay).toBe(dayKeyOf(seasonWeeks[8].end));
+  });
+
+  it('ignores an event with an unparseable date rather than poisoning the bound', () => {
+    // 'NaN-NaN-NaN' sorts above every real day key, so letting a bad row
+    // through would silently widen endDay for the whole app. Every other
+    // call site just drops the row; this one must match.
+    const events: Event[] = [
+      { id: 'good', title: 'good', startDate: new Date(2026, 6, 20, 9, 0).toISOString() } as Event,
+      { id: 'bad', title: 'bad', startDate: 'not-a-date' } as Event,
+    ];
+    const bounds = navigableBounds(seasonWeeks, events);
+    expect(bounds.startDay).toBe(dayKeyOf(seasonWeeks[0].start));
+    expect(bounds.endDay).toBe(dayKeyOf(seasonWeeks[8].end));
+  });
+});
+
+describe('windowContains', () => {
+  // A synthetic window is enough here: this is testing the half-open
+  // comparison itself, not any scope's derivation of start/endExclusive.
+  const w = {
+    startDay: '2026-07-15',
+    endDay: '2026-07-15',
+    start: new Date(2026, 6, 15, 0, 0, 0, 0),
+    endExclusive: new Date(2026, 6, 16, 0, 0, 0, 0),
+  };
+
+  it('contains an instant exactly at start', () => {
+    expect(windowContains(w, w.start)).toBe(true);
+  });
+
+  it('contains an instant strictly inside', () => {
+    expect(windowContains(w, new Date(2026, 6, 15, 12, 0, 0, 0))).toBe(true);
+  });
+
+  it('does not contain an instant exactly at endExclusive', () => {
+    // This is the half-openness the whole shared model exists to enforce:
+    // endExclusive belongs to the next window, not this one.
+    expect(windowContains(w, w.endExclusive)).toBe(false);
   });
 });
 
@@ -251,5 +290,24 @@ describe('viewWindow expansion', () => {
       expandedEndDay: '2026-12-31',
     });
     expect(w).toBeNull();
+  });
+
+  it("does not invert an off-season 'today' window", () => {
+    // The season runs roughly June-August 2026; this 'today' sits entirely
+    // outside `bounds` for the other ~10 months of the year — the app's
+    // normal state most of the time. `bounds` must clamp how far navigation
+    // can reach, not rewrite one edge of a scope's own window: doing the
+    // latter here would put startDay/endDay in December against endDay
+    // clamped back to the August season end, inverting the window.
+    const offSeasonNow = new Date(2026, 11, 25, 12, 0, 0, 0);
+    const w = viewWindow({
+      dateFilter: 'today',
+      seasonWeeks,
+      currentWeekNumber: null,
+      now: offSeasonNow,
+      bounds,
+    })!;
+    expect(w.startDay <= w.endDay).toBe(true);
+    expect(w.start.getTime()).toBeLessThan(w.endExclusive.getTime());
   });
 });

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect } from 'vitest';
+import {
+  dayKeyOf,
+  startOfDay,
+  dayAfter,
+  lastDayCovered,
+  addDays,
+  dayKeys,
+  navigableBounds,
+  baseWindow,
+  viewWindow,
+} from '@/lib/utils/dayWindow';
+import { getChautauquaSeasonWeeks, getCurrentWeekNumber } from '@/lib/utils/dateHelpers';
+import type { Event } from '@/lib/types';
+
+const seasonWeeks = getChautauquaSeasonWeeks(2026);
+
+function makeEvent(id: string, date: Date): Event {
+  return { id, title: id, startDate: date.toISOString() } as Event;
+}
+
+describe('day key arithmetic', () => {
+  it('formats a date as a zero-padded local day key', () => {
+    expect(dayKeyOf(new Date(2026, 6, 5, 23, 30))).toBe('2026-07-05');
+    expect(dayKeyOf(new Date(2026, 11, 31, 0, 0))).toBe('2026-12-31');
+  });
+
+  it('sorts lexicographically in chronological order', () => {
+    const keys = ['2026-12-31', '2026-07-05', '2026-07-15'];
+    expect([...keys].sort()).toEqual(['2026-07-05', '2026-07-15', '2026-12-31']);
+  });
+
+  it('adds and subtracts days across month and year boundaries', () => {
+    expect(addDays('2026-07-31', 1)).toBe('2026-08-01');
+    expect(addDays('2026-08-01', -1)).toBe('2026-07-31');
+    expect(addDays('2026-12-31', 1)).toBe('2027-01-01');
+    expect(addDays('2026-01-01', -1)).toBe('2025-12-31');
+    expect(addDays('2026-07-15', 0)).toBe('2026-07-15');
+  });
+
+  it('crosses a DST transition without drifting', () => {
+    // US DST ends 2026-11-01. A naive +86400000ms lands on 2026-10-31
+    // 23:00, whose day key is the day it started from.
+    expect(addDays('2026-10-31', 1)).toBe('2026-11-01');
+    expect(addDays('2026-11-01', 1)).toBe('2026-11-02');
+    // DST begins 2026-03-08.
+    expect(addDays('2026-03-07', 1)).toBe('2026-03-08');
+    expect(addDays('2026-03-08', 1)).toBe('2026-03-09');
+  });
+
+  it('produces inclusive contiguous ranges', () => {
+    expect(dayKeys('2026-07-14', '2026-07-16')).toEqual([
+      '2026-07-14',
+      '2026-07-15',
+      '2026-07-16',
+    ]);
+    expect(dayKeys('2026-07-14', '2026-07-14')).toEqual(['2026-07-14']);
+  });
+
+  it('returns an empty range when the bounds are inverted', () => {
+    expect(dayKeys('2026-07-16', '2026-07-14')).toEqual([]);
+  });
+
+  it('bounds a day at local midnight and one ms before the next', () => {
+    expect(startOfDay('2026-07-15').getTime()).toBe(new Date(2026, 6, 15, 0, 0, 0, 0).getTime());
+    expect(dayAfter('2026-07-15').getTime()).toBe(new Date(2026, 6, 16, 0, 0, 0, 0).getTime());
+  });
+
+  it('names the last day shown, stepping back only on an exact midnight', () => {
+    // A window ending at midnight does not show that day; one ending mid-day
+    // does. `this-week` ends at noon Saturday and that Saturday has events.
+    expect(lastDayCovered(new Date(2026, 6, 16, 0, 0, 0, 0))).toBe('2026-07-15');
+    expect(lastDayCovered(new Date(2026, 6, 18, 12, 0, 0, 0))).toBe('2026-07-18');
+  });
+});
+
+describe('navigableBounds', () => {
+  it('spans the season when every event is inside it', () => {
+    const events = [makeEvent('mid', new Date(2026, 6, 15, 9, 0))];
+    const bounds = navigableBounds(seasonWeeks, events);
+    expect(bounds.startDay).toBe(dayKeyOf(seasonWeeks[0].start));
+    expect(bounds.endDay).toBe(dayKeyOf(seasonWeeks[8].end));
+  });
+
+  it('widens to contain events outside the season', () => {
+    const events = [
+      makeEvent('early', new Date(2026, 4, 1, 9, 0)),
+      makeEvent('late', new Date(2026, 9, 1, 9, 0)),
+    ];
+    const bounds = navigableBounds(seasonWeeks, events);
+    expect(bounds.startDay).toBe('2026-05-01');
+    expect(bounds.endDay).toBe('2026-10-01');
+  });
+
+  it('falls back to the season alone when there are no events', () => {
+    const bounds = navigableBounds(seasonWeeks, []);
+    expect(bounds.startDay).toBe(dayKeyOf(seasonWeeks[0].start));
+    expect(bounds.endDay).toBe(dayKeyOf(seasonWeeks[8].end));
+  });
+});
+
+describe('baseWindow', () => {
+  const NOW = new Date(2026, 6, 15, 15, 0, 0, 0);
+  const bounds = navigableBounds(seasonWeeks, []);
+  const currentWeekNumber = (() => {
+    // getCurrentWeekNumber reads the real clock, so derive it from NOW
+    // directly rather than faking timers in a pure-module test.
+    const w = seasonWeeks.find((week) => NOW >= week.start && NOW <= week.end);
+    return w ? w.number : null;
+  })();
+
+  it("'today' spans exactly the current calendar day", () => {
+    const w = baseWindow({
+      dateFilter: 'today', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    expect(w.startDay).toBe('2026-07-15');
+    expect(w.endDay).toBe('2026-07-15');
+    expect(w.start.getTime()).toBe(new Date(2026, 6, 15, 0, 0, 0, 0).getTime());
+    expect(w.endExclusive.getTime()).toBe(new Date(2026, 6, 16, 0, 0, 0, 0).getTime());
+  });
+
+  it("'next' starts one hour before now, not at midnight", () => {
+    const adaptiveEndDate = new Date(2026, 6, 17, 23, 59, 59, 999);
+    const w = baseWindow({
+      dateFilter: 'next', seasonWeeks, currentWeekNumber, now: NOW, adaptiveEndDate, bounds,
+    })!;
+    expect(w.start.getTime()).toBe(new Date(2026, 6, 15, 14, 0, 0, 0).getTime());
+    // adaptiveEndDate is an inclusive 23:59:59.999; the half-open bound is
+    // the following midnight. No representable event falls in the gap.
+    expect(w.endExclusive.getTime()).toBe(new Date(2026, 6, 18, 0, 0, 0, 0).getTime());
+    expect(w.startDay).toBe('2026-07-15');
+    expect(w.endDay).toBe('2026-07-17');
+  });
+
+  it("'next' near midnight puts startDay on the previous calendar day", () => {
+    // 00:30 minus one hour is 23:30 yesterday. The navigation-facing
+    // startDay has to follow the actual bound, not "today".
+    const nearMidnight = new Date(2026, 6, 15, 0, 30, 0, 0);
+    const w = baseWindow({
+      dateFilter: 'next',
+      seasonWeeks,
+      currentWeekNumber,
+      now: nearMidnight,
+      adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+      bounds,
+    })!;
+    expect(w.startDay).toBe('2026-07-14');
+  });
+
+  it("'this-week' carries the week's own exclusive noon bound through", () => {
+    const week = seasonWeeks[currentWeekNumber! - 1];
+    const w = baseWindow({
+      dateFilter: 'this-week', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    expect(w.start.getTime()).toBe(week.start.getTime());
+    expect(w.endExclusive.getTime()).toBe(week.end.getTime());
+  });
+
+  it("'this-week' spans both boundary Saturdays", () => {
+    const w = baseWindow({
+      dateFilter: 'this-week', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    expect(dayKeys(w.startDay, w.endDay)).toHaveLength(8);
+  });
+
+  it("'this-week' is null outside the season", () => {
+    const w = baseWindow({
+      dateFilter: 'this-week',
+      seasonWeeks,
+      currentWeekNumber: null,
+      now: new Date(2026, 11, 25, 12, 0),
+      bounds,
+    });
+    expect(w).toBeNull();
+  });
+
+  it("'all' bounds no instant, but still reports navigable days", () => {
+    const w = baseWindow({
+      dateFilter: 'all', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    expect(w.start.getTime()).toBeLessThan(new Date(1900, 0, 1).getTime());
+    expect(w.endExclusive.getTime()).toBeGreaterThan(new Date(2200, 0, 1).getTime());
+    expect(w.startDay).toBe(bounds.startDay);
+    expect(w.endDay).toBe(bounds.endDay);
+  });
+});
+
+describe('viewWindow expansion', () => {
+  const NOW = new Date(2026, 6, 15, 15, 0, 0, 0);
+  const bounds = navigableBounds(seasonWeeks, []);
+  const currentWeekNumber =
+    seasonWeeks.find((w) => NOW >= w.start && NOW <= w.end)?.number ?? null;
+
+  const todayOpts = {
+    dateFilter: 'today' as const, seasonWeeks, currentWeekNumber, now: NOW, bounds,
+  };
+
+  it('is the base window when nothing is expanded', () => {
+    const w = viewWindow(todayOpts)!;
+    expect(w.startDay).toBe('2026-07-15');
+    expect(w.endDay).toBe('2026-07-15');
+  });
+
+  it('extends the end and uses a full day for the added region', () => {
+    const w = viewWindow({ ...todayOpts, expandedEndDay: '2026-07-17' })!;
+    expect(w.endDay).toBe('2026-07-17');
+    expect(w.endExclusive.getTime()).toBe(new Date(2026, 6, 18, 0, 0, 0, 0).getTime());
+    // The start is untouched, so it keeps the base window's exact instant.
+    expect(w.start.getTime()).toBe(new Date(2026, 6, 15, 0, 0, 0, 0).getTime());
+  });
+
+  it('extends the start backwards', () => {
+    const w = viewWindow({ ...todayOpts, expandedStartDay: '2026-07-13' })!;
+    expect(w.startDay).toBe('2026-07-13');
+    expect(w.start.getTime()).toBe(new Date(2026, 6, 13, 0, 0, 0, 0).getTime());
+  });
+
+  it('drops the intra-day start instant once expanded earlier', () => {
+    // 'next' starts at now-1h. Once the user reaches back past that day,
+    // they want the whole earlier day, not a window that still begins at
+    // 14:00 on a day they have scrolled away from.
+    const w = viewWindow({
+      dateFilter: 'next',
+      seasonWeeks,
+      currentWeekNumber,
+      now: NOW,
+      adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+      bounds,
+      expandedStartDay: '2026-07-13',
+    })!;
+    expect(w.start.getTime()).toBe(new Date(2026, 6, 13, 0, 0, 0, 0).getTime());
+  });
+
+  it('ignores an expansion that would narrow the base window', () => {
+    const w = viewWindow({ ...todayOpts, expandedEndDay: '2026-07-10' })!;
+    expect(w.endDay).toBe('2026-07-15');
+  });
+
+  it('clamps expansion to the navigable bounds', () => {
+    const w = viewWindow({ ...todayOpts, expandedEndDay: '2030-01-01' })!;
+    expect(w.endDay).toBe(bounds.endDay);
+  });
+
+  it('stays null when the base window is null', () => {
+    const w = viewWindow({
+      dateFilter: 'this-week',
+      seasonWeeks,
+      currentWeekNumber: null,
+      now: new Date(2026, 11, 25, 12, 0),
+      bounds,
+      expandedEndDay: '2026-12-31',
+    });
+    expect(w).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -222,6 +222,45 @@ describe('baseWindow', () => {
     expect(w.startDay).toBe(bounds.startDay);
     expect(w.endDay).toBe(bounds.endDay);
   });
+
+  it("does not leak the 'all' singleton Dates — mutating a returned window must not corrupt a later one", () => {
+    const first = baseWindow({
+      dateFilter: 'all', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    const originalStart = first.start.getTime();
+    const originalEnd = first.endExclusive.getTime();
+
+    first.start.setFullYear(2026, 6, 15);
+    first.endExclusive.setFullYear(2026, 6, 15);
+
+    const second = baseWindow({
+      dateFilter: 'all', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    expect(second.start.getTime()).toBe(originalStart);
+    expect(second.endExclusive.getTime()).toBe(originalEnd);
+  });
+
+  it("does not leak the 'this-week' SeasonWeek Dates — mutating a returned window must not corrupt the season or a later window", () => {
+    const week = seasonWeeks[currentWeekNumber! - 1];
+    const originalWeekStart = week.start.getTime();
+    const originalWeekEnd = week.end.getTime();
+
+    const first = baseWindow({
+      dateFilter: 'this-week', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    first.start.setFullYear(1999, 0, 1);
+    first.endExclusive.setFullYear(1999, 0, 1);
+
+    // The caller's seasonWeeks array itself must be untouched.
+    expect(week.start.getTime()).toBe(originalWeekStart);
+    expect(week.end.getTime()).toBe(originalWeekEnd);
+
+    const second = baseWindow({
+      dateFilter: 'this-week', seasonWeeks, currentWeekNumber, now: NOW, bounds,
+    })!;
+    expect(second.start.getTime()).toBe(originalWeekStart);
+    expect(second.endExclusive.getTime()).toBe(originalWeekEnd);
+  });
 });
 
 describe('viewWindow expansion', () => {

--- a/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { filterEvents, type FilterOptions } from '@/lib/utils/filterHelpers';
 import { getChautauquaSeasonWeeks, getCurrentWeekNumber } from '@/lib/utils/dateHelpers';
+import { navigableBounds, viewWindow } from '@/lib/utils/dayWindow';
 import type { Event } from '@/lib/types';
 
 // Fixed reference instant: Wednesday 2026-07-15, 15:00 local. Mid-season,
@@ -26,16 +27,33 @@ function makeEvent(id: string, date: Date): Event {
 
 const seasonWeeks = getChautauquaSeasonWeeks(2026);
 
-function baseOptions(overrides: Partial<FilterOptions>): FilterOptions {
+function baseOptions(overrides: {
+  dateFilter?: 'all' | 'today' | 'next' | 'this-week';
+  selectedWeeks?: number[];
+  seasonWeeks?: typeof seasonWeeks;
+  currentWeekNumber?: number | null;
+  adaptiveEndDate?: Date;
+  searchTerm?: string;
+}): FilterOptions {
+  const weeks = overrides.seasonWeeks ?? seasonWeeks;
+  const currentWeekNumber =
+    overrides.currentWeekNumber !== undefined
+      ? overrides.currentWeekNumber
+      : getCurrentWeekNumber(weeks);
   return {
-    searchTerm: '',
-    dateFilter: 'all',
-    selectedWeeks: [],
+    searchTerm: overrides.searchTerm ?? '',
+    selectedWeeks: overrides.selectedWeeks ?? [],
     selectedTagsLowerSet: new Set<string>(),
     selectedLocationsLowerSet: new Set<string>(),
-    seasonWeeks,
-    currentWeekNumber: getCurrentWeekNumber(seasonWeeks),
-    ...overrides,
+    seasonWeeks: weeks,
+    viewWindow: viewWindow({
+      dateFilter: overrides.dateFilter ?? 'all',
+      seasonWeeks: weeks,
+      currentWeekNumber,
+      now: new Date(),
+      adaptiveEndDate: overrides.adaptiveEndDate,
+      bounds: navigableBounds(weeks, []),
+    }),
   };
 }
 

--- a/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
@@ -208,3 +208,24 @@ describe('filterEvents date stage — characterization', () => {
     });
   });
 });
+
+// Post-refactor deltas: unlike every describe block above, this one pins
+// behavior the ViewWindow refactor deliberately CHANGED, not behavior it
+// preserved. Before the refactor, `dateFilter: 'all'` ran no date predicate
+// at all, so an event with an unparseable `startDate` reached
+// `groupEventsByDay` and rendered as an "Invalid Date" section. Now `'all'`
+// is a real ViewWindow (MIN_INSTANT..MAX_INSTANT) checked via
+// `windowContains`, and `new Date('garbage')` is `Invalid Date` — every
+// comparison against `NaN` is false, so the row is dropped. This is called
+// out in the PR description; this test exists so a future change to the
+// parsing path can't silently reintroduce the "Invalid Date" row.
+describe('filterEvents date stage — post-refactor deltas', () => {
+  it("dateFilter: 'all' drops an event with an unparseable startDate", () => {
+    const events = [
+      makeEvent('good', new Date(2026, 6, 15, 9, 0)),
+      { id: 'bad', title: 'Event bad', startDate: 'garbage' } as Event,
+    ];
+    const result = filterEvents(events, baseOptions({ dateFilter: 'all' }));
+    expect(result.map((e) => e.id)).toEqual(['good']);
+  });
+});

--- a/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
@@ -1,0 +1,192 @@
+// Characterization tests: these pin what filterEvents' DATE stage does
+// TODAY, before the ViewWindow refactor replaces four scope-specific
+// predicates with one range check.
+//
+// They are the safety net for that refactor. Do NOT edit them to make a
+// later change pass — if one of these goes red, the refactor is wrong, not
+// the test. Written first because filterEvents had no direct coverage at
+// all.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { filterEvents, type FilterOptions } from '@/lib/utils/filterHelpers';
+import { getChautauquaSeasonWeeks, getCurrentWeekNumber } from '@/lib/utils/dateHelpers';
+import type { Event } from '@/lib/types';
+
+// Fixed reference instant: Wednesday 2026-07-15, 15:00 local. Mid-season,
+// mid-week, mid-afternoon — so "one hour ago" stays on the same calendar
+// day and the week boundaries sit clear of it in both directions.
+const NOW = new Date(2026, 6, 15, 15, 0, 0, 0);
+
+function makeEvent(id: string, date: Date): Event {
+  return {
+    id,
+    title: `Event ${id}`,
+    startDate: date.toISOString(),
+  } as Event;
+}
+
+const seasonWeeks = getChautauquaSeasonWeeks(2026);
+
+function baseOptions(overrides: Partial<FilterOptions>): FilterOptions {
+  return {
+    searchTerm: '',
+    dateFilter: 'all',
+    selectedWeeks: [],
+    selectedTagsLowerSet: new Set<string>(),
+    selectedLocationsLowerSet: new Set<string>(),
+    seasonWeeks,
+    currentWeekNumber: getCurrentWeekNumber(seasonWeeks),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('filterEvents date stage — characterization', () => {
+  describe("dateFilter: 'all'", () => {
+    it('filters nothing by date, including events years away', () => {
+      const events = [
+        makeEvent('past', new Date(2020, 0, 1, 9, 0)),
+        makeEvent('today', new Date(2026, 6, 15, 9, 0)),
+        makeEvent('future', new Date(2030, 0, 1, 9, 0)),
+      ];
+      const result = filterEvents(events, baseOptions({ dateFilter: 'all' }));
+      expect(result.map((e) => e.id)).toEqual(['past', 'today', 'future']);
+    });
+  });
+
+  describe("dateFilter: 'today'", () => {
+    it('keeps only events on the current calendar day', () => {
+      const events = [
+        makeEvent('yesterday-2359', new Date(2026, 6, 14, 23, 59)),
+        makeEvent('today-0000', new Date(2026, 6, 15, 0, 0)),
+        makeEvent('today-2359', new Date(2026, 6, 15, 23, 59)),
+        makeEvent('tomorrow-0000', new Date(2026, 6, 16, 0, 0)),
+      ];
+      const result = filterEvents(events, baseOptions({ dateFilter: 'today' }));
+      expect(result.map((e) => e.id)).toEqual(['today-0000', 'today-2359']);
+    });
+
+    it('keeps an event earlier today that has already finished', () => {
+      // 'today' is a whole-day filter, NOT a from-now filter. This is the
+      // distinction that separates it from 'next'.
+      const events = [makeEvent('this-morning', new Date(2026, 6, 15, 8, 0))];
+      const result = filterEvents(events, baseOptions({ dateFilter: 'today' }));
+      expect(result.map((e) => e.id)).toEqual(['this-morning']);
+    });
+  });
+
+  describe("dateFilter: 'next'", () => {
+    it('includes an event that started within the last hour', () => {
+      const events = [makeEvent('started-30m-ago', new Date(2026, 6, 15, 14, 30))];
+      const result = filterEvents(
+        events,
+        baseOptions({
+          dateFilter: 'next',
+          adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+        })
+      );
+      expect(result.map((e) => e.id)).toEqual(['started-30m-ago']);
+    });
+
+    it('excludes an event that started more than an hour ago', () => {
+      const events = [makeEvent('started-90m-ago', new Date(2026, 6, 15, 13, 30))];
+      const result = filterEvents(
+        events,
+        baseOptions({
+          dateFilter: 'next',
+          adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+        })
+      );
+      expect(result).toEqual([]);
+    });
+
+    it('excludes an event after adaptiveEndDate', () => {
+      const events = [
+        makeEvent('inside', new Date(2026, 6, 17, 20, 0)),
+        makeEvent('outside', new Date(2026, 6, 18, 9, 0)),
+      ];
+      const result = filterEvents(
+        events,
+        baseOptions({
+          dateFilter: 'next',
+          adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+        })
+      );
+      expect(result.map((e) => e.id)).toEqual(['inside']);
+    });
+
+    it('falls back to a six-day end-of-day window when adaptiveEndDate is absent', () => {
+      const events = [
+        makeEvent('day-6', new Date(2026, 6, 21, 23, 0)),
+        makeEvent('day-7', new Date(2026, 6, 22, 9, 0)),
+      ];
+      const result = filterEvents(events, baseOptions({ dateFilter: 'next' }));
+      expect(result.map((e) => e.id)).toEqual(['day-6']);
+    });
+  });
+
+  describe("dateFilter: 'this-week'", () => {
+    it('uses noon-Saturday boundaries, not calendar-week ones', () => {
+      const current = getCurrentWeekNumber(seasonWeeks);
+      expect(current, 'NOW must fall inside the 2026 season').not.toBeNull();
+      const week = seasonWeeks[current! - 1];
+
+      const events = [
+        makeEvent('one-ms-before-start', new Date(week.start.getTime() - 1)),
+        makeEvent('exactly-at-start', new Date(week.start.getTime())),
+        makeEvent('one-ms-before-end', new Date(week.end.getTime() - 1)),
+        makeEvent('exactly-at-end', new Date(week.end.getTime())),
+      ];
+      const result = filterEvents(events, baseOptions({ dateFilter: 'this-week' }));
+      // Start is inclusive, end is exclusive. The boundary Saturday
+      // therefore belongs to two weeks, which is why the season cannot be
+      // paged into disjoint weeks.
+      expect(result.map((e) => e.id)).toEqual(['exactly-at-start', 'one-ms-before-end']);
+    });
+
+    it('returns nothing when NOW is outside the season', () => {
+      vi.setSystemTime(new Date(2026, 11, 25, 12, 0));
+      const offSeasonWeeks = getChautauquaSeasonWeeks(2026);
+      const events = [makeEvent('anything', new Date(2026, 11, 25, 12, 0))];
+      const result = filterEvents(
+        events,
+        baseOptions({
+          dateFilter: 'this-week',
+          seasonWeeks: offSeasonWeeks,
+          currentWeekNumber: getCurrentWeekNumber(offSeasonWeeks),
+        })
+      );
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('the weeks stage is independent of the date stage', () => {
+    it('ANDs a week selection with the date filter', () => {
+      // This is the behavior the ViewWindow refactor must NOT change in
+      // phase 1: scope and weeks are two separate AND-ed stages today.
+      // Mutual exclusion arrives in phase 3.
+      const week1 = seasonWeeks[0];
+      const inWeek1 = new Date(week1.start.getTime() + 60 * 60 * 1000);
+      const events = [makeEvent('week1-not-today', inWeek1)];
+
+      const weekOnly = filterEvents(
+        events,
+        baseOptions({ dateFilter: 'all', selectedWeeks: [1] })
+      );
+      expect(weekOnly.map((e) => e.id)).toEqual(['week1-not-today']);
+
+      const weekAndToday = filterEvents(
+        events,
+        baseOptions({ dateFilter: 'today', selectedWeeks: [1] })
+      );
+      expect(weekAndToday).toEqual([]);
+    });
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useAvailableYears } from '@/hooks/useAvailableYears';
 import { useSelectedYear } from '@/hooks/useSelectedYear';
 import { useDebounce } from '@/hooks/useDebounce';
 import { getChautauquaSeasonWeeks, getCurrentWeekNumber, getAdaptiveEndDate } from '@/lib/utils/dateHelpers';
 import { groupEventsByDay } from '@/lib/utils/eventHelpers';
 import { filterEvents, type FilterOptions } from '@/lib/utils/filterHelpers';
+import { navigableBounds, viewWindow, addDays } from '@/lib/utils/dayWindow';
 import { useFilterState } from '@/hooks/useFilterState';
 import { useFavorites } from '@/hooks/useFavorites';
 import { useHorizontalScroll, useVerticalScroll, useWeekDragSelection } from '@/hooks/useScrollState';
@@ -79,31 +80,65 @@ function HomeContent() {
   const debouncedSearch = useDebounce(filters.searchTerm, 200);
   const adaptiveEndDate = useMemo(() => {
     if (filters.dateFilter !== 'next' || !events.length) return undefined;
-    const now = new Date();
-    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
-    const baseEnd = getAdaptiveEndDate(events, oneHourAgo, 50);
-    if (filters.extraDays > 0) {
-      const extended = new Date(baseEnd);
-      extended.setDate(extended.getDate() + filters.extraDays);
-      extended.setHours(23, 59, 59, 999);
-      return extended;
-    }
-    return baseEnd;
-  }, [filters.dateFilter, events, filters.extraDays]);
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    return getAdaptiveEndDate(events, oneHourAgo, 50);
+  }, [filters.dateFilter, events]);
+
+  // The outer limit of everything navigation can reach: the season, widened
+  // to contain any event outside it.
+  const navBounds = useMemo(
+    () => navigableBounds(seasonWeeks, events),
+    [seasonWeeks, events]
+  );
+
+  // The single date filter. Every scope reduces to this range, and so does
+  // however far the user has navigated past the scope's own edge.
+  const dateWindow = useMemo(
+    () =>
+      viewWindow({
+        dateFilter: filters.dateFilter,
+        seasonWeeks,
+        currentWeekNumber,
+        now: new Date(),
+        adaptiveEndDate,
+        bounds: navBounds,
+        expandedStartDay: filters.windowStartDay,
+        expandedEndDay: filters.windowEndDay,
+      }),
+    [
+      filters.dateFilter, seasonWeeks, currentWeekNumber, adaptiveEndDate,
+      navBounds, filters.windowStartDay, filters.windowEndDay,
+    ]
+  );
+
   const filterOpts: FilterOptions = useMemo(() => ({
-    searchTerm: debouncedSearch, dateFilter: filters.dateFilter, selectedWeeks: filters.selectedWeeks,
-    selectedTagsLowerSet: filters.selectedTagsLowerSet, selectedLocationsLowerSet: filters.selectedLocationsLowerSet,
-    seasonWeeks, currentWeekNumber,
+    searchTerm: debouncedSearch,
+    selectedWeeks: filters.selectedWeeks,
+    selectedTagsLowerSet: filters.selectedTagsLowerSet,
+    selectedLocationsLowerSet: filters.selectedLocationsLowerSet,
+    seasonWeeks,
+    viewWindow: dateWindow,
     showFavoritesOnly: filters.showFavoritesOnly,
     favoriteIds: favorites.favoriteIds,
-    adaptiveEndDate,
-  }), [debouncedSearch, filters.dateFilter, filters.selectedWeeks, filters.selectedTagsLowerSet, filters.selectedLocationsLowerSet, seasonWeeks, currentWeekNumber, filters.showFavoritesOnly, favorites.favoriteIds, adaptiveEndDate]);
+  }), [
+    debouncedSearch, filters.selectedWeeks, filters.selectedTagsLowerSet,
+    filters.selectedLocationsLowerSet, seasonWeeks, dateWindow,
+    filters.showFavoritesOnly, favorites.favoriteIds,
+  ]);
   const filteredEvents = useMemo(() => filterEvents(events, filterOpts), [events, filterOpts]);
   const groupedEvents = useMemo(() => groupEventsByDay(filteredEvents, seasonWeeks), [filteredEvents, seasonWeeks]);
   const hasMoreDays = useMemo(() => {
-    if (filters.dateFilter !== 'next' || !adaptiveEndDate || !events.length) return false;
-    return events.some(e => new Date(e.startDate) > adaptiveEndDate);
-  }, [filters.dateFilter, adaptiveEndDate, events]);
+    if (filters.dateFilter !== 'next' || !dateWindow || !events.length) return false;
+    return events.some(e => new Date(e.startDate) >= dateWindow.endExclusive);
+  }, [filters.dateFilter, dateWindow, events]);
+
+  // "Show next day" widens the window by one calendar day from wherever it
+  // currently ends — which is the same operation whether the end came from
+  // the scope or from a previous widening.
+  const showNextDay = useCallback(() => {
+    if (!dateWindow) return;
+    filters.expandWindowEnd(addDays(dateWindow.endDay, 1));
+  }, [dateWindow, filters.expandWindowEnd]);
   const activeChips = useMemo(() => buildActiveChips({
     searchTerm: filters.searchTerm, setSearchTerm: filters.setSearchTerm,
     dateFilter: filters.dateFilter, setDateFilter: filters.setDateFilter,
@@ -180,7 +215,7 @@ function HomeContent() {
               <EventList groupedEvents={groupedEvents} expandedDescriptions={filters.expandedDescriptions}
                 onToggleDescription={filters.toggleDescription} onToggleTag={filters.toggleTag} isTagSelected={filters.isTagSelected}
                 favoriteIds={favorites.favoriteIds} onToggleFavorite={favorites.toggleFavorite}
-                dateFilter={filters.dateFilter} onShowNextDay={filters.addExtraDay}
+                dateFilter={filters.dateFilter} onShowNextDay={showNextDay}
                 hasMoreDays={hasMoreDays} weeklyThemes={weeklyThemes} articleLinks={articleLinks} programLinks={programLinks} />
             )}
           </div>

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -15,7 +15,17 @@ interface FilterState {
   availableCategories: string[];
   availableLocations: string[];
   showFavoritesOnly: boolean;
-  extraDays: number;
+  /**
+   * How far the user has navigated beyond the current scope's own window,
+   * as day keys. `null` means "not expanded in that direction".
+   *
+   * Session-only: deliberately absent from the localStorage payload below,
+   * matching iOS's `selectedDayKey` and the `extraDays` this replaced. A
+   * date pinned days ago and silently restored on launch would be worse
+   * than no restore.
+   */
+  windowStartDay: string | null;
+  windowEndDay: string | null;
 }
 
 type FilterAction =
@@ -28,8 +38,9 @@ type FilterAction =
   | { type: 'SET_AVAILABLE_CATEGORIES'; payload: string[] }
   | { type: 'SET_AVAILABLE_LOCATIONS'; payload: string[] }
   | { type: 'TOGGLE_FAVORITES_ONLY' }
-  | { type: 'ADD_EXTRA_DAY' }
-  | { type: 'CLEAR_EXTRA_DAYS' }
+  | { type: 'EXPAND_WINDOW_START'; payload: string }
+  | { type: 'EXPAND_WINDOW_END'; payload: string }
+  | { type: 'RESET_WINDOW' }
   | { type: 'RECONCILE_FILTERS'; payload: { availableCategories: string[]; availableLocations: string[]; isCurrentYear: boolean } }
   | { type: 'CLEAR_FILTERS' }
   | { type: 'CLEAR_NON_DATE_FILTERS' };
@@ -49,7 +60,11 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
     case 'SET_SEARCH':
       return { ...state, searchTerm: action.payload };
     case 'SET_DATE_FILTER':
-      return { ...state, dateFilter: action.payload };
+      // Resetting here rather than in an effect keyed on dateFilter: the
+      // effect this replaces ran a second render pass to undo state the
+      // first pass had already applied, and left a frame in which the
+      // window belonged to the previous scope.
+      return { ...state, dateFilter: action.payload, windowStartDay: null, windowEndDay: null };
     case 'SET_SELECTED_WEEKS': {
       const weeks = typeof action.payload === 'function' ? action.payload(state.selectedWeeks) : action.payload;
       return { ...state, selectedWeeks: weeks };
@@ -81,10 +96,12 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
       return { ...state, availableLocations: action.payload };
     case 'TOGGLE_FAVORITES_ONLY':
       return { ...state, showFavoritesOnly: !state.showFavoritesOnly };
-    case 'ADD_EXTRA_DAY':
-      return { ...state, extraDays: state.extraDays + 1 };
-    case 'CLEAR_EXTRA_DAYS':
-      return { ...state, extraDays: 0 };
+    case 'EXPAND_WINDOW_START':
+      return { ...state, windowStartDay: action.payload };
+    case 'EXPAND_WINDOW_END':
+      return { ...state, windowEndDay: action.payload };
+    case 'RESET_WINDOW':
+      return { ...state, windowStartDay: null, windowEndDay: null };
     case 'RECONCILE_FILTERS': {
       const { availableCategories, availableLocations, isCurrentYear } = action.payload;
       const availCatsLower = new Set(availableCategories.map(c => c.toLowerCase()));
@@ -95,11 +112,12 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
         selectedLocations: state.selectedLocations.filter(l => availLocsLower.has(l.toLowerCase())),
         selectedWeeks: [],
         dateFilter: isCurrentYear ? 'next' : 'all',
-        extraDays: 0,
+        windowStartDay: null,
+        windowEndDay: null,
       };
     }
     case 'CLEAR_FILTERS':
-      return { ...state, searchTerm: '', selectedTags: [], selectedLocations: [], dateFilter: 'all', selectedWeeks: [], showFavoritesOnly: false, extraDays: 0 };
+      return { ...state, searchTerm: '', selectedTags: [], selectedLocations: [], dateFilter: 'all', selectedWeeks: [], showFavoritesOnly: false, windowStartDay: null, windowEndDay: null };
     case 'CLEAR_NON_DATE_FILTERS':
       return { ...state, searchTerm: '', selectedTags: [], selectedLocations: [], showFavoritesOnly: false };
     default:
@@ -119,7 +137,8 @@ const initialState: FilterState = {
   availableCategories: [],
   availableLocations: [],
   showFavoritesOnly: false,
-  extraDays: 0,
+  windowStartDay: null,
+  windowEndDay: null,
 };
 
 function loadInitialState(): FilterState {
@@ -159,7 +178,9 @@ export function useFilterState() {
   const setAvailableCategories = useCallback((cats: string[]) => dispatch({ type: 'SET_AVAILABLE_CATEGORIES', payload: cats }), []);
   const setAvailableLocations = useCallback((locs: string[]) => dispatch({ type: 'SET_AVAILABLE_LOCATIONS', payload: locs }), []);
   const toggleFavoritesOnly = useCallback(() => dispatch({ type: 'TOGGLE_FAVORITES_ONLY' }), []);
-  const addExtraDay = useCallback(() => dispatch({ type: 'ADD_EXTRA_DAY' }), []);
+  const expandWindowStart = useCallback((day: string) => dispatch({ type: 'EXPAND_WINDOW_START', payload: day }), []);
+  const expandWindowEnd = useCallback((day: string) => dispatch({ type: 'EXPAND_WINDOW_END', payload: day }), []);
+  const resetWindow = useCallback(() => dispatch({ type: 'RESET_WINDOW' }), []);
   const clearFilters = useCallback(() => dispatch({ type: 'CLEAR_FILTERS' }), []);
   const clearNonDateFilters = useCallback(() => dispatch({ type: 'CLEAR_NON_DATE_FILTERS' }), []);
   const reconcileFilters = useCallback(
@@ -205,13 +226,6 @@ export function useFilterState() {
     } catch (e) { console.warn('Failed to save user state:', e); }
   }, [state]);
 
-  // Reset extra days when date filter changes
-  useEffect(() => {
-    if (state.extraDays > 0) {
-      dispatch({ type: 'CLEAR_EXTRA_DAYS' });
-    }
-  }, [state.dateFilter]); // intentionally only depends on dateFilter
-
   return {
     expandedDescriptions: state.expandedDescriptions,
     searchTerm: state.searchTerm, setSearchTerm,
@@ -228,7 +242,8 @@ export function useFilterState() {
     toggleDescription, toggleTag, isTagSelected, toggleLocation, isLocationSelected,
     clearFilters, clearNonDateFilters,
     showFavoritesOnly: state.showFavoritesOnly, toggleFavoritesOnly,
-    extraDays: state.extraDays, addExtraDay,
+    windowStartDay: state.windowStartDay, windowEndDay: state.windowEndDay,
+    expandWindowStart, expandWindowEnd, resetWindow,
     reconcileFilters,
   };
 }

--- a/frontend/src/hooks/useFilterState.ts
+++ b/frontend/src/hooks/useFilterState.ts
@@ -64,6 +64,14 @@ function filterReducer(state: FilterState, action: FilterAction): FilterState {
       // effect this replaces ran a second render pass to undo state the
       // first pass had already applied, and left a frame in which the
       // window belonged to the previous scope.
+      //
+      // Guard on an actual change: unlike the effect (which only fired when
+      // dateFilter changed), a reducer case fires on every dispatch,
+      // including same-value ones — and those happen. useScrollState calls
+      // setDateFilter('all') unconditionally from several handlers, so a
+      // week mouse-down/drag/tap while already on 'all' re-dispatches the
+      // same value and would otherwise silently discard the window.
+      if (state.dateFilter === action.payload) return state;
       return { ...state, dateFilter: action.payload, windowStartDay: null, windowEndDay: null };
     case 'SET_SELECTED_WEEKS': {
       const weeks = typeof action.payload === 'function' ? action.payload(state.selectedWeeks) : action.payload;

--- a/frontend/src/lib/utils/dateHelpers.ts
+++ b/frontend/src/lib/utils/dateHelpers.ts
@@ -49,24 +49,6 @@ export function getChautauquaSeasonWeeks(year: number): SeasonWeek[] {
   return weeks;
 }
 
-export function isToday(dateString: string): boolean {
-  const today = new Date();
-  const eventDate = new Date(dateString);
-  return eventDate.toDateString() === today.toDateString();
-}
-
-
-export function isThisWeek(dateString: string, seasonWeeks: SeasonWeek[], currentWeekNumber: number | null): boolean {
-  const eventDate = new Date(dateString);
-
-  if (currentWeekNumber === null) {
-    return false; // Not in season
-  }
-
-  const currentWeek = seasonWeeks[currentWeekNumber - 1];
-  return eventDate >= currentWeek.start && eventDate < currentWeek.end;
-}
-
 export function isInChautauquaWeek(dateString: string, weekNumber: number, seasonWeeks: SeasonWeek[]): boolean {
   const eventDate = new Date(dateString);
   const week = seasonWeeks[weekNumber - 1];

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -1,0 +1,252 @@
+import type { Event, SeasonWeek } from '@/lib/types';
+
+/**
+ * A calendar day as `yyyy-mm-dd`, zero-padded, in local time.
+ *
+ * Lexicographic order is chronological, which is what makes plain string
+ * comparison a correct date comparison throughout this module. Matches
+ * iOS's `ChqTime.dayKey` byte for byte, so the two platforms describe the
+ * same day the same way.
+ */
+export type DayKey = string;
+
+/** The widest instants a `Date` can hold — used by the unbounded scope. */
+const MIN_INSTANT = new Date(-8640000000000000);
+const MAX_INSTANT = new Date(8640000000000000);
+
+export function dayKeyOf(d: Date): DayKey {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+function partsOf(key: DayKey): [number, number, number] {
+  const [y, m, d] = key.split('-').map(Number);
+  return [y, m, d];
+}
+
+export function startOfDay(key: DayKey): Date {
+  const [y, m, d] = partsOf(key);
+  return new Date(y, m - 1, d, 0, 0, 0, 0);
+}
+
+/**
+ * The exclusive upper bound of `key` — the next day's midnight.
+ *
+ * Deliberately not "23:59:59.999": that is an inclusive bound whose
+ * correctness depends on `Date` being integer milliseconds. It is here, and
+ * it is not on iOS, where `Date` wraps a `Double`. A half-open bound needs
+ * no such assumption and tiles exactly with the next day's window.
+ */
+export function dayAfter(key: DayKey): Date {
+  const [y, m, d] = partsOf(key);
+  const date = new Date(y, m - 1, d);
+  date.setDate(date.getDate() + 1);
+  return date;
+}
+
+/**
+ * The last day a window actually shows, given its exclusive upper bound.
+ *
+ * One rule for two cases that look unrelated at the call site: a window
+ * ending at midnight does not show that day (`'today'`, `'next'`), while one
+ * ending mid-day does (`'this-week'` ends at noon Saturday, and that
+ * Saturday morning has events).
+ */
+export function lastDayCovered(endExclusive: Date): DayKey {
+  const isMidnight =
+    endExclusive.getHours() === 0 && endExclusive.getMinutes() === 0 &&
+    endExclusive.getSeconds() === 0 && endExclusive.getMilliseconds() === 0;
+  const key = dayKeyOf(endExclusive);
+  return isMidnight ? addDays(key, -1) : key;
+}
+
+/**
+ * `key` shifted by `n` calendar days.
+ *
+ * Built from date parts and `setDate`, never from millisecond arithmetic:
+ * adding 86,400,000 ms across a DST transition lands on the previous or
+ * next day's 23:00/01:00 and produces the wrong key. Mirrors iOS's
+ * `ChqTime.day(_:offsetBy:)`, which uses `Calendar` for the same reason.
+ */
+export function addDays(key: DayKey, n: number): DayKey {
+  const [y, m, d] = partsOf(key);
+  const date = new Date(y, m - 1, d);
+  date.setDate(date.getDate() + n);
+  return dayKeyOf(date);
+}
+
+/** Every day from `from` through `through`, inclusive. Empty if inverted. */
+export function dayKeys(from: DayKey, through: DayKey): DayKey[] {
+  const out: DayKey[] = [];
+  let cursor = from;
+  while (cursor <= through) {
+    out.push(cursor);
+    cursor = addDays(cursor, 1);
+  }
+  return out;
+}
+
+/**
+ * The instants the list is filtered to, plus the days that range covers.
+ *
+ * **Half-open**: `start <= x < endExclusive`. Never inclusive with a
+ * subtracted epsilon — `end - 1` is exact here because `Date` is integer
+ * milliseconds, but it is not on iOS where `Date` wraps a `Double`, and the
+ * same written rule meaning two different things per platform is the drift
+ * this shared model exists to prevent.
+ *
+ * Half-open is also what the existing code already used, so most scopes need
+ * no conversion: the week filter is `>= week.start && < week.end`, and
+ * `localDateKey` equality is exactly `[startOfDay(d), startOfDay(d+1))`.
+ * Those bounds are carried through verbatim below.
+ *
+ * `startDay`/`endDay` are the navigation-facing projection: what a day rail
+ * or a step control moves through. They are derived from `start`/`end`, not
+ * the other way round, so they can never disagree with what is filtered.
+ */
+export interface ViewWindow {
+  startDay: DayKey;
+  endDay: DayKey;
+  start: Date;
+  endExclusive: Date;
+}
+
+/** `d >= w.start && d < w.endExclusive`. */
+export function windowContains(w: ViewWindow, d: Date): boolean {
+  return d >= w.start && d < w.endExclusive;
+}
+
+/** The outer limit of everything navigation can reach. */
+export interface NavigableBounds {
+  startDay: DayKey;
+  endDay: DayKey;
+}
+
+/**
+ * The season, widened to contain every day that has an event.
+ *
+ * The widening is not cosmetic: without it a pre- or post-season event
+ * would be permanently unreachable by stepping. Mirrors iOS's
+ * `DayWindow.bounds(year:starredDays:)`, which widens by starred days for
+ * the same reason.
+ */
+export function navigableBounds(
+  seasonWeeks: SeasonWeek[],
+  events: Event[]
+): NavigableBounds {
+  let startDay = dayKeyOf(seasonWeeks[0].start);
+  let endDay = dayKeyOf(seasonWeeks[seasonWeeks.length - 1].end);
+
+  for (const event of events) {
+    const key = dayKeyOf(new Date(event.startDate));
+    if (key < startDay) startDay = key;
+    if (key > endDay) endDay = key;
+  }
+
+  return { startDay, endDay };
+}
+
+export interface WindowOptions {
+  dateFilter: 'all' | 'today' | 'next' | 'this-week';
+  seasonWeeks: SeasonWeek[];
+  currentWeekNumber: number | null;
+  now: Date;
+  adaptiveEndDate?: Date;
+  bounds: NavigableBounds;
+  expandedStartDay?: DayKey | null;
+  expandedEndDay?: DayKey | null;
+}
+
+/**
+ * The window a scope defines before any expansion.
+ *
+ * `null` means "this scope matches nothing right now", which is reachable
+ * only for `'this-week'` outside the season — the case the old
+ * `isThisWeek` handled by returning `false` for every event.
+ */
+export function baseWindow(o: WindowOptions): ViewWindow | null {
+  switch (o.dateFilter) {
+    case 'all':
+      // No instant bound at all. Deliberately not derived from the event
+      // list: a window computed from the events being filtered would be
+      // circular, and would behave differently for a caller that passed a
+      // subset.
+      return {
+        startDay: o.bounds.startDay,
+        endDay: o.bounds.endDay,
+        start: MIN_INSTANT,
+        endExclusive: MAX_INSTANT,
+      };
+
+    case 'today': {
+      const key = dayKeyOf(o.now);
+      return { startDay: key, endDay: key, start: startOfDay(key), endExclusive: dayAfter(key) };
+    }
+
+    case 'next': {
+      // One hour of grace so an event that has just begun is still "next".
+      const start = new Date(o.now.getTime() - 60 * 60 * 1000);
+      // `adaptiveEndDate` is an inclusive end-of-day; the half-open
+      // equivalent is that day's exclusive end. No representable event falls
+      // in the difference — event times carry no sub-second component.
+      let inclusiveEnd = o.adaptiveEndDate;
+      if (!inclusiveEnd) {
+        inclusiveEnd = new Date(o.now.getTime() + 6 * 24 * 60 * 60 * 1000);
+        inclusiveEnd.setHours(23, 59, 59, 999);
+      }
+      const endExclusive = dayAfter(dayKeyOf(inclusiveEnd));
+      return {
+        startDay: dayKeyOf(start),
+        endDay: lastDayCovered(endExclusive),
+        start,
+        endExclusive,
+      };
+    }
+
+    case 'this-week': {
+      if (o.currentWeekNumber === null) return null;
+      const week = o.seasonWeeks[o.currentWeekNumber - 1];
+      // The week's own bounds, carried through verbatim — `SeasonWeek` is
+      // already half-open (`>= start && < end`).
+      return {
+        startDay: dayKeyOf(week.start),
+        endDay: lastDayCovered(week.end),
+        start: week.start,
+        endExclusive: week.end,
+      };
+    }
+  }
+}
+
+/**
+ * The base window, widened by however far the user has navigated.
+ *
+ * Expansion only ever grows the window — an `expanded*` value that would
+ * narrow it is ignored, so a stale value can never hide events. The added
+ * region uses whole days, while an untouched end keeps the base window's
+ * exact instant. That is what preserves `'next'`'s one-hour grace and
+ * `'this-week'`'s noon boundaries until the user actually navigates past
+ * them.
+ */
+export function viewWindow(o: WindowOptions): ViewWindow | null {
+  const base = baseWindow(o);
+  if (!base) return null;
+
+  let startDay = base.startDay;
+  let endDay = base.endDay;
+
+  if (o.expandedStartDay && o.expandedStartDay < startDay) startDay = o.expandedStartDay;
+  if (o.expandedEndDay && o.expandedEndDay > endDay) endDay = o.expandedEndDay;
+
+  if (startDay < o.bounds.startDay) startDay = o.bounds.startDay;
+  if (endDay > o.bounds.endDay) endDay = o.bounds.endDay;
+
+  return {
+    startDay,
+    endDay,
+    start: startDay === base.startDay ? base.start : startOfDay(startDay),
+    endExclusive: endDay === base.endDay ? base.endExclusive : dayAfter(endDay),
+  };
+}

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -179,11 +179,15 @@ export function baseWindow(o: WindowOptions): ViewWindow | null {
       // list: a window computed from the events being filtered would be
       // circular, and would behave differently for a caller that passed a
       // subset.
+      // Defensive copies: MIN_INSTANT/MAX_INSTANT are module-level
+      // singletons, and a `Date` is mutable. Handing out the singletons
+      // themselves would let one `w.start.setHours(...)` in a future caller
+      // permanently corrupt every subsequent `'all'` window.
       return {
         startDay: o.bounds.startDay,
         endDay: o.bounds.endDay,
-        start: MIN_INSTANT,
-        endExclusive: MAX_INSTANT,
+        start: new Date(MIN_INSTANT),
+        endExclusive: new Date(MAX_INSTANT),
       };
 
     case 'today': {
@@ -215,12 +219,15 @@ export function baseWindow(o: WindowOptions): ViewWindow | null {
       if (o.currentWeekNumber === null) return null;
       const week = o.seasonWeeks[o.currentWeekNumber - 1];
       // The week's own bounds, carried through verbatim — `SeasonWeek` is
-      // already half-open (`>= start && < end`).
+      // already half-open (`>= start && < end`). Copied, not aliased: these
+      // `Date`s belong to the caller's `seasonWeeks` array, and returning
+      // them by reference would let a mutation of the returned window reach
+      // back into that array.
       return {
         startDay: dayKeyOf(week.start),
         endDay: lastDayCovered(week.end),
-        start: week.start,
-        endExclusive: week.end,
+        start: new Date(week.start),
+        endExclusive: new Date(week.end),
       };
     }
   }

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -140,7 +140,13 @@ export function navigableBounds(
   let endDay = dayKeyOf(seasonWeeks[seasonWeeks.length - 1].end);
 
   for (const event of events) {
-    const key = dayKeyOf(new Date(event.startDate));
+    const parsed = new Date(event.startDate);
+    // An unparseable date must not poison the global bound: 'NaN-NaN-NaN'
+    // sorts above every real key, so a single bad row would otherwise widen
+    // endDay for the whole app. Every other call site (filterHelpers,
+    // eventHelpers, dateHelpers) already just drops such a row — match that.
+    if (Number.isNaN(parsed.getTime())) continue;
+    const key = dayKeyOf(parsed);
     if (key < startDay) startDay = key;
     if (key > endDay) endDay = key;
   }
@@ -229,19 +235,33 @@ export function baseWindow(o: WindowOptions): ViewWindow | null {
  * exact instant. That is what preserves `'next'`'s one-hour grace and
  * `'this-week'`'s noon boundaries until the user actually navigates past
  * them.
+ *
+ * `bounds` is clamped onto the *expansion inputs*, not onto the merged
+ * result. The base window itself is never touched by the clamp: a scope's
+ * own window (e.g. off-season `'today'`, which sits entirely outside
+ * `bounds` for ~10 months a year) is never rewritten on only one edge, which
+ * is what would invert `startDay`/`endDay` if the clamp ran after the merge.
+ * `bounds` exists to bound how far navigation can *reach* — it has nothing
+ * to say about a scope that hasn't been navigated at all.
  */
 export function viewWindow(o: WindowOptions): ViewWindow | null {
   const base = baseWindow(o);
   if (!base) return null;
 
+  let expandedStartDay = o.expandedStartDay;
+  if (expandedStartDay && expandedStartDay < o.bounds.startDay) {
+    expandedStartDay = o.bounds.startDay;
+  }
+  let expandedEndDay = o.expandedEndDay;
+  if (expandedEndDay && expandedEndDay > o.bounds.endDay) {
+    expandedEndDay = o.bounds.endDay;
+  }
+
   let startDay = base.startDay;
   let endDay = base.endDay;
 
-  if (o.expandedStartDay && o.expandedStartDay < startDay) startDay = o.expandedStartDay;
-  if (o.expandedEndDay && o.expandedEndDay > endDay) endDay = o.expandedEndDay;
-
-  if (startDay < o.bounds.startDay) startDay = o.bounds.startDay;
-  if (endDay > o.bounds.endDay) endDay = o.bounds.endDay;
+  if (expandedStartDay && expandedStartDay < startDay) startDay = expandedStartDay;
+  if (expandedEndDay && expandedEndDay > endDay) endDay = expandedEndDay;
 
   return {
     startDay,

--- a/frontend/src/lib/utils/filterHelpers.ts
+++ b/frontend/src/lib/utils/filterHelpers.ts
@@ -1,44 +1,42 @@
 import type { Event, SeasonWeek } from '@/lib/types';
-import { isToday, isThisWeek, isInChautauquaWeek } from './dateHelpers';
+import { isInChautauquaWeek } from './dateHelpers';
+import { windowContains, type ViewWindow } from './dayWindow';
 import { searchEvents } from './searchHelpers';
 
 export interface FilterOptions {
   searchTerm: string;
-  dateFilter: 'all' | 'today' | 'next' | 'this-week';
   selectedWeeks: number[];
   selectedTagsLowerSet: Set<string>;
   selectedLocationsLowerSet: Set<string>;
   seasonWeeks: SeasonWeek[];
-  currentWeekNumber: number | null;
+  /**
+   * The instant range the list is narrowed to, derived by `dayWindow`.
+   * `null` means the current scope matches nothing — reachable only for
+   * `'this-week'` outside the season.
+   */
+  viewWindow: ViewWindow | null;
   showFavoritesOnly?: boolean;
   favoriteIds?: Set<string>;
-  adaptiveEndDate?: Date;
 }
 
 export function filterEvents(events: Event[], options: FilterOptions): Event[] {
+  // A null window means the scope matches nothing. Returning early also
+  // keeps the weeks/venue/category stages from running over a set that is
+  // already empty.
+  if (options.viewWindow === null) return [];
+
   let filtered = [...events];
 
-  // Search filter
   if (options.searchTerm) {
     filtered = searchEvents(filtered, options.searchTerm);
   }
 
-  // Date filter
-  if (options.dateFilter === 'today') {
-    filtered = filtered.filter(event => isToday(event.startDate));
-  } else if (options.dateFilter === 'next') {
-    const now = new Date();
-    const oneHourAgo = new Date(now.getTime() - 60 * 60 * 1000);
-    const endDateFallback = new Date(now.getTime() + 6 * 24 * 60 * 60 * 1000);
-    endDateFallback.setHours(23, 59, 59, 999);
-    const endDate = options.adaptiveEndDate || endDateFallback;
-    filtered = filtered.filter(event => {
-      const eventDate = new Date(event.startDate);
-      return eventDate >= oneHourAgo && eventDate <= endDate;
-    });
-  } else if (options.dateFilter === 'this-week') {
-    filtered = filtered.filter(event => isThisWeek(event.startDate, options.seasonWeeks, options.currentWeekNumber));
-  }
+  // The date stage. One half-open range check for every scope — the four
+  // scope-specific predicates this replaced (isToday, isThisWeek, the
+  // inline 'next' arithmetic, and 'all' doing nothing) all reduce to this
+  // once the scope has been turned into a window.
+  const window = options.viewWindow;
+  filtered = filtered.filter((event) => windowContains(window, new Date(event.startDate)));
 
   // Week filter (independent of date filter)
   if (options.selectedWeeks.length > 0) {

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -32,6 +32,15 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    // Pin the test-run timezone to the app's own zone (Chautauqua
+    // Institution, America/New_York). Without this, DST-transition tests
+    // (see dayWindow.test.ts) only discriminate a DST-safe date-parts
+    // implementation from a naive millisecond-arithmetic one in a
+    // DST-observing zone — GitHub-hosted runners are UTC, where 2026-03-08
+    // and 2026-11-01 are not transitions, so the naive version would pass
+    // there. Set before test files load (see vitest `test.env` docs), which
+    // is early enough that Node's Date/Intl machinery picks it up.
+    env: { TZ: 'America/New_York' },
     setupFiles: ['./src/__tests__/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
     coverage: {


### PR DESCRIPTION
Phase 1a of the cross-platform date-navigation initiative (#225 web / #226 iOS). Phase 0 (the area-split deploy) merged as #231; this is the web half of the shared window model.

Plan: `docs/superpowers/plans/2026-08-15-date-navigation-phase-1a-web-window-model.md`
Spec: `docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md`

## What changes

`filterEvents`' date stage was four scope-specific branches — `isToday`, `isThisWeek`, inline `'next'` arithmetic, and `'all'` doing nothing. All four reduce to a single half-open range check once the scope is turned into a `ViewWindow`, so `isToday` and `isThisWeek` are deleted; each had exactly one caller.

`extraDays: number` is replaced by `windowStartDay` / `windowEndDay` day keys. It was only ever the window's end expressed as an offset that meant something under one scope, which is why it needed an effect to clear it on every scope change. Absolute day keys make that reset part of `SET_DATE_FILTER` itself, so the state cannot outlive the scope it belongs to — the bug class behind #156, closed by construction. The effect is deleted with it.

New module `frontend/src/lib/utils/dayWindow.ts` is pure and owns all day-key arithmetic and the window derivation. Day keys are `yyyy-mm-dd` local, matching iOS's `ChqTime.dayKey` byte for byte, so lexicographic comparison is chronological comparison and the two platforms name the same day the same way.

This is the de-risking phase: **no rail, no stepping, no scope-set change.** Those are phases 2–4.

## Behavior

Zero user-visible change, with two footnotes worth naming rather than burying:

1. **Under `All`, an event with an unparseable `startDate` is now dropped.** Previously `'all'` ran no date predicate at all, so such a row reached `groupEventsByDay`, which keyed it `'NaN-NaN-NaN'` and rendered it as an **"Invalid Date" day section at the bottom of the list**. Dropping it is a fix, and it matches what `Today`/`Now`/`This Week` always did.
2. **`now` is captured in a memo,** so `Today` and `Now` no longer self-correct across midnight on an unrelated filter interaction. That refresh was incidental, never designed — `currentWeekNumber` was already frozen for the whole session — so this makes the scopes consistent with each other. A real fix is a ticking `now` on midnight / `visibilitychange`, which belongs with phase 2's `⟳ Now` control.

Verified by hand in the browser: default `Now` lists events; "Show next day (…)" names the day after the last one shown and, on click, appends exactly one day and relabels; reload drops the widening; `Today` shows one day with the button gone; `This Week` spans 8 day-keys and `All` spans 88; year switch to 2025 and back restores cleanly with no page errors.

## Two things the review process caught

**The clamp goes on the expansion inputs, not the merged window.** The plan and the spec both said clamp-after-merge. That **inverts the window** (`startDay > endDay`, `start > endExclusive`) whenever the base window sits outside the season — off-season `Today`, i.e. the app's state ~10 months a year. The spec's justification, that the bounds contain every event day by construction, is false for exactly those scopes. `ce0fe2f` corrects the spec **and the iOS phase-1b plan**, which carried the same form and papered over the inversion with a `guard start < endExclusive` that would have made off-season `.today` return "matches nothing" on iOS while the web returned today's window. Same function name, two semantics — the drift a shared model exists to prevent.

**The DST guard was inert in CI.** `addDays` builds from date parts and `setDate` rather than adding 86,400,000 ms, and a test pins that. But hosted runners are UTC, where neither 2026-03-08 nor 2026-11-01 is a transition — so the naive implementation passed the whole suite. `frontend/vitest.config.ts` now pins `TZ=America/New_York`; vitest's `test.env` reaches the forks-pool child at spawn, before `Date` initializes. Re-running the naive mutation under a hostile `TZ=UTC` shell now fails, as it should.

## Commits

| commit | what |
|---|---|
| `f3ec42d` | characterization tests for the date stage, written first — `filterEvents` had no direct coverage at all |
| `bed2d57` | the `dayWindow` module, pure and unwired |
| `c9e97ed` | hardening: the `TZ` pin, a parse guard so one bad event cannot poison the global bounds, coverage for `windowContains`, and the clamp rework |
| `b10924d` | the atomic wiring change across `filterHelpers`, `dateHelpers`, `useFilterState` and `page.tsx` |
| `f6ae507` | `SET_DATE_FILTER` no-op guard — the reducer case fired on same-value dispatches where the effect it replaced only fired on a change |
| `ce0fe2f` | the spec + iOS phase-1b plan clamp correction |

## Tests

689 frontend (up from 630; the characterization suite pins all four scopes and that weeks AND with the date stage rather than replacing it), 909 backend, type-check clean, both builds clean. Exactly one pre-existing test changed — `'clears extraDays on reconciliation'` named the deleted API and was translated rather than dropped.

## Deferred to phase 2's first task

`dayKeys` has no termination guard. In the start direction of expansion, growth is tested but the narrowing-ignored and clamp-to-bounds cases are not — and there is no production caller until the rail lands, so that half of the code stays dark until phase 2 turns it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PN8JR7jFsQuzmhnrLxDDT
