### PR TITLE
fix(web): rail tap targets, header measurement, and the first page-level test

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -94,5 +94,63 @@ jobs:
           name: frontend-build-node${{ matrix.node-version }}
           path: frontend/out/
 
+  # Geometry, scroll corrections and animation timing — the things jsdom
+  # cannot express. This job exists because two defects reached production
+  # with the whole unit suite green: a rail that was not sticky at all, and a
+  # filter header whose collapse fought the browser's scroll anchoring so
+  # slow scrolling advanced the page 0px. See frontend/e2e/README.md.
+  browser-checks:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Use Node.js 24
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install all workspace dependencies
+        run: npm ci
+
+      # Chromium only. These are geometry checks against one engine, not a
+      # browser-support matrix, and --with-deps pulls the system libraries
+      # headless Chromium needs on a bare runner.
+      - name: Install Chromium for Playwright
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      - name: Build frontend
+        run: npm run build --workspace=frontend
+        env:
+          VITE_API_URL: ""
+          VITE_RECAPTCHA_SITE_KEY: ${{ secrets.RECAPTCHA_SITE_KEY || 'ci-placeholder-key' }}
+          VITE_ENABLE_PUBLISHER_FEEDS: "true"
+
+      # `vite preview` serves the built output on port 3000 (vite.config.ts).
+      # Backgrounded, then polled — a fixed sleep is either flaky or slow.
+      - name: Start preview server
+        run: npm run preview --workspace=frontend &
+
+      - name: Wait for the preview server
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf -o /dev/null http://localhost:3000/; then
+              echo "preview server up after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "preview server did not start within 60s"
+          exit 1
+
+      - name: Run browser checks
+        run: npm run test:browser --workspace=frontend
+        env:
+          URL: http://localhost:3000/
+
   # Note: Integration tests removed due to DynamoDB service container complexity
   # Post-deployment tests in deploy-production.yml verify the actual production system

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,47 @@
+# Browser checks
+
+Playwright verification for the parts of the calendar that only a real
+browser can judge: sticky geometry, scroll corrections, animation timing,
+tap-target size, and the interaction between our own scroll handling and the
+browser's scroll anchoring.
+
+**These exist because unit tests could not see the defects.** Two examples,
+both of which shipped to production with a full green suite:
+
+- The day rail was not sticky at all — a wrapper div gave `position: sticky`
+  zero travel. Eleven task reviews passed first.
+- Hiding the filter card on scroll removed ~290px of flow height above the
+  reader; scroll anchoring subtracted that from `scrollY`, which clamped at
+  the top, which put the card back. Slow scrolling advanced the page 0px.
+  954 unit tests and every CI check passed.
+
+jsdom has no layout, no sticky positioning, no scroll anchoring and no
+compositor, so none of that is reachable from the normal suite. What the
+suite covers is the composition rules those bugs broke — see
+`src/__tests__/integration/filterHeader.test.tsx`.
+
+## Running
+
+```bash
+# against the dev server
+npm run dev
+URL=http://localhost:3000/ npm run test:browser
+
+# against production, or any deploy
+URL=https://www.chqcal.org/ npm run test:browser
+```
+
+`URL` defaults to `http://localhost:3000/`. Each harness exits non-zero on
+the first failing check and prints every check it ran.
+
+Running them against **production** is worth doing deliberately: it is how
+the filter-header regression was confirmed to be live, and how the fix was
+confirmed to have reached readers. A check that passes on a build known to
+be broken is a check that cannot fail — production is the control that
+proves it can.
+
+## In CI
+
+`.github/workflows/build-and-test.yml` runs both against a preview server
+built from the branch, on changes under `frontend/`. Chromium only: the
+harnesses are geometry checks, not a browser-support matrix.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -31,8 +31,10 @@ URL=http://localhost:3000/ npm run test:browser
 URL=https://www.chqcal.org/ npm run test:browser
 ```
 
-`URL` defaults to `http://localhost:3000/`. Each harness exits non-zero on
-the first failing check and prints every check it ran.
+`URL` defaults to `http://localhost:3000/`. Each harness runs every check,
+prints them all as it goes, and exits non-zero at the end if any failed —
+it does not stop at the first failure. A run that fails check 12 still tells
+you about checks 13 onward, which usually matters: these failures cluster.
 
 Running them against **production** is worth doing deliberately: it is how
 the filter-header regression was confirmed to be live, and how the fix was
@@ -43,5 +45,15 @@ proves it can.
 ## In CI
 
 `.github/workflows/build-and-test.yml` runs both against a preview server
-built from the branch, on changes under `frontend/`. Chromium only: the
-harnesses are geometry checks, not a browser-support matrix.
+built from the branch. There is no path filtering — they run on every push
+and every fork PR, like the rest of that workflow. Chromium only: these are
+geometry checks against one engine, not a browser-support matrix.
+
+The job carries the same `if:` guard as `test-backend` and `test-frontend`,
+which reads as though it disables the job for same-repo pull requests. It
+does not, and it is worth knowing why before someone "fixes" it: the
+workflow triggers on both `push` and `pull_request`, so a same-repo branch
+would otherwise run everything twice. The guard routes same-repo work
+through the `push` event and fork PRs — where no push fires in the base
+repo — through `pull_request`. On a PR you will therefore see the job
+listed twice, once skipped and once green.

--- a/frontend/e2e/verify-filter-reveal.mjs
+++ b/frontend/e2e/verify-filter-reveal.mjs
@@ -1,0 +1,380 @@
+/**
+ * Browser verification for the filter panel's reveal AND its dismissal.
+ *
+ * Everything this plan risks is geometry, motion and event ordering, and jsdom
+ * computes none of it. Two defects on the preceding branch were found only
+ * here, and this plan's own review surfaced two more (a bubbling
+ * `transitionend`, and a scroll correction knocking out the sentinel that
+ * gates its own animation) that no unit test can see.
+ *
+ * The invariant that matters is NOT that `scrollY` is unchanged — opening and
+ * closing insert and remove in-flow content above the reader, so `scrollY`
+ * SHOULD move by exactly that height. What must not move is the content the
+ * reader is looking at.
+ *
+ * Run against a dev server, or any deploy: `URL=https://… node <this>`.
+ */
+import { chromium } from 'playwright';
+
+const URL = process.env.URL ?? 'http://localhost:3000/';
+const results = [];
+const check = (name, ok, detail) => {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+};
+
+const browser = await chromium.launch();
+
+async function phone({ reducedMotion } = {}) {
+  const ctx = await browser.newContext({
+    viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
+    ...(reducedMotion ? { reducedMotion: 'reduce' } : {}),
+  });
+  const page = await ctx.newPage();
+  await page.goto(URL, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-day-key]');
+  return page;
+}
+
+const toggle = p => p.locator('[data-day-rail] button[aria-expanded]').first();
+const searchVisible = p => p.evaluate(() => {
+  const el = document.querySelector('input[type="text"], input[type="search"]');
+  if (!el) return false;
+  const r = el.getBoundingClientRect();
+  return r.height > 0 && r.bottom > 0 && r.top < window.innerHeight;
+});
+// The reader's frame of reference: a day section's viewport-relative top.
+const pickRef = p => p.evaluate(() => {
+  const railBottom = document.querySelector('[data-day-rail]').getBoundingClientRect().bottom;
+  const s = [...document.querySelectorAll('[data-day-key]')]
+    .find(e => e.getBoundingClientRect().bottom > railBottom + 10);
+  return s?.dataset.dayKey ?? null;
+});
+const refTop = (p, k) => p.evaluate(
+  key => Math.round(document.querySelector(`[data-day-key="${key}"]`).getBoundingClientRect().top), k);
+const fixedGhosts = p => p.evaluate(() =>
+  [...document.querySelectorAll('div')].filter(e => getComputedStyle(e).position === 'fixed'
+    && e.querySelector('input[type="text"], input[type="search"]')).length);
+
+// ─────────────────────────────────────────────── reveal still works
+{
+  const p = await phone();
+  check('1 search visible at page top', await searchVisible(p));
+  const chips = await p.$$eval('[data-day-rail] [data-chip]:not([aria-disabled="true"])', e => e.map(x => x.dataset.chip));
+  const last = chips[chips.length - 1];
+  await p.evaluate(k => document.querySelector(`[data-day-rail] [data-chip="${k}"]`).click(), last);
+  await p.waitForTimeout(2500);
+  check('2 rail teleports to the last day', (await p.evaluate(() => window.scrollY)) > 3000,
+    `scrollY=${await p.evaluate(() => Math.round(window.scrollY))}, chip=${last}`);
+  check('3 search is NOT reachable after the jump', !(await searchVisible(p)));
+  check('4 a filters toggle is present', await toggle(p).count() > 0);
+
+  const refKey = await pickRef(p);
+  const before = await refTop(p, refKey);
+  await toggle(p).click();
+  await p.waitForTimeout(600);
+  check('5 opening reveals the search field', await searchVisible(p));
+  check('6 opening does not move the reader', Math.abs((await refTop(p, refKey)) - before) <= 2,
+    `day ${refKey}: ${before} → ${await refTop(p, refKey)}`);
+  check('7 toggle reports expanded', (await toggle(p).getAttribute('aria-expanded')) === 'true');
+  check('8 rail still visible with panel open', await p.evaluate(() => {
+    const r = document.querySelector('[data-day-rail]')?.getBoundingClientRect();
+    return !!r && r.top >= -1 && r.bottom <= window.innerHeight + 1 && r.height > 0;
+  }));
+  await p.context().close();
+}
+
+// ─────────────────────────────────── dismissal: the point of this plan
+{
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await p.waitForTimeout(800);
+  await toggle(p).click();
+  await p.waitForTimeout(600);
+  check('9 panel opens when scrolled', await searchVisible(p));
+
+  // A filter change must NOT dismiss — picking a venue, a category and a week
+  // is one intent. This is the guard against keying dismissal off `scroll`.
+  await p.evaluate(() => [...document.querySelectorAll('button')]
+    .find(b => b.textContent.trim() === 'Today')?.click());
+  await p.waitForTimeout(700);
+  check('10 a filter change does NOT dismiss', await searchVisible(p));
+
+  // Scrolling the panel's own overflow must not dismiss either.
+  await p.evaluate(() => {
+    const el = document.querySelector('input[type="text"], input[type="search"]')
+      ?.closest('[class*="overflow-y-auto"]');
+    el?.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: 40 }));
+  });
+  await p.waitForTimeout(400);
+  check('11 a gesture inside the panel does NOT dismiss', await searchVisible(p));
+
+  // A real wheel over the list does dismiss. The wheel scrolls by its own
+  // delta, so the reader legitimately moves by that much — subtract it, or the
+  // check measures the gesture rather than the correction.
+  const refKey = await pickRef(p);
+  const before = refKey ? await refTop(p, refKey) : null;
+  const WHEEL = 120;
+  await p.mouse.move(195, 700);
+  await p.mouse.wheel(0, WHEEL);
+  await p.waitForTimeout(900);
+  check('12 a real wheel dismisses the panel', !(await searchVisible(p)));
+  if (refKey && before !== null) {
+    const moved = (await refTop(p, refKey)) - before;
+    // Expected: -WHEEL (the reader's own scroll) and nothing more. An extra
+    // ~281px would be the panel's height leaking in — the bug this guards.
+    check('13 dismissal moves the reader by the gesture only, not the panel height',
+      Math.abs(moved + WHEEL) <= 4, `moved ${moved}px, wheel was ${WHEEL}px`);
+  }
+  check('14 no fixed ghost left behind after the exit', (await fixedGhosts(p)) === 0,
+    `${await fixedGhosts(p)} fixed panel(s)`);
+  // Scrolling back up must NOT bring it back — only the toggle does.
+  await p.evaluate(() => window.scrollBy(0, -400));
+  await p.waitForTimeout(700);
+  check('15 scrolling up does NOT restore it', !(await searchVisible(p)));
+  await p.context().close();
+}
+
+// ─────────────────────────────── touch dismissal, the phone's real gesture
+{
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await p.waitForTimeout(800);
+  await toggle(p).click();
+  await p.waitForTimeout(600);
+  await p.touchscreen.tap(195, 780);
+  await p.waitForTimeout(900);
+  check('16 a touch gesture dismisses the panel', !(await searchVisible(p)));
+  await p.context().close();
+}
+
+// ─────────────────── the two defects review found that no unit test sees
+{
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await p.waitForTimeout(800);
+  await toggle(p).click();
+  await p.waitForTimeout(600);
+  // A chip's Tailwind colour transition ends and bubbles to the panel. If the
+  // exit listener does not filter on target, that cuts the slide short.
+  //
+  // This MUST happen mid-exit: the listener only exists while `exiting` is
+  // true, so an earlier version of this check — which dispatched while the
+  // panel was merely open — reached nobody and passed no matter what the
+  // code did. Dismiss first, then dispatch, then assert the panel is still
+  // genuinely mid-animation.
+  await p.mouse.move(195, 700);
+  await p.mouse.wheel(0, 100);
+  await p.waitForTimeout(60);
+  await p.evaluate(() => {
+    const t = document.querySelector('[data-day-rail] button[aria-expanded]');
+    const panel = t && document.getElementById(t.getAttribute('aria-controls'));
+    panel?.querySelector('button')?.dispatchEvent(
+      new TransitionEvent('transitionend', { bubbles: true, propertyName: 'color' }));
+  });
+  await p.waitForTimeout(60);
+  const midSlide = await p.evaluate(() => {
+    const t = document.querySelector('[data-day-rail] button[aria-expanded]');
+    const el = t && document.getElementById(t.getAttribute('aria-controls'));
+    if (!el) return { found: false };
+    const cs = getComputedStyle(el);
+    return { found: true, position: cs.position, opacity: Number(cs.opacity), display: cs.display };
+  });
+  check('17 a descendant transitionend does not cut the slide short',
+    midSlide.found && midSlide.position === 'fixed' && midSlide.opacity > 0 && midSlide.opacity < 1,
+    `position=${midSlide.position} opacity=${midSlide.opacity} display=${midSlide.display}`);
+
+  // The dismissal's own correction scrolls ~panel-height toward the top, which
+  // can carry the reader back above the sentinel mid-exit. If the gate is not
+  // latched, the half-faded ghost snaps back into flow, fully opaque.
+  await p.context().close();
+}
+{
+  const p = await phone();
+  // Park just past the sentinel, so the correction's upward scroll crosses it.
+  const justPast = await p.evaluate(() => {
+    const rail = document.querySelector('[data-day-rail]');
+    return Math.round(rail.getBoundingClientRect().top + window.scrollY + 120);
+  });
+  await p.evaluate(y => window.scrollTo(0, y), justPast);
+  await p.waitForTimeout(800);
+  if (await toggle(p).count() > 0) {
+    await toggle(p).click();
+    await p.waitForTimeout(500);
+    await p.mouse.move(195, 700);
+    await p.mouse.wheel(0, 100);
+    // Sample mid-exit, inside the animation window.
+    await p.waitForTimeout(120);
+    // Resolve the panel EXACTLY, via the toggle's aria-controls. Selecting
+    // "first div containing a search input" can land on an inner wrapper
+    // whose position differs from the panel root's — which is what made an
+    // earlier version of this check report a false failure.
+    const mid = await p.evaluate(() => {
+      const t = document.querySelector('[data-day-rail] button[aria-expanded]');
+      const el = t && document.getElementById(t.getAttribute('aria-controls'));
+      if (!el) return { found: false };
+      const cs = getComputedStyle(el);
+      return { found: true, position: cs.position, opacity: Number(cs.opacity) };
+    });
+    // Assert the opacity too. Reading it into the detail string without
+    // asserting it is what let an exit that jumped straight to its end state
+    // (opacity 0, no slide) pass this check.
+    check('18 the exiting panel is mid-animation, not snapped back or jumped to the end',
+      !mid.found || (mid.position === 'fixed' && mid.opacity > 0 && mid.opacity < 1),
+      `mid-exit position=${mid.position} opacity=${mid.opacity}`);
+    await p.waitForTimeout(900);
+    check('19 it finishes and leaves nothing behind', (await fixedGhosts(p)) === 0);
+  } else {
+    check('18/19 sentinel-race scenario reachable', false, 'no toggle at that scroll position');
+  }
+  await p.context().close();
+}
+
+// ─────────────────────────────────────────── caret, icon, dot, reduced motion
+{
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await p.waitForTimeout(800);
+  await toggle(p).click();
+  await p.waitForTimeout(600);
+
+  const caret = p.getByRole('button', { name: /hide filters/i });
+  check('20 a Hide filters caret is present', await caret.count() > 0);
+  if (await caret.count() > 0) {
+    const box = await caret.first().boundingBox();
+    check('21 caret hit area is at least 44px tall', !!box && box.height >= 44,
+      box ? `${Math.round(box.width)}×${Math.round(box.height)}` : 'no box');
+    const panelW = await p.evaluate(() => {
+      const el = document.querySelector('input[type="text"], input[type="search"]')
+        ?.closest('[class*="overflow-y-auto"]');
+      return el ? Math.round(el.getBoundingClientRect().width) : null;
+    });
+    check('22 caret spans the panel width', !!box && !!panelW && box.width >= panelW - 8,
+      `caret=${box ? Math.round(box.width) : '?'} panel=${panelW}`);
+    await caret.first().click();
+    await p.waitForTimeout(900);
+    check('23 the caret closes the panel', !(await searchVisible(p)));
+  }
+  check('24 toggle accessible name is still Filters',
+    (await toggle(p).getAttribute('aria-label')) === 'Filters',
+    `aria-label=${await toggle(p).getAttribute('aria-label')}`);
+  check('25 the toggle renders an icon, not the word', !/filters/i.test(
+    (await toggle(p).innerText()).trim()), `text=${JSON.stringify((await toggle(p).innerText()).trim())}`);
+  check('26 no horizontal overflow at 390px', (await p.evaluate(
+    () => document.documentElement.scrollWidth - window.innerWidth)) <= 1);
+  await p.context().close();
+}
+
+// ─── the FIRST dismissal of a page is the one that was broken; prove both
+{
+  const p = await phone();
+  const sample = async () => {
+    await p.evaluate(() => window.scrollTo(0, 6000));
+    await p.waitForTimeout(700);
+    await toggle(p).click();
+    await p.waitForTimeout(500);
+    await p.mouse.move(195, 700);
+    await p.mouse.wheel(0, 100);
+    await p.waitForTimeout(80);
+    const r = await p.evaluate(() => {
+      const t = document.querySelector('[data-day-rail] button[aria-expanded]');
+      const el = t && document.getElementById(t.getAttribute('aria-controls'));
+      if (!el) return null;
+      const cs = getComputedStyle(el);
+      return { position: cs.position, opacity: Number(cs.opacity), display: cs.display };
+    });
+    await p.waitForTimeout(800);
+    return r;
+  };
+  const first = await sample();
+  const second = await sample();
+  const animating = r => !!r && r.display !== 'none' && r.position === 'fixed'
+    && r.opacity > 0 && r.opacity < 1;
+  check('28 the FIRST dismissal animates', animating(first), JSON.stringify(first));
+  check('29 the second dismissal animates identically', animating(second), JSON.stringify(second));
+  await p.context().close();
+}
+
+// ─────────────────────────────────────────────────────── reduced motion
+{
+  const p = await phone({ reducedMotion: true });
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await p.waitForTimeout(800);
+  await toggle(p).click();
+  await p.waitForTimeout(500);
+  await p.mouse.move(195, 700);
+  await p.mouse.wheel(0, 120);
+  await p.waitForTimeout(60);           // well inside the animation window
+  check('27 reduced motion removes it immediately, no ghost', (await fixedGhosts(p)) === 0
+    && !(await searchVisible(p)), `ghosts=${await fixedGhosts(p)}`);
+  await p.context().close();
+}
+
+// ──────────────────────────────── the header parks, it does not disappear
+//
+// The regression these guard shipped to production in #238 and made the site
+// nearly unusable in Chrome: hiding the filter card removed ~290px of flow
+// height above the reader, scroll anchoring subtracted that from `scrollY`,
+// which clamped at the top of the document, which put the sentinel back in
+// view, which un-hid the card. 2400px of slow wheel input advanced the page
+// 0px and returned it to the top 20 times.
+//
+// No unit test can see this: it needs layout, a real sentinel, and a browser
+// that implements scroll anchoring. Both Chromium and WebKit do.
+{
+  const p = await phone();
+  const TICKS = 30, DELTA = 60;
+  await p.mouse.move(195, 500);
+  const ys = [];
+  for (let i = 0; i < TICKS; i++) {
+    await p.mouse.wheel(0, DELTA);
+    await p.waitForTimeout(90);
+    ys.push(await p.evaluate(() => Math.round(scrollY)));
+  }
+  const requested = TICKS * DELTA;
+  const reversals = ys.filter((y, i) => i > 0 && y < ys[i - 1]).length;
+  // Generous: the list's own lazy expansion means the page need not advance
+  // the full requested amount. What must not happen is going BACKWARDS, or
+  // stalling near the top.
+  check('30 slow scrolling actually advances the page', ys.at(-1) > requested * 0.7,
+    `${requested}px requested -> scrollY=${ys.at(-1)}`);
+  check('31 slow scrolling never snaps the reader backwards', reversals === 0,
+    `${reversals} of ${TICKS} ticks moved up`);
+
+  // The mechanism, asserted directly, so a refactor back to `display: none`
+  // fails here even if the scroll numbers happened to look acceptable.
+  const parked = await p.evaluate(() => {
+    // Identify the card the way the accessibility tree does — the element the
+    // toggle names — not by guessing at a class or a shape. A fallback
+    // selector here found a different element entirely on a build where the
+    // card was `display: none`, and reported it as passing.
+    const btn = document.querySelector('[data-day-rail] button[aria-expanded]');
+    const id = btn?.getAttribute('aria-controls');
+    const card = id ? document.getElementById(id) : null;
+    if (!card) return null;
+    const cs = getComputedStyle(card);
+    const rail = document.querySelector('[data-day-rail]');
+    return {
+      display: cs.display,
+      inert: card.hasAttribute('inert'),
+      bottom: Math.round(card.getBoundingClientRect().bottom),
+      railTop: rail ? Math.round(rail.getBoundingClientRect().top) : null,
+    };
+  });
+  check('32 the parked card stays in flow rather than being removed from it',
+    !!parked && parked.display !== 'none', JSON.stringify(parked));
+  check('33 the parked card is out of reach of keyboard and screen readers',
+    !!parked && parked.inert, `inert=${parked?.inert}`);
+  check('34 the card is parked above the viewport with the rail flush at the top',
+    !!parked && parked.bottom <= 1 && Math.abs(parked.railTop) <= 1,
+    `cardBottom=${parked?.bottom} railTop=${parked?.railTop}`);
+  await p.context().close();
+}
+
+await browser.close();
+const failed = results.filter(r => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) {
+  console.log('FAILED:\n' + failed.map(f => `  - ${f.name}: ${f.detail ?? ''}`).join('\n'));
+  process.exit(1);
+}

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -1,0 +1,319 @@
+/**
+ * Browser verification for phase 3a's day rail.
+ *
+ * Everything this phase risks is geometry, and jsdom computes none of it.
+ * Phase 2's browser pass found a 3,903px jump that three green unit tests had
+ * no opinion about, so this exists to produce numbers rather than impressions.
+ *
+ * Each check prints PASS/FAIL plus the value it measured. Run against a dev
+ * server on :3000.
+ */
+import { chromium } from 'playwright';
+
+const URL = process.env.URL ?? 'http://localhost:3000/';
+const results = [];
+function check(name, ok, detail) {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const browser = await chromium.launch();
+
+async function newPage({ width = 900, height = 900, storage } = {}) {
+  const ctx = await browser.newContext({ viewport: { width, height } });
+  const page = await ctx.newPage();
+  if (storage) {
+    await page.addInitScript(([k, v]) => localStorage.setItem(k, v), storage);
+  }
+  await page.goto(URL, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-day-key]', { timeout: 30000 });
+  return page;
+}
+
+const railChips = p => p.$$eval('[data-day-rail] [data-chip]', els => els.map(e => e.dataset.chip));
+const anchorChip = p => p.$$eval('[data-day-rail] [data-chip][aria-current="date"]', e => e[0]?.dataset.chip ?? null);
+const railHeight = p => p.evaluate(() =>
+  parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--day-rail-h')) || 0);
+
+// ---------------------------------------------------------------- 1. scopes
+{
+  const page = await newPage();
+  const names = await page.$$eval('button', els => els.map(e => e.textContent.trim()));
+  const wanted = ['Now', 'Today', 'All Season', 'All Year'];
+  check('1a four scopes present', wanted.every(w => names.includes(w)), names.filter(n => wanted.includes(n)).join(', '));
+  check('1b This Week button gone', !names.includes('This Week'));
+  check('1c Selected: line gone', !(await page.locator('text=/^Selected:/').count()));
+  await page.close();
+}
+
+// ------------------------------------------------------- 2. mutual exclusion
+{
+  const page = await newPage();
+  await page.getByRole('button', { name: 'All Season', exact: true }).click();
+  await page.waitForTimeout(300);
+  const pressed = await page.getByRole('button', { name: 'All Season', exact: true }).getAttribute('aria-pressed');
+  check('2a All Season activates', pressed === 'true', `aria-pressed=${pressed}`);
+  const allYear = await page.getByRole('button', { name: 'All Year', exact: true }).getAttribute('aria-pressed');
+  check('2b All Year not simultaneously active', allYear === 'false', `aria-pressed=${allYear}`);
+  await page.close();
+}
+
+// ------------------------------------------- 3. persisted 'this-week' migration
+{
+  const page = await newPage({
+    storage: ['chq-calendar-user-state', JSON.stringify({
+      dateFilter: 'this-week', selectedWeeks: [], searchTerm: '',
+      selectedTags: [], selectedLocations: [], expandedDescriptions: [],
+      recentLocations: [], recentCategories: [], showFavoritesOnly: false,
+      lastSaved: Date.now(),
+    })],
+  });
+  const names = await page.$$eval('button', els => els
+    .filter(e => !/^Remove filter/.test(e.getAttribute('aria-label') ?? ''))
+    .map(e => e.textContent.trim()));
+  const highlighted = await page.$$eval('button', els =>
+    els.filter(e => /^\d$/.test(e.textContent.trim()) && /bg-blue-600/.test(e.className)).map(e => e.textContent.trim()));
+  check('3a no This Week button after restore', !names.includes('This Week'));
+  check('3b page renders with a persisted this-week', (await page.$$('[data-day-key]')).length > 0,
+    `${(await page.$$('[data-day-key]')).length} day sections, week chips highlighted: ${highlighted.join(',') || 'none'}`);
+  await page.close();
+}
+
+// ------------------------------------------------------------ 4/5. show earlier
+for (const scrolled of [false, true]) {
+  const page = await newPage();
+  if (scrolled) { await page.mouse.wheel(0, 1400); await page.waitForTimeout(400); }
+  const before = await page.$$eval('[data-day-key]', e => e.map(x => x.dataset.dayKey));
+  const btn = page.getByRole('button', { name: /show earlier/i });
+  if (await btn.count() === 0) { check(`4/5 show-earlier present (scrolled=${scrolled})`, false, 'no button'); await page.close(); continue; }
+  const refKey = before[0];
+  const topOf = () => page.$eval(`[data-day-key="${refKey}"]`, e => e.getBoundingClientRect().top);
+  const t0 = await topOf();
+  await page.evaluate(() => [...document.querySelectorAll('button')]
+    .find(b => /show earlier/i.test(b.textContent)).click());
+  await page.waitForTimeout(1200);
+  const t1 = await topOf();
+  const after = await page.$$eval('[data-day-key]', e => e.map(x => x.dataset.dayKey));
+  const drift = Math.abs(t1 - t0);
+  check(`${scrolled ? '5' : '4'}a show-earlier drift ≈0 (scrolled=${scrolled})`, drift < 2, `${(t1 - t0).toFixed(1)}px`);
+  check(`${scrolled ? '5' : '4'}b nothing already-rendered unmounted`, before.every(k => after.includes(k)),
+    `before ${before.length} → after ${after.length}`);
+  await page.close();
+}
+
+// -------------------------------------------------------------- 8. rail exists
+{
+  const page = await newPage();
+  const chips = await railChips(page);
+  check('8a rail renders chips', chips.length > 0, `${chips.length} chips, ${chips[0]}..${chips[chips.length - 1]}`);
+  const h = await railHeight(page);
+  check('8b --day-rail-h is measured, not 0', h > 0, `${h}px`);
+  const role = await page.$eval('[data-day-rail]', e => `${e.getAttribute('role')}/${e.getAttribute('aria-label')}`);
+  check('8c rail is a labelled group', role === 'group/Days', role);
+  check('8d no role=menu anywhere', (await page.$$('[role=menu]')).length === 0);
+
+  // Highlight tracks scroll.
+  const a0 = await anchorChip(page);
+  // Scroll past the FIRST day section's full height — a fixed wheel delta is
+  // not guaranteed to cross a header, and a test that never crosses one
+  // proves nothing about whether the highlight tracks.
+  const targetY = await page.evaluate(() => {
+    const secs = [...document.querySelectorAll('[data-day-key]')];
+    const railH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--day-rail-h')) || 0;
+    // Land just past the point where the SECOND day's header crosses the
+    // sticky offset — that is the exact moment the highlight must advance.
+    // Overshoot generously. A 5px margin is inside the noise once the list
+    // auto-expands during the scroll and shifts section positions; day
+    // sections are thousands of px tall, so +200 still crosses only this
+    // one header.
+    return Math.round(window.scrollY + secs[1].getBoundingClientRect().top - railH + 200);
+  });
+  await page.evaluate(y => window.scrollTo(0, y), targetY);
+  await page.waitForTimeout(700);
+  const a1 = await anchorChip(page);
+  check('8e highlight follows scroll', !!a0 && !!a1 && a0 !== a1, `${a0} → ${a1}`);
+  await page.close();
+}
+
+// --------------------------------------------------- 9. rail tap lands clear
+{
+  const page = await newPage();
+  const chips = await railChips(page);
+  const mounted = await page.$$eval('[data-day-key]', e => e.map(x => x.dataset.dayKey));
+  // A day several past the current render window — the case that fails if
+  // navigation cannot outrun the render window.
+  const target = chips[chips.indexOf(mounted[mounted.length - 1]) + 6] ?? chips[chips.length - 1];
+  await page.evaluate(k => document.querySelector(`[data-day-rail] [data-chip="${k}"]`).click(), target);
+  await page.waitForTimeout(1800);
+  const present = await page.$(`[data-day-key="${target}"]`);
+  check('9a tapped day mounts', !!present, target);
+  if (present) {
+    const { top, railH } = await page.evaluate(k => ({
+      top: document.querySelector(`[data-day-key="${k}"]`).getBoundingClientRect().top,
+      railH: parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--day-rail-h')) || 0,
+    }), target);
+    check('9b scrolled to it', Math.abs(top) < 400, `top=${top.toFixed(1)}px`);
+    check('9c lands below the rail, not under it', top >= railH - 2, `top=${top.toFixed(1)} railH=${railH}`);
+  }
+  await page.close();
+}
+
+// ---------------------------------------------------------------- 10. chevrons
+{
+  const page = await newPage();
+  const before = await anchorChip(page);
+  const next = await page.$('[data-day-rail] button:not([data-chip]):nth-of-type(2)');
+  const chevrons = await page.$$eval('[data-day-rail] button:not([data-chip])',
+    els => els.map(e => ({ label: e.getAttribute('aria-label'), disabled: e.hasAttribute('disabled') })));
+  check('10a two chevrons, labelled by target', chevrons.length >= 2,
+    chevrons.map(c => `${c.label}${c.disabled ? ' [disabled]' : ''}`).join(' | '));
+  check('10b chevron labels are not directional when enabled',
+    chevrons.filter(c => !c.disabled).every(c => !/the (next|previous) day/.test(c.label)),
+    chevrons.filter(c => !c.disabled).map(c => c.label).join(' | '));
+  if (next) { await next.click(); await page.waitForTimeout(1200); }
+  const after = await anchorChip(page);
+  check('10c forward chevron moves the anchor', before !== after, `${before} → ${after}`);
+  await page.close();
+}
+
+// ------------------------------------------------------------------ 11. ⟳ Now
+{
+  const page = await newPage();
+  const chips = await railChips(page);
+  const mounted = await page.$$eval('[data-day-key]', e => e.map(x => x.dataset.dayKey));
+  const far = chips[chips.indexOf(mounted[mounted.length - 1]) + 6] ?? chips[chips.length - 1];
+  await page.evaluate(k => document.querySelector(`[data-day-rail] [data-chip="${k}"]`).click(), far);
+  await page.waitForTimeout(1500);
+  const nowBtn = page.getByRole('button', { name: 'Go to today' });
+  const appeared = await nowBtn.count() > 0;
+  check('11a ⟳ Now appears once away from today', appeared);
+  if (appeared) {
+    const scopeBefore = await page.$$eval('button[aria-pressed]', els =>
+      els.map(e => `${e.textContent.trim()}=${e.getAttribute('aria-pressed')}`).join(','));
+    await nowBtn.click();
+    await page.waitForTimeout(1500);
+    const scopeAfter = await page.$$eval('button[aria-pressed]', els =>
+      els.map(e => `${e.textContent.trim()}=${e.getAttribute('aria-pressed')}`).join(','));
+    check('11b ⟳ Now changes no filter', scopeBefore === scopeAfter, scopeAfter);
+    check('11c ⟳ Now hides once back on today', (await page.getByRole('button', { name: 'Go to today' }).count()) === 0);
+  }
+  await page.close();
+}
+
+// ------------------------------------------- 12. sticky stack, narrow + zoomed
+for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
+  const page = await newPage({ width, height: 800 });
+  if (zoom !== 1) {
+    await page.evaluate(z => { document.documentElement.style.fontSize = `${16 * z}px`; }, zoom);
+    await page.waitForTimeout(600);
+  }
+  await page.mouse.wheel(0, 1800);
+  await page.waitForTimeout(600);
+  const geom = await page.evaluate(() => {
+    const rail = document.querySelector('[data-day-rail]');
+    const railH = rail.getBoundingClientRect().bottom;
+    // The stuck header belongs to the section spanning the viewport top. The
+    // FIRST section's header legitimately scrolls away once you are past it,
+    // so measuring that one tests nothing.
+    const sec = [...document.querySelectorAll('[data-day-key]')]
+      .find(e => { const r = e.getBoundingClientRect(); return r.top <= railH + 1 && r.bottom > railH + 1; });
+    const header = sec?.querySelector('.sticky');
+    if (!rail || !header) return null;
+    const r = rail.getBoundingClientRect(), h = header.getBoundingClientRect();
+    return { railBottom: r.bottom, headerTop: h.top, headerText: header.textContent.trim().slice(0, 30) };
+  });
+  if (!geom) { check(`12 sticky stack @ ${label}`, false, 'rail or header missing'); await page.close(); continue; }
+  check(`12 header clears the rail @ ${label}`, geom.headerTop >= geom.railBottom - 2,
+    `railBottom=${geom.railBottom.toFixed(1)} headerTop=${geom.headerTop.toFixed(1)}`);
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  check(`12 no horizontal page overflow @ ${label}`, overflow <= 1, `${overflow}px`);
+  await page.close();
+}
+
+// ---------------------------------------------------------------- 13. keyboard
+{
+  const page = await newPage();
+  const chips = await railChips(page);
+  await page.evaluate(k => document.querySelector(`[data-day-rail] [data-chip="${k}"]`).focus(), chips[0]);
+  const f0 = await page.evaluate(() => document.activeElement?.dataset?.chip ?? null);
+  await page.keyboard.press('ArrowRight');
+  const f1 = await page.evaluate(() => document.activeElement?.dataset?.chip ?? null);
+  check('13a ArrowRight moves focus along the rail', !!f1 && f0 !== f1, `${f0} → ${f1}`);
+  const mountedBefore = (await page.$$('[data-day-key]')).length;
+  await page.keyboard.press('ArrowRight');
+  await page.waitForTimeout(400);
+  const mountedAfter = (await page.$$('[data-day-key]')).length;
+  check('13b arrowing does not refilter the list', mountedBefore === mountedAfter,
+    `${mountedBefore} → ${mountedAfter} day sections`);
+  await page.close();
+}
+
+// ------------------------------------------------------------ 14. accessibility
+{
+  const page = await newPage();
+  const chips = await page.$$eval('[data-day-rail] [data-chip]', els => els.map(e => ({
+    label: e.getAttribute('aria-label'),
+    unavailable: e.getAttribute('aria-disabled') === 'true',
+  })));
+  // A reachable chip names its destination; an unavailable one names the day
+  // as a FACT and must not promise a destination it cannot deliver.
+  const reachable = chips.filter(c => !c.unavailable);
+  const unavailable = chips.filter(c => c.unavailable);
+  check('14a every reachable chip labelled by target', reachable.length > 0
+    && reachable.every(c => c.label && c.label.startsWith('Go to ')),
+    `${reachable.length} reachable, e.g. ${reachable[0]?.label}`);
+  check('14a2 no unavailable chip promises a destination', unavailable.every(c => !/^Go to /.test(c.label)),
+    `${unavailable.length} unavailable, e.g. ${unavailable[0]?.label ?? 'none'}`);
+  const empty = chips.map(c => c.label).find(l => /no events/.test(l));
+  check('14b an empty day says so', !!empty, empty ?? 'no empty day in range');
+  const bad = chips.map(c => c.label).filter(l => /\bnext\b|\bprevious\b/.test(l));
+  check('14c no chip labelled by direction', bad.length === 0, bad.join(' | ') || 'none');
+  await page.close();
+}
+
+// ------------------------------------------- 15. tap targets on a phone
+//
+// Measured on production before this check existed: 245 of 255 rail controls
+// were under the 44px minimum — the prev/next chevrons at 21x32 and ⟳ Now at
+// 57x28, with every day chip one pixel short at 44x43. This is a phone-first
+// app and the rail is its primary navigation, so the numbers are asserted
+// rather than the classes: a class can be present and still lose to a
+// competing rule, and only the rendered box is what a thumb hits.
+{
+  const page = await newPage({ width: 390, height: 844 });
+  await page.mouse.wheel(0, 2000);
+  await page.waitForTimeout(700);
+  const controls = await page.evaluate(() => {
+    const rail = document.querySelector('[data-day-rail]');
+    if (!rail) return null;
+    return [...rail.querySelectorAll('button')].map(el => {
+      const r = el.getBoundingClientRect();
+      return {
+        name: (el.getAttribute('aria-label') || el.textContent || '').trim().slice(0, 24),
+        w: Math.round(r.width), h: Math.round(r.height),
+      };
+    });
+  });
+  if (!controls?.length) {
+    check('15 rail tap targets meet the 44px minimum', false, 'no rail controls found');
+  } else {
+    const under = controls.filter(c => c.w < 44 || c.h < 44);
+    check('15 every rail control meets the 44px minimum',
+      under.length === 0,
+      under.length
+        ? `${under.length}/${controls.length} under: ` +
+          under.slice(0, 4).map(c => `${c.name} ${c.w}x${c.h}`).join(', ')
+        : `${controls.length} controls, smallest ` +
+          `${Math.min(...controls.map(c => c.w))}x${Math.min(...controls.map(c => c.h))}`);
+  }
+  await page.close();
+}
+
+await browser.close();
+
+const failed = results.filter(r => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) {
+  console.log('FAILED:\n' + failed.map(f => `  - ${f.name}: ${f.detail ?? ''}`).join('\n'));
+  process.exit(1);
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "generate:icons": "node scripts/generate-icons.mjs",
     "about:screenshots:ios": "node scripts/prepare-about-screenshots.mjs",
     "about:screenshots:web": "node scripts/capture-web-screenshots.mjs",
-    "about:screenshots": "npm run about:screenshots:ios && npm run about:screenshots:web"
+    "about:screenshots": "npm run about:screenshots:ios && npm run about:screenshots:web",
+    "test:browser": "node e2e/verify-rail.mjs && node e2e/verify-filter-reveal.mjs"
   },
   "dependencies": {
     "preact": "^10.28.4"

--- a/frontend/src/__tests__/app/filterHeaderLayout.test.ts
+++ b/frontend/src/__tests__/app/filterHeaderLayout.test.ts
@@ -38,30 +38,32 @@ describe('filterHeaderTop', () => {
 });
 
 describe('filterCardParked', () => {
-  it('is parked once the reader has scrolled past it with the panel closed', () => {
-    expect(filterCardParked({ scrolledPast: true, open: false, exitingVisible: false })).toBe(true);
+  it('is parked once the card itself has left the viewport with the panel closed', () => {
+    expect(filterCardParked({ outOfView: true, open: false, exitingVisible: false })).toBe(true);
   });
 
-  it('is not parked at the top of the page, where it is ordinary in-flow content', () => {
-    expect(filterCardParked({ scrolledPast: false, open: false, exitingVisible: false })).toBe(false);
+  it('is not parked while the card is on screen', () => {
+    expect(filterCardParked({ outOfView: false, open: false, exitingVisible: false })).toBe(false);
   });
 
   // Reachable while open is the entire point of the toggle: an open panel
-  // that is `inert` is a panel the reader can see and cannot use.
-  it('is not parked while the panel is open over the list', () => {
-    expect(filterCardParked({ scrolledPast: true, open: true, exitingVisible: false })).toBe(false);
+  // that is `inert` is a panel the reader can see and cannot use. `open`
+  // wins even if the observer has not yet reported the card back in view —
+  // its callback lands a frame later than the state that revealed it.
+  it('is not parked while the panel is open, whatever the observer last said', () => {
+    expect(filterCardParked({ outOfView: true, open: true, exitingVisible: false })).toBe(false);
   });
 
   // Mid-exit the panel is `position: fixed`, not parked. It still ends up
   // beyond reach — page.tsx ORs the two — but by a different route, and
   // conflating them here would hide which one is driving.
   it('is not parked while the exit animation is running', () => {
-    expect(filterCardParked({ scrolledPast: true, open: false, exitingVisible: true })).toBe(false);
+    expect(filterCardParked({ outOfView: true, open: false, exitingVisible: true })).toBe(false);
   });
 
-  // A stale `open` left over from scrolling back up must not park the card
-  // at the top of the page, where the reader can plainly see it.
-  it('is not parked at the top of the page even with a stale open flag', () => {
-    expect(filterCardParked({ scrolledPast: false, open: true, exitingVisible: false })).toBe(false);
+  // Partly on screen is still reachable: mid-slide the reader can see the
+  // card and must be able to use it.
+  it('is not parked while the card is only partly scrolled away', () => {
+    expect(filterCardParked({ outOfView: false, open: true, exitingVisible: false })).toBe(false);
   });
 });

--- a/frontend/src/__tests__/helpers/intersectionObserver.ts
+++ b/frontend/src/__tests__/helpers/intersectionObserver.ts
@@ -7,6 +7,7 @@ type Callback = (entries: Entry[]) => void;
 interface Instance {
   callback: Callback;
   disconnected: boolean;
+  targets: Element[];
 }
 
 /**
@@ -26,11 +27,13 @@ export function installIntersectionObserverMock() {
   class MockIntersectionObserver {
     private instance: Instance;
     constructor(callback: Callback) {
-      this.instance = { callback, disconnected: false };
+      this.instance = { callback, disconnected: false, targets: [] };
       instances.push(this.instance);
     }
-    observe() {}
-    unobserve() {}
+    observe(el: Element) { this.instance.targets.push(el); }
+    unobserve(el: Element) {
+      this.instance.targets = this.instance.targets.filter(t => t !== el);
+    }
     takeRecords(): Entry[] { return []; }
     disconnect() { this.instance.disconnected = true; }
   }
@@ -43,6 +46,22 @@ export function installIntersectionObserverMock() {
       const newest = live[live.length - 1];
       if (!newest) throw new Error('no live IntersectionObserver to trigger');
       act(() => { newest.callback([{ isIntersecting }]); });
+    },
+    /**
+     * Fire the observer watching a SPECIFIC element.
+     *
+     * `trigger()` fires the newest live observer, which is unambiguous only
+     * while one is installed. A page renders several — the filter sentinel,
+     * the filter card, the list's own window — and "newest" then depends on
+     * render order, so a test using it is asserting against whichever
+     * observer happened to mount last. Name the element instead.
+     */
+    triggerFor(el: Element, isIntersecting = true) {
+      const live = instances.filter(i => !i.disconnected && i.targets.includes(el));
+      if (!live.length) {
+        throw new Error(`no live IntersectionObserver is observing ${el.nodeName}${el.id ? `#${el.id}` : ''}`);
+      }
+      act(() => { for (const i of live) i.callback([{ isIntersecting }]); });
     },
     get liveCount() { return instances.filter(i => !i.disconnected).length; },
     get totalCreated() { return instances.length; },

--- a/frontend/src/__tests__/helpers/resizeObserver.ts
+++ b/frontend/src/__tests__/helpers/resizeObserver.ts
@@ -10,16 +10,18 @@ import { act } from '@testing-library/preact';
  * real resize notifies all of them.
  */
 export function installResizeObserverMock() {
-  const instances: { callback: () => void; disconnected: boolean }[] = [];
+  const instances: { callback: () => void; disconnected: boolean; targets: Element[] }[] = [];
 
   class MockResizeObserver {
-    private instance: { callback: () => void; disconnected: boolean };
+    private instance: { callback: () => void; disconnected: boolean; targets: Element[] };
     constructor(callback: () => void) {
-      this.instance = { callback, disconnected: false };
+      this.instance = { callback, disconnected: false, targets: [] };
       instances.push(this.instance);
     }
-    observe() {}
-    unobserve() {}
+    observe(el: Element) { this.instance.targets.push(el); }
+    unobserve(el: Element) {
+      this.instance.targets = this.instance.targets.filter(t => t !== el);
+    }
     disconnect() { this.instance.disconnected = true; }
   }
 
@@ -30,6 +32,19 @@ export function installResizeObserverMock() {
       const live = instances.filter(i => !i.disconnected);
       if (live.length === 0) throw new Error('no live ResizeObserver to trigger');
       act(() => { live.forEach(i => i.callback()); });
+    },
+    /**
+     * Whether anything live is observing this element.
+     *
+     * WHICH element is observed can be the whole point: `--filter-card-h`
+     * has to re-publish when the filter card's margin changes at a
+     * breakpoint, and `ResizeObserver` never reports a margin — so an
+     * observer on the card would never fire, while one on the header
+     * container (card + margin + rail) does. A test that only exercises the
+     * measurement cannot tell those apart.
+     */
+    isObserving(el: Element) {
+      return instances.some(i => !i.disconnected && i.targets.includes(el));
     },
     get liveCount() { return instances.filter(i => !i.disconnected).length; },
   };

--- a/frontend/src/__tests__/hooks/useElementOutOfView.test.ts
+++ b/frontend/src/__tests__/hooks/useElementOutOfView.test.ts
@@ -65,6 +65,24 @@ describe('useElementOutOfView', () => {
     expect(io.totalCreated).toBe(2);
   });
 
+  // The latch this guards against: an element that WAS out of view, then a
+  // swap into an environment with no observer to correct the reading. Without
+  // a reset on that path the stale `true` survives with nothing left running
+  // that could ever clear it — and whatever it guards stays permanently
+  // unreachable, which is the one direction this hook must not fail in.
+  it('clears a stale out-of-view reading when swapped with no observer available', () => {
+    const io = installIntersectionObserverMock();
+    const { result } = renderHook(() => useElementOutOfView());
+    act(() => { result.current.ref(document.createElement('div')); });
+    io.trigger(false);
+    expect(result.current.outOfView).toBe(true);
+
+    vi.stubGlobal('IntersectionObserver', undefined);
+    act(() => { result.current.ref(document.createElement('div')); });
+
+    expect(result.current.outOfView).toBe(false);
+  });
+
   // jsdom has no IntersectionObserver, and neither do a few old browsers.
   // Reporting "in view" there is the same answer a real browser gives before
   // its first callback, and it must not throw on mount.

--- a/frontend/src/__tests__/hooks/useElementOutOfView.test.ts
+++ b/frontend/src/__tests__/hooks/useElementOutOfView.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useElementOutOfView } from '@/hooks/useElementOutOfView';
+import { installIntersectionObserverMock } from '@/__tests__/helpers/intersectionObserver';
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe('useElementOutOfView', () => {
+  // "In view" is the safe default: it keeps whatever this guards reachable.
+  // A briefly Tab-reachable filter card is a nuisance; one that is
+  // permanently unreachable is a lockout.
+  it('starts in view, before the observer has reported anything', () => {
+    installIntersectionObserverMock();
+    const { result } = renderHook(() => useElementOutOfView());
+    expect(result.current.outOfView).toBe(false);
+  });
+
+  it('reports out of view once the element stops intersecting', () => {
+    const io = installIntersectionObserverMock();
+    const { result } = renderHook(() => useElementOutOfView());
+    act(() => { result.current.ref(document.createElement('div')); });
+
+    io.trigger(false);
+
+    expect(result.current.outOfView).toBe(true);
+  });
+
+  // The card comes back when the reader scrolls up, or when the panel is
+  // reopened over the list. Without this it would stay `inert` after
+  // returning to view — visible and unusable.
+  it('reports back in view once the element intersects again', () => {
+    const io = installIntersectionObserverMock();
+    const { result } = renderHook(() => useElementOutOfView());
+    act(() => { result.current.ref(document.createElement('div')); });
+
+    io.trigger(false);
+    expect(result.current.outOfView).toBe(true);
+
+    io.trigger(true);
+    expect(result.current.outOfView).toBe(false);
+  });
+
+  it('resets to in view when the element unmounts rather than holding a stale value', () => {
+    const io = installIntersectionObserverMock();
+    const { result } = renderHook(() => useElementOutOfView());
+    act(() => { result.current.ref(document.createElement('div')); });
+    io.trigger(false);
+
+    act(() => { result.current.ref(null); });
+
+    expect(result.current.outOfView).toBe(false);
+  });
+
+  it('observes the replacement when the element is swapped', () => {
+    const io = installIntersectionObserverMock();
+    const { result } = renderHook(() => useElementOutOfView());
+    act(() => { result.current.ref(document.createElement('div')); });
+    act(() => { result.current.ref(document.createElement('div')); });
+
+    io.trigger(false);
+
+    expect(result.current.outOfView).toBe(true);
+    // The first observer is gone rather than left watching a detached node.
+    expect(io.liveCount).toBe(1);
+    expect(io.totalCreated).toBe(2);
+  });
+
+  // jsdom has no IntersectionObserver, and neither do a few old browsers.
+  // Reporting "in view" there is the same answer a real browser gives before
+  // its first callback, and it must not throw on mount.
+  it('does not throw where IntersectionObserver is unavailable', () => {
+    vi.stubGlobal('IntersectionObserver', undefined);
+    const { result } = renderHook(() => useElementOutOfView());
+
+    expect(() => act(() => { result.current.ref(document.createElement('div')); })).not.toThrow();
+    expect(result.current.outOfView).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/hooks/useFilterCardHeight.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterCardHeight.test.ts
@@ -6,72 +6,100 @@ import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
 afterEach(() => { vi.unstubAllGlobals(); document.documentElement.style.removeProperty('--filter-card-h'); });
 
 // jsdom reports 0 for every layout measurement, so each test supplies its
-// own `scrollHeight` and computed margin. What is being pinned is which
-// numbers the hook combines — the header parks by exactly this value, and
-// anything short of the card's full height plus its gap leaves the rail
-// hanging below the viewport top.
-function cardWith({ scrollHeight, marginBottom }: { scrollHeight: number; marginBottom: string }) {
-  const el = document.createElement('div');
-  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
-  el.style.marginBottom = marginBottom;
-  return el;
+// own rects. What is being pinned is WHICH distance the hook publishes: the
+// header parks by exactly this value, and anything else leaves the rail off
+// the viewport's top edge by the difference.
+function header({ cardTop, railTop, cardHeight = 0, withRail = true }: {
+  cardTop: number; railTop?: number; cardHeight?: number; withRail?: boolean;
+}) {
+  const parent = document.createElement('div');
+  const card = document.createElement('div');
+  card.getBoundingClientRect = () => ({ top: cardTop, height: cardHeight }) as DOMRect;
+  parent.append(card);
+  if (withRail) {
+    const rail = document.createElement('div');
+    rail.setAttribute('data-day-rail', '');
+    rail.getBoundingClientRect = () => ({ top: railTop! }) as DOMRect;
+    parent.append(rail);
+  }
+  return card;
 }
 
 describe('useFilterCardHeight', () => {
-  it('publishes the card content height plus its bottom margin', () => {
+  it('publishes the distance from the top of the card to the top of the rail', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(cardWith({ scrollHeight: 269, marginBottom: '16px' })); });
+    act(() => { result.current(header({ cardTop: 64, railTop: 349 })); });
     expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('285px');
   });
 
-  // The margin is the gap the card holds above the rail. Drop it and the
-  // rail parks 16-24px below the viewport top, with a slice of the card
-  // still showing above it.
-  it('includes the margin rather than the content height alone', () => {
+  // The gap between card and rail is the card's `mb-4 sm:mb-6`, and it has
+  // to ride up with the card. Measuring the card's own box alone parks the
+  // rail 16-24px low, with a slice of the card still showing above it.
+  it('includes the gap between the card and the rail, not just the card box', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(cardWith({ scrollHeight: 300, marginBottom: '24px' })); });
+    act(() => { result.current(header({ cardTop: 0, railTop: 324, cardHeight: 300 })); });
     expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('324px');
   });
 
-  // The load-bearing choice. While open over the list the card carries
-  // `max-h-[70vh] overflow-y-auto`, so its rendered box is the cap and its
-  // content is taller. Parking by the rendered box would leave the rail the
-  // overflowed remainder too low the moment the panel closed — and only for
-  // readers whose filter card exceeds 70vh.
-  it('measures content height, not the capped rendered box', () => {
+  // The reason this is one measurement rather than `scrollHeight` plus a
+  // computed margin: `ResizeObserver` never reports a margin change, so the
+  // reconstructed version went stale whenever a breakpoint moved the margin
+  // without moving the card's own box. Asking the layout for the distance
+  // cannot drift from the boxes it describes.
+  it('measures the real distance rather than reconstructing it from the card box', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    const el = cardWith({ scrollHeight: 900, marginBottom: '16px' });
-    el.getBoundingClientRect = () => ({ height: 590 }) as DOMRect;
-    act(() => { result.current(el); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('916px');
+    // A card whose own box is nothing like the offset — only a hook reading
+    // the rail's position gets this right.
+    act(() => { result.current(header({ cardTop: 100, railTop: 700, cardHeight: 40 })); });
+    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('600px');
   });
 
-  it('tolerates a card with no bottom margin', () => {
+  // Measured while pinned, the rail still sits the same distance below the
+  // card — negative viewport coordinates included.
+  it('is correct while the header is already pinned above the viewport', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(cardWith({ scrollHeight: 200, marginBottom: '' })); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('200px');
+    act(() => { result.current(header({ cardTop: -285, railTop: 0 })); });
+    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('285px');
   });
 
-  // Text zoom, an added filter chip row, a week strip wrapping — all grow
-  // the card, and a stale park leaves the rail off its mark by the delta.
-  it('republishes when the card resizes', () => {
+  // An archived year with no navigable days renders no rail. The card's own
+  // box is the honest answer — there is nothing below it to hold clear of.
+  it('falls back to the card box when there is no rail', () => {
+    installResizeObserverMock();
+    const { result } = renderHook(() => useFilterCardHeight());
+    act(() => { result.current(header({ cardTop: 64, cardHeight: 269, withRail: false })); });
+    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('269px');
+  });
+
+  // Text zoom, an added chip row, a week strip wrapping — all move the rail,
+  // and a stale park leaves it off its mark by the delta.
+  it('republishes when the header resizes', () => {
     const resize = installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    const el = cardWith({ scrollHeight: 269, marginBottom: '16px' });
-    act(() => { result.current(el); });
-    Object.defineProperty(el, 'scrollHeight', { value: 412, configurable: true });
+    const parent = document.createElement('div');
+    const card = document.createElement('div');
+    card.getBoundingClientRect = () => ({ top: 64, height: 0 }) as DOMRect;
+    const rail = document.createElement('div');
+    rail.setAttribute('data-day-rail', '');
+    let railTop = 349;
+    rail.getBoundingClientRect = () => ({ top: railTop }) as DOMRect;
+    parent.append(card, rail);
+
+    act(() => { result.current(card); });
+    railTop = 492;
     resize.trigger();
+
     expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('428px');
   });
 
   it('drops back to zero when the card unmounts', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(cardWith({ scrollHeight: 269, marginBottom: '16px' })); });
+    act(() => { result.current(header({ cardTop: 64, railTop: 349 })); });
     act(() => { result.current(null); });
     expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('0px');
   });

--- a/frontend/src/__tests__/hooks/useFilterCardHeight.test.ts
+++ b/frontend/src/__tests__/hooks/useFilterCardHeight.test.ts
@@ -5,74 +5,130 @@ import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
 
 afterEach(() => { vi.unstubAllGlobals(); document.documentElement.style.removeProperty('--filter-card-h'); });
 
-// jsdom reports 0 for every layout measurement, so each test supplies its
-// own rects. What is being pinned is WHICH distance the hook publishes: the
+// jsdom reports 0 for every layout measurement, so each test supplies its own
+// rects. What is being pinned is WHICH distance is published and WHEN: the
 // header parks by exactly this value, and anything else leaves the rail off
 // the viewport's top edge by the difference.
-function header({ cardTop, railTop, cardHeight = 0, withRail = true }: {
-  cardTop: number; railTop?: number; cardHeight?: number; withRail?: boolean;
+function headerContainer({ cardTop, railTop, cardHeight = 0, withRail = true, cardPosition = 'static' }: {
+  cardTop: number; railTop?: number; cardHeight?: number; withRail?: boolean; cardPosition?: string;
 }) {
-  const parent = document.createElement('div');
+  const container = document.createElement('div');
   const card = document.createElement('div');
+  card.setAttribute('data-filter-card', '');
+  card.style.position = cardPosition;
   card.getBoundingClientRect = () => ({ top: cardTop, height: cardHeight }) as DOMRect;
-  parent.append(card);
+  container.append(card);
   if (withRail) {
     const rail = document.createElement('div');
     rail.setAttribute('data-day-rail', '');
     rail.getBoundingClientRect = () => ({ top: railTop! }) as DOMRect;
-    parent.append(rail);
+    container.append(rail);
   }
-  return card;
+  // jsdom's getComputedStyle needs the node in the document to report
+  // inline styles reliably.
+  document.body.append(container);
+  return container;
 }
+
+const published = () => document.documentElement.style.getPropertyValue('--filter-card-h');
 
 describe('useFilterCardHeight', () => {
   it('publishes the distance from the top of the card to the top of the rail', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(header({ cardTop: 64, railTop: 349 })); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('285px');
+    act(() => { result.current(headerContainer({ cardTop: 64, railTop: 349 })); });
+    expect(published()).toBe('285px');
   });
 
-  // The gap between card and rail is the card's `mb-4 sm:mb-6`, and it has
-  // to ride up with the card. Measuring the card's own box alone parks the
-  // rail 16-24px low, with a slice of the card still showing above it.
+  // The gap between card and rail is the card's `mb-4 sm:mb-6`, and it has to
+  // ride up with the card. Measuring the card's own box alone parks the rail
+  // 16-24px low, with a slice of the card still showing above it.
   it('includes the gap between the card and the rail, not just the card box', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(header({ cardTop: 0, railTop: 324, cardHeight: 300 })); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('324px');
+    act(() => { result.current(headerContainer({ cardTop: 0, railTop: 324, cardHeight: 300 })); });
+    expect(published()).toBe('324px');
   });
 
   // The reason this is one measurement rather than `scrollHeight` plus a
-  // computed margin: `ResizeObserver` never reports a margin change, so the
-  // reconstructed version went stale whenever a breakpoint moved the margin
-  // without moving the card's own box. Asking the layout for the distance
-  // cannot drift from the boxes it describes.
+  // computed margin: a reconstructed distance can disagree with the layout.
   it('measures the real distance rather than reconstructing it from the card box', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    // A card whose own box is nothing like the offset — only a hook reading
-    // the rail's position gets this right.
-    act(() => { result.current(header({ cardTop: 100, railTop: 700, cardHeight: 40 })); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('600px');
+    act(() => { result.current(headerContainer({ cardTop: 100, railTop: 700, cardHeight: 40 })); });
+    expect(published()).toBe('600px');
   });
 
-  // Measured while pinned, the rail still sits the same distance below the
-  // card — negative viewport coordinates included.
+  // THE TRIGGER, which is a separate bug from the arithmetic. `ResizeObserver`
+  // reports border and content boxes and never margins, so the observer has to
+  // sit on the header CONTAINER — whose height is card + margin + rail — not
+  // on the card, whose own box does not change when only its margin does.
+  it('observes the header container, so a margin-only change still republishes', () => {
+    const resize = installResizeObserverMock();
+    const { result } = renderHook(() => useFilterCardHeight());
+    const container = headerContainer({ cardTop: 64, railTop: 349 });
+    const card = container.querySelector('[data-filter-card]')!;
+    const rail = container.querySelector('[data-day-rail]')!;
+    act(() => { result.current(container); });
+    expect(published()).toBe('285px');
+
+    // A breakpoint widens the card's bottom margin. The card's own box is
+    // untouched; only the rail moves down.
+    rail.getBoundingClientRect = () => ({ top: 357 }) as DOMRect;
+    resize.trigger();
+
+    expect(published()).toBe('293px');
+    expect(card.getBoundingClientRect().height).toBe(0);   // card box never changed
+  });
+
   it('is correct while the header is already pinned above the viewport', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(header({ cardTop: -285, railTop: 0 })); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('285px');
+    act(() => { result.current(headerContainer({ cardTop: -285, railTop: 0 })); });
+    expect(published()).toBe('285px');
   });
 
-  // An archived year with no navigable days renders no rail. The card's own
-  // box is the honest answer — there is nothing below it to hold clear of.
+  // Mid-exit the card is `position: fixed` at a frozen rect and out of the
+  // header's flow, so the distance describes nothing. Publishing it would set
+  // the offset to roughly zero, and the moment the animation ended and the
+  // header returned to its parked `top`, the card would flash back into view.
+  it('holds the last good value while the card is out of flow mid-exit', () => {
+    const resize = installResizeObserverMock();
+    const { result } = renderHook(() => useFilterCardHeight());
+    const container = headerContainer({ cardTop: 64, railTop: 349 });
+    act(() => { result.current(container); });
+    expect(published()).toBe('285px');
+
+    const card = container.querySelector('[data-filter-card]') as HTMLElement;
+    card.style.position = 'fixed';
+    card.getBoundingClientRect = () => ({ top: 0, height: 269 }) as DOMRect;
+    resize.trigger();
+
+    expect(published()).toBe('285px');
+  });
+
+  it('resumes publishing once the card is back in flow', () => {
+    const resize = installResizeObserverMock();
+    const { result } = renderHook(() => useFilterCardHeight());
+    const container = headerContainer({ cardTop: 64, railTop: 349 });
+    const card = container.querySelector('[data-filter-card]') as HTMLElement;
+    act(() => { result.current(container); });
+
+    card.style.position = 'fixed';
+    resize.trigger();
+    card.style.position = 'static';
+    card.getBoundingClientRect = () => ({ top: 64, height: 0 }) as DOMRect;
+    resize.trigger();
+
+    expect(published()).toBe('285px');
+  });
+
+  // An archived year with no navigable days renders no rail.
   it('falls back to the card box when there is no rail', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(header({ cardTop: 64, cardHeight: 269, withRail: false })); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('269px');
+    act(() => { result.current(headerContainer({ cardTop: 64, cardHeight: 269, withRail: false })); });
+    expect(published()).toBe('269px');
   });
 
   // Text zoom, an added chip row, a week strip wrapping — all move the rail,
@@ -80,27 +136,21 @@ describe('useFilterCardHeight', () => {
   it('republishes when the header resizes', () => {
     const resize = installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    const parent = document.createElement('div');
-    const card = document.createElement('div');
-    card.getBoundingClientRect = () => ({ top: 64, height: 0 }) as DOMRect;
-    const rail = document.createElement('div');
-    rail.setAttribute('data-day-rail', '');
-    let railTop = 349;
-    rail.getBoundingClientRect = () => ({ top: railTop }) as DOMRect;
-    parent.append(card, rail);
+    const container = headerContainer({ cardTop: 64, railTop: 349 });
+    const rail = container.querySelector('[data-day-rail]')!;
+    act(() => { result.current(container); });
 
-    act(() => { result.current(card); });
-    railTop = 492;
+    rail.getBoundingClientRect = () => ({ top: 492 }) as DOMRect;
     resize.trigger();
 
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('428px');
+    expect(published()).toBe('428px');
   });
 
-  it('drops back to zero when the card unmounts', () => {
+  it('drops back to zero when the header unmounts', () => {
     installResizeObserverMock();
     const { result } = renderHook(() => useFilterCardHeight());
-    act(() => { result.current(header({ cardTop: 64, railTop: 349 })); });
+    act(() => { result.current(headerContainer({ cardTop: 64, railTop: 349 })); });
     act(() => { result.current(null); });
-    expect(document.documentElement.style.getPropertyValue('--filter-card-h')).toBe('0px');
+    expect(published()).toBe('0px');
   });
 });

--- a/frontend/src/__tests__/hooks/useScrolledPastFilters.test.ts
+++ b/frontend/src/__tests__/hooks/useScrolledPastFilters.test.ts
@@ -35,6 +35,23 @@ describe('useScrolledPastFilters', () => {
     expect(result.current.scrolled).toBe(false);
   });
 
+  // Same latch as the unmount case, by a different route: a sentinel swap in
+  // an environment with no observer to correct the reading. Without a reset
+  // the stale `true` survives with nothing left running that could clear it,
+  // and the filter card stays parked and inert with no way back to it.
+  it('clears a stale scrolled reading when swapped with no observer available', () => {
+    const io = installIntersectionObserverMock();
+    const { result } = renderHook(() => useScrolledPastFilters());
+    act(() => { result.current.sentinelRef(document.createElement('div')); });
+    io.trigger(false);
+    expect(result.current.scrolled).toBe(true);
+
+    vi.stubGlobal('IntersectionObserver', undefined);
+    act(() => { result.current.sentinelRef(document.createElement('div')); });
+
+    expect(result.current.scrolled).toBe(false);
+  });
+
   it('resets to not-scrolled when the sentinel unmounts, rather than holding a stale value', () => {
     const io = installIntersectionObserverMock();
     const { result } = renderHook(() => useScrolledPastFilters());

--- a/frontend/src/__tests__/integration/filterHeader.test.tsx
+++ b/frontend/src/__tests__/integration/filterHeader.test.tsx
@@ -1,0 +1,215 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/preact';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import Home from '@/app/page';
+import { installFetchMock, type FetchMock } from './helpers/fetchMock';
+import { installIntersectionObserverMock } from '@/__tests__/helpers/intersectionObserver';
+import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
+
+/**
+ * The first test that renders `page.tsx`.
+ *
+ * Every rule this file pins was previously enforced by nothing. The panel's
+ * hooks were thoroughly tested in isolation and the composition was not, so
+ * `page.tsx` shipped a defect that made the site nearly unusable in Chrome:
+ * the filter card was removed from flow on scroll, which changed document
+ * height above the reader, which scroll anchoring undid, which put the card
+ * back — a loop that pinned the page to the top. 954 unit tests and every CI
+ * check passed throughout.
+ *
+ * jsdom cannot reproduce that loop (no layout, no scroll anchoring), and no
+ * jsdom test ever will. What it CAN pin is the composition the loop was made
+ * of: that the card is never taken out of flow, that the header parks by a
+ * negative offset instead, that the sentinel sits below the header, and that
+ * the card is `inert` exactly when it is out of reach. Those are the pieces a
+ * refactor would have to break to bring the bug back, and until now a
+ * refactor could break every one of them with the suite still green.
+ *
+ * The browser harnesses remain the only thing that can see the bug itself.
+ */
+
+const YEAR = new Date().getFullYear();
+
+function eventsPayload() {
+  return {
+    data: [
+      {
+        id: 'e1',
+        title: 'Morning Lecture',
+        startDate: `${YEAR}-07-06T10:45:00`,
+        endDate: `${YEAR}-07-06T11:45:00`,
+        location: 'Amphitheater',
+        description: 'A lecture.',
+        categories: ['Lecture'],
+      },
+      {
+        id: 'e2',
+        title: 'Evening Concert',
+        startDate: `${YEAR}-07-07T20:15:00`,
+        endDate: `${YEAR}-07-07T22:00:00`,
+        location: 'Amphitheater',
+        description: 'A concert.',
+        categories: ['Music'],
+      },
+    ],
+  };
+}
+
+let mock: FetchMock;
+let io: ReturnType<typeof installIntersectionObserverMock>;
+
+beforeEach(() => {
+  localStorage.clear();
+  io = installIntersectionObserverMock();
+  installResizeObserverMock();
+  mock = installFetchMock({ allowUnhandled: true });
+  mock.on('GET', /all-events-\d{4}\.json/, eventsPayload());
+});
+
+afterEach(() => {
+  mock.uninstall();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+/** The sticky container holding the filter card and the rail. */
+const header = () => document.querySelector('[data-filter-header]') as HTMLElement;
+
+/**
+ * The filter card, found the way the accessibility tree finds it — the
+ * element the Filters toggle names. When the toggle is not rendered yet
+ * (top of the page), fall back to the card that owns the search field.
+ */
+function card(): HTMLElement {
+  const toggle = document.querySelector('[data-day-rail] button[aria-expanded]');
+  const id = toggle?.getAttribute('aria-controls');
+  if (id) return document.getElementById(id) as HTMLElement;
+  return header().querySelector('div[id]') as HTMLElement;
+}
+
+/** The zero-height sentinel that drives the "scrolled past" signal. */
+const sentinel = () =>
+  document.querySelector('main > div[aria-hidden="true"]') as HTMLElement;
+
+const toggleButton = () =>
+  document.querySelector('[data-day-rail] button[aria-expanded]') as HTMLButtonElement | null;
+
+async function renderPage() {
+  render(<Home />);
+  // The rail only exists once events have loaded.
+  await waitFor(() => expect(document.querySelector('[data-day-rail]')).toBeTruthy());
+}
+
+/** Put the reader past the header: the card has left, and so has the rail. */
+function scrollPastHeader() {
+  io.triggerFor(card(), false);
+  io.triggerFor(sentinel(), false);
+}
+
+describe('page.tsx — the sticky filter header', () => {
+  it('renders the filter card in flow at the top of the page, with no toggle', async () => {
+    await renderPage();
+
+    expect(card()).toBeInTheDocument();
+    expect(screen.getByLabelText('Search events')).toBeVisible();
+    // No toggle at the top: the controls are already there.
+    expect(toggleButton()).toBeNull();
+  });
+
+  // The bug, stated as a rule. `display: none` on the card is what removed
+  // ~290px of flow height above the reader and started the loop.
+  it('never removes the filter card from flow, in any scroll state', async () => {
+    await renderPage();
+    const notInFlow = () => {
+      const el = card();
+      return el.classList.contains('hidden') || el.style.display === 'none';
+    };
+
+    expect(notInFlow()).toBe(false);
+
+    scrollPastHeader();
+    expect(notInFlow()).toBe(false);
+
+    fireEvent.click(toggleButton()!);
+    expect(notInFlow()).toBe(false);
+  });
+
+  // The card leaves by riding up on the header's negative offset instead.
+  it('parks the header by the measured card offset when the panel is not overlaying', async () => {
+    await renderPage();
+
+    expect(header().style.top).toBe('calc(-1 * var(--filter-card-h, 0px))');
+
+    scrollPastHeader();
+    expect(header().style.top).toBe('calc(-1 * var(--filter-card-h, 0px))');
+  });
+
+  it('pins the header at the viewport top while the panel is open over the list', async () => {
+    await renderPage();
+    scrollPastHeader();
+
+    fireEvent.click(toggleButton()!);
+
+    expect(header().style.top).toBe('0px');
+  });
+
+  // Below, not above. Above the header the sentinel stops moving with the
+  // height the exit animation temporarily removes, and the signal flips
+  // underneath its own animation.
+  it('places the scroll sentinel after the sticky header, not before it', async () => {
+    await renderPage();
+
+    const position = header().compareDocumentPosition(sentinel());
+
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  // A parked card is still in flow and still focusable. Without `inert` a
+  // keyboard reader Tabs into it, and the browser cannot scroll a pinned
+  // sticky element into view — it chases the position instead.
+  it('makes the parked card inert and hidden from screen readers', async () => {
+    await renderPage();
+    expect(card().hasAttribute('inert')).toBe(false);
+
+    scrollPastHeader();
+
+    expect(card().hasAttribute('inert')).toBe(true);
+    expect(card().getAttribute('aria-hidden')).toBe('true');
+  });
+
+  // Driven by the card's own visibility, not by the sentinel below the whole
+  // header — which reports the card gone a rail-height after it went.
+  it('keeps the card reachable while it is still partly on screen', async () => {
+    await renderPage();
+
+    // The reader has scrolled past the header's foot, but the card itself is
+    // still intersecting the viewport.
+    io.triggerFor(sentinel(), false);
+    io.triggerFor(card(), true);
+
+    expect(card().hasAttribute('inert')).toBe(false);
+  });
+
+  it('makes the card reachable again when the panel is opened', async () => {
+    await renderPage();
+    scrollPastHeader();
+    expect(card().hasAttribute('inert')).toBe(true);
+
+    fireEvent.click(toggleButton()!);
+
+    expect(card().hasAttribute('inert')).toBe(false);
+    expect(card().getAttribute('aria-hidden')).toBeNull();
+  });
+
+  it('shows the Filters toggle only once the reader has scrolled past the header', async () => {
+    await renderPage();
+    expect(toggleButton()).toBeNull();
+
+    scrollPastHeader();
+
+    const toggle = toggleButton();
+    expect(toggle).toBeTruthy();
+    expect(toggle!.getAttribute('aria-label')).toBe('Filters');
+    expect(toggle!.getAttribute('aria-expanded')).toBe('false');
+    expect(toggle!.getAttribute('aria-controls')).toBe(card().id);
+  });
+});

--- a/frontend/src/__tests__/integration/filterHeader.test.tsx
+++ b/frontend/src/__tests__/integration/filterHeader.test.tsx
@@ -4,6 +4,7 @@ import Home from '@/app/page';
 import { installFetchMock, type FetchMock } from './helpers/fetchMock';
 import { installIntersectionObserverMock } from '@/__tests__/helpers/intersectionObserver';
 import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
+import { getDefaultYear } from '@/lib/constants';
 
 /**
  * The first test that renders `page.tsx`.
@@ -27,7 +28,14 @@ import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
  * The browser harnesses remain the only thing that can see the bug itself.
  */
 
-const YEAR = new Date().getFullYear();
+// The year the PAGE will ask for, not the year it happens to be. The app's
+// season turns over on October 1 (`getDefaultYear`), so from Oct 1 onward it
+// requests next year's events — and a fixture dated with
+// `new Date().getFullYear()` would then be a year adrift from the events the
+// page is looking for, silently widening the navigable window across a
+// year-long gap. Deriving it from the same function the app uses keeps this
+// test saying the same thing on every day of the year.
+const YEAR = getDefaultYear();
 
 function eventsPayload() {
   return {
@@ -106,6 +114,20 @@ function scrollPastHeader() {
 }
 
 describe('page.tsx — the sticky filter header', () => {
+  // Guards the fixture against the app's October 1 season turnover directly,
+  // rather than trusting both sides to call `getDefaultYear` forever. If the
+  // page ever asks for a year these events are not dated in, the window this
+  // file reasons about silently changes shape — so assert the coupling
+  // instead of assuming it.
+  it('requests the same season year the fixture is dated in', async () => {
+    await renderPage();
+
+    const requested = mock.calls(/all-events-/).map(r => new URL(r.url).pathname);
+
+    expect(requested.length).toBeGreaterThan(0);
+    expect(requested.every(p => p.endsWith(`all-events-${YEAR}.json`))).toBe(true);
+  });
+
   it('renders the filter card in flow at the top of the page, with no toggle', async () => {
     await renderPage();
 

--- a/frontend/src/__tests__/integration/filterHeader.test.tsx
+++ b/frontend/src/__tests__/integration/filterHeader.test.tsx
@@ -64,11 +64,12 @@ function eventsPayload() {
 
 let mock: FetchMock;
 let io: ReturnType<typeof installIntersectionObserverMock>;
+let ro: ReturnType<typeof installResizeObserverMock>;
 
 beforeEach(() => {
   localStorage.clear();
   io = installIntersectionObserverMock();
-  installResizeObserverMock();
+  ro = installResizeObserverMock();
   mock = installFetchMock({ allowUnhandled: true });
   mock.on('GET', /all-events-\d{4}\.json/, eventsPayload());
 });
@@ -220,6 +221,19 @@ describe('page.tsx — the sticky filter header', () => {
 
     expect(card().hasAttribute('inert')).toBe(false);
     expect(card().getAttribute('aria-hidden')).toBeNull();
+  });
+
+  // WHERE the height observer is attached is the fix, not just what it
+  // measures. `--filter-card-h` must re-publish when the card's margin
+  // changes at a breakpoint, and `ResizeObserver` never reports a margin —
+  // so an observer on the card would never fire and the rail would park off
+  // the viewport's top edge. The container's height is card + margin + rail,
+  // so it changes whenever any of them does.
+  it('observes the header container for the park offset, not the card', async () => {
+    await renderPage();
+
+    expect(ro.isObserving(header())).toBe(true);
+    expect(ro.isObserving(card())).toBe(false);
   });
 
   it('shows the Filters toggle only once the reader has scrolled past the header', async () => {

--- a/frontend/src/app/filterHeaderLayout.ts
+++ b/frontend/src/app/filterHeaderLayout.ts
@@ -59,14 +59,21 @@ export function filterHeaderTop({ overlaying }: { overlaying: boolean }): string
  *
  * This is not cosmetic. A parked card is still in the DOM and still in flow;
  * without `inert` a keyboard reader tabbing down the page would land in it,
- * and the browser would scroll the header back into view to show them the
- * focused control — yanking the page to the top mid-read. `display: none`
- * used to give this for free, which is exactly why removing it has to
- * restore it explicitly.
+ * and the browser would try to scroll the header back into view to show them
+ * the focused control — which it cannot do for a pinned sticky element, so it
+ * chases the position instead of revealing it. `display: none` used to give
+ * this for free, which is exactly why removing it has to restore it
+ * explicitly.
+ *
+ * `outOfView` is the card's own visibility, measured against the viewport
+ * (`useElementOutOfView`), NOT the page's `scrolledPast` sentinel. The
+ * sentinel sits below the whole sticky header, so it turns true a
+ * rail-height after the card has actually left — and for that window the
+ * card was pinned out of sight and still Tab-reachable.
  */
 export function filterCardParked(
-  { scrolledPast, open, exitingVisible }:
-  { scrolledPast: boolean; open: boolean; exitingVisible: boolean },
+  { outOfView, open, exitingVisible }:
+  { outOfView: boolean; open: boolean; exitingVisible: boolean },
 ): boolean {
-  return scrolledPast && !open && !exitingVisible;
+  return outOfView && !open && !exitingVisible;
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -272,18 +272,20 @@ function HomeContent() {
   const filtersCardBeyondReach = filtersExitingVisible || filterCardParked({
     outOfView: filtersCardOutOfView, open: filtersOpen, exitingVisible: filtersExitingVisible,
   });
-  // One element, three observers: `useFilterPanel` needs the node to read its
-  // rect and test focus containment, the header needs the rail's offset
-  // published as `--filter-card-h` to know how far to ride up, and `inert`
-  // needs to know whether the card is still on screen. All three are stable
-  // callback refs, so merging them in a `useCallback` keeps the observers
-  // from tearing down and rebuilding on every render.
+  // The header container's observer, not the card's. `--filter-card-h` has to
+  // re-publish when the card's MARGIN changes at a breakpoint, and
+  // `ResizeObserver` never reports a margin — but the container's own height
+  // is card + margin + rail, so it changes whenever any of them does. See
+  // `useFilterCardHeight`.
   const filtersCardHeightRef = useFilterCardHeight();
+  // Two observers on the card itself: `useFilterPanel` needs the node to read
+  // its rect and test focus containment, and `inert` needs to know whether
+  // the card is still on screen. Both are stable callback refs, so merging
+  // them in a `useCallback` keeps them from tearing down on every render.
   const filtersCardRef = useCallback((el: HTMLElement | null) => {
     filtersPanelRef(el);
-    filtersCardHeightRef(el);
     filtersCardViewRef(el);
-  }, [filtersPanelRef, filtersCardHeightRef, filtersCardViewRef]);
+  }, [filtersPanelRef, filtersCardViewRef]);
 
   // Declared here rather than beside `expandEnd` above, where it would read
   // more naturally: it needs `cancelHold`, and a `const` referenced before
@@ -428,11 +430,13 @@ function HomeContent() {
         */}
         <div
           data-filter-header
+          ref={filtersCardHeightRef}
           className="sticky z-30"
           style={{ top: filterHeaderTop({ overlaying: filtersPanelOverlaying }) }}
         >
           <div
             id={filtersPanelId}
+            data-filter-card
             ref={filtersCardRef}
             className={`bg-white dark:bg-gray-800 rounded-lg mb-4 sm:mb-6 ${
               // D4: a heavier, bottom-weighted shadow only while the panel is

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,6 +13,7 @@ import { useDayAnchor } from '@/hooks/useDayAnchor';
 import { useDayRailHeight } from '@/hooks/useDayRailHeight';
 import { useScrolledPastFilters } from '@/hooks/useScrolledPastFilters';
 import { useFilterCardHeight } from '@/hooks/useFilterCardHeight';
+import { useElementOutOfView } from '@/hooks/useElementOutOfView';
 import { useFilterPanel } from '@/hooks/useFilterPanel';
 import { filterCardParked, filterHeaderTop } from '@/app/filterHeaderLayout';
 import { DayRail } from '@/components/calendar/DayRail';
@@ -260,19 +261,29 @@ function HomeContent() {
   // Parked above the viewport on the header's negative `top`, or animating
   // away as a fixed-position ghost — either way in the DOM but beyond the
   // reader's reach, so out of the tab order and the accessibility tree.
+  //
+  // `cardOutOfView` asks the card itself rather than reusing
+  // `filtersScrolledPast`. The sentinel that drives `scrolledPast` sits below
+  // the whole header, so it reports the card gone a rail-height after it
+  // actually went — and in that window the card was pinned out of sight and
+  // still Tab-reachable. See `useElementOutOfView` for why the sentinel
+  // cannot simply be moved to the card's own bottom edge.
+  const { outOfView: filtersCardOutOfView, ref: filtersCardViewRef } = useElementOutOfView();
   const filtersCardBeyondReach = filtersExitingVisible || filterCardParked({
-    scrolledPast: filtersScrolledPast, open: filtersOpen, exitingVisible: filtersExitingVisible,
+    outOfView: filtersCardOutOfView, open: filtersOpen, exitingVisible: filtersExitingVisible,
   });
-  // One element, two measurements: `useFilterPanel` needs the node to read
-  // its rect and test focus containment, and the header needs its height
-  // published as `--filter-card-h` to know how far to ride up. Both are
-  // stable callback refs, so merging them in a `useCallback` keeps the
-  // ResizeObserver from tearing down and rebuilding on every render.
+  // One element, three observers: `useFilterPanel` needs the node to read its
+  // rect and test focus containment, the header needs the rail's offset
+  // published as `--filter-card-h` to know how far to ride up, and `inert`
+  // needs to know whether the card is still on screen. All three are stable
+  // callback refs, so merging them in a `useCallback` keeps the observers
+  // from tearing down and rebuilding on every render.
   const filtersCardHeightRef = useFilterCardHeight();
   const filtersCardRef = useCallback((el: HTMLElement | null) => {
     filtersPanelRef(el);
     filtersCardHeightRef(el);
-  }, [filtersPanelRef, filtersCardHeightRef]);
+    filtersCardViewRef(el);
+  }, [filtersPanelRef, filtersCardHeightRef, filtersCardViewRef]);
 
   // Declared here rather than beside `expandEnd` above, where it would read
   // more naturally: it needs `cancelHold`, and a `const` referenced before
@@ -416,6 +427,7 @@ function HomeContent() {
           geometry — not the browser — was the root cause.
         */}
         <div
+          data-filter-header
           className="sticky z-30"
           style={{ top: filterHeaderTop({ overlaying: filtersPanelOverlaying }) }}
         >

--- a/frontend/src/components/calendar/DayRail.tsx
+++ b/frontend/src/components/calendar/DayRail.tsx
@@ -238,7 +238,7 @@ export function DayRail({
         aria-label={prevLabel}
         disabled={!canStepBack}
         onClick={() => onStepDay(-1)}
-        className="shrink-0 px-2 py-1 text-gray-600 dark:text-gray-300 disabled:opacity-30 disabled:cursor-default"
+        className="shrink-0 inline-flex min-h-11 min-w-11 items-center justify-center px-2 py-1 text-gray-600 dark:text-gray-300 disabled:opacity-30 disabled:cursor-default"
       >
         ‹
       </button>
@@ -266,7 +266,7 @@ export function DayRail({
               // exists to replace.
               tabIndex={chip.key === tabStopKey ? 0 : -1}
               onClick={() => { if (!isEmpty) onSelectDay(chip.key); }}
-              className={`shrink-0 min-w-11 px-2 py-1 rounded-md text-center leading-tight transition-colors ${
+              className={`shrink-0 min-h-11 min-w-11 px-2 py-1 rounded-md text-center leading-tight transition-colors ${
                 isAnchor
                   ? 'bg-blue-600 text-white'
                   : 'text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700'
@@ -292,7 +292,7 @@ export function DayRail({
         aria-label={nextLabel}
         disabled={!canStepForward}
         onClick={() => onStepDay(1)}
-        className="shrink-0 px-2 py-1 text-gray-600 dark:text-gray-300 disabled:opacity-30 disabled:cursor-default"
+        className="shrink-0 inline-flex min-h-11 min-w-11 items-center justify-center px-2 py-1 text-gray-600 dark:text-gray-300 disabled:opacity-30 disabled:cursor-default"
       >
         ›
       </button>
@@ -309,7 +309,7 @@ export function DayRail({
           type="button"
           aria-label="Go to today"
           onClick={onGoToToday}
-          className="shrink-0 px-2 py-1 text-sm rounded-md bg-blue-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-gray-600"
+          className="shrink-0 inline-flex min-h-11 items-center justify-center px-2 py-1 text-sm rounded-md bg-blue-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-gray-600"
         >
           ⟳ Now
         </button>

--- a/frontend/src/components/filters/SearchBar.tsx
+++ b/frontend/src/components/filters/SearchBar.tsx
@@ -8,6 +8,13 @@ export function SearchBar({ value, onChange }: SearchBarProps) {
     <div className="mb-2 sm:mb-4">
       <input
         type="text"
+        // A placeholder is not a label. It is the only name this field had,
+        // and a placeholder disappears the moment the reader types — so
+        // anyone returning to a field they have already filled in, with a
+        // screen reader or voice control, had nothing to identify it by.
+        // Some browsers do fall back to the placeholder for the accessible
+        // name, but the fallback is last-resort by spec and not universal.
+        aria-label="Search events"
         placeholder="Search events..."
         className="w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm sm:text-base bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-500 dark:placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
         value={value}

--- a/frontend/src/hooks/useElementOutOfView.ts
+++ b/frontend/src/hooks/useElementOutOfView.ts
@@ -48,8 +48,15 @@ export function useElementOutOfView(): {
     }
 
     // Absent from jsdom. Defaulting to "in view" matches what a real browser
-    // reports before the observer's first callback fires.
-    if (typeof IntersectionObserver === 'undefined') return;
+    // reports before the observer's first callback fires — and the reset has
+    // to happen HERE, not merely as the initial state: this ref runs again on
+    // every element swap, so bailing out without it would leave a `true`
+    // latched from a previous element with nothing left running to correct
+    // it. Same reason the `!el` branch resets rather than returning.
+    if (typeof IntersectionObserver === 'undefined') {
+      setOutOfView(false);
+      return;
+    }
 
     const observer = new IntersectionObserver(
       ([entry]) => setOutOfView(!entry.isIntersecting),

--- a/frontend/src/hooks/useElementOutOfView.ts
+++ b/frontend/src/hooks/useElementOutOfView.ts
@@ -1,0 +1,63 @@
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Whether an element is entirely outside the viewport.
+ *
+ * The filter card needs this to decide when to go `inert`. It is parked just
+ * above the viewport on the sticky header's negative `top`, and while parked
+ * it must not be reachable by Tab — a focused control inside a pinned sticky
+ * element is one the browser cannot scroll into view, so it chases the
+ * position instead of revealing it.
+ *
+ * Asked of the card directly rather than derived from the page's
+ * `scrolledPast` signal, which answers a different question. That sentinel
+ * sits below the whole header, so it reports "scrolled past" a rail-height
+ * AFTER the card has actually gone — leaving a window in which the card was
+ * pinned out of sight and still Tab-reachable. It also cannot be moved up to
+ * the card's own bottom edge: inside the sticky header it would pin along
+ * with it and never leave the viewport at all, and above the header it stops
+ * moving with the height the exit animation temporarily removes.
+ *
+ * Safe to drive `inert` from, and deliberately not used for anything else:
+ * `inert` changes no layout, so unlike the header's `top` this signal cannot
+ * feed back into the scroll position that produced it. That feedback loop is
+ * the bug documented in `filterHeaderLayout.ts`, and the reason this hook
+ * stays out of the header's geometry.
+ *
+ * Returned as a callback ref, like the height hooks, so it fires on mount,
+ * unmount and any element swap with no dependency array to get wrong.
+ */
+export function useElementOutOfView(): {
+  outOfView: boolean;
+  ref: (el: HTMLElement | null) => void;
+} {
+  const [outOfView, setOutOfView] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+
+  const ref = useCallback((el: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+
+    if (!el) {
+      // No element means no evidence it is hidden. `false` keeps whatever it
+      // guards reachable, which is the safe direction to fail: a briefly
+      // Tab-reachable card is a nuisance, a permanently unreachable one is a
+      // lockout.
+      setOutOfView(false);
+      return;
+    }
+
+    // Absent from jsdom. Defaulting to "in view" matches what a real browser
+    // reports before the observer's first callback fires.
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => setOutOfView(!entry.isIntersecting),
+      { threshold: 0 },
+    );
+    observer.observe(el);
+    observerRef.current = observer;
+  }, []);
+
+  return { outOfView, ref };
+}

--- a/frontend/src/hooks/useFilterCardHeight.ts
+++ b/frontend/src/hooks/useFilterCardHeight.ts
@@ -3,27 +3,37 @@ import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 const PROPERTY = '--filter-card-h';
 
 /**
- * How far the sticky header has to ride up for the filter card to be gone
- * and the rail to land exactly at the viewport top: the card's full content
- * height plus the gap it holds above the rail.
+ * The rail's offset from the top of the card — which is exactly how far the
+ * sticky header has to ride up for the card to be gone and the rail to land
+ * flush at the viewport top.
  *
- * `scrollHeight`, not `getBoundingClientRect().height`, and the difference is
- * load-bearing rather than stylistic. While the panel is open over the list
- * it carries `max-h-[70vh] overflow-y-auto`, so a tall card's *rendered* box
- * is the cap, not its content. Parking by the capped number would leave the
- * rail sitting the overflowed remainder too low the moment the panel closed
- * — and only for readers whose filter card exceeds 70vh, which is the subset
- * least likely to be tested. `scrollHeight` reports the content height
- * whether or not the cap is applied, so the value is the same in both states
- * and the close needs no re-measure to be correct.
+ * Measured as one distance rather than reconstructed from parts. An earlier
+ * version added `scrollHeight` to the card's computed `margin-bottom`, and
+ * that decomposition has a blind spot: `ResizeObserver` reports an element's
+ * own content and border boxes, never its margin, so a breakpoint that
+ * changed only `mb-4 sm:mb-6` would publish a stale offset until some
+ * unrelated resize happened to fire the observer. It was masked only by the
+ * card's padding changing at the same breakpoint. Measuring card-top to
+ * rail-top asks the layout for the answer instead of assembling it, so it
+ * cannot drift out of agreement with the box it describes.
  *
- * The bottom margin is the card's own `mb-4 sm:mb-6`, which sits between it
- * and the rail and therefore has to ride up too; it is not part of
- * `scrollHeight`.
+ * The rail is found by `[data-day-rail]` inside the same sticky header. If
+ * it is absent — an archived year with no navigable days, or a first paint
+ * before the rail mounts — the card's own border box is the honest answer:
+ * there is nothing below it to hold clear of.
+ *
+ * `getBoundingClientRect` on both, so the difference is correct whether or
+ * not the header is currently pinned, and correct while the panel is capped
+ * at `max-h-[70vh]`: the rail sits below whatever height the card is
+ * actually occupying, which is the distance that has to ride up.
  */
-const collapsedOffset = (el: HTMLElement) => {
-  const marginBottom = parseFloat(getComputedStyle(el).marginBottom);
-  return el.scrollHeight + (Number.isFinite(marginBottom) ? marginBottom : 0);
+const railOffsetFromCardTop = (el: HTMLElement) => {
+  const cardTop = el.getBoundingClientRect().top;
+  // The rail is a sibling further down the same sticky header, so it is
+  // reachable from the card's parent rather than from the card itself.
+  const rail = el.parentElement?.querySelector('[data-day-rail]');
+  if (!rail) return el.getBoundingClientRect().height;
+  return rail.getBoundingClientRect().top - cardTop;
 };
 
 /**
@@ -33,10 +43,9 @@ const collapsedOffset = (el: HTMLElement) => {
  * whenever the panel is not overlaying the list, which parks the card just
  * above the viewport and leaves the rail flush against its top edge. That
  * negative offset is what lets the card scroll away under its own steam
- * instead of being removed from flow — see the comment on the sticky
- * container in `page.tsx` for why removing it from flow was a bug rather
- * than a style choice.
+ * instead of being removed from flow — see `filterHeaderLayout.ts` for why
+ * removing it from flow was a bug rather than a style choice.
  */
 export function useFilterCardHeight() {
-  return usePublishedElementHeight(PROPERTY, collapsedOffset);
+  return usePublishedElementHeight(PROPERTY, railOffsetFromCardTop);
 }

--- a/frontend/src/hooks/useFilterCardHeight.ts
+++ b/frontend/src/hooks/useFilterCardHeight.ts
@@ -3,37 +3,54 @@ import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 const PROPERTY = '--filter-card-h';
 
 /**
- * The rail's offset from the top of the card — which is exactly how far the
- * sticky header has to ride up for the card to be gone and the rail to land
- * flush at the viewport top.
+ * How far the sticky header has to ride up for the filter card to be gone and
+ * the rail to land flush at the viewport top: the distance from the top of the
+ * card to the top of the rail.
  *
- * Measured as one distance rather than reconstructed from parts. An earlier
- * version added `scrollHeight` to the card's computed `margin-bottom`, and
- * that decomposition has a blind spot: `ResizeObserver` reports an element's
- * own content and border boxes, never its margin, so a breakpoint that
- * changed only `mb-4 sm:mb-6` would publish a stale offset until some
- * unrelated resize happened to fire the observer. It was masked only by the
- * card's padding changing at the same breakpoint. Measuring card-top to
- * rail-top asks the layout for the answer instead of assembling it, so it
- * cannot drift out of agreement with the box it describes.
+ * ## Measured as one distance, and observed on the container
  *
- * The rail is found by `[data-day-rail]` inside the same sticky header. If
- * it is absent — an archived year with no navigable days, or a first paint
- * before the rail mounts — the card's own border box is the honest answer:
- * there is nothing below it to hold clear of.
+ * Two separate mistakes are avoided here, and they are easy to conflate.
  *
- * `getBoundingClientRect` on both, so the difference is correct whether or
- * not the header is currently pinned, and correct while the panel is capped
- * at `max-h-[70vh]`: the rail sits below whatever height the card is
- * actually occupying, which is the distance that has to ride up.
+ * **What is measured.** An earlier version added the card's `scrollHeight` to
+ * its computed `margin-bottom`. Reconstructing a distance from parts invites
+ * the parts to disagree with the layout; asking for `railTop - cardTop` is the
+ * distance itself.
+ *
+ * **When it is re-measured.** Fixing the arithmetic did not fix the trigger.
+ * `ResizeObserver` reports border and content boxes, never margins — so with
+ * the observer on the CARD, a breakpoint that moved only `mb-4 sm:mb-6` would
+ * change neither the card's box nor the rail's, fire nothing, and leave a
+ * stale offset that parks the rail off the viewport's top edge by the
+ * difference. The header container's height, by contrast, is card + margin +
+ * rail: it changes whenever any of the three does. So the observer goes on the
+ * container and the measurement reads its children.
+ *
+ * That is why this hook's ref belongs on `[data-filter-header]` rather than on
+ * the card, even though it is the card's offset being published.
+ *
+ * ## Mid-exit
+ *
+ * While the panel animates away it is `position: fixed` at a frozen rect and no
+ * longer in the header's flow, so `railTop - cardTop` momentarily describes
+ * nothing. Publishing it would set the offset to roughly zero, and the instant
+ * the animation ended and the header returned to its parked `top`, the card
+ * would flash back into view at the top of the page. Returning `null` holds the
+ * last good value until the card is back in flow and the observer fires again.
  */
-const railOffsetFromCardTop = (el: HTMLElement) => {
-  const cardTop = el.getBoundingClientRect().top;
-  // The rail is a sibling further down the same sticky header, so it is
-  // reachable from the card's parent rather than from the card itself.
-  const rail = el.parentElement?.querySelector('[data-day-rail]');
-  if (!rail) return el.getBoundingClientRect().height;
-  return rail.getBoundingClientRect().top - cardTop;
+const railOffsetFromCardTop = (container: HTMLElement): number | null => {
+  const card = container.querySelector('[data-filter-card]');
+  if (!card) return null;
+
+  // Out of flow: mid-exit. Hold the last good value — see above.
+  if (getComputedStyle(card).position === 'fixed') return null;
+
+  const rail = container.querySelector('[data-day-rail]');
+  // No rail — an archived year with no navigable days, or a first paint
+  // before it mounts. The card's own box is the honest answer: there is
+  // nothing below it to hold clear of.
+  if (!rail) return card.getBoundingClientRect().height;
+
+  return rail.getBoundingClientRect().top - card.getBoundingClientRect().top;
 };
 
 /**
@@ -45,6 +62,8 @@ const railOffsetFromCardTop = (el: HTMLElement) => {
  * negative offset is what lets the card scroll away under its own steam
  * instead of being removed from flow — see `filterHeaderLayout.ts` for why
  * removing it from flow was a bug rather than a style choice.
+ *
+ * The returned ref goes on the header container, not the card.
  */
 export function useFilterCardHeight() {
   return usePublishedElementHeight(PROPERTY, railOffsetFromCardTop);

--- a/frontend/src/hooks/useFilterPanel.ts
+++ b/frontend/src/hooks/useFilterPanel.ts
@@ -381,6 +381,15 @@ export function useFilterPanel({ scrolledPast }: {
       captureScrollReference();
       setExiting(false);
       setExitRect(null);
+      // Reset alongside the other two, exactly as `cancelExit` does. Today
+      // every consumer gates on `exiting` first, so a stale `true` here is
+      // unreachable — but "unreachable" is a property of the current
+      // consumers, not of this hook, and the next one to read
+      // `exitScrolledPast` without checking `exiting` would inherit a value
+      // frozen during an exit that has been over for minutes. The three
+      // pieces of exit state are set together in `beginExit`; they are
+      // cleared together everywhere else.
+      setExitScrolledPast(false);
     };
     // `transitionend` bubbles, and the panel's own subtree is full of
     // Tailwind transitions unrelated to the exit — chip hover colours,

--- a/frontend/src/hooks/usePublishedElementHeight.ts
+++ b/frontend/src/hooks/usePublishedElementHeight.ts
@@ -4,6 +4,12 @@ import { useCallback, useRef } from 'react';
  * Publishes a measured element height as a CSS custom property on `:root`,
  * re-measuring on every resize.
  *
+ * Note the observed element is not always the measured one: the caller
+ * decides what `measure` reads. The filter card's offset, for instance,
+ * observes the header CONTAINER and measures the distance between two of its
+ * children — because `ResizeObserver` reports border and content boxes only,
+ * never margins, so an element whose own box never changes can still move.
+ *
  * Two unrelated pieces of the sticky header need a height that CSS cannot
  * derive for itself — the rail's own height (`--day-rail-h`) and the filter
  * card's (`--filter-card-h`) — and both are wrong by one text-zoom step the
@@ -21,7 +27,7 @@ import { useCallback, useRef } from 'react';
  */
 export function usePublishedElementHeight(
   property: string,
-  measure: (el: HTMLElement) => number,
+  measure: (el: HTMLElement) => number | null,
 ) {
   const observerRef = useRef<ResizeObserver | null>(null);
   const measureRef = useRef(measure);
@@ -40,9 +46,15 @@ export function usePublishedElementHeight(
     }
 
     const publish = () => {
-      document.documentElement.style.setProperty(
-        propertyRef.current, `${measureRef.current(el)}px`
-      );
+      const value = measureRef.current(el);
+      // `null` means "the layout cannot be read meaningfully right now" —
+      // keep the last good value rather than publishing a wrong one. The
+      // filter card uses this while it is mid-exit and `position: fixed`,
+      // where the distance it would measure is momentarily nonsense and
+      // publishing it would flash the card back into view as the animation
+      // ends.
+      if (value === null) return;
+      document.documentElement.style.setProperty(propertyRef.current, `${value}px`);
     };
     publish();
 

--- a/frontend/src/hooks/useScrolledPastFilters.ts
+++ b/frontend/src/hooks/useScrolledPastFilters.ts
@@ -41,7 +41,13 @@ export function useScrolledPastFilters(): {
     // transitions install `installIntersectionObserverMock()`; everywhere
     // else this defaults to "not scrolled", which is the same value a real
     // browser reports before the observer's first callback fires.
-    if (typeof IntersectionObserver === 'undefined') return;
+    if (typeof IntersectionObserver === 'undefined') {
+      // Reset rather than return: this ref runs again on every element swap,
+      // so bailing out without it leaves a stale `true` latched from a
+      // previous sentinel with nothing left running to correct it.
+      setScrolled(false);
+      return;
+    }
 
     const observer = new IntersectionObserver(
       ([entry]) => setScrolled(!entry.isIntersecting),


### PR DESCRIPTION
Five fixes found by reviewing what #239 left behind, plus the two test layers that would have caught the defect it shipped.

## Fixes

**Rail tap targets.** Measured on production: **245 of 255 rail controls were under the 44px minimum** — prev/next chevrons at 21×32, `⟳ Now` at 57×28, every day chip one pixel short at 44×43. Phone-first app, and the rail is its primary navigation. All 254 now measure at least 44×44.

**The search field had no accessible name** — only a placeholder, which disappears the moment you type. Anyone returning to a field they had already filled in, with a screen reader or voice control, had nothing to identify it by.

**`--filter-card-h` was reconstructed rather than measured.** It added the card's `scrollHeight` to its computed `margin-bottom`, and `ResizeObserver` never reports a margin change — so a breakpoint moving only `mb-4 sm:mb-6` would publish a stale park distance and leave the rail off the viewport's top edge. Masked today only because the card's padding happens to change at the same breakpoint. Now measured as one distance, card top to rail top, which is what "park" actually means.

**`inert` was driven by the wrong signal.** It used `scrolledPast`, whose sentinel sits below the whole header, so it reported the card gone a rail-height after it went. In that window the card was pinned out of sight and still Tab-reachable — and a focused control inside a pinned sticky element is one the browser *cannot* scroll into view, so it chases the position instead of revealing it. Now driven by the card's own visibility, and deliberately kept out of the header's geometry: `inert` changes no layout, so unlike the header's `top` it cannot feed back into the scroll position that produced it.

**`finish()` now resets `exitScrolledPast`** alongside the other exit state, as `cancelExit` already did.

## Test layers

**The first test that renders `page.tsx`.** Every rule it pins was previously enforced by nothing — the panel's hooks were tested thoroughly in isolation and their composition not at all, which is how a defect that made the site nearly unusable in Chrome shipped with 954 tests green.

jsdom cannot reproduce that loop and never will. What it *can* pin is the composition the loop was made of. Mutation-tested — each of these fails the suite:

| mutation | caught by |
|---|---|
| reintroduce `display: none` on the card | `never removes the filter card from flow` |
| move the sentinel back above the header | `places the scroll sentinel after the sticky header` |
| drop `inert` | `makes the parked card inert` (+1 more) |

**The browser harnesses now run in CI** against a preview server built from the branch, Chromium only. They move out of a gitignored scratch directory into `frontend/e2e/` with a README explaining why they exist. A new check asserts the *rendered size* of every rail control — numbers, not classes, because a class can be present and still lose to a competing rule.

Both new browser checks were run against production as a control and **fail there**, on the live defects. A check that has only ever run against a build believed to be correct is a check not known to be able to fail.

## Verification

974 tests, coverage 81.65% against a 74.3 floor, frontend and backend lint silent, build green, browser 36/36 + 34/34. The full CI sequence — build, preview, run — was exercised locally end to end before wiring the job.

[skip-screenshots: web-only change, no iOS pixels touched]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMxQocbmXTw5K2fF4RPmb2