### PR TITLE
refactor(ios): derive one date window and one owner for the scope downgrade

### DIFF
--- a/docs/superpowers/plans/2026-08-15-date-navigation-phase-1b-ios-window-model.md
+++ b/docs/superpowers/plans/2026-08-15-date-navigation-phase-1b-ios-window-model.md
@@ -23,7 +23,7 @@
 - **`windowStartDayKey` / `windowEndDayKey` are session-only.** `UserStateStore.saveFilters` builds a separate `PersistedFilters` struct (`UserStateStore.swift:279-290`) that already omits `searchText`, `extraDays`, and `selectedDayKey` — so **no persistence change is required**, and none may be added. They must also be excluded from `FilterSelection.isDefault`.
 - **The `.day` exemption is the highest-risk change in this plan.** It currently lives in three places that must agree: `EventFilter.swift:42`, `DateFilterLabel.swift:74-78`, and `FilterChipState.swift:56, 66, 92, 101`. `FilterChipState` is the one where getting it wrong is a **silent behavioral bug** rather than a compile error. Task 1 pins all three before Task 2 touches any of them.
 - **Screenshot obligation.** This plan modifies `ios/ChqCalendar/Features/Calendar/EventListView.swift` and `ios/ChqCalendarShared/**`, both matched by `.github/workflows/app-store-assets.yml`. **No pixel changes** — the "Show next day" button keeps its label, placement, and behavior. Opt out explicitly in the PR description with `[skip-screenshots: phase 1b is a pure refactor; no visible change — button label, placement and behavior are unchanged]`.
-- **Version is 1.1.3** wherever a version is referenced. Do not reintroduce 1.1.2.
+- **This plan does not touch `MARKETING_VERSION`.** `project.pbxproj` is at `1.1.2` on `main` as of this writing; that is current, not stale. If a version bump is ever needed alongside this work, confirm the live value in `project.pbxproj` first rather than trusting a number written into this plan on an earlier day.
 
 ---
 
@@ -1332,14 +1332,36 @@ import Testing
 /// Nothing compiles across that boundary, so the two can drift in silence —
 /// these are the invariants a reader of either file is entitled to assume
 /// hold on both. The web's mirror lives in
-/// `frontend/src/__tests__/lib/utils/dayWindow.test.ts`.
+/// `frontend/src/__tests__/lib/utils/dayWindow.test.ts`; each test below
+/// names the web test it mirrors.
 struct WindowParityTests {
 
-    @Test func dayKeysAreZeroPaddedAndSortChronologically() {
-        let keys = ["2026-12-31", "2026-07-05", "2026-07-15"]
-        #expect(keys.sorted() == ["2026-07-05", "2026-07-15", "2026-12-31"])
+    private static func at(_ s: String) throws -> Date {
+        try #require(ChqTime.parse(s))
     }
 
+    private func bounds() -> ClosedRange<String> {
+        DayWindow.bounds(year: 2026, starredDays: [])
+    }
+
+    /// Mirrors "formats a date as a zero-padded local day key" + "sorts
+    /// lexicographically in chronological order". Round-trips through
+    /// `ChqTime.dayKey(for:)` itself — every hand-typed key is already
+    /// zero-padded by construction, so a test built only from hand-typed
+    /// strings cannot fail no matter what the formatter does.
+    @Test func dayKeysAreZeroPaddedAndSortChronologically() throws {
+        let jan5 = try Self.at("2026-01-05 08:00:00")
+        let jul15 = try Self.at("2026-07-15 08:00:00")
+        let dec31 = try Self.at("2026-12-31 08:00:00")
+
+        #expect(ChqTime.dayKey(for: jan5) == "2026-01-05")
+        #expect(ChqTime.dayKey(for: jul15) == "2026-07-15")
+
+        let keys = [ChqTime.dayKey(for: dec31), ChqTime.dayKey(for: jan5), ChqTime.dayKey(for: jul15)]
+        #expect(keys.sorted() == ["2026-01-05", "2026-07-15", "2026-12-31"])
+    }
+
+    /// Mirrors "crosses a DST transition without drifting".
     @Test func dayArithmeticCrossesMonthYearAndDstBoundaries() {
         #expect(ChqTime.day("2026-07-31", offsetBy: 1) == "2026-08-01")
         #expect(ChqTime.day("2026-08-01", offsetBy: -1) == "2026-07-31")
@@ -1352,6 +1374,8 @@ struct WindowParityTests {
         #expect(ChqTime.day("2026-03-08", offsetBy: 1) == "2026-03-09")
     }
 
+    /// Mirrors "produces inclusive contiguous ranges" and "returns an empty
+    /// range when the bounds are inverted".
     @Test func dayRangesAreInclusiveAndEmptyWhenInverted() {
         #expect(ChqTime.dayKeys(from: "2026-07-14", through: "2026-07-16")
             == ["2026-07-14", "2026-07-15", "2026-07-16"])
@@ -1359,15 +1383,71 @@ struct WindowParityTests {
         #expect(ChqTime.dayKeys(from: "2026-07-16", through: "2026-07-14") == [])
     }
 
+    /// Mirrors "spans both boundary Saturdays" (noon-to-noon) — extended to
+    /// actually assert noon, which the original wording claimed without any
+    /// clock-component check.
     @Test func theSeasonIsNineWeeksOfNoonSaturdayBoundaries() {
         let weeks = SeasonCalendar.weeks(forYear: 2026)
         #expect(weeks.count == 9)
+        let calendar = ChqTime.calendar
+        for week in weeks {
+            #expect(
+                calendar.component(.hour, from: week.start) == 12,
+                "week \(week.number) start must be noon")
+            #expect(
+                calendar.component(.hour, from: week.end) == 12,
+                "week \(week.number) end must be noon")
+        }
         for i in 0..<(weeks.count - 1) {
             #expect(weeks[i].end == weeks[i + 1].start, "week \(i + 1) end must equal week \(i + 2) start")
         }
     }
+
+    /// Mirrors `windowContains`'s "does not contain an instant exactly at
+    /// endExclusive" — the half-openness the whole shared model exists to
+    /// enforce — exercised through the real `ViewWindow.make`, not a
+    /// synthetic window.
+    @Test func endExclusiveBelongsToTheNextWindowNotThisOne() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(ViewWindow.make(
+            selection: FilterSelection(dateScope: .today), events: [], now: now,
+            year: 2026, isCurrentYear: true, bounds: bounds()))
+        #expect(w.contains(w.start))
+        #expect(!w.contains(w.endExclusive))
+    }
+
+    /// Mirrors `lastDayCovered`'s "names the last day shown, stepping back
+    /// only on an exact midnight": a window ending at midnight does not show
+    /// that day (`.today`), one ending mid-day does (`.thisWeek`'s noon
+    /// Saturday).
+    @Test func lastDayCoveredOnMidnightAndNoonBounds() throws {
+        #expect(ViewWindow.lastDayCovered(try Self.at("2026-07-16 00:00:00")) == "2026-07-15")
+        #expect(ViewWindow.lastDayCovered(try Self.at("2026-07-18 12:00:00")) == "2026-07-18")
+    }
+
+    /// Mirrors "ignores an expansion that would narrow the base window".
+    @Test func anExpansionNarrowerThanTheBaseWindowIsIgnored() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2026-07-10"
+        let w = try #require(ViewWindow.make(
+            selection: sel, events: [], now: now,
+            year: 2026, isCurrentYear: true, bounds: bounds()))
+        #expect(w.endDay == "2026-07-15")
+    }
 }
 ```
+
+**Not one of these tests may name only `ChqTime` or `SeasonCalendar` without also
+exercising `ViewWindow` itself** — that was the defect in an earlier draft of
+this task: a "parity" suite where three of four tests never touched
+`ViewWindow` at all, and the fourth (`theSeasonIsNineWeeksOfNoonSaturdayBoundaries`,
+as originally drafted) asserted contiguity but never checked the "noon" its own
+name promised — a test that could not fail no matter what the code did. Every
+test above either calls `ViewWindow.make`/`ViewWindow.lastDayCovered` directly,
+or — for the `ChqTime`/`SeasonCalendar` helpers `ViewWindow` is built from —
+round-trips through the real formatter rather than asserting a property of
+`Array<String>.sorted()` that holds regardless of this codebase.
 
 - [ ] **Step 2: Run, then run the full suite**
 
@@ -1384,8 +1464,13 @@ git commit -m "test(ios): pin the invariants shared with the web window module
 Nothing compiles across the platform boundary, so the two ViewWindow
 implementations can drift in silence. These pin what a reader of either
 file is entitled to assume holds on both: zero-padded day keys that sort
-chronologically, DST-safe day arithmetic, inclusive ranges that go empty
-when inverted, and nine contiguous noon-Saturday weeks."
+chronologically (round-tripped through the real formatter, not hand-typed
+strings), DST-safe day arithmetic, inclusive ranges that go empty when
+inverted, nine contiguous noon-Saturday weeks (asserting noon, not just
+contiguity), ViewWindow's half-open endExclusive bound, lastDayCovered on
+both a midnight and a noon bound, and an expansion narrower than the base
+window being ignored — exercised through ViewWindow.make itself, not just
+its ChqTime/SeasonCalendar building blocks."
 ```
 
 ---

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1015,10 +1015,12 @@ final class AppModel {
     /// to the selection as a whole, so changing scope cannot leave a
     /// previous scope's state behind to take effect again later.
     ///
-    /// - `extraDays` is `.next`-only (`EventFilter.apply` reads it in that
-    ///   branch and nowhere else). Without this, "Show next day" ×2 → This
-    ///   Week → Now returns to a window two days wider than a fresh `.next`
-    ///   selection, with nothing on screen explaining why (#156).
+    /// - `windowStartDayKey`/`windowEndDayKey` are how far the user has
+    ///   navigated beyond whatever scope was active when they did it —
+    ///   meaningless once that scope is gone. Without this, "Show next day"
+    ///   ×2 → This Week → Now returns to a window two days wider than a
+    ///   fresh `.next` selection, with nothing on screen explaining why
+    ///   (#156).
     /// - `selectedDayKey` is `.day`-only. Leaving it set is inert *today*
     ///   because it is read only while `dateScope == .day`, but that is an
     ///   invariant held by convention across three methods; clearing it
@@ -1027,11 +1029,12 @@ final class AppModel {
     ///   `DateFilterLabel` would have to describe (#197 item 5).
     ///
     /// `browseDay` deliberately does *not* call this: it is the one writer
-    /// that sets `selectedDayKey` and clears `extraDays` in the same
+    /// that sets `selectedDayKey` and clears the window fields in the same
     /// assignment, in that order.
     private func clearScopeLocalDateState() {
-        filter.extraDays = 0
         filter.selectedDayKey = nil
+        filter.windowStartDayKey = nil
+        filter.windowEndDayKey = nil
     }
 
     /// Replaces the week selection wholesale — the strip owns tap/drag
@@ -1067,8 +1070,9 @@ final class AppModel {
     /// a non-canonical (but validly parsed) key.
     ///
     /// Clears `selectedWeeks`, since a standing week filter can exclude the
-    /// very day the user asked for, and `extraDays`, which is a `.next`-only
-    /// concept. Deliberately leaves `searchText`, venues, categories, and
+    /// very day the user asked for, and the window-expansion fields, which
+    /// only mean something relative to the scope being left behind.
+    /// Deliberately leaves `searchText`, venues, categories, and
     /// favorites-only alone: those are the user's standing preferences, not
     /// date state.
     func browseDay(_ dayKey: String) {
@@ -1076,7 +1080,8 @@ final class AppModel {
         filter.dateScope = .day
         filter.selectedDayKey = ChqTime.dayKey(for: parsed)
         filter.selectedWeeks = []
-        filter.extraDays = 0
+        filter.windowStartDayKey = nil
+        filter.windowEndDayKey = nil
         persistFilter()
     }
 
@@ -1194,8 +1199,8 @@ final class AppModel {
     }
 
     /// "Show all events" — clears every filter, including the search term
-    /// and `extraDays`, and drops the scope to `.all`. Mirrors the web's
-    /// CLEAR_FILTERS.
+    /// and the window-expansion fields, and drops the scope to `.all`.
+    /// Mirrors the web's CLEAR_FILTERS.
     ///
     /// This deliberately clears `searchText`, which the previous
     /// `clearFilters()` preserved. That preservation only made sense while
@@ -1231,8 +1236,20 @@ final class AppModel {
         }
     }
 
-    func showNextDay() {
-        filter.extraDays += 1
+    /// Widens the window by one calendar day from wherever it currently ends
+    /// — the same operation whether that end came from the scope or from a
+    /// previous widening.
+    func expandWindowEnd() {
+        let bounds = ViewWindow.navigableBounds(
+            year: selectedYear, events: snapshot?.events ?? [], starredDays: [])
+        guard
+            let window = ViewWindow.make(
+                selection: filter, events: snapshot?.events ?? [], now: now(),
+                year: selectedYear, isCurrentYear: isCurrentYear, bounds: bounds),
+            let next = ChqTime.day(window.endDay, offsetBy: 1),
+            next <= bounds.upperBound
+        else { return }
+        filter.windowEndDayKey = next
     }
 
     private func persistFilter() {

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -177,7 +177,16 @@ struct EventListView: View {
                 }
             }
 
-            if model.isCurrentYear && model.filter.dateScope == .next {
+            // `EffectiveScope.resolve(_:isCurrentYear:) == .next` is exactly
+            // `model.isCurrentYear && model.filter.dateScope == .next`: for
+            // any scope other than `.day`, `resolve` returns the stored
+            // scope unchanged when `isCurrentYear` and `.all` otherwise, so
+            // it equals `.next` iff both halves of the old condition held.
+            // `.day` is never `.next`, so its branch never enters into the
+            // comparison. Same button in the same states — this is the
+            // fourth site that duplicated the downgrade rule, collapsed
+            // like the other three (#192, #197).
+            if EffectiveScope.resolve(model.filter, isCurrentYear: model.isCurrentYear) == .next {
                 Button("Show next day") {
                     model.expandWindowEnd()
                 }

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -179,7 +179,7 @@ struct EventListView: View {
 
             if model.isCurrentYear && model.filter.dateScope == .next {
                 Button("Show next day") {
-                    model.showNextDay()
+                    model.expandWindowEnd()
                 }
             }
         }

--- a/ios/ChqCalendarShared/Data/UserStateStore.swift
+++ b/ios/ChqCalendarShared/Data/UserStateStore.swift
@@ -16,10 +16,11 @@ nonisolated enum DateScope: String, Codable, CaseIterable, Sendable {
     /// empty-day "Browse …" action (#192).
     ///
     /// Unlike every other case here it names an **absolute** date, not a
-    /// window relative to "now". That is why both `EventFilter.apply` and
-    /// `DateFilterLabel.text` exempt it from their non-current-year
-    /// downgrade to `.all`: a named day is just as meaningful in an archived
-    /// season as in the live one.
+    /// window relative to "now". That is why `EffectiveScope.resolve` — the
+    /// one place `EventFilter.apply`, `DateFilterLabel.text`, and
+    /// `FilterChipState` all go for this — exempts it from the
+    /// non-current-year downgrade to `.all`: a named day is just as
+    /// meaningful in an archived season as in the live one.
     case day
 
     var label: String {
@@ -37,12 +38,12 @@ nonisolated enum DateScope: String, Codable, CaseIterable, Sendable {
 
 /// The user's current filter/search state for the event list.
 ///
-/// `searchText`, `extraDays`, and `selectedDayKey` are session-only: they
-/// affect what's shown right now but are deliberately excluded from
-/// `isDefault` and are never persisted by `UserStateStore` — which also
-/// persists a live `.day` scope as `.next`, since without its day key it
-/// would mean nothing on the way back in (matches web intent — a fresh app
-/// launch always starts with an empty search box) (#192).
+/// `searchText`, `selectedDayKey`, `windowStartDayKey`, and `windowEndDayKey`
+/// are session-only: they affect what's shown right now but are deliberately
+/// excluded from `isDefault` and are never persisted by `UserStateStore` —
+/// which also persists a live `.day` scope as `.next`, since without its day
+/// key it would mean nothing on the way back in (matches web intent — a
+/// fresh app launch always starts with an empty search box) (#192).
 nonisolated struct FilterSelection: Codable, Equatable, Sendable {
     var searchText: String = ""
     var dateScope: DateScope = .next
@@ -50,8 +51,8 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
     /// The single day a `.day` scope names, as a `ChqTime.dayKey`
     /// (`"yyyy-MM-dd"`). Meaningful only while `dateScope == .day`.
     ///
-    /// **Session-only**, like `searchText` and `extraDays`: never persisted
-    /// by `UserStateStore`. Restoring a date pinned days ago would be worse
+    /// **Session-only**, like `searchText`: never persisted by
+    /// `UserStateStore`. Restoring a date pinned days ago would be worse
     /// than not restoring at all (#192).
     var selectedDayKey: String?
     /// Venue and category selections hold the feed's **original casing** in
@@ -63,11 +64,10 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
     var selectedLocations: [String] = []
     var selectedCategories: [String] = []
     var showFavoritesOnly: Bool = false
-    var extraDays: Int = 0
     /// How far the user has navigated beyond the current scope's own window,
     /// as `ChqTime.dayKey` strings. `nil` means "not expanded that way".
     ///
-    /// **Session-only**, like `searchText`, `extraDays` and `selectedDayKey`:
+    /// **Session-only**, like `searchText` and `selectedDayKey`:
     /// `UserStateStore.saveFilters` builds a separate `PersistedFilters`
     /// that does not carry them, so no persistence change is needed — and
     /// none may be added. Restoring a window pinned days ago would be worse
@@ -83,7 +83,6 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
         selectedLocations: [String] = [],
         selectedCategories: [String] = [],
         showFavoritesOnly: Bool = false,
-        extraDays: Int = 0,
         windowStartDayKey: String? = nil,
         windowEndDayKey: String? = nil
     ) {
@@ -94,14 +93,14 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
         self.selectedLocations = selectedLocations
         self.selectedCategories = selectedCategories
         self.showFavoritesOnly = showFavoritesOnly
-        self.extraDays = extraDays
         self.windowStartDayKey = windowStartDayKey
         self.windowEndDayKey = windowEndDayKey
     }
 
     /// Whether the *persisted* facets (weeks/locations/categories/
     /// favorites-only/scope) match a brand-new `FilterSelection()`.
-    /// `searchText`/`extraDays` are session-only and excluded.
+    /// `searchText`/`windowStartDayKey`/`windowEndDayKey` are session-only
+    /// and excluded.
     var isDefault: Bool {
         selectedWeeks.isEmpty
             && selectedLocations.isEmpty
@@ -161,12 +160,13 @@ nonisolated struct RecentFilters: Codable, Equatable, Sendable {
 /// each with a 30-day expiry so a user who hasn't opened the app in a
 /// month starts fresh rather than seeing stale/confusing filters.
 ///
-/// `searchText`/`extraDays`/`selectedDayKey` are session-only and are never
-/// written to disk: `saveFilters` persists a payload with those fields
-/// reset to their defaults, so `loadFilters` always returns an empty
-/// search, zero extra days, and no day key even immediately after a round
-/// trip. A live `.day` scope is likewise persisted as `.next`, since
-/// without its day key it would mean nothing on the way back in (#192).
+/// `searchText`/`selectedDayKey`/`windowStartDayKey`/`windowEndDayKey` are
+/// session-only and are never written to disk: `saveFilters` persists a
+/// payload with those fields reset to their defaults, so `loadFilters`
+/// always returns an empty search and no day key or window expansion even
+/// immediately after a round trip. A live `.day` scope is likewise
+/// persisted as `.next`, since without its day key it would mean nothing on
+/// the way back in (#192).
 nonisolated struct UserStateStore {
     private static let filtersKey = "chq-filters"
     private static let favoritesKey = "chq-favorites"
@@ -175,8 +175,9 @@ nonisolated struct UserStateStore {
     private static let expiry: TimeInterval = 30 * 24 * 3600
 
     /// The subset of `FilterSelection` that's actually persisted —
-    /// `searchText`/`extraDays`/`selectedDayKey` are intentionally omitted,
-    /// and a `.day` scope is stored as `.next` (#192).
+    /// `searchText`/`selectedDayKey`/`windowStartDayKey`/`windowEndDayKey`
+    /// are intentionally omitted, and a `.day` scope is stored as `.next`
+    /// (#192).
     private struct PersistedFilters: Codable {
         var dateScope: DateScope
         var selectedWeeks: Set<Int>
@@ -266,9 +267,9 @@ nonisolated struct UserStateStore {
     }
 
     /// Loads the persisted filter facets, or `nil` if nothing was saved or
-    /// the saved state is 30+ days old. `searchText`, `extraDays`, and
-    /// `selectedDayKey` are always returned at their defaults (empty/0/nil)
-    /// since they aren't persisted.
+    /// the saved state is 30+ days old. `searchText`, `selectedDayKey`,
+    /// `windowStartDayKey`, and `windowEndDayKey` are always returned at
+    /// their defaults (empty/nil) since they aren't persisted.
     func loadFilters() -> FilterSelection? {
         guard
             let data = defaults.data(forKey: Self.filtersKey),
@@ -287,9 +288,10 @@ nonisolated struct UserStateStore {
     }
 
     /// Persists `f`'s facets, stamped with the current time. `searchText`,
-    /// `extraDays`, and `selectedDayKey` are deliberately dropped — they're
-    /// session-only — and a live `.day` scope is persisted as `.next`, since
-    /// without its day key it would mean nothing on the way back in.
+    /// `selectedDayKey`, `windowStartDayKey`, and `windowEndDayKey` are
+    /// deliberately dropped — they're session-only — and a live `.day` scope
+    /// is persisted as `.next`, since without its day key it would mean
+    /// nothing on the way back in.
     func saveFilters(_ f: FilterSelection) {
         let persisted = PersistedFilters(
             dateScope: f.dateScope == .day ? .next : f.dateScope,

--- a/ios/ChqCalendarShared/Data/UserStateStore.swift
+++ b/ios/ChqCalendarShared/Data/UserStateStore.swift
@@ -16,11 +16,15 @@ nonisolated enum DateScope: String, Codable, CaseIterable, Sendable {
     /// empty-day "Browse …" action (#192).
     ///
     /// Unlike every other case here it names an **absolute** date, not a
-    /// window relative to "now". That is why `EffectiveScope.resolve` — the
-    /// one place `EventFilter.apply`, `DateFilterLabel.text`, and
-    /// `FilterChipState` all go for this — exempts it from the
-    /// non-current-year downgrade to `.all`: a named day is just as
-    /// meaningful in an archived season as in the live one.
+    /// window relative to "now". That is why `EffectiveScope.resolve`
+    /// exempts it from the non-current-year downgrade to `.all`: a named
+    /// day is just as meaningful in an archived season as in the live one.
+    /// `DateFilterLabel.text` and `FilterChipState` call
+    /// `EffectiveScope.resolve` directly; `EventFilter.apply` gets the same
+    /// rule only indirectly, through `ViewWindow.base` — so grepping
+    /// `EventFilter.swift` for `EffectiveScope` finds nothing. That isn't
+    /// this rule being skipped there; `ViewWindow` is applying it on
+    /// `EventFilter`'s behalf.
     case day
 
     var label: String {

--- a/ios/ChqCalendarShared/Data/UserStateStore.swift
+++ b/ios/ChqCalendarShared/Data/UserStateStore.swift
@@ -64,6 +64,16 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
     var selectedCategories: [String] = []
     var showFavoritesOnly: Bool = false
     var extraDays: Int = 0
+    /// How far the user has navigated beyond the current scope's own window,
+    /// as `ChqTime.dayKey` strings. `nil` means "not expanded that way".
+    ///
+    /// **Session-only**, like `searchText`, `extraDays` and `selectedDayKey`:
+    /// `UserStateStore.saveFilters` builds a separate `PersistedFilters`
+    /// that does not carry them, so no persistence change is needed — and
+    /// none may be added. Restoring a window pinned days ago would be worse
+    /// than not restoring (#192).
+    var windowStartDayKey: String?
+    var windowEndDayKey: String?
 
     init(
         searchText: String = "",
@@ -73,7 +83,9 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
         selectedLocations: [String] = [],
         selectedCategories: [String] = [],
         showFavoritesOnly: Bool = false,
-        extraDays: Int = 0
+        extraDays: Int = 0,
+        windowStartDayKey: String? = nil,
+        windowEndDayKey: String? = nil
     ) {
         self.searchText = searchText
         self.dateScope = dateScope
@@ -83,6 +95,8 @@ nonisolated struct FilterSelection: Codable, Equatable, Sendable {
         self.selectedCategories = selectedCategories
         self.showFavoritesOnly = showFavoritesOnly
         self.extraDays = extraDays
+        self.windowStartDayKey = windowStartDayKey
+        self.windowEndDayKey = windowEndDayKey
     }
 
     /// Whether the *persisted* facets (weeks/locations/categories/

--- a/ios/ChqCalendarShared/Domain/DateFilterLabel.swift
+++ b/ios/ChqCalendarShared/Domain/DateFilterLabel.swift
@@ -46,55 +46,20 @@ nonisolated enum DateFilterLabel {
     ) -> String {
         let weeks = selection.selectedWeeks.sorted()
 
-        // `.day` is resolved *before* both the week logic and the
-        // `isCurrentYear` shortcut, because it is the only scope that
-        // survives on both axes.
-        //
-        // Before the weeks: `EventFilter.apply` runs the weeks stage
-        // *outside* the scope `switch`, so a selection carrying both is
-        // day-filtered *and* week-filtered. The day is never the wider of
-        // the two, so naming it cannot overclaim; naming the week can — and
-        // when the day falls outside the selected week the list is empty,
-        // which "Week 3" describes especially badly (#197 item 5).
-        //
-        // Before the `isCurrentYear` shortcut: that shortcut is correct only
-        // because every other scope is downgraded to `.all` for a
-        // non-current year, which makes "All Year" a true statement about
-        // what the list is showing. `.day` survives that downgrade (see
-        // `EventFilter.apply`), so taking the shortcut would leave the pill
-        // claiming "All Year" over a day-filtered list — the pill lying
-        // about the filter, which is exactly the failure this type's doc
-        // comment warns about for `.next` (#192).
-        //
-        // A `.day` scope whose key is `nil` or unparseable filters nothing,
-        // so it deliberately falls through to the week/scope logic below
-        // rather than being caught here: with a week selection still
-        // standing, the weeks are then the only real filter and must be the
-        // ones named.
-        if selection.dateScope == .day,
+        let scope = EffectiveScope.resolve(selection, isCurrentYear: isCurrentYear)
+
+        // Resolved before the week logic: a selection carrying both a day and
+        // weeks is filtered by both, and the day is never the wider of the
+        // two — so naming it cannot overclaim, while naming the week can
+        // (#197 item 5).
+        if scope == .day,
            let dayKey = selection.selectedDayKey,
            let date = ChqTime.parse("\(dayKey) 00:00:00") {
             return ChqTime.pillDayLabel(for: date, includingYear: !isCurrentYear)
         }
 
         guard !weeks.isEmpty else {
-            guard isCurrentYear else { return "All Year" }
-            switch selection.dateScope {
-            case .all: return DateScope.all.label            // "All Year"
-            case .next, .today, .thisWeek, .season: return selection.dateScope.label
-            // Reached when the `.day` branch above declined the selection:
-            // `selectedDayKey` is `nil`, or it's a non-nil string that parse
-            // can't read. Either way `EventFilter` filters no days, so with
-            // no weeks selected either "All Year" is the true statement.
-            //
-            // The unparseable case can no longer arise through the app's
-            // only writer: `AppModel.browseDay` parses the key with the same
-            // `ChqTime.parse("\(dayKey) 00:00:00")` call, and normalizes it
-            // through `ChqTime.dayKey(for:)`, before ever assigning
-            // `selectedDayKey` — so a key that fails here would already have
-            // failed there and never been stored.
-            case .day: return DateScope.all.label
-            }
+            return scope == .all ? DateScope.all.label : scope.label
         }
 
         if weeks.count == seasonWeekCount, weeks == Array(1...seasonWeekCount) {

--- a/ios/ChqCalendarShared/Domain/DateFilterLabel.swift
+++ b/ios/ChqCalendarShared/Domain/DateFilterLabel.swift
@@ -24,12 +24,11 @@ nonisolated enum DateFilterLabel {
     /// - Parameter isCurrentYear: must be the same value the caller passes
     ///   to `EventFilter.apply`. The label has to know it because
     ///   `EventFilter` **ignores** a time-relative `dateScope` when it is
-    ///   `false` (`let scope: DateScope = (isCurrentYear || sel.dateScope ==
-    ///   .day) ? sel.dateScope : .all`) — a past or future season has no
-    ///   "now" — **except `.day`**, which names an absolute date and is
-    ///   exempt from that downgrade. Without this parameter a user whose
-    ///   persisted scope is `.next`, viewing 2025, read "Now" on a list that
-    ///   was not date-filtered at all.
+    ///   `false` — see `EffectiveScope.resolve` for the exact rule — a past
+    ///   or future season has no "now" — **except `.day`**, which names an
+    ///   absolute date and is exempt from that downgrade. Without this
+    ///   parameter a user whose persisted scope is `.next`, viewing 2025,
+    ///   read "Now" on a list that was not date-filtered at all.
     ///
     ///   Deliberately **not defaulted**: a default is exactly what would let
     ///   a future call site forget to pass it and silently reintroduce that
@@ -59,7 +58,14 @@ nonisolated enum DateFilterLabel {
         }
 
         guard !weeks.isEmpty else {
-            return scope == .all ? DateScope.all.label : scope.label
+            // `scope == .day` reaching here means the early return above
+            // declined the selection — `EffectiveScope.resolve` only
+            // downgrades `.day` to `.all` when `selectedDayKey` is `nil`, so
+            // a non-nil-but-unparseable key still resolves to `.day` and
+            // falls through. `EventFilter.apply` filters no days for that
+            // key either, so "All Year" is the true statement, matching
+            // every other non-week-selected scope that isn't itself `.all`.
+            return scope == .day ? DateScope.all.label : scope.label
         }
 
         if weeks.count == seasonWeekCount, weeks == Array(1...seasonWeekCount) {

--- a/ios/ChqCalendarShared/Domain/EffectiveScope.swift
+++ b/ios/ChqCalendarShared/Domain/EffectiveScope.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+/// Which `DateScope` the pipeline **actually applies**, as opposed to the one
+/// stored in `FilterSelection`.
+///
+/// Two rules make those differ, and before this type existed both were
+/// duplicated across `EventFilter.apply`, `DateFilterLabel.text`, and
+/// `FilterChipState.isScopeSelected` — three sites that had to agree, with
+/// no compiler help if they drifted. `FilterChipState` is the one where
+/// drift is a *silent* wrong answer: a chip renders selected or unselected
+/// against a filter that is doing something else entirely (#192, #197).
+///
+/// 1. **A past or future season has no "now"**, so every scope relative to
+///    it degrades to `.all`.
+/// 2. **`.day` is exempt from that**, because it names an absolute calendar
+///    day — just as meaningful in an archived season as in the live one —
+///    but only while it actually carries a key. A `.day` with no key names
+///    no date and filters nothing, which is precisely what `.all` means.
+nonisolated enum EffectiveScope {
+    /// - Parameter isCurrentYear: must be the same value the caller passes to
+    ///   `EventFilter.apply`. Deliberately not defaulted: a default is what
+    ///   lets a future call site forget it and silently reintroduce the bug
+    ///   where a pill read "Now" over a list that was not date-filtered.
+    ///
+    /// Idempotent — resolving an already-resolved scope returns it unchanged
+    /// — so a consumer that resolves twice cannot disagree with one that
+    /// resolves once.
+    static func resolve(
+        scope: DateScope,
+        selectedDayKey: String?,
+        isCurrentYear: Bool
+    ) -> DateScope {
+        if scope == .day {
+            return selectedDayKey == nil ? .all : .day
+        }
+        return isCurrentYear ? scope : .all
+    }
+
+    /// Convenience over a whole selection.
+    static func resolve(_ selection: FilterSelection, isCurrentYear: Bool) -> DateScope {
+        resolve(
+            scope: selection.dateScope,
+            selectedDayKey: selection.selectedDayKey,
+            isCurrentYear: isCurrentYear)
+    }
+}

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -14,11 +14,17 @@ nonisolated enum EventFilter {
     /// window relative to "now", so it is just as meaningful off the current
     /// year.
     ///
-    /// `SeasonCalendar.weeks(forYear:)` is computed once here and reused by
-    /// the weeks filter below — it rebuilds all 9 `SeasonWeek` structs on
-    /// every call, so recomputing it per event would be wasteful. The date
-    /// stage no longer needs its own copy: `.thisWeek`/`.season` compute
-    /// theirs inside `ViewWindow.base`.
+    /// `SeasonCalendar.weeks(forYear:)` is computed once here, for the weeks
+    /// filter below — it rebuilds all 9 `SeasonWeek` structs, so
+    /// recomputing it per event would be wasteful. `ViewWindow.base` builds
+    /// its own separate copy, but only for the two scopes that actually
+    /// read it (`.season`, `.thisWeek`), not on every call — and it isn't
+    /// shared with the copy here, since threading a `[SeasonWeek]` across
+    /// that boundary would trade one cheap 9-struct build for coupling the
+    /// two call sites together. `bounds` below is `DayWindow.bounds`'s
+    /// cheaper season-only range on the common path, not
+    /// `navigableBounds`'s O(n) per-event scan — see the comment at its
+    /// call site for why that scan is skippable here.
     static func apply(
         _ sel: FilterSelection,
         to events: [Event],
@@ -39,14 +45,34 @@ nonisolated enum EventFilter {
         // The date stage. One half-open range check for every scope — the six
         // branches this replaced all reduce to this once the scope has been
         // turned into a window. A `nil` window means the scope resolves to no
-        // window at all — reachable via a `.day` scope whose key doesn't
-        // parse. That is the same outcome the old string comparison produced
-        // for the same input: it compared events against a string no
-        // `dayKey` ever emits and matched nothing, so `return []` here is
-        // observably identical. `.thisWeek` out of season does NOT hit this:
+        // window at all — reachable via a `.day` scope whose key doesn't parse
+        // at all. For a key that *does* parse but isn't canonical (e.g.
+        // `"2026-8-9"`), the old string comparison matched nothing — it
+        // compared events against a string no `dayKey` ever emits — while
+        // `ChqTime.parse`'s variable-width digits now produce a real window,
+        // so the two are NOT observably identical for that input. That input
+        // is unreachable in practice: `browseDay` normalizes every key
+        // through `ChqTime.dayKey(for: parsed)` before storing it, and
+        // `selectedDayKey` is never persisted, so no non-canonical key can
+        // reach here. `.thisWeek` out of season does NOT hit any of this:
         // `ViewWindow.base` gives it a seven-day fallback and never returns
         // `nil` for it.
-        let bounds = ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
+        //
+        // `navigableBounds` is an O(n) scan over every event (via
+        // `ChqTime.dayKey(for:)`) to build the season-and-starred-and-event
+        // widened bounds. `EventFilter` reads only `window.contains(_:)`
+        // below, never `startDay`/`endDay`, so those bounds matter only to
+        // clamp `ViewWindow.make`'s expansion inputs — and those inputs are
+        // `nil` on almost every call, since expansion only happens once the
+        // user has actually navigated. When neither is set, the cheaper
+        // season-only `DayWindow.bounds` is enough: it can't disagree with
+        // `navigableBounds` about anything this function reads, only about
+        // the `.all` scope's (here-unused) day-key projection — see
+        // `ViewWindow.make`'s doc for that.
+        let hasExpansion = sel.windowStartDayKey != nil || sel.windowEndDayKey != nil
+        let bounds = hasExpansion
+            ? ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
+            : DayWindow.bounds(year: year, starredDays: [])
         guard let window = ViewWindow.make(
             selection: sel, events: events, now: now,
             year: year, isCurrentYear: isCurrentYear, bounds: bounds)

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -14,10 +14,11 @@ nonisolated enum EventFilter {
     /// window relative to "now", so it is just as meaningful off the current
     /// year.
     ///
-    /// `SeasonCalendar.weeks(forYear:)` is computed exactly once here and
-    /// reused for both the `.thisWeek` scope and the weeks filter — it
-    /// rebuilds all 9 `SeasonWeek` structs on every call, so recomputing it
-    /// per event (or per stage) would be wasteful.
+    /// `SeasonCalendar.weeks(forYear:)` is computed once here and reused by
+    /// the weeks filter below — it rebuilds all 9 `SeasonWeek` structs on
+    /// every call, so recomputing it per event would be wasteful. The date
+    /// stage no longer needs its own copy: `.thisWeek`/`.season` compute
+    /// theirs inside `ViewWindow.base`.
     static func apply(
         _ sel: FilterSelection,
         to events: [Event],
@@ -34,55 +35,23 @@ nonisolated enum EventFilter {
         }
 
         let weeks = SeasonCalendar.weeks(forYear: year)
-        // Which scope actually applies — the non-current-year downgrade and
-        // the `.day` exemption both live in `EffectiveScope` now, so this
-        // type, `DateFilterLabel` and `FilterChipState` cannot drift apart.
-        let scope = EffectiveScope.resolve(sel, isCurrentYear: isCurrentYear)
 
-        switch scope {
-        case .all:
-            break
-
-        case .season:
-            if let first = weeks.first, let last = weeks.last {
-                result = result.filter { first.start <= $0.start && $0.start < last.end }
-            }
-
-        case .today:
-            let nowKey = ChqTime.dayKey(for: now)
-            result = result.filter { ChqTime.dayKey(for: $0.start) == nowKey }
-
-        case .day:
-            // `EffectiveScope` only returns `.day` when the key is non-nil,
-            // so this binding cannot fail; it exists because the stored type
-            // is still optional.
-            if let dayKey = sel.selectedDayKey {
-                result = result.filter { ChqTime.dayKey(for: $0.start) == dayKey }
-            }
-
-        case .next:
-            let from = now.addingTimeInterval(-3600)
-            // The adaptive window is sized against the *full* event set
-            // passed to `apply` — not the search-narrowed `result` — so an
-            // active search term doesn't shrink or grow the window itself;
-            // it only narrows what the window is applied to below.
-            let adaptiveEnd = adaptiveEndDate(events: events, from: from, minCount: 50)
-            let end: Date
-            if sel.extraDays > 0, let advanced = ChqTime.calendar.date(byAdding: .day, value: sel.extraDays, to: adaptiveEnd) {
-                end = ChqTime.endOfDay(advanced)
-            } else {
-                end = adaptiveEnd
-            }
-            result = result.filter { $0.start >= from && $0.start <= end }
-
-        case .thisWeek:
-            if let currentWeek = weeks.first(where: { $0.contains(now) }) {
-                result = result.filter { currentWeek.contains($0.start) }
-            } else {
-                let weekLater = now.addingTimeInterval(7 * 24 * 3600)
-                result = result.filter { $0.start >= now && $0.start < weekLater }
-            }
-        }
+        // The date stage. One half-open range check for every scope — the six
+        // branches this replaced all reduce to this once the scope has been
+        // turned into a window. A `nil` window means the scope resolves to no
+        // window at all — reachable via a `.day` scope whose key doesn't
+        // parse. That is the same outcome the old string comparison produced
+        // for the same input: it compared events against a string no
+        // `dayKey` ever emits and matched nothing, so `return []` here is
+        // observably identical. `.thisWeek` out of season does NOT hit this:
+        // `ViewWindow.base` gives it a seven-day fallback and never returns
+        // `nil` for it.
+        let bounds = ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
+        guard let window = ViewWindow.make(
+            selection: sel, events: events, now: now,
+            year: year, isCurrentYear: isCurrentYear, bounds: bounds)
+        else { return [] }
+        result = result.filter { window.contains($0.start) }
 
         if !sel.selectedWeeks.isEmpty {
             let selected = weeks.filter { sel.selectedWeeks.contains($0.number) }

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -34,12 +34,10 @@ nonisolated enum EventFilter {
         }
 
         let weeks = SeasonCalendar.weeks(forYear: year)
-        // `.day` is exempt from the non-current-year downgrade: it names an
-        // absolute NY calendar day, not a window relative to "now", so it is
-        // just as meaningful in an archived season as in the live one.
-        // Downgrading it would silently un-filter the list in exactly the
-        // case My Day's browse-this-day action is most useful for (#192).
-        let scope: DateScope = (isCurrentYear || sel.dateScope == .day) ? sel.dateScope : .all
+        // Which scope actually applies — the non-current-year downgrade and
+        // the `.day` exemption both live in `EffectiveScope` now, so this
+        // type, `DateFilterLabel` and `FilterChipState` cannot drift apart.
+        let scope = EffectiveScope.resolve(sel, isCurrentYear: isCurrentYear)
 
         switch scope {
         case .all:
@@ -55,8 +53,9 @@ nonisolated enum EventFilter {
             result = result.filter { ChqTime.dayKey(for: $0.start) == nowKey }
 
         case .day:
-            // A `nil` key means no day was ever set — filter nothing rather
-            // than filtering everything out.
+            // `EffectiveScope` only returns `.day` when the key is non-nil,
+            // so this binding cannot fail; it exists because the stored type
+            // is still optional.
             if let dayKey = sel.selectedDayKey {
                 result = result.filter { ChqTime.dayKey(for: $0.start) == dayKey }
             }

--- a/ios/ChqCalendarShared/Domain/FilterChipState.swift
+++ b/ios/ChqCalendarShared/Domain/FilterChipState.swift
@@ -10,13 +10,12 @@ import Foundation
 nonisolated enum FilterChipState {
     /// - Parameter isCurrentYear: must be the same value the caller passes
     ///   to `EventFilter.apply` (and to `DateFilterLabel.text`). When it is
-    ///   `false` the stored `dateScope` is **meaningless** — the pipeline
-    ///   forces it to `.all` (`let scope: DateScope = (isCurrentYear ||
-    ///   sel.dateScope == .day) ? sel.dateScope : .all`), because a past or
-    ///   future season has no "now" — **except `.day`**, which names an
-    ///   absolute date and is exempt from that downgrade. Selection is
-    ///   therefore derived from that reality rather than from what happens
-    ///   to be persisted.
+    ///   `false` the stored `dateScope` is **meaningless** — see
+    ///   `EffectiveScope.resolve` for the exact rule the pipeline forces it
+    ///   to `.all` under, because a past or future season has no "now" —
+    ///   **except `.day`**, which names an absolute date and is exempt from
+    ///   that downgrade. Selection is therefore derived from that reality
+    ///   rather than from what happens to be persisted.
     ///
     ///   Deliberately **not defaulted**, for the same reason
     ///   `DateFilterLabel.text` isn't: a default lets a future call site

--- a/ios/ChqCalendarShared/Domain/FilterChipState.swift
+++ b/ios/ChqCalendarShared/Domain/FilterChipState.swift
@@ -39,68 +39,36 @@ nonisolated enum FilterChipState {
         currentWeek: Int?,
         isCurrentYear: Bool
     ) -> Bool {
-        guard isCurrentYear else {
-            switch scope {
-            case .all:
-                // The weeks stage of `EventFilter` runs regardless of
-                // `isCurrentYear`, and an *active* `.day` filter is exempt
-                // from the downgrade outright (it names an absolute date
-                // rather than a window around "now") — so those are the two
-                // date filters still in force on a past season, and either
-                // one un-selects "All" exactly as it does on the current
-                // year. A `.day` scope with no key isn't one of them —
-                // `isDayFilterActive` is `false` and it filters nothing —
-                // so it doesn't un-select "All" either. With none of the
-                // above, nothing is filtering dates, which is precisely what
-                // "All" means.
-                return selection.selectedWeeks.isEmpty && !selection.isDayFilterActive
-            case .day:
-                // Never rendered as a chip — `.day` is derived, not
-                // pickable — but answered honestly rather than left to the
-                // caller, per this type's existing convention. Unlike the
-                // relative scopes below, the pipeline does *not* ignore this
-                // one on a past season. Honesty means agreeing with the
-                // `.all` case above: a `.day` scope with no key isn't
-                // filtering anything, so it must not report itself selected
-                // while "All" simultaneously reports itself selected too.
-                return selection.isDayFilterActive
-            case .next, .today, .season, .thisWeek:
-                // Unreachable through `DateFilterSheet`, whose
-                // `visibleScopes` collapses to `[.all]` off the current
-                // year — but answered rather than trusted to the caller.
-                // The pipeline is ignoring these scopes, so no chip
-                // claiming one may light up.
-                return false
-            }
-        }
+        // The one place the pipeline's real scope is decided. Before this,
+        // the same rules were restated here in a `guard isCurrentYear else`
+        // block that had to stay in step with `EventFilter` by hand.
+        let effective = EffectiveScope.resolve(selection, isCurrentYear: isCurrentYear)
 
         switch scope {
         case .thisWeek:
-            if selection.dateScope == .thisWeek { return true }
+            if effective == .thisWeek { return true }
             // Selecting *only* the current week is the same range as
-            // "This Week"; selecting it alongside others is not.
-            guard let currentWeek else { return false }
+            // "This Week"; selecting it alongside others is not. That
+            // equivalence is itself a current-year concept — off-year there
+            // is no "current week" for the browsed season to match against
+            // — so it is additionally gated on `isCurrentYear`, matching the
+            // unconditional `false` the old `guard isCurrentYear else` block
+            // returned for `.thisWeek`.
+            guard isCurrentYear, let currentWeek else { return false }
             return selection.selectedWeeks == [currentWeek]
+
         case .all:
             // "All" means unfiltered dates, so a week selection un-selects it
-            // even though `dateScope` is still `.all` — and so does an
-            // *active* `.day` filter. A `.day` scope with no key isn't
-            // filtering anything (`isDayFilterActive` is `false`), so it
-            // counts as "All" too, same as `FilterSelection.hasDateFilters`
-            // treats it.
-            let dateScopeAllowsAll = selection.dateScope == .all
-                || (selection.dateScope == .day && !selection.isDayFilterActive)
-            return dateScopeAllowsAll && selection.selectedWeeks.isEmpty
+            // even when the effective scope is `.all`.
+            return effective == .all && selection.selectedWeeks.isEmpty
+
         case .day:
-            // Never rendered as a chip; answered rather than trusted. The
-            // `.all` case above already excludes an *active* `.day` filter,
-            // since `.day` is not `.all` — but a keyless `.day` scope isn't
-            // filtering anything, so honesty means agreeing with `.all`
-            // rather than contradicting it: it must not report itself
-            // selected while "All" does too.
-            return selection.isDayFilterActive
+            // Never rendered as a chip — `.day` is derived, not pickable —
+            // but answered honestly rather than left to the caller.
+            return effective == .day
+
         case .next, .today, .season:
-            return selection.dateScope == scope
+            return effective == scope
         }
     }
 

--- a/ios/ChqCalendarShared/Domain/ViewWindow.swift
+++ b/ios/ChqCalendarShared/Domain/ViewWindow.swift
@@ -98,6 +98,15 @@ nonisolated struct ViewWindow: Equatable, Sendable {
     /// and `base` can legitimately sit outside them (off-season `.today`,
     /// most of the year). Clamping the merged result instead of the inputs
     /// would invert the window (`startDay > endDay`) whenever that happens.
+    ///
+    /// - Parameter bounds: does double duty. Besides clamping the expansion
+    ///   inputs above, `base`'s `.all` case also returns it verbatim as
+    ///   `startDay`/`endDay` — so a caller that passes a season-only range
+    ///   (`DayWindow.bounds`, skipping the per-event `navigableBounds` scan)
+    ///   gets a season-only day-key pair back for `.all`, not one widened to
+    ///   cover every event. `EventFilter` is one such caller on its common
+    ///   path, and can be precisely because it reads `contains(_:)` only and
+    ///   never touches `startDay`/`endDay`.
     static func make(
         selection: FilterSelection,
         events: [Event],
@@ -154,7 +163,6 @@ nonisolated struct ViewWindow: Equatable, Sendable {
         bounds: ClosedRange<String>
     ) -> ViewWindow? {
         let scope = EffectiveScope.resolve(selection, isCurrentYear: isCurrentYear)
-        let weeks = SeasonCalendar.weeks(forYear: year)
 
         switch scope {
         case .all:
@@ -168,6 +176,11 @@ nonisolated struct ViewWindow: Equatable, Sendable {
 
         case .season:
             // `first.start <= x && x < last.end`, carried through verbatim.
+            // `weeks` is built here rather than once for the whole switch —
+            // it's only `.season` and `.thisWeek` that read it, and the
+            // other four scopes shouldn't pay for a 9-struct build they
+            // never use.
+            let weeks = SeasonCalendar.weeks(forYear: year)
             guard let first = weeks.first, let last = weeks.last else { return nil }
             return windowed(first.start..<last.end)
 
@@ -195,6 +208,7 @@ nonisolated struct ViewWindow: Equatable, Sendable {
             return windowed(from..<end)
 
         case .thisWeek:
+            let weeks = SeasonCalendar.weeks(forYear: year)
             if let current = weeks.first(where: { $0.contains(now) }) {
                 // Literally `SeasonWeek.contains`.
                 return windowed(current.start..<current.end)

--- a/ios/ChqCalendarShared/Domain/ViewWindow.swift
+++ b/ios/ChqCalendarShared/Domain/ViewWindow.swift
@@ -33,8 +33,12 @@ nonisolated struct ViewWindow: Equatable, Sendable {
     /// `start <= date < endExclusive`.
     func contains(_ date: Date) -> Bool { range.contains(date) }
 
-    private static let minInstant = Date(timeIntervalSince1970: -62_135_596_800) // year 1
-    private static let maxInstant = Date(timeIntervalSince1970: 32_503_680_000)  // year 3000
+    /// `.all`'s instant bounds. `Date.distantPast`/`distantFuture` rather
+    /// than an arbitrary "year 1"/"year 3000" pair — genuinely the full
+    /// `Date` domain, matching the web's `.all`, which bounds no instant at
+    /// all.
+    private static let minInstant = Date.distantPast
+    private static let maxInstant = Date.distantFuture
 
     /// The exclusive upper bound of `dayKey` — the next day's midnight.
     ///
@@ -129,23 +133,31 @@ nonisolated struct ViewWindow: Equatable, Sendable {
             expandedEndDayKey = bounds.upperBound
         }
 
+        // Each side is applied atomically: `startDay`/`endDay` only ever
+        // change together with the `Date` they describe. If an expansion key
+        // survives the clamp above but fails `ChqTime.parse` below (it
+        // shouldn't — `browseDay` only ever writes a canonical `dayKey` — but
+        // these fields are plain `String?`, unvalidated by the type system),
+        // the expansion is dropped entirely rather than applied to one of
+        // `startDay`/`range` and not the other. Anything else would let
+        // `startDay`/`endDay` name a day the actual filtered range
+        // disagrees with — exactly what this type's doc promises can't
+        // happen.
         var startDay = base.startDay
-        var endDay = base.endDay
-        if let expanded = expandedStartDayKey, expanded < startDay { startDay = expanded }
-        if let expanded = expandedEndDayKey, expanded > endDay { endDay = expanded }
-
-        let start: Date
-        if startDay == base.startDay {
-            start = base.start
-        } else if let parsed = ChqTime.parse("\(startDay) 00:00:00") {
+        var start = base.start
+        if let expanded = expandedStartDayKey, expanded < startDay,
+           let parsed = ChqTime.parse("\(expanded) 00:00:00") {
+            startDay = expanded
             start = ChqTime.calendar.startOfDay(for: parsed)
-        } else {
-            start = base.start
         }
 
-        let endExclusive = endDay == base.endDay
-            ? base.endExclusive
-            : (dayAfter(endDay) ?? base.endExclusive)
+        var endDay = base.endDay
+        var endExclusive = base.endExclusive
+        if let expanded = expandedEndDayKey, expanded > endDay,
+           let after = dayAfter(expanded) {
+            endDay = expanded
+            endExclusive = after
+        }
 
         // No `guard start < endExclusive` here: unlike the clamp-after-merge
         // form this replaced, expansion only ever widens outward from a
@@ -166,13 +178,7 @@ nonisolated struct ViewWindow: Equatable, Sendable {
 
         switch scope {
         case .all:
-            // No instant bound. Deliberately not derived from `events`: a
-            // window computed from the very list being filtered would be
-            // circular and would behave differently for a caller passing a
-            // subset.
-            return ViewWindow(
-                startDay: bounds.lowerBound, endDay: bounds.upperBound,
-                range: minInstant..<maxInstant)
+            return allWindow(bounds: bounds)
 
         case .season:
             // `first.start <= x && x < last.end`, carried through verbatim.
@@ -188,9 +194,7 @@ nonisolated struct ViewWindow: Equatable, Sendable {
             return day(ChqTime.dayKey(for: now))
 
         case .day:
-            // `EffectiveScope` returns `.day` only with a non-nil key.
-            guard let key = selection.selectedDayKey else { return nil }
-            return day(key)
+            return dayWindow(forDayScope: selection.selectedDayKey, bounds: bounds)
 
         case .next:
             let from = now.addingTimeInterval(-3600)
@@ -213,9 +217,57 @@ nonisolated struct ViewWindow: Equatable, Sendable {
                 // Literally `SeasonWeek.contains`.
                 return windowed(current.start..<current.end)
             }
-            // Out of season: the pipeline's existing seven-day fallback.
+            // Out of season: the pipeline's existing seven-day rolling
+            // window from `now`. Deliberately `86_400`-second arithmetic —
+            // the one place in this file that ignores the "never `86_400`,
+            // always `Calendar`" rule — because this is verbatim parity with
+            // the pre-refactor pipeline, and unlike every other boundary
+            // here it is a `now`-relative INSTANT, not a day-key computation:
+            // there is no day key on either side for `ChqTime.day(_:offsetBy:)`
+            // to compute DST-safely. Do not "fix" this to `Calendar` day
+            // arithmetic — that would change what gets shown across a DST
+            // boundary, which is exactly the drift this exception avoids.
+            //
+            // This is also the one place iOS and the web's shared model
+            // genuinely disagree: the web's `this-week` returns `null` out
+            // of season (the list shows nothing), while iOS returns this
+            // rolling week. Both preserve their own platform's pre-refactor
+            // behavior, so neither changes here — reconciling the two is
+            // Phase 3's job.
             return windowed(now..<now.addingTimeInterval(7 * 24 * 3600))
         }
+    }
+
+    /// The `.all` scope's window: no instant bound, `bounds` reported
+    /// verbatim as the day projection. Deliberately not derived from
+    /// `events`: a window computed from the very list being filtered would
+    /// be circular and would behave differently for a caller passing a
+    /// subset. Shared by the real `.all` case above and `.day`'s
+    /// fail-open fallback, which is what `.all` degrades to for a `.day`
+    /// naming no date.
+    private static func allWindow(bounds: ClosedRange<String>) -> ViewWindow {
+        ViewWindow(
+            startDay: bounds.lowerBound, endDay: bounds.upperBound,
+            range: minInstant..<maxInstant)
+    }
+
+    /// `.day`'s window: the named day, or — if `key` is `nil` — the
+    /// unbounded `.all` window rather than `nil`.
+    ///
+    /// `EffectiveScope` guarantees `.day` is only resolved with a non-nil
+    /// key, so the nil branch is unreachable through `ViewWindow.make`
+    /// today (and would still be unreachable calling `base` directly, since
+    /// `base` re-derives the same scope from the same guarantee). It exists
+    /// so that if that guarantee were ever weakened, the failure mode is
+    /// OPEN — show everything, what `EffectiveScope` itself would have
+    /// produced for a keyless `.day` — rather than CLOSED, which is what a
+    /// bare `nil` here would give `EventFilter` (zero events), flipping the
+    /// pre-refactor behavior (a keyless day scope showed everything) to its
+    /// opposite. Internal, not private, so a test can pin it directly
+    /// without first needing to defeat `EffectiveScope`'s guarantee.
+    static func dayWindow(forDayScope key: String?, bounds: ClosedRange<String>) -> ViewWindow? {
+        guard let key else { return allWindow(bounds: bounds) }
+        return day(key)
     }
 
     /// Wraps a half-open instant range with its day projection.

--- a/ios/ChqCalendarShared/Domain/ViewWindow.swift
+++ b/ios/ChqCalendarShared/Domain/ViewWindow.swift
@@ -1,0 +1,224 @@
+import Foundation
+
+/// The instants the event list is narrowed to, plus the calendar days that
+/// range covers. The iOS counterpart of the web's `dayWindow.ts`.
+///
+/// **Half-open**: `start <= x < endExclusive`, carried as a `Range<Date>` so
+/// the type system enforces it and `contains(_:)` comes for free. Never an
+/// inclusive bound with a subtracted epsilon: `Date` wraps a `Double`, so
+/// there is no last representable instant to subtract to, and an
+/// `end - 0.001` bound silently drops `23:59:59.9995` — while the identical
+/// expression is exact on the web, where `Date` is integer milliseconds. The
+/// same written rule meaning two different things is exactly the drift this
+/// shared model exists to prevent.
+///
+/// Half-open is also what the pipeline already used everywhere, so most
+/// scopes need no conversion at all: `SeasonWeek.contains` is
+/// `start <= x && x < end`, `.season` is `< last.end`, the `.thisWeek`
+/// fallback is `< now + 7d`, and `dayKey` equality is exactly
+/// `[startOfDay(d), startOfDay(d+1))`. Those bounds are carried through
+/// verbatim below rather than re-derived.
+///
+/// `startDay`/`endDay` are the navigation-facing projection — what a day rail
+/// or a step control moves through. They are derived from the range, never
+/// the other way round, so they cannot disagree with what is filtered.
+nonisolated struct ViewWindow: Equatable, Sendable {
+    let startDay: String
+    let endDay: String
+    let range: Range<Date>
+
+    var start: Date { range.lowerBound }
+    var endExclusive: Date { range.upperBound }
+
+    /// `start <= date < endExclusive`.
+    func contains(_ date: Date) -> Bool { range.contains(date) }
+
+    private static let minInstant = Date(timeIntervalSince1970: -62_135_596_800) // year 1
+    private static let maxInstant = Date(timeIntervalSince1970: 32_503_680_000)  // year 3000
+
+    /// The exclusive upper bound of `dayKey` — the next day's midnight.
+    ///
+    /// Goes through `Calendar`, not `+86_400`, because a DST day is 23 or 25
+    /// hours. **Deliberately not `ChqTime.endOfDay`**, which returns
+    /// `startOfDay + 1 day - 1 second` (`23:59:59.000`) and is an inclusive
+    /// bound of the wrong precision for a window.
+    static func dayAfter(_ dayKey: String) -> Date? {
+        guard
+            let start = ChqTime.parse("\(dayKey) 00:00:00"),
+            let next = ChqTime.calendar.date(byAdding: .day, value: 1, to: start)
+        else { return nil }
+        return next
+    }
+
+    /// The last day a window actually shows, given its exclusive upper bound.
+    ///
+    /// One rule for two cases that look unrelated at the call site: a window
+    /// ending at midnight does not show that day (`.today`, `.day`, `.next`),
+    /// while one ending mid-day does (`.thisWeek` and `.season` end at noon
+    /// Saturday, and that Saturday morning has events). Implemented once here
+    /// rather than reasoned about at each construction site.
+    static func lastDayCovered(_ endExclusive: Date) -> String {
+        let cal = ChqTime.calendar
+        let key = ChqTime.dayKey(for: endExclusive)
+        guard cal.startOfDay(for: endExclusive) == endExclusive else { return key }
+        return ChqTime.day(key, offsetBy: -1) ?? key
+    }
+
+    /// The outer limit of everything navigation can reach: the season, widened
+    /// to contain every day that carries an event and every starred day.
+    /// Reuses `DayWindow.bounds` for the season-and-starred half so its
+    /// existing tests keep pinning that.
+    static func navigableBounds(
+        year: Int, events: [Event], starredDays: [String]
+    ) -> ClosedRange<String> {
+        let base = DayWindow.bounds(year: year, starredDays: starredDays)
+        var lower = base.lowerBound
+        var upper = base.upperBound
+        for event in events {
+            let key = ChqTime.dayKey(for: event.start)
+            if key < lower { lower = key }
+            if key > upper { upper = key }
+        }
+        return lower...upper
+    }
+
+    /// The window a scope defines, widened by however far the user has
+    /// navigated. `nil` means the scope matches nothing right now.
+    ///
+    /// Expansion only ever grows the window — a `windowStartDayKey` or
+    /// `windowEndDayKey` that would narrow it is ignored, so a stale value can
+    /// never hide events. The added region uses whole days, while an untouched
+    /// end keeps the base window's exact instant: that is what preserves
+    /// `.next`'s one-hour grace and `.thisWeek`'s noon boundaries until the
+    /// user actually navigates past them.
+    ///
+    /// `bounds` clamps the *expansion inputs*, before they are merged with
+    /// `base` — never the merged result. The bounds limit how far navigation
+    /// can reach; they say nothing about a scope the user hasn't navigated,
+    /// and `base` can legitimately sit outside them (off-season `.today`,
+    /// most of the year). Clamping the merged result instead of the inputs
+    /// would invert the window (`startDay > endDay`) whenever that happens.
+    static func make(
+        selection: FilterSelection,
+        events: [Event],
+        now: Date,
+        year: Int,
+        isCurrentYear: Bool,
+        bounds: ClosedRange<String>
+    ) -> ViewWindow? {
+        guard let base = base(
+            selection: selection, events: events, now: now,
+            year: year, isCurrentYear: isCurrentYear, bounds: bounds)
+        else { return nil }
+
+        var expandedStartDayKey = selection.windowStartDayKey
+        if let expanded = expandedStartDayKey, expanded < bounds.lowerBound {
+            expandedStartDayKey = bounds.lowerBound
+        }
+        var expandedEndDayKey = selection.windowEndDayKey
+        if let expanded = expandedEndDayKey, expanded > bounds.upperBound {
+            expandedEndDayKey = bounds.upperBound
+        }
+
+        var startDay = base.startDay
+        var endDay = base.endDay
+        if let expanded = expandedStartDayKey, expanded < startDay { startDay = expanded }
+        if let expanded = expandedEndDayKey, expanded > endDay { endDay = expanded }
+
+        let start: Date
+        if startDay == base.startDay {
+            start = base.start
+        } else if let parsed = ChqTime.parse("\(startDay) 00:00:00") {
+            start = ChqTime.calendar.startOfDay(for: parsed)
+        } else {
+            start = base.start
+        }
+
+        let endExclusive = endDay == base.endDay
+            ? base.endExclusive
+            : (dayAfter(endDay) ?? base.endExclusive)
+
+        // No `guard start < endExclusive` here: unlike the clamp-after-merge
+        // form this replaced, expansion only ever widens outward from a
+        // `base` that is already a valid (non-empty) range, so `start` can
+        // never cross `endExclusive`.
+        return ViewWindow(startDay: startDay, endDay: endDay, range: start..<endExclusive)
+    }
+
+    private static func base(
+        selection: FilterSelection,
+        events: [Event],
+        now: Date,
+        year: Int,
+        isCurrentYear: Bool,
+        bounds: ClosedRange<String>
+    ) -> ViewWindow? {
+        let scope = EffectiveScope.resolve(selection, isCurrentYear: isCurrentYear)
+        let weeks = SeasonCalendar.weeks(forYear: year)
+
+        switch scope {
+        case .all:
+            // No instant bound. Deliberately not derived from `events`: a
+            // window computed from the very list being filtered would be
+            // circular and would behave differently for a caller passing a
+            // subset.
+            return ViewWindow(
+                startDay: bounds.lowerBound, endDay: bounds.upperBound,
+                range: minInstant..<maxInstant)
+
+        case .season:
+            // `first.start <= x && x < last.end`, carried through verbatim.
+            guard let first = weeks.first, let last = weeks.last else { return nil }
+            return windowed(first.start..<last.end)
+
+        case .today:
+            return day(ChqTime.dayKey(for: now))
+
+        case .day:
+            // `EffectiveScope` returns `.day` only with a non-nil key.
+            guard let key = selection.selectedDayKey else { return nil }
+            return day(key)
+
+        case .next:
+            let from = now.addingTimeInterval(-3600)
+            // Sized against the FULL event set, not a search-narrowed one — an
+            // active search must not change how wide the window is, only what
+            // it is applied to.
+            //
+            // `adaptiveEndDate` returns an inclusive `ChqTime.endOfDay`
+            // (23:59:59.000); the half-open equivalent is that day's exclusive
+            // end. No representable event falls in the difference — event
+            // times parse from "yyyy-MM-dd HH:mm:ss" and carry no sub-second
+            // component — which `ViewWindowTests` asserts rather than assumes.
+            let inclusiveEnd = EventFilter.adaptiveEndDate(events: events, from: from, minCount: 50)
+            guard let end = dayAfter(ChqTime.dayKey(for: inclusiveEnd)) else { return nil }
+            return windowed(from..<end)
+
+        case .thisWeek:
+            if let current = weeks.first(where: { $0.contains(now) }) {
+                // Literally `SeasonWeek.contains`.
+                return windowed(current.start..<current.end)
+            }
+            // Out of season: the pipeline's existing seven-day fallback.
+            return windowed(now..<now.addingTimeInterval(7 * 24 * 3600))
+        }
+    }
+
+    /// Wraps a half-open instant range with its day projection.
+    private static func windowed(_ range: Range<Date>) -> ViewWindow {
+        ViewWindow(
+            startDay: ChqTime.dayKey(for: range.lowerBound),
+            endDay: lastDayCovered(range.upperBound),
+            range: range)
+    }
+
+    private static func day(_ key: String) -> ViewWindow? {
+        guard
+            let parsed = ChqTime.parse("\(key) 00:00:00"),
+            let end = dayAfter(key)
+        else { return nil }
+        return ViewWindow(
+            startDay: key, endDay: key,
+            range: ChqTime.calendar.startOfDay(for: parsed)..<end)
+    }
+}

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1019,24 +1019,35 @@ struct AppModelTests {
     /// window ("Show next day"), so it must not survive a move to another
     /// scope and silently re-widen the window when the user comes back to
     /// Now.
+    /// Both window-expansion fields belong to the scope being left, not
+    /// just `windowEndDayKey` — `windowStartDayKey` has no writer today
+    /// (there is no `expandWindowStart()` yet), so it's set directly here
+    /// to pin that `clearScopeLocalDateState()` clears it too rather than
+    /// only the field the UI happens to exercise.
     @Test func selectScopeResetsWindowExpansion() throws {
         let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
         #expect(model.filter.dateScope == .next)
         model.expandWindowEnd()
         model.expandWindowEnd()
         #expect(model.filter.windowEndDayKey == "2026-08-05")
+        model.filter.windowStartDayKey = "2026-08-01"
 
         model.selectScope(.thisWeek)
 
         #expect(model.filter.windowEndDayKey == nil)
+        #expect(model.filter.windowStartDayKey == nil)
     }
 
     /// The failure #156 actually describes: Now → This Week → Now leaves the
     /// window wider than a fresh `.next` selection, with nothing on screen
-    /// explaining why.
+    /// explaining why. The intermediate assertion pins that the first
+    /// `expandWindowEnd()` actually did something before the scope change
+    /// throws it away — without it, a no-op `expandWindowEnd()` would let
+    /// this test go green while pinning nothing.
     @Test func returningToNowAfterAScopeChangeStartsFromAFreshWindow() throws {
         let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
         model.expandWindowEnd()
+        #expect(model.filter.windowEndDayKey == "2026-08-04")
         model.selectScope(.thisWeek)
 
         model.selectScope(.next)
@@ -1046,11 +1057,19 @@ struct AppModelTests {
 
     /// #197 item 3: `selectedDayKey` is only meaningful under `.day`. Leaving
     /// it set after a scope change is inert today only because nothing else
-    /// reads it — this makes the invariant hold by construction.
+    /// reads it — this makes the invariant hold by construction. Also pins
+    /// that `browseDay` itself clears both window-expansion fields (per its
+    /// doc comment), not just `selectedDayKey` via the later `selectScope`.
     @Test func selectScopeClearsTheBrowsedDay() throws {
         let model = try makeInSeasonModel(defaults: makeDefaults())
+        model.filter.windowStartDayKey = "2026-08-01"
+        model.filter.windowEndDayKey = "2026-08-05"
+
         model.browseDay("2026-08-09")
+
         #expect(model.filter.selectedDayKey == "2026-08-09")
+        #expect(model.filter.windowStartDayKey == nil)
+        #expect(model.filter.windowEndDayKey == nil)
 
         model.selectScope(.today)
 

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -978,6 +978,28 @@ struct AppModelTests {
         )
     }
 
+    /// Same fixture as `makeInSeasonModel`, plus a snapshot of 50 events
+    /// packed into the hour before `now` — enough to satisfy the `.next`
+    /// scope's `adaptiveEndDate` `minCount` on day 0 itself, so its base
+    /// window settles at `2026-08-03` rather than the empty-snapshot
+    /// fallback (the 90-day cap, which sits past the season's `bounds` and
+    /// would make `expandWindowEnd()` a no-op — see `expandWindowEnd`'s test
+    /// coverage below for that edge case in isolation).
+    private func makeInSeasonModelWithSeedEvents(defaults: UserDefaults) throws -> AppModel {
+        let model = try makeInSeasonModel(defaults: defaults)
+        let now = try #require(ChqTime.parse("2026-08-03 12:00:00"))
+        let from = now.addingTimeInterval(-3600)
+        let events: [Event] = try (0..<50).map { i in
+            makeEvent(
+                id: "seed\(i)",
+                start: try #require(ChqTime.calendar.date(byAdding: .minute, value: i, to: from)))
+        }
+        model.snapshot = CalendarSnapshot(
+            year: 2026, events: events, articleLinks: [:], programLinks: [:],
+            themes: [], fetchedAt: now)
+        return model
+    }
+
     @Test func selectScopeClearsWeeksAndPersists() throws {
         let defaults = makeDefaults()
         let model = try makeInSeasonModel(defaults: defaults)
@@ -993,32 +1015,33 @@ struct AppModelTests {
         #expect(reloaded?.selectedWeeks.isEmpty == true)
     }
 
-    /// #156: `extraDays` is a `.next`-only widening ("Show next day"), so it
-    /// must not survive a move to another scope and silently re-widen the
-    /// window when the user comes back to Now.
-    @Test func selectScopeResetsExtraDays() throws {
-        let model = try makeInSeasonModel(defaults: makeDefaults())
+    /// #156: `windowEndDayKey` is how far the user has widened the `.next`
+    /// window ("Show next day"), so it must not survive a move to another
+    /// scope and silently re-widen the window when the user comes back to
+    /// Now.
+    @Test func selectScopeResetsWindowExpansion() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
         #expect(model.filter.dateScope == .next)
-        model.showNextDay()
-        model.showNextDay()
-        #expect(model.filter.extraDays == 2)
+        model.expandWindowEnd()
+        model.expandWindowEnd()
+        #expect(model.filter.windowEndDayKey == "2026-08-05")
 
         model.selectScope(.thisWeek)
 
-        #expect(model.filter.extraDays == 0)
+        #expect(model.filter.windowEndDayKey == nil)
     }
 
     /// The failure #156 actually describes: Now → This Week → Now leaves the
     /// window wider than a fresh `.next` selection, with nothing on screen
     /// explaining why.
     @Test func returningToNowAfterAScopeChangeStartsFromAFreshWindow() throws {
-        let model = try makeInSeasonModel(defaults: makeDefaults())
-        model.showNextDay()
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.expandWindowEnd()
         model.selectScope(.thisWeek)
 
         model.selectScope(.next)
 
-        #expect(model.filter.extraDays == 0)
+        #expect(model.filter.windowEndDayKey == nil)
     }
 
     /// #197 item 3: `selectedDayKey` is only meaningful under `.day`. Leaving
@@ -1046,13 +1069,14 @@ struct AppModelTests {
         #expect(model.filter.selectedDayKey == nil)
     }
 
-    @Test func setWeekSelectionResetsExtraDays() throws {
-        let model = try makeInSeasonModel(defaults: makeDefaults())
-        model.showNextDay()
+    @Test func setWeekSelectionResetsWindowExpansion() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.expandWindowEnd()
+        #expect(model.filter.windowEndDayKey == "2026-08-04")
 
         model.setWeekSelection([3])
 
-        #expect(model.filter.extraDays == 0)
+        #expect(model.filter.windowEndDayKey == nil)
     }
 
     @Test func reselectingTheActiveScopeIsANoOp() throws {
@@ -1197,7 +1221,7 @@ struct AppModelTests {
         )
 
         model.filter.searchText = "opera"
-        model.filter.extraDays = 2
+        model.filter.windowEndDayKey = "2026-07-13"
         model.setWeekSelection([4])
         model.toggleLocation("Amphitheater")
         model.filter.showFavoritesOnly = true
@@ -1205,7 +1229,7 @@ struct AppModelTests {
         model.clearAll()
 
         #expect(model.filter.searchText.isEmpty)
-        #expect(model.filter.extraDays == 0)
+        #expect(model.filter.windowEndDayKey == nil)
         #expect(model.filter.dateScope == .all)
         #expect(model.filter.selectedWeeks.isEmpty)
         #expect(model.filter.selectedLocations.isEmpty)
@@ -1351,19 +1375,33 @@ struct AppModelTests {
         #expect(eventCalls.isEmpty)
     }
 
-    // MARK: - showNextDay
+    // MARK: - expandWindowEnd
 
-    @Test func showNextDayIncrementsExtraDays() {
-        let model = AppModel(
-            repository: EventRepository(api: MockAPI(), cache: MockCache()),
-            store: UserStateStore(defaults: makeDefaults(), now: { Date() })
-        )
+    @Test func expandWindowEndSetsWindowEndDayKeyOneDayAtATime() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
 
-        #expect(model.filter.extraDays == 0)
-        model.showNextDay()
-        #expect(model.filter.extraDays == 1)
-        model.showNextDay()
-        #expect(model.filter.extraDays == 2)
+        #expect(model.filter.windowEndDayKey == nil)
+        model.expandWindowEnd()
+        #expect(model.filter.windowEndDayKey == "2026-08-04")
+        model.expandWindowEnd()
+        #expect(model.filter.windowEndDayKey == "2026-08-05")
+    }
+
+    /// With no snapshot loaded, `.next`'s `adaptiveEndDate` never reaches its
+    /// `minCount` and falls back to its 90-day cap — which lands past the
+    /// season's `bounds.upperBound` (`navigableBounds` has no event days to
+    /// widen it with). `expandWindowEnd()`'s own clamp then has nothing
+    /// forward of the base window to grant, so it's a no-op. That's a real
+    /// behavior delta from the old `extraDays` counter, which had no bounds
+    /// to respect at all — deliberate per the Phase 1b design: navigation
+    /// cannot go past the last day that could ever have an event.
+    @Test func expandWindowEndIsANoOpWhenTheBaseWindowAlreadyExceedsBounds() throws {
+        let model = try makeInSeasonModel(defaults: makeDefaults())
+        #expect(model.filter.windowEndDayKey == nil)
+
+        model.expandWindowEnd()
+
+        #expect(model.filter.windowEndDayKey == nil)
     }
 
     // MARK: - Recents

--- a/ios/ChqCalendarTests/DateScopeExemptionTests.swift
+++ b/ios/ChqCalendarTests/DateScopeExemptionTests.swift
@@ -9,8 +9,15 @@ import Testing
 ///
 /// Written BEFORE the `EffectiveScope` refactor collapses them into one.
 /// `FilterChipState` is the site where disagreement is a *silent* wrong
-/// answer rather than a compile error, which is why the matrix below is
-/// exhaustive rather than illustrative.
+/// answer rather than a compile error, which is why the matrix below aims
+/// to be exhaustive rather than illustrative.
+///
+/// It is not, in fact, exhaustive: the off-year `.thisWeek` scope combined
+/// with `selectedWeeks == [currentWeek]` is a cell this matrix never
+/// covers. That gap let a bug through the plan's own `FilterChipState`
+/// code during this refactor; it was caught by
+/// `FilterChipStateTests.swift`'s `timeRelativeChipsNeverLightOnANonCurrentYear`
+/// (lines 126-129) instead, which is the guard actually covering that cell.
 ///
 /// Do NOT edit these to make a later change pass. If one goes red, the
 /// refactor is wrong.
@@ -67,7 +74,12 @@ struct DateScopeExemptionTests {
         }
     }
 
-    @Test func seasonScopeStillFiltersOnAPastSeason() throws {
+    // Renamed from `seasonScopeStillFiltersOnAPastSeason`, which asserted
+    // the opposite of what it said: the event OUTSIDE the season is what
+    // survives the filter, because `.season` is downgraded (not exempt),
+    // so nothing is being filtered on a past season at all. Rename only —
+    // per this file's header, not a single assertion below has changed.
+    @Test func seasonScopeIsDowngradedNotFilteredOnAPastSeason() throws {
         // .season is NOT relative to "now" either, but it is currently
         // downgraded anyway. Pinned so the refactor cannot quietly "fix" it.
         let outside = makeEvent(id: "outside", start: try #require(ChqTime.parse("2026-01-05 10:00:00")))

--- a/ios/ChqCalendarTests/DateScopeExemptionTests.swift
+++ b/ios/ChqCalendarTests/DateScopeExemptionTests.swift
@@ -1,0 +1,179 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+/// Characterization tests for the `.day` / `isCurrentYear` exemption, which
+/// today is duplicated across three types that must agree:
+/// `EventFilter.apply`, `DateFilterLabel.text`, and
+/// `FilterChipState.isScopeSelected`.
+///
+/// Written BEFORE the `EffectiveScope` refactor collapses them into one.
+/// `FilterChipState` is the site where disagreement is a *silent* wrong
+/// answer rather than a compile error, which is why the matrix below is
+/// exhaustive rather than illustrative.
+///
+/// Do NOT edit these to make a later change pass. If one goes red, the
+/// refactor is wrong.
+struct DateScopeExemptionTests {
+
+    private static let dayKey = "2026-07-15"
+
+    private func selection(
+        scope: DateScope, dayKey: String? = nil, weeks: Set<Int> = []
+    ) -> FilterSelection {
+        FilterSelection(dateScope: scope, selectedWeeks: weeks, selectedDayKey: dayKey)
+    }
+
+    // MARK: - EventFilter: which scope actually narrows the list
+
+    @Test func dayScopeWithKeyFiltersOnAPastSeason() throws {
+        // The exemption itself: `.day` names an absolute date, so it stays
+        // in force even when `isCurrentYear` is false.
+        let onDay = makeEvent(id: "on", start: try #require(ChqTime.parse("2026-07-15 10:00:00")))
+        let offDay = makeEvent(id: "off", start: try #require(ChqTime.parse("2026-07-16 10:00:00")))
+        let result = EventFilter.apply(
+            selection(scope: .day, dayKey: Self.dayKey),
+            to: [onDay, offDay],
+            favorites: [],
+            now: try #require(ChqTime.parse("2027-01-01 12:00:00")),
+            year: 2026,
+            isCurrentYear: false)
+        #expect(result.map(\.id) == ["on"])
+    }
+
+    @Test func dayScopeWithoutKeyFiltersNothing() throws {
+        let a = makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-15 10:00:00")))
+        let b = makeEvent(id: "b", start: try #require(ChqTime.parse("2026-08-20 10:00:00")))
+        let result = EventFilter.apply(
+            selection(scope: .day, dayKey: nil),
+            to: [a, b],
+            favorites: [],
+            now: try #require(ChqTime.parse("2026-07-15 12:00:00")),
+            year: 2026,
+            isCurrentYear: true)
+        #expect(result.map(\.id) == ["a", "b"])
+    }
+
+    @Test func relativeScopesAreIgnoredOnAPastSeason() throws {
+        // .next/.today/.thisWeek all downgrade to .all — a past season has
+        // no "now".
+        let far = makeEvent(id: "far", start: try #require(ChqTime.parse("2026-06-28 10:00:00")))
+        let now = try #require(ChqTime.parse("2027-01-01 12:00:00"))
+        for scope in [DateScope.next, .today, .thisWeek] {
+            let result = EventFilter.apply(
+                selection(scope: scope), to: [far], favorites: [],
+                now: now, year: 2026, isCurrentYear: false)
+            #expect(result.map(\.id) == ["far"], "scope \(scope) should not filter off-year")
+        }
+    }
+
+    @Test func seasonScopeStillFiltersOnAPastSeason() throws {
+        // .season is NOT relative to "now" either, but it is currently
+        // downgraded anyway. Pinned so the refactor cannot quietly "fix" it.
+        let outside = makeEvent(id: "outside", start: try #require(ChqTime.parse("2026-01-05 10:00:00")))
+        let result = EventFilter.apply(
+            selection(scope: .season), to: [outside], favorites: [],
+            now: try #require(ChqTime.parse("2027-01-01 12:00:00")),
+            year: 2026, isCurrentYear: false)
+        #expect(result.map(\.id) == ["outside"], "season currently downgrades to all off-year")
+    }
+
+    @Test func weeksApplyRegardlessOfCurrentYear() throws {
+        // The weeks stage sits OUTSIDE the scope switch, so it survives the
+        // downgrade. Phase 1 must not change that.
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let inWeek1 = makeEvent(id: "w1", start: weeks[0].start.addingTimeInterval(3600))
+        let inWeek5 = makeEvent(id: "w5", start: weeks[4].start.addingTimeInterval(3600))
+        let result = EventFilter.apply(
+            selection(scope: .next, weeks: [1]), to: [inWeek1, inWeek5], favorites: [],
+            now: try #require(ChqTime.parse("2027-01-01 12:00:00")),
+            year: 2026, isCurrentYear: false)
+        #expect(result.map(\.id) == ["w1"])
+    }
+
+    // MARK: - DateFilterLabel
+
+    @Test func labelNamesTheDayEvenOffYear() {
+        let text = DateFilterLabel.text(
+            for: selection(scope: .day, dayKey: Self.dayKey),
+            seasonWeekCount: 9, isCurrentYear: false)
+        #expect(text.contains("Jul") || text.contains("15"), "got \(text)")
+    }
+
+    @Test func labelSaysAllYearForAKeylessDay() {
+        let text = DateFilterLabel.text(
+            for: selection(scope: .day, dayKey: nil),
+            seasonWeekCount: 9, isCurrentYear: true)
+        #expect(text == "All Year")
+    }
+
+    @Test func labelSaysAllYearForRelativeScopesOffYear() {
+        for scope in [DateScope.next, .today, .thisWeek, .season] {
+            let text = DateFilterLabel.text(
+                for: selection(scope: scope), seasonWeekCount: 9, isCurrentYear: false)
+            #expect(text == "All Year", "scope \(scope) gave \(text)")
+        }
+    }
+
+    @Test func labelPrefersTheDayOverAWeekSelection() {
+        let text = DateFilterLabel.text(
+            for: selection(scope: .day, dayKey: Self.dayKey, weeks: [3]),
+            seasonWeekCount: 9, isCurrentYear: true)
+        #expect(!text.contains("Week"), "got \(text)")
+    }
+
+    // MARK: - FilterChipState (silent-failure site)
+
+    @Test func activeDayUnselectsAllOnBothYearAxes() {
+        for isCurrentYear in [true, false] {
+            let sel = selection(scope: .day, dayKey: Self.dayKey)
+            #expect(
+                FilterChipState.isScopeSelected(
+                    .all, selection: sel, currentWeek: 3, isCurrentYear: isCurrentYear) == false,
+                "All should be unselected with an active day, isCurrentYear=\(isCurrentYear)")
+            #expect(
+                FilterChipState.isScopeSelected(
+                    .day, selection: sel, currentWeek: 3, isCurrentYear: isCurrentYear) == true)
+        }
+    }
+
+    @Test func keylessDayReadsAsAllOnBothYearAxes() {
+        for isCurrentYear in [true, false] {
+            let sel = selection(scope: .day, dayKey: nil)
+            #expect(
+                FilterChipState.isScopeSelected(
+                    .all, selection: sel, currentWeek: 3, isCurrentYear: isCurrentYear) == true,
+                "isCurrentYear=\(isCurrentYear)")
+            #expect(
+                FilterChipState.isScopeSelected(
+                    .day, selection: sel, currentWeek: 3, isCurrentYear: isCurrentYear) == false)
+        }
+    }
+
+    @Test func offYearRelativeScopesNeverReadSelected() {
+        for scope in [DateScope.next, .today, .thisWeek, .season] {
+            #expect(
+                FilterChipState.isScopeSelected(
+                    scope, selection: selection(scope: scope),
+                    currentWeek: 3, isCurrentYear: false) == false,
+                "scope \(scope)")
+        }
+    }
+
+    @Test func offYearAllIsSelectedOnlyWithoutWeeksOrDay() {
+        #expect(FilterChipState.isScopeSelected(
+            .all, selection: selection(scope: .next), currentWeek: 3, isCurrentYear: false) == true)
+        #expect(FilterChipState.isScopeSelected(
+            .all, selection: selection(scope: .next, weeks: [2]),
+            currentWeek: 3, isCurrentYear: false) == false)
+    }
+
+    @Test func onlyCurrentWeekSelectedEqualsThisWeek() {
+        #expect(FilterChipState.isScopeSelected(
+            .thisWeek, selection: selection(scope: .all, weeks: [3]),
+            currentWeek: 3, isCurrentYear: true) == true)
+        #expect(FilterChipState.isScopeSelected(
+            .thisWeek, selection: selection(scope: .all, weeks: [3, 4]),
+            currentWeek: 3, isCurrentYear: true) == false)
+    }
+}

--- a/ios/ChqCalendarTests/EffectiveScopeTests.swift
+++ b/ios/ChqCalendarTests/EffectiveScopeTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+struct EffectiveScopeTests {
+
+    @Test func currentYearKeepsEveryRelativeScope() {
+        for scope in [DateScope.next, .today, .thisWeek, .season, .all] {
+            #expect(
+                EffectiveScope.resolve(scope: scope, selectedDayKey: nil, isCurrentYear: true) == scope,
+                "scope \(scope)")
+        }
+    }
+
+    @Test func pastSeasonDowngradesEveryScopeButDay() {
+        for scope in [DateScope.next, .today, .thisWeek, .season] {
+            #expect(
+                EffectiveScope.resolve(scope: scope, selectedDayKey: nil, isCurrentYear: false) == .all,
+                "scope \(scope)")
+        }
+    }
+
+    @Test func activeDaySurvivesThePastSeasonDowngrade() {
+        #expect(
+            EffectiveScope.resolve(
+                scope: .day, selectedDayKey: "2026-07-15", isCurrentYear: false) == .day)
+    }
+
+    @Test func keylessDayResolvesToAllOnBothYearAxes() {
+        // A .day naming no date filters nothing, which is exactly what .all
+        // means. Resolving it here is what lets all three consumers stop
+        // special-casing it.
+        for isCurrentYear in [true, false] {
+            #expect(
+                EffectiveScope.resolve(
+                    scope: .day, selectedDayKey: nil, isCurrentYear: isCurrentYear) == .all,
+                "isCurrentYear=\(isCurrentYear)")
+        }
+    }
+
+    @Test func allStaysAll() {
+        for isCurrentYear in [true, false] {
+            #expect(
+                EffectiveScope.resolve(
+                    scope: .all, selectedDayKey: nil, isCurrentYear: isCurrentYear) == .all)
+        }
+    }
+
+    @Test func resolvingIsIdempotent() {
+        // Resolving a resolved scope must be a no-op, or a consumer that
+        // resolves twice (or resolves an already-resolved value handed to it)
+        // gets a different answer than one that resolves once.
+        for scope in DateScope.allCases {
+            let once = EffectiveScope.resolve(
+                scope: scope, selectedDayKey: "2026-07-15", isCurrentYear: false)
+            let twice = EffectiveScope.resolve(
+                scope: once, selectedDayKey: "2026-07-15", isCurrentYear: false)
+            #expect(once == twice, "scope \(scope): \(once) then \(twice)")
+        }
+    }
+}

--- a/ios/ChqCalendarTests/EventFilterTests.swift
+++ b/ios/ChqCalendarTests/EventFilterTests.swift
@@ -87,7 +87,7 @@ struct EventFilterTests {
         #expect(result.map(\.id) == ["late"])
     }
 
-    // MARK: - apply: .next adaptive window + grace + extraDays
+    // MARK: - apply: .next adaptive window + grace + windowEndDayKey
 
     @Test func adaptiveEndDateStopsAtFirstDayReachingMinCount() throws {
         let from = try #require(ChqTime.parse("2026-07-10 08:00:00"))
@@ -157,7 +157,7 @@ struct EventFilterTests {
         #expect(result.map(\.id) == ["kayak"])
     }
 
-    @Test func extraDaysWidensNextWindowByWholeDays() throws {
+    @Test func windowEndDayKeyWidensNextWindowByWholeDays() throws {
         let now = try #require(ChqTime.parse("2026-07-10 09:00:00"))
         let from = now.addingTimeInterval(-3600) // 08:00
 
@@ -169,13 +169,13 @@ struct EventFilterTests {
         let later = makeEvent(id: "later", start: try #require(ChqTime.parse("2026-07-11 10:00:00")))
         events.append(later)
 
-        let noExtra = FilterSelection(dateScope: .next, extraDays: 0)
-        let resultNoExtra = EventFilter.apply(noExtra, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
-        #expect(!resultNoExtra.contains { $0.id == "later" })
+        let noExpansion = FilterSelection(dateScope: .next)
+        let resultNoExpansion = EventFilter.apply(noExpansion, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
+        #expect(!resultNoExpansion.contains { $0.id == "later" })
 
-        let withExtra = FilterSelection(dateScope: .next, extraDays: 1)
-        let resultWithExtra = EventFilter.apply(withExtra, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
-        #expect(resultWithExtra.contains { $0.id == "later" })
+        let withExpansion = FilterSelection(dateScope: .next, windowEndDayKey: "2026-07-11")
+        let resultWithExpansion = EventFilter.apply(withExpansion, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
+        #expect(resultWithExpansion.contains { $0.id == "later" })
     }
 
     // MARK: - apply: weeks filter

--- a/ios/ChqCalendarTests/FilterChipStateTests.swift
+++ b/ios/ChqCalendarTests/FilterChipStateTests.swift
@@ -41,6 +41,15 @@ struct FilterChipStateTests {
             .today, selection: sel, currentWeek: 6, isCurrentYear: true))
     }
 
+    /// The positive branch for `.today` — its siblings `.next` and `.season`
+    /// are pinned above and below, but nothing previously asserted that
+    /// selecting `.today` itself reads the `.today` chip as selected.
+    @Test func todayChipTracksScopeDirectlyWhenSelected() {
+        #expect(FilterChipState.isScopeSelected(
+            .today, selection: FilterSelection(dateScope: .today),
+            currentWeek: 3, isCurrentYear: true))
+    }
+
     @Test func seasonChipFollowsTheScope() {
         #expect(FilterChipState.isScopeSelected(
             .season, selection: FilterSelection(dateScope: .season),

--- a/ios/ChqCalendarTests/MyDayModelTests.swift
+++ b/ios/ChqCalendarTests/MyDayModelTests.swift
@@ -247,16 +247,17 @@ struct MyDayModelTests {
         let now = try #require(ChqTime.parse("2026-08-09 08:00:00"))
         let model = makeSnapshotModel(events: [], now: now)
         model.filter.selectedWeeks = [3]
-        model.filter.extraDays = 2
+        model.filter.windowEndDayKey = "2026-08-11"
 
         model.browseDay("2026-08-09")
 
         #expect(model.filter.dateScope == .day)
         #expect(model.filter.selectedDayKey == "2026-08-09")
         // A standing week filter can exclude the very day the user asked
-        // for, and extraDays is a `.next`-only concept.
+        // for, and the window-expansion fields only mean something relative
+        // to the scope being left behind.
         #expect(model.filter.selectedWeeks.isEmpty)
-        #expect(model.filter.extraDays == 0)
+        #expect(model.filter.windowEndDayKey == nil)
     }
 
     @Test func browseDayLeavesStandingNonDatePreferencesAlone() throws {
@@ -280,7 +281,7 @@ struct MyDayModelTests {
         let model = makeSnapshotModel(events: [], now: now)
         model.filter.dateScope = .all
         model.filter.selectedWeeks = [3]
-        model.filter.extraDays = 2
+        model.filter.windowEndDayKey = "2026-08-11"
         model.filter.searchText = "yoga"
         let before = model.filter
 

--- a/ios/ChqCalendarTests/UserStateStoreTests.swift
+++ b/ios/ChqCalendarTests/UserStateStoreTests.swift
@@ -38,9 +38,9 @@ struct UserStateStoreTests {
         #expect(filter.isDefault)
     }
 
-    @Test func filterSelectionWithExtraDaysOnlyIsStillDefault() {
+    @Test func filterSelectionWithWindowExpansionOnlyIsStillDefault() {
         var filter = FilterSelection()
-        filter.extraDays = 3
+        filter.windowEndDayKey = "2026-07-13"
         #expect(filter.isDefault)
     }
 
@@ -77,18 +77,20 @@ struct UserStateStoreTests {
         #expect(loaded.dateScope == .thisWeek)
     }
 
-    @Test func filtersRoundTripDoesNotPersistSearchTextOrExtraDays() throws {
+    @Test func filtersRoundTripDoesNotPersistSearchTextOrWindowExpansion() throws {
         let store = UserStateStore(defaults: makeDefaults(), now: { Date() })
         var filter = FilterSelection()
         filter.searchText = "opera"
-        filter.extraDays = 5
+        filter.windowStartDayKey = "2026-07-08"
+        filter.windowEndDayKey = "2026-07-15"
         filter.selectedWeeks = [2]
 
         store.saveFilters(filter)
         let loaded = try #require(store.loadFilters())
 
         #expect(loaded.searchText == "")
-        #expect(loaded.extraDays == 0)
+        #expect(loaded.windowStartDayKey == nil)
+        #expect(loaded.windowEndDayKey == nil)
         #expect(loaded.selectedWeeks == [2])
     }
 
@@ -374,8 +376,9 @@ struct UserStateStoreTests {
     @Test func dayScopeIsPersistedAsNextAndTheDayKeyIsNeverWritten() {
         // A date pinned three days ago and silently restored on launch would
         // be worse than not restoring at all — same reasoning as
-        // searchText/extraDays. `.day` names an absolute date, so it cannot
-        // survive a relaunch the way a relative scope can.
+        // searchText/windowStartDayKey/windowEndDayKey. `.day` names an
+        // absolute date, so it cannot survive a relaunch the way a relative
+        // scope can.
         let defaults = UserDefaults(suiteName: UUID().uuidString)!
         let store = UserStateStore(defaults: defaults, now: { Date() })
 

--- a/ios/ChqCalendarTests/ViewWindowTests.swift
+++ b/ios/ChqCalendarTests/ViewWindowTests.swift
@@ -230,11 +230,90 @@ struct ViewWindowTests {
         #expect(w.endDay == "2026-07-15")
     }
 
+    @Test func expansionNeverNarrowsTheStartOfTheBaseWindow() throws {
+        // The mirror of expansionNeverNarrowsTheBaseWindow, for the start
+        // side: a windowStartDayKey that names a LATER day than the base's
+        // own start is not a widening, so it's ignored rather than applied.
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2026-07-20"
+        let w = try #require(window(sel, now: now))
+        #expect(w.startDay == "2026-07-15")
+    }
+
     @Test func expansionClampsToNavigableBounds() throws {
         let now = try Self.at("2026-07-15 15:00:00")
         var sel = FilterSelection(dateScope: .today)
         sel.windowEndDayKey = "2030-01-01"
         let w = try #require(window(sel, now: now))
         #expect(w.endDay == bounds().upperBound)
+    }
+
+    @Test func expansionClampsStartToNavigableBounds() throws {
+        // The mirror of expansionClampsToNavigableBounds, for the start side.
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2000-01-01"
+        let w = try #require(window(sel, now: now))
+        #expect(w.startDay == bounds().lowerBound)
+    }
+
+    @Test func expandingTheStartPreservesTheOriginalEndExclusive() throws {
+        // The mirror of expansionGrowsTheEndAndUsesWholeDays' check that
+        // expanding the end leaves `start` untouched: expanding the start
+        // must not perturb the end by so much as an instant.
+        let now = try Self.at("2026-07-15 15:00:00")
+        let base = try #require(window(FilterSelection(dateScope: .today), now: now))
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2026-07-13"
+        let w = try #require(window(sel, now: now))
+        #expect(w.endDay == base.endDay)
+        #expect(w.endExclusive == base.endExclusive)
+    }
+
+    // The clamp on the expansion inputs (not on the merged startDay/endDay)
+    // only diverges from the rejected "clamp the merged result" design when
+    // `base` itself sits outside `bounds` — the off-season `.today` case,
+    // which is where the app spends most of the year. In-season, both
+    // designs agree, so a test built from an in-season `.today` cannot tell
+    // them apart (see the mutation proof recorded in
+    // .superpowers/sdd/2026-08-15-date-navigation-phase-1b-ios-window-model/task-3-report.md).
+    // With the rejected design these two produce an inverted window
+    // (`startDay > endDay`), which crashes when `range: start..<endExclusive`
+    // is constructed.
+
+    @Test func offSeasonTodayIgnoresAnOutOfBoundsEndExpansion() throws {
+        let now = try Self.at("2026-12-15 12:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2026-12-20"
+        let w = try #require(window(sel, now: now))
+        #expect(w.startDay <= w.endDay)
+        #expect(w.start < w.endExclusive)
+        // The expansion target is entirely past `bounds`, so once clamped to
+        // `bounds.upperBound` it is still earlier than the base window's own
+        // (also out-of-season) day, and is ignored rather than applied.
+        #expect(w.startDay == "2026-12-15")
+        #expect(w.endDay == "2026-12-15")
+    }
+
+    @Test func offSeasonTodayIgnoresAnOutOfBoundsStartExpansion() throws {
+        let now = try Self.at("2026-01-01 12:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2020-01-01"
+        let w = try #require(window(sel, now: now))
+        #expect(w.startDay <= w.endDay)
+        #expect(w.start < w.endExclusive)
+        // Symmetric to the end-side case above: clamped to `bounds.lowerBound`,
+        // still later than the base window's own (also out-of-season) day.
+        #expect(w.startDay == "2026-01-01")
+        #expect(w.endDay == "2026-01-01")
+    }
+
+    // MARK: - nil contract
+
+    @Test func makeReturnsNilForADayScopeWithAnUnparseableSelectedDayKey() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let sel = FilterSelection(dateScope: .day, selectedDayKey: "not-a-day")
+        #expect(window(sel, now: now) == nil)
     }
 }

--- a/ios/ChqCalendarTests/ViewWindowTests.swift
+++ b/ios/ChqCalendarTests/ViewWindowTests.swift
@@ -309,6 +309,64 @@ struct ViewWindowTests {
         #expect(w.endDay == "2026-01-01")
     }
 
+    // MARK: - robustness
+
+    @Test func allUsesTheFullDateDomainNotAYear1To3000Range() throws {
+        // `.all`'s bounds are `Date.distantPast`/`distantFuture` — genuinely
+        // unbounded, matching the web's `.all`, not an arbitrary wide range.
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(window(FilterSelection(dateScope: .all), now: now))
+        #expect(w.start == Date.distantPast)
+        #expect(w.endExclusive == Date.distantFuture)
+    }
+
+    @Test func anUnparseableStartExpansionIsIgnoredEntirelyRatherThanDesyncingFromRange() throws {
+        // If an expansion key survives the bounds clamp but fails
+        // `ChqTime.parse`, `startDay` must not name a day that `range`
+        // disagrees with. "2026-07-00" sorts before the base window's own
+        // "2026-07-15" (so it would widen if it parsed) and sorts after
+        // the season's lower bound (so it survives the clamp), but day 00
+        // does not exist and `ChqTime.parse` rejects it.
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2026-07-00"
+        let w = try #require(window(sel, now: now))
+        #expect(w.startDay == "2026-07-15")
+        #expect(w.start == ChqTime.calendar.startOfDay(for: now))
+    }
+
+    @Test func anUnparseableEndExpansionIsIgnoredEntirelyRatherThanDesyncingFromRange() throws {
+        // Mirror of the start-side case: "2026-07-32" sorts after the base
+        // window's own "2026-07-15" (so it would widen if it parsed) and
+        // sorts before the season's upper bound (so it survives the clamp),
+        // but July has no 32nd day.
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2026-07-32"
+        let w = try #require(window(sel, now: now))
+        #expect(w.endDay == "2026-07-15")
+        #expect(w.endExclusive == (try Self.at("2026-07-16 00:00:00")))
+    }
+
+    @Test func dayWindowFailsOpenToAllWhenTheKeyIsNil() throws {
+        // `.day` with no key is unreachable through `ViewWindow.make` — a
+        // nil key resolves to `.all` before `base` ever sees `.day` — so
+        // this exercises `dayWindow(forDayScope:bounds:)` directly, pinning
+        // that the fallback is `.all` (show everything), not `nil` (show
+        // nothing), if that guarantee were ever weakened.
+        let w = try #require(ViewWindow.dayWindow(forDayScope: nil, bounds: bounds()))
+        #expect(w.start == Date.distantPast)
+        #expect(w.endExclusive == Date.distantFuture)
+        #expect(w.startDay == bounds().lowerBound)
+        #expect(w.endDay == bounds().upperBound)
+    }
+
+    @Test func dayWindowStillSpansTheNamedDayWhenAKeyIsPresent() throws {
+        let w = try #require(ViewWindow.dayWindow(forDayScope: "2026-07-15", bounds: bounds()))
+        #expect(w.startDay == "2026-07-15")
+        #expect(w.endDay == "2026-07-15")
+    }
+
     // MARK: - nil contract
 
     @Test func makeReturnsNilForADayScopeWithAnUnparseableSelectedDayKey() throws {
@@ -364,5 +422,50 @@ struct EventFilterWindowTests {
         let result = EventFilter.apply(
             sel, to: [inWeek1, inWeek2], favorites: [], now: now, year: 2026, isCurrentYear: true)
         #expect(result.map(\.id) == ["w1"])
+    }
+
+    /// `EventFilter.apply` picks a cheap season-only `DayWindow.bounds` when
+    /// no expansion key is set, and the pricier event-widened
+    /// `ViewWindow.navigableBounds` when one is — safe today only because
+    /// `EventFilter` reads `window.contains(_:)` and never `startDay`/
+    /// `endDay`, the one field `bounds` actually changes for `.all`. Pins
+    /// that contract directly, rather than trusting the comment at
+    /// `EventFilter.apply`'s call site: the same selection and events must
+    /// filter identically no matter which bounds source computed the
+    /// window, so the day someone wires `startDay`/`endDay` into
+    /// `EventFilter`'s filtering, this goes red instead of silently
+    /// drifting.
+    @Test func eventFilterOutputIsIdenticalRegardlessOfWhichBoundsSourceComputedTheWindow() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let inSeason = makeEvent(id: "in", start: try Self.at("2026-07-15 18:00:00"))
+        let outOfSeason = makeEvent(id: "out", start: try Self.at("2026-05-01 09:00:00"))
+        let events = [inSeason, outOfSeason]
+        let sel = FilterSelection(dateScope: .all)
+
+        let seasonOnlyBounds = DayWindow.bounds(year: 2026, starredDays: [])
+        let eventWidenedBounds = ViewWindow.navigableBounds(year: 2026, events: events, starredDays: [])
+        // If these happened to be equal, the test below couldn't tell the
+        // two bounds sources apart.
+        #expect(seasonOnlyBounds != eventWidenedBounds)
+
+        let seasonOnlyWindow = try #require(ViewWindow.make(
+            selection: sel, events: events, now: now, year: 2026, isCurrentYear: true,
+            bounds: seasonOnlyBounds))
+        let eventWidenedWindow = try #require(ViewWindow.make(
+            selection: sel, events: events, now: now, year: 2026, isCurrentYear: true,
+            bounds: eventWidenedBounds))
+
+        // The day projection genuinely differs between the two bounds
+        // sources...
+        #expect(seasonOnlyWindow.startDay != eventWidenedWindow.startDay)
+        // ...but `.all`'s instant range does not, so `contains(_:)` — the
+        // only thing `EventFilter` reads — agrees regardless of which
+        // bounds source computed the window.
+        #expect(seasonOnlyWindow.range == eventWidenedWindow.range)
+
+        let viaApply = EventFilter.apply(
+            sel, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
+        let viaEventWidenedWindow = events.filter { eventWidenedWindow.contains($0.start) }
+        #expect(viaApply.map(\.id) == viaEventWidenedWindow.map(\.id))
     }
 }

--- a/ios/ChqCalendarTests/ViewWindowTests.swift
+++ b/ios/ChqCalendarTests/ViewWindowTests.swift
@@ -317,3 +317,52 @@ struct ViewWindowTests {
         #expect(window(sel, now: now) == nil)
     }
 }
+
+struct EventFilterWindowTests {
+
+    private static func at(_ s: String) throws -> Date {
+        try #require(ChqTime.parse(s))
+    }
+
+    @Test func expandingTheWindowEndAddsThatDaysEvents() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let today = makeEvent(id: "today", start: try Self.at("2026-07-15 18:00:00"))
+        let tomorrow = makeEvent(id: "tomorrow", start: try Self.at("2026-07-16 18:00:00"))
+
+        var sel = FilterSelection(dateScope: .today)
+        let before = EventFilter.apply(
+            sel, to: [today, tomorrow], favorites: [], now: now, year: 2026, isCurrentYear: true)
+        #expect(before.map(\.id) == ["today"])
+
+        sel.windowEndDayKey = "2026-07-16"
+        let after = EventFilter.apply(
+            sel, to: [today, tomorrow], favorites: [], now: now, year: 2026, isCurrentYear: true)
+        #expect(after.map(\.id) == ["today", "tomorrow"])
+    }
+
+    @Test func expandingTheWindowStartAddsEarlierDays() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let yesterday = makeEvent(id: "yesterday", start: try Self.at("2026-07-14 18:00:00"))
+        let today = makeEvent(id: "today", start: try Self.at("2026-07-15 18:00:00"))
+
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2026-07-14"
+        let result = EventFilter.apply(
+            sel, to: [yesterday, today], favorites: [], now: now, year: 2026, isCurrentYear: true)
+        #expect(result.map(\.id) == ["yesterday", "today"])
+    }
+
+    @Test func windowExpansionStillRespectsTheWeeksStage() throws {
+        // The weeks stage is separate and ANDed. Phase 1 does not change that.
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let now = weeks[0].start.addingTimeInterval(3600)
+        let inWeek1 = makeEvent(id: "w1", start: now.addingTimeInterval(600))
+        let inWeek2 = makeEvent(id: "w2", start: weeks[1].start.addingTimeInterval(3600))
+
+        var sel = FilterSelection(dateScope: .today, selectedWeeks: [1])
+        sel.windowEndDayKey = ChqTime.dayKey(for: weeks[1].start.addingTimeInterval(3600))
+        let result = EventFilter.apply(
+            sel, to: [inWeek1, inWeek2], favorites: [], now: now, year: 2026, isCurrentYear: true)
+        #expect(result.map(\.id) == ["w1"])
+    }
+}

--- a/ios/ChqCalendarTests/ViewWindowTests.swift
+++ b/ios/ChqCalendarTests/ViewWindowTests.swift
@@ -1,0 +1,240 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+struct ViewWindowTests {
+
+    private static func at(_ s: String) throws -> Date {
+        try #require(ChqTime.parse(s))
+    }
+
+    private func bounds() -> ClosedRange<String> {
+        DayWindow.bounds(year: 2026, starredDays: [])
+    }
+
+    private func window(
+        _ sel: FilterSelection,
+        events: [Event] = [],
+        now: Date,
+        isCurrentYear: Bool = true
+    ) -> ViewWindow? {
+        ViewWindow.make(
+            selection: sel, events: events, now: now,
+            year: 2026, isCurrentYear: isCurrentYear, bounds: bounds())
+    }
+
+    // MARK: - day boundaries
+
+    @Test func dayAfterIsTheNextDaysMidnight() throws {
+        let bound = try #require(ViewWindow.dayAfter("2026-07-15"))
+        #expect(bound == (try Self.at("2026-07-16 00:00:00")))
+    }
+
+    @Test func dayAfterHandlesADstDay() throws {
+        // 2026-11-01 is 25 hours long in America/New_York. Adding 86_400
+        // seconds would land at 23:00 on the 1st, not midnight on the 2nd.
+        let bound = try #require(ViewWindow.dayAfter("2026-11-01"))
+        #expect(bound == (try Self.at("2026-11-02 00:00:00")))
+    }
+
+    @Test func dayAfterRejectsAnUnparseableKey() {
+        #expect(ViewWindow.dayAfter("not-a-day") == nil)
+    }
+
+    @Test func lastDayCoveredStepsBackOnAnExactDayBoundary() throws {
+        // A window ending at midnight does NOT show that day.
+        #expect(ViewWindow.lastDayCovered(try Self.at("2026-07-16 00:00:00")) == "2026-07-15")
+    }
+
+    @Test func lastDayCoveredKeepsTheDayOnAMidDayBoundary() throws {
+        // A week ends at noon Saturday, and that Saturday morning has events,
+        // so the Saturday counts as shown.
+        #expect(ViewWindow.lastDayCovered(try Self.at("2026-07-18 12:00:00")) == "2026-07-18")
+    }
+
+    // MARK: - navigableBounds
+
+    @Test func boundsCoverTheSeasonWhenEveryEventIsInside() throws {
+        let inside = makeEvent(id: "in", start: try Self.at("2026-07-15 10:00:00"))
+        let range = ViewWindow.navigableBounds(year: 2026, events: [inside], starredDays: [])
+        #expect(range == DayWindow.bounds(year: 2026, starredDays: []))
+    }
+
+    @Test func boundsWidenToContainOutOfSeasonEvents() throws {
+        let early = makeEvent(id: "early", start: try Self.at("2026-05-01 10:00:00"))
+        let late = makeEvent(id: "late", start: try Self.at("2026-10-01 10:00:00"))
+        let range = ViewWindow.navigableBounds(year: 2026, events: [early, late], starredDays: [])
+        #expect(range.lowerBound == "2026-05-01")
+        #expect(range.upperBound == "2026-10-01")
+    }
+
+    @Test func boundsAlsoWidenForStarredDaysOutsideTheSeason() {
+        let range = ViewWindow.navigableBounds(
+            year: 2026, events: [], starredDays: ["2026-04-01", "2026-12-25"])
+        #expect(range.lowerBound == "2026-04-01")
+        #expect(range.upperBound == "2026-12-25")
+    }
+
+    // MARK: - base windows, one per scope
+
+    @Test func todaySpansExactlyTheCurrentDay() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(window(FilterSelection(dateScope: .today), now: now))
+        #expect(w.startDay == "2026-07-15")
+        #expect(w.endDay == "2026-07-15")
+        #expect(w.start == ChqTime.calendar.startOfDay(for: now))
+        #expect(w.endExclusive == (try Self.at("2026-07-16 00:00:00")))
+    }
+
+    @Test func todayIncludesTheFinalSubSecondAndExcludesTheNextMidnight() throws {
+        // Half-open means no epsilon and no precision assumption: anything
+        // strictly before the next midnight is in, midnight itself is out.
+        // ChqTime.endOfDay (23:59:59.000) would have dropped the first of
+        // these, and an `end - 1ms` bound would have dropped it on iOS while
+        // keeping it on the web, where Date is integer milliseconds.
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(window(FilterSelection(dateScope: .today), now: now))
+        #expect(w.contains(try Self.at("2026-07-15 23:59:59").addingTimeInterval(0.9995)))
+        #expect(!w.contains(try Self.at("2026-07-16 00:00:00")))
+        #expect(w.contains(try Self.at("2026-07-15 00:00:00")))
+    }
+
+    @Test func adjacentDayWindowsTileWithoutGapOrOverlap() throws {
+        // The property an inclusive-with-epsilon scheme cannot give you, and
+        // the one scroll-stitching depends on.
+        let day1 = try #require(window(
+            FilterSelection(dateScope: .day, selectedDayKey: "2026-07-15"),
+            now: try Self.at("2026-07-15 12:00:00")))
+        let day2 = try #require(window(
+            FilterSelection(dateScope: .day, selectedDayKey: "2026-07-16"),
+            now: try Self.at("2026-07-15 12:00:00")))
+        #expect(day1.endExclusive == day2.start)
+    }
+
+    @Test func nextStartsOneHourBeforeNow() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let events = [makeEvent(id: "e", start: try Self.at("2026-07-16 10:00:00"))]
+        let w = try #require(window(FilterSelection(dateScope: .next), events: events, now: now))
+        #expect(w.start == now.addingTimeInterval(-3600))
+        #expect(w.startDay == "2026-07-15")
+    }
+
+    @Test func nextUpperBoundAdmitsNoRepresentableEventBeyondTheOldOne() throws {
+        // The one deliberate difference from the pre-refactor pipeline:
+        // `.next` used `<= adaptiveEndDate`, which is ChqTime.endOfDay =
+        // 23:59:59.000. The half-open bound is the next midnight, so it also
+        // admits 23:59:59.5 — but event times are parsed from
+        // "yyyy-MM-dd HH:mm:ss" and carry no sub-second component, so no
+        // representable event can land in that gap. Asserted rather than
+        // claimed in a comment: verified against the live formatter (a
+        // trailing ".500" is unmatched pattern text and DateFormatter's
+        // strict "yyyy-MM-dd HH:mm:ss" parse rejects it outright) before
+        // pinning both properties.
+        #expect(ChqTime.parse("2026-07-15 23:59:59.500") == nil)
+        let onTheSecond = try #require(ChqTime.parse("2026-07-15 23:59:59"))
+        #expect(onTheSecond.timeIntervalSince1970 == onTheSecond.timeIntervalSince1970.rounded())
+    }
+
+    @Test func nextNearMidnightPutsStartDayOnThePreviousDay() throws {
+        let now = try Self.at("2026-07-15 00:30:00")
+        let w = try #require(window(FilterSelection(dateScope: .next), now: now))
+        #expect(w.startDay == "2026-07-14")
+    }
+
+    @Test func seasonCarriesTheWeeksBoundsThroughVerbatim() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let w = try #require(window(FilterSelection(dateScope: .season), now: now))
+        #expect(w.start == weeks[0].start)
+        #expect(w.endExclusive == weeks[8].end)
+    }
+
+    @Test func thisWeekCarriesTheWeeksNoonBoundsThroughVerbatim() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let current = try #require(weeks.first { $0.contains(now) })
+        let w = try #require(window(FilterSelection(dateScope: .thisWeek), now: now))
+        #expect(w.start == current.start)
+        #expect(w.endExclusive == current.end)
+    }
+
+    @Test func thisWeekSpansBothBoundarySaturdays() throws {
+        // A week runs noon-Saturday to noon-Saturday, so both boundary
+        // Saturdays carry events and the window covers eight day keys. This is
+        // why the season cannot be paged into disjoint weeks.
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(window(FilterSelection(dateScope: .thisWeek), now: now))
+        #expect(ChqTime.dayKeys(from: w.startDay, through: w.endDay).count == 8)
+    }
+
+    @Test func dayScopeSpansItsNamedDay() throws {
+        let now = try Self.at("2027-01-01 12:00:00")
+        let sel = FilterSelection(dateScope: .day, selectedDayKey: "2026-07-15")
+        let w = try #require(window(sel, now: now, isCurrentYear: false))
+        #expect(w.startDay == "2026-07-15")
+        #expect(w.endDay == "2026-07-15")
+    }
+
+    @Test func allIsUnboundedInInstantsButBoundedInDays() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(window(FilterSelection(dateScope: .all), now: now))
+        #expect(w.start < (try Self.at("1900-01-01 00:00:00")))
+        #expect(w.endExclusive > (try Self.at("2200-01-01 00:00:00")))
+        #expect(w.startDay == bounds().lowerBound)
+        #expect(w.endDay == bounds().upperBound)
+    }
+
+    @Test func aPastSeasonCollapsesRelativeScopesToAll() throws {
+        let now = try Self.at("2027-01-01 12:00:00")
+        let w = try #require(window(FilterSelection(dateScope: .today), now: now, isCurrentYear: false))
+        #expect(w.start < (try Self.at("1900-01-01 00:00:00")))
+    }
+
+    // MARK: - expansion
+
+    @Test func expansionGrowsTheEndAndUsesWholeDays() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2026-07-17"
+        let w = try #require(window(sel, now: now))
+        #expect(w.endDay == "2026-07-17")
+        #expect(w.endExclusive == (try Self.at("2026-07-18 00:00:00")))
+        #expect(w.start == ChqTime.calendar.startOfDay(for: now))
+    }
+
+    @Test func expansionGrowsTheStart() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowStartDayKey = "2026-07-13"
+        let w = try #require(window(sel, now: now))
+        #expect(w.startDay == "2026-07-13")
+        #expect(w.start == ChqTime.calendar.startOfDay(for: try Self.at("2026-07-13 00:00:00")))
+    }
+
+    @Test func expandingEarlierDropsTheIntraDayStartInstant() throws {
+        // `.next` starts at now-1h. Once the user reaches back past that day
+        // they want the whole earlier day, not a window still beginning at
+        // 14:00 on a day they scrolled away from.
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .next)
+        sel.windowStartDayKey = "2026-07-13"
+        let w = try #require(window(sel, now: now))
+        #expect(w.start == ChqTime.calendar.startOfDay(for: try Self.at("2026-07-13 00:00:00")))
+    }
+
+    @Test func expansionNeverNarrowsTheBaseWindow() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2026-07-10"
+        let w = try #require(window(sel, now: now))
+        #expect(w.endDay == "2026-07-15")
+    }
+
+    @Test func expansionClampsToNavigableBounds() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2030-01-01"
+        let w = try #require(window(sel, now: now))
+        #expect(w.endDay == bounds().upperBound)
+    }
+}

--- a/ios/ChqCalendarTests/WindowParityTests.swift
+++ b/ios/ChqCalendarTests/WindowParityTests.swift
@@ -6,14 +6,37 @@ import Testing
 /// Nothing compiles across that boundary, so the two can drift in silence —
 /// these are the invariants a reader of either file is entitled to assume
 /// hold on both. The web's mirror lives in
-/// `frontend/src/__tests__/lib/utils/dayWindow.test.ts`.
+/// `frontend/src/__tests__/lib/utils/dayWindow.test.ts`; each test below
+/// names the web test it mirrors.
 struct WindowParityTests {
 
-    @Test func dayKeysAreZeroPaddedAndSortChronologically() {
-        let keys = ["2026-12-31", "2026-07-05", "2026-07-15"]
-        #expect(keys.sorted() == ["2026-07-05", "2026-07-15", "2026-12-31"])
+    private static func at(_ s: String) throws -> Date {
+        try #require(ChqTime.parse(s))
     }
 
+    private func bounds() -> ClosedRange<String> {
+        DayWindow.bounds(year: 2026, starredDays: [])
+    }
+
+    /// Mirrors "formats a date as a zero-padded local day key" +
+    /// "sorts lexicographically in chronological order". Round-trips
+    /// through `ChqTime.dayKey(for:)` itself rather than hand-typed
+    /// strings — every hand-typed key is already zero-padded by
+    /// construction, so a hand-typed-only test (the bug this replaces)
+    /// cannot fail no matter what the formatter does.
+    @Test func dayKeysAreZeroPaddedAndSortChronologically() throws {
+        let jan5 = try Self.at("2026-01-05 08:00:00")
+        let jul15 = try Self.at("2026-07-15 08:00:00")
+        let dec31 = try Self.at("2026-12-31 08:00:00")
+
+        #expect(ChqTime.dayKey(for: jan5) == "2026-01-05")
+        #expect(ChqTime.dayKey(for: jul15) == "2026-07-15")
+
+        let keys = [ChqTime.dayKey(for: dec31), ChqTime.dayKey(for: jan5), ChqTime.dayKey(for: jul15)]
+        #expect(keys.sorted() == ["2026-01-05", "2026-07-15", "2026-12-31"])
+    }
+
+    /// Mirrors "crosses a DST transition without drifting".
     @Test func dayArithmeticCrossesMonthYearAndDstBoundaries() {
         #expect(ChqTime.day("2026-07-31", offsetBy: 1) == "2026-08-01")
         #expect(ChqTime.day("2026-08-01", offsetBy: -1) == "2026-07-31")
@@ -26,6 +49,8 @@ struct WindowParityTests {
         #expect(ChqTime.day("2026-03-08", offsetBy: 1) == "2026-03-09")
     }
 
+    /// Mirrors "produces inclusive contiguous ranges" and "returns an empty
+    /// range when the bounds are inverted".
     @Test func dayRangesAreInclusiveAndEmptyWhenInverted() {
         #expect(ChqTime.dayKeys(from: "2026-07-14", through: "2026-07-16")
             == ["2026-07-14", "2026-07-15", "2026-07-16"])
@@ -33,11 +58,56 @@ struct WindowParityTests {
         #expect(ChqTime.dayKeys(from: "2026-07-16", through: "2026-07-14") == [])
     }
 
+    /// Mirrors "spans both boundary Saturdays" (noon-to-noon), extended to
+    /// actually assert noon — the original wording claimed it without a
+    /// clock-component check anywhere in the test.
     @Test func theSeasonIsNineWeeksOfNoonSaturdayBoundaries() {
         let weeks = SeasonCalendar.weeks(forYear: 2026)
         #expect(weeks.count == 9)
+        let calendar = ChqTime.calendar
+        for week in weeks {
+            #expect(
+                calendar.component(.hour, from: week.start) == 12,
+                "week \(week.number) start must be noon")
+            #expect(
+                calendar.component(.hour, from: week.end) == 12,
+                "week \(week.number) end must be noon")
+        }
         for i in 0..<(weeks.count - 1) {
             #expect(weeks[i].end == weeks[i + 1].start, "week \(i + 1) end must equal week \(i + 2) start")
         }
+    }
+
+    /// Mirrors `windowContains`'s "does not contain an instant exactly at
+    /// endExclusive" — the half-openness the whole shared model exists to
+    /// enforce, exercised here through the real `ViewWindow.make`, not a
+    /// synthetic window.
+    @Test func endExclusiveBelongsToTheNextWindowNotThisOne() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        let w = try #require(ViewWindow.make(
+            selection: FilterSelection(dateScope: .today), events: [], now: now,
+            year: 2026, isCurrentYear: true, bounds: bounds()))
+        #expect(w.contains(w.start))
+        #expect(!w.contains(w.endExclusive))
+    }
+
+    /// Mirrors `lastDayCovered`'s "names the last day shown, stepping back
+    /// only on an exact midnight": a window ending at midnight does not show
+    /// that day (`.today`), one ending mid-day does (`.thisWeek`'s noon
+    /// Saturday).
+    @Test func lastDayCoveredOnMidnightAndNoonBounds() throws {
+        #expect(ViewWindow.lastDayCovered(try Self.at("2026-07-16 00:00:00")) == "2026-07-15")
+        #expect(ViewWindow.lastDayCovered(try Self.at("2026-07-18 12:00:00")) == "2026-07-18")
+    }
+
+    /// Mirrors "ignores an expansion that would narrow the base window".
+    @Test func anExpansionNarrowerThanTheBaseWindowIsIgnored() throws {
+        let now = try Self.at("2026-07-15 15:00:00")
+        var sel = FilterSelection(dateScope: .today)
+        sel.windowEndDayKey = "2026-07-10"
+        let w = try #require(ViewWindow.make(
+            selection: sel, events: [], now: now,
+            year: 2026, isCurrentYear: true, bounds: bounds()))
+        #expect(w.endDay == "2026-07-15")
     }
 }

--- a/ios/ChqCalendarTests/WindowParityTests.swift
+++ b/ios/ChqCalendarTests/WindowParityTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+/// Pins the facts iOS's `ViewWindow` shares with the web's `dayWindow.ts`.
+/// Nothing compiles across that boundary, so the two can drift in silence —
+/// these are the invariants a reader of either file is entitled to assume
+/// hold on both. The web's mirror lives in
+/// `frontend/src/__tests__/lib/utils/dayWindow.test.ts`.
+struct WindowParityTests {
+
+    @Test func dayKeysAreZeroPaddedAndSortChronologically() {
+        let keys = ["2026-12-31", "2026-07-05", "2026-07-15"]
+        #expect(keys.sorted() == ["2026-07-05", "2026-07-15", "2026-12-31"])
+    }
+
+    @Test func dayArithmeticCrossesMonthYearAndDstBoundaries() {
+        #expect(ChqTime.day("2026-07-31", offsetBy: 1) == "2026-08-01")
+        #expect(ChqTime.day("2026-08-01", offsetBy: -1) == "2026-07-31")
+        #expect(ChqTime.day("2026-12-31", offsetBy: 1) == "2027-01-01")
+        #expect(ChqTime.day("2026-01-01", offsetBy: -1) == "2025-12-31")
+        // DST ends 2026-11-01, begins 2026-03-08 in America/New_York.
+        #expect(ChqTime.day("2026-10-31", offsetBy: 1) == "2026-11-01")
+        #expect(ChqTime.day("2026-11-01", offsetBy: 1) == "2026-11-02")
+        #expect(ChqTime.day("2026-03-07", offsetBy: 1) == "2026-03-08")
+        #expect(ChqTime.day("2026-03-08", offsetBy: 1) == "2026-03-09")
+    }
+
+    @Test func dayRangesAreInclusiveAndEmptyWhenInverted() {
+        #expect(ChqTime.dayKeys(from: "2026-07-14", through: "2026-07-16")
+            == ["2026-07-14", "2026-07-15", "2026-07-16"])
+        #expect(ChqTime.dayKeys(from: "2026-07-14", through: "2026-07-14") == ["2026-07-14"])
+        #expect(ChqTime.dayKeys(from: "2026-07-16", through: "2026-07-14") == [])
+    }
+
+    @Test func theSeasonIsNineWeeksOfNoonSaturdayBoundaries() {
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        #expect(weeks.count == 9)
+        for i in 0..<(weeks.count - 1) {
+            #expect(weeks[i].end == weeks[i + 1].start, "week \(i + 1) end must equal week \(i + 2) start")
+        }
+    }
+}


### PR DESCRIPTION
Phase 1b of the cross-platform date-navigation initiative (#225 web / #226 iOS). The web half merged yesterday as #232; this is the iOS mirror. Phase 0 (the area-split deploy) was #231.

Plan: `docs/superpowers/plans/2026-08-15-date-navigation-phase-1b-ios-window-model.md`
Spec: `docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md`

[skip-screenshots: phase 1b is a pure refactor; no visible change — button label, placement and behavior are unchanged]

## What changes

**`EffectiveScope` is now the single owner of two rules** that were restated in four places: a past or future season has no "now", so relative scopes degrade to `.all`; and `.day` is exempt because it names an absolute calendar date — but only while it carries a key, since a keyless `.day` filters nothing, which is exactly what `.all` means. `EventFilter`, `DateFilterLabel`, `FilterChipState` and `EventListView` each restated some part of that by hand, with no compiler help if they drifted. `FilterChipState` is the one where drift is a **silent** wrong answer: a chip renders selected against a filter doing something else.

**`ViewWindow` replaces `EventFilter`'s six-branch date `switch` with one range check.** It mirrors the web's `dayWindow.ts`: half-open (`start <= x < endExclusive`, carried as a `Range<Date>` so the type enforces it), day keys derived from the range rather than alongside it, expansion that only ever grows, and a `bounds` clamp applied to the expansion *inputs*.

**`extraDays: Int` is deleted** in favour of `windowStartDayKey`/`windowEndDayKey`. It was only ever the window's end expressed as an offset meaningful under one scope, which is why `clearScopeLocalDateState` existed to sweep it up on every scope change. Absolute day keys make the state impossible to misapply rather than merely tidied — the #156 bug class closed by construction. Both fields are session-only; `saveFilters` builds a separate `PersistedFilters` that omits them, so the on-disk schema is untouched.

No rail, no stepping, no scope-set change — those are phases 2–4. iOS's scope set is already the target one, so unlike the web it has nothing to change there.

## Behavior

Zero user-visible change. The "Show next day" button keeps its label, placement and visibility condition in every reachable state; only its call site is renamed and its condition rewritten to an equivalent expression (proven equivalent case-by-case, including `.day`, keyless `.day`, and archived years).

One deliberate delta: `expandWindowEnd` is bounded by the navigable range where `extraDays += 1` was unbounded. This can never hide an event — `navigableBounds.upperBound` is by definition the max over every event's day key, so any day it withholds provably has no event. The button becomes inert exactly where it previously did nothing visible.

## Three defects in the plan, caught before merge

The plan is a session artifact, and this branch corrects it where it was wrong:

1. **Its own tests referenced a `w.end` property its `ViewWindow` never defines**, and two asserted an inclusive-minus-epsilon relationship its own Global Constraints forbid. Those tests now assert exact equality on `endExclusive` — strictly stronger, since `.season` and `.thisWeek` carry `SeasonWeek`'s bounds through verbatim.
2. **Its `EventFilter` line was `$0.start >= window.start && $0.start <= window.end`** — the phantom property again, plus an inclusive comparison on an exclusive bound. Now `window.contains($0.start)`, so the rule lives in one place.
3. **Its `FilterChipState.isScopeSelected` dropped an `isCurrentYear` gate** on the "only the current week is selected" equivalence. A pre-existing test caught it. Restored, and the collapse was then verified cell-by-cell against the deleted block across every combination of scope, selection, week and year axis.

`WindowParityTests` also shipped from the plan containing a test that **could not fail** — it asserted that `Array<String>.sorted()` sorts strings, in the file meant to prove this phase's whole point. It now round-trips through `ChqTime.dayKey` and exercises `ViewWindow` directly, citing the web's mirror tests by name. The plan is corrected so the next reader does not regenerate it.

## Cross-platform parity

The two implementations agree on day-key format and ordering, half-openness, `lastDayCovered`'s midnight rule, growth-only expansion, input-clamping, and DST-safe day arithmetic. `WindowParityTests.swift` pins those, naming the web's mirror in `frontend/src/__tests__/lib/utils/dayWindow.test.ts`.

One real divergence is documented rather than papered over: **`this-week` out of season returns `null` on the web** (list shows nothing) **but a rolling 7-day window on iOS**. Both preserve their own platform's prior behavior, so neither changes here; phase 3 reconciles it.

## Mutation proofs

Every load-bearing invariant was verified by breaking it and watching the right tests fail:

- Deleting the `.day` exemption → 3 characterization tests fail.
- `dayAfter` returning `ChqTime.endOfDay` (`23:59:59.000`), and returning `next - 0.001` → 6 tests fail, including the day-tiling one. The second is the mutation that matters: it is exact on the web, where `Date` is integer milliseconds, and wrong here, where `Date` wraps a `Double`.
- Switching the clamp to the rejected clamp-after-merge form → a real `Fatal error: Range requires lowerBound <= upperBound`. Worth noting the obvious test did **not** catch this: only a base sitting *outside* the bounds discriminates the two, which is the off-season case.

## Tests

789 tests, 57 suites. The 14-test characterization matrix written before any refactor passed unmodified at every commit, and no pre-existing test was deleted — the ten that named `extraDays`/`showNextDay` were translated, two of them to stronger assertions.

**One known-red test, pre-existing and environmental:** `AppGroupTests.containerURLIsNilInTheUnitTestHost` asserts that no App Group container exists in the unit-test host. On a machine whose simulator has the container provisioned, that premise is false. Verified by running it against `main` at `5d3e169` in a clean worktree, where it fails identically. It should pass on CI, whose runners are freshly provisioned — worth a follow-up to make the test assert something environment-independent.

## Deferred to phase 2

`ViewWindow.make`'s `bounds` parameter defines both the expansion clamp and the `.all` scope's day-key projection, and `EventFilter` passes cheaper season-only bounds when no expansion is active (skipping an O(n) `DateFormatter` scan the common path discards). That is invisible today because `EventFilter` reads only `contains`, and it is now pinned by a contract test — but phase 2's day rail is the first caller that will read `startDay...endDay`, and should revisit the seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014PN8JR7jFsQuzmhnrLxDDT
