### PR TITLE
fix(web): make the day rail's highlight move with your finger

### DIFF
--- a/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
+++ b/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
@@ -1,7 +1,7 @@
 # Day rail — scroll-linked highlight
 
-**Status:** Implemented and browser-verified. Branch pushed, PR not yet
-opened.
+**Status:** Implemented and browser-verified on branch. Not pushed, no PR
+yet.
 **Branch:** `feat/web-rail-scroll-linked-highlight`
 **Follows:** phase 3a (#238, #239, #240) — the day rail itself.
 
@@ -96,9 +96,11 @@ any explicit commit. Snapping back to centre the instant the reader scrolls
 one pixel would destroy the peek they just made; scrolling around within
 today's events keeps it, scrolling into tomorrow re-centres.
 
-**Suspension trigger:** `pointerdown` **and** `wheel` on the strip. A
-trackpad two-finger horizontal pan fires no pointer event and would otherwise
-be fought by the per-frame writes.
+**Suspension trigger:** the strip's scroll position diverging from the last
+value this hook wrote. *(Revised during the browser pass — the original plan
+said `pointerdown` and `wheel` on the strip, which also fires for a plain
+vertical page scroll that merely passed over the rail. See the browser
+verification section below.)*
 
 ## Architecture
 
@@ -142,17 +144,31 @@ thrash.
 ```
 <div ref=strip class="overflow-x-auto">                              scroller
   <div class="relative flex gap-1 w-max">                            content
-    <div ref=pill  class="absolute bg-blue-600 rounded-md" />        z-0
-    {chips}                                                          z-10  base colours
+    {chips}                                                          static, base colours
+    <div ref=pill  class="absolute inset-y-0 bg-blue-600" />         z-10
     <div ref=clip aria-hidden class="absolute inset-0 flex gap-1
          text-white pointer-events-none" style="clip-path: inset()"> z-20  duplicate row
-      {chips as divs, not buttons}
+      {chips again, as buttons with tabIndex -1}
     </div>
   </div>
 </div>
 ```
 
 Both layers share one `scrollLeft`, so they cannot desync.
+
+Two details settled while building, against the sketch above:
+
+- **The pill sits ABOVE the chips, not behind them.** Behind, a chip's
+  `hover:bg-blue-50` paints over the highlight on the current day — the one
+  chip whose highlight matters. Above, the pill covers the base text and the
+  clipped copy puts legible text back, which is the same result the layering
+  was for.
+- **The copy's chips are `<button>`, not `<div>`.** The copy must match the
+  real row's box metrics exactly or a width difference opens a seam through a
+  digit, and a `<div>` does not inherit the same UA and preflight rules.
+  `tabIndex={-1}` inside an `aria-hidden` container keeps them out of the tab
+  order and the accessibility tree. Measured worst delta across 251 pairs:
+  0px.
 
 **The pill and the clip layer live in content coordinates**, computed from
 `f` alone and never touched by `scrollLeft`. `scrollLeft` is a wholly

--- a/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
+++ b/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
@@ -147,7 +147,7 @@ thrash.
     <div ref=pill  class="absolute inset-y-0 bg-blue-600" />         z-10
     <div ref=clip aria-hidden class="absolute inset-0 flex gap-1
          text-white pointer-events-none" style="clip-path: inset()"> z-20  duplicate row
-      {chips again, as buttons with tabIndex -1}
+      {chips again, as non-interactive divs}
     </div>
   </div>
 </div>
@@ -162,12 +162,16 @@ Two details settled while building, against the sketch above:
   chip whose highlight matters. Above, the pill covers the base text and the
   clipped copy puts legible text back, which is the same result the layering
   was for.
-- **The copy's chips are `<button>`, not `<div>`.** The copy must match the
-  real row's box metrics exactly or a width difference opens a seam through a
-  digit, and a `<div>` does not inherit the same UA and preflight rules.
-  `tabIndex={-1}` inside an `aria-hidden` container keeps them out of the tab
-  order and the accessibility tree. Measured worst delta across 251 pairs:
-  0px.
+- **The copy's chips are `<div>`, not `<button>`.** They were buttons first,
+  chosen for box-metric parity, and `e2e/verify-rail.mjs` proved that wrong:
+  the rail's own chevron selector is `button:not([data-chip])`, the copy
+  carries no `data-chip`, so the copy matched it and a chevron click landed on
+  inert paint. Adding `data-chip` to fix that would instead double every
+  `[data-day-rail] [data-chip]` query in the same suite; a `<div>` is the only
+  shape satisfying both. Parity turned out not to need a button at all —
+  Tailwind's preflight normalises a button's font, padding, border and margin
+  to a div's. Measured worst delta across all 251 pairs: 0px on left, width,
+  top and height.
 
 **The pill and the clip layer live in content coordinates**, computed from
 `f` alone and never touched by `scrollLeft`. `scrollLeft` is a wholly
@@ -201,10 +205,16 @@ reader's own gesture and stays as-is.
 - **Pure** (`railPosition`): ramp floor on a one-event day, clamping at both
   ends of the season, `f` continuity across the flip.
 - **Hook** (`useRailHighlight`): stubbed rects, following the existing
-  `useDayAnchor.test.ts` pattern. Suspension on `pointerdown`/`wheel`; resume
-  on anchor change.
+  `useDayAnchor.test.ts` pattern. Suspension by scroll divergence — the strip
+  landing somewhere other than the last value written — and *not* on a
+  vertical scroll that merely passed over the rail; resume on anchor change,
+  on an explicit commit, and against a scroll event still in flight from the
+  pan just lifted. Plus listeners attaching to elements that appear after the
+  first mount, and no listeners at all while nothing is rendered.
 - **Component** (`DayRail`): clip layer is `aria-hidden`, contains nothing
-  focusable, `aria-current` still lands on the anchor.
+  focusable, contributes nothing to the chevron selector, `aria-current`
+  still lands on the anchor, and the highlight attaches when the strip
+  appears only after the scope resolves.
 - **Browser, mandatory.** Chrome on a phone viewport, with a GIF of a slow
   drag *stopped mid-transition* showing the half-and-half chip. This is the
   acceptance criterion and no test can reach it — phase 3a shipped eleven

--- a/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
+++ b/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
@@ -1,7 +1,6 @@
 # Day rail — scroll-linked highlight
 
-**Status:** Implemented and browser-verified on branch. Not pushed, no PR
-yet.
+**Status:** Implemented and browser-verified. In review as PR #241.
 **Branch:** `feat/web-rail-scroll-linked-highlight`
 **Follows:** phase 3a (#238, #239, #240) — the day rail itself.
 

--- a/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
+++ b/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
@@ -1,6 +1,7 @@
 # Day rail — scroll-linked highlight
 
-**Status:** Approved design, not yet implemented.
+**Status:** Implemented and browser-verified. Branch pushed, PR not yet
+opened.
 **Branch:** `feat/web-rail-scroll-linked-highlight`
 **Follows:** phase 3a (#238, #239, #240) — the day rail itself.
 
@@ -197,15 +198,56 @@ reader's own gesture and stays as-is.
 Existing rail tests assert `aria-current` and "the strip writes its own
 `scrollLeft`". Both stay true, so test churn is minimal.
 
-## Risks to verify early in the browser
+## Browser verification (390x844, Chromium, real production data)
 
-1. Whether `clip-path` on the absolutely-positioned layer resolves against
-   its own border box (expected) rather than the scroller's.
-2. Whether the duplicated row's ~64 extra nodes cost anything measurable on a
-   phone.
-3. Whether the browser's native axis-locking on `overflow-x-auto` keeps a
-   diagonal drag near the screen's top edge from stealing vertical page
-   scroll.
+All three risks resolved, plus one defect found that no test reached.
+
+1. **`clip-path` coordinate space** — resolves against the layer's own border
+   box, as expected. Measured mid-handover: `inset(0 1079.88px 0 10920.1px)`
+   on a 12044px content box, and 10920.1 + 44 + 1079.88 = 12043.98.
+2. **Cost of the duplicated row** — none measurable. The rail turned out to
+   span **251 chips**, not the ~64 estimated here, so the copy is 502 buttons
+   over a 12044px strip. Median frame 8.3ms with the copy and 8.3ms with it
+   `display: none`; p95 9.9 vs 10.0. The 8.3ms is the page's own scroll cost.
+3. **Layer alignment** — worst chip delta across all 251 pairs: **0px**. The
+   shared `chipBoxClass` holds.
+4. **Continuity** — 13 distinct pill positions across the 200px ramp
+   (header 33px), and `pillLeft` is exactly the predicted function of the
+   measured distance in every sample. Critically, the last pre-flip position
+   equals the post-flip position (10896 + 48 = 10944), so the handover is
+   continuous across the anchor change rather than merely smooth either side
+   of it.
+5. **Peek** — a 200px pan leaves the page at rest, the pill on its day, and
+   the peek intact through subsequent same-day scrolling.
+6. **Commit** — tapping a chip six days ahead scrolls the page and eases the
+   strip through 24 distinct positions over ~400ms; under
+   `prefers-reduced-motion` the same tap uses 2 (start and end).
+
+### Defect found: peek detection inferred intent from event type
+
+Suspending on `wheel`/`pointerdown` over the strip also fired for a plain
+**vertical** page scroll with the pointer resting on the rail — and the rail
+is sticky at the top of a phone screen, which is where swipes start.
+Measured: one vertical wheel, then 120px of page scroll, moved the strip
+**0px**. Centring stayed dead until the next day boundary.
+
+Fixed by detecting divergence instead: every write goes through one
+`writeScrollLeft` that reads the value back, and a strip `scroll` finding a
+position other than the one we wrote means the reader moved it. Strictly
+more accurate in both directions — it cannot fire for a scroll that merely
+passed over the rail, and it catches touch drag, trackpad pan, scrollbar and
+keyboard rather than the two events the old list named. After the fix the
+same measurement gives 24px.
+
+This was green on all 1029 tests before the browser pass.
+
+### Remaining, not verified
+
+Native axis-locking on a diagonal touch drag starting on the rail. Chromium
+headless does not reproduce real touch gesture arbitration, so this needs a
+device or simulator pass rather than a scripted one. Low risk: the strip is
+an ordinary `overflow-x-auto` element with no touch-action override, so it
+gets the platform's default behaviour.
 
 ## Files
 

--- a/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
+++ b/docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md
@@ -1,0 +1,218 @@
+# Day rail — scroll-linked highlight
+
+**Status:** Approved design, not yet implemented.
+**Branch:** `feat/web-rail-scroll-linked-highlight`
+**Follows:** phase 3a (#238, #239, #240) — the day rail itself.
+
+## The problem
+
+The rail's highlight arrives in two discrete jumps that do not agree with
+each other:
+
+- `useDayAnchor` emits a **day key**. It flips the instant a section's top
+  crosses the sticky line.
+- `DayRail`'s effect fires on `[anchorDay]` and sets `strip.scrollLeft` to
+  centre that chip — instantly. Meanwhile the `bg-blue-600` swap is a CSS
+  `transition-colors`, so the colour crossfades on its own timer while the
+  strip has already teleported.
+
+Reported as: "the highlight changes to the other date and then moves to the
+centre location."
+
+## The mechanism to copy
+
+The day-title replacement in the list is **scroll-linked, not time-linked**.
+The headers are `position: sticky` at `top: var(--day-rail-h)`, so the
+outgoing title is pushed up by the incoming one over exactly one
+header-height of scroll. Nothing animates on a duration — position is a pure
+function of scroll offset, which is why it tracks the reader's finger and
+stops half-done when they stop.
+
+The rail must be driven the same way: a **fractional** anchor, not a key.
+
+## Decisions
+
+| Decision | Choice | Rejected |
+|---|---|---|
+| Placement | Centre window, days slide through | Pill moves and pins near the edges |
+| Partial state | True clip — the chip splits at the window edge | Per-chip crossfade; text flips at halfway |
+| Ramp | `max(headerH, min(sectionH * 0.25, 200))` | Exactly the header height; the whole section |
+| Drag | Drag peeks, tap commits | Release-to-commit; live scrub |
+
+### Why the generous ramp
+
+Matching the title handoff exactly (~36px) is 1:1 faithful but passes in
+about two frames at flick speed, so it would still read as a jump. ~200px is
+roughly 12 frames. The rail then leads the title slightly into the next day,
+which reads as anticipation rather than desync. The `headerH` floor keeps a
+one-event day working.
+
+### Why the whole section is wrong
+
+`f` would never rest at 0, so a crisp "you are here" state stops existing —
+and halfway through Tuesday's events the window would sit halfway between
+Tue and Wed, misreporting what the reader is looking at.
+
+### Why live scrub is wrong
+
+~48px of rail travel is one whole day section, which can be 3,000px of page.
+A 60x amplification means a lazy thumb-flick on the rail throws the list a
+week, and the content underneath is unreadable for the whole gesture.
+
+## The core invariant
+
+> `anchorDay` is derived from page scroll and nothing else. The rail only
+> ever reads it.
+
+Every commit goes page-scroll-first; the rail redraws as a consequence.
+Reversing this for the drag gesture would give the value two owners and a
+feedback loop (page scrolls -> `f` changes -> writes `scrollLeft` -> ...)
+that needs a mode flag to break.
+
+## Interaction model
+
+| Gesture | Page | Rail `scrollLeft` | Pill |
+|---|---|---|---|
+| Scroll the list | moves | follows, keeping the pill centred | tracks `f`, glides day->day |
+| Drag/wheel the rail sideways | **still** | reader owns it; sync suspended | stays glued to its day, drifts off-centre |
+| Tap a chip | scrolls to that day | resumes, tweens ~220ms | eases to centre |
+| `<` `>` / `Now` | scrolls | resumes, tweens | eases to centre |
+| Scroll into a new day after a peek | moves | sync resumes here | re-centres |
+
+Dragging a day into the centre does **not** make it current. The pill is not
+a selector parked at the centre; it is attached to the day being read, and it
+only *appears* centred because the rail auto-scrolls to keep it there. When
+the reader takes hold of the rail, that auto-scroll suspends and the pill
+travels with its chip — off-centre, and off-screen if they pan far enough.
+That is honest: it says "the day you are reading is back that way."
+
+Peeking is fully undoable, and every commit stays an explicit button
+activation, so assistive technology still hears "Go to Saturday, July 4, 12
+events" on every navigation. A release-to-commit drag announces nothing.
+
+**Resume rule:** sync resumes when the anchor day actually *changes*, or on
+any explicit commit. Snapping back to centre the instant the reader scrolls
+one pixel would destroy the peek they just made; scrolling around within
+today's events keeps it, scrolling into tomorrow re-centres.
+
+**Suspension trigger:** `pointerdown` **and** `wheel` on the strip. A
+trackpad two-finger horizontal pan fires no pointer event and would otherwise
+be fought by the per-frame writes.
+
+## Architecture
+
+### The fraction never becomes React state
+
+A fractional anchor in `useState` would re-render `page.tsx` — the whole app
+— on every scroll frame. `useDayAnchor` keeps owning the *discrete*
+`anchorDay` exactly as today (state, `aria-current`, `Now` visibility, the
+settle hold — all untouched). The continuous value is computed in a rAF and
+written straight to three DOM properties. Zero re-renders while scrolling.
+
+### `lib/utils/railPosition.ts` (new, pure)
+
+Layout-free, so it unit-tests without jsdom.
+
+```
+resolveAnchor(keys, limit)        -> { key, nextKey, nextTop }
+rampDistance(sectionH, headerH)   -> max(headerH, min(sectionH * 0.25, 200))
+dayProgress(nextTop, limit, ramp) -> f in [0,1]
+stripScrollLeft(pillCentre, clientW, maxScroll) -> clamped
+lerp(a, b, t)
+```
+
+`useDayAnchor`'s existing section walk is replaced by a call to
+`resolveAnchor`. This is the one refactor folded in, and it is load-bearing:
+the pill and `aria-current` must never name different days, and sharing the
+walk makes that structurally impossible rather than a thing two copies happen
+to agree on. `f` reaching 1 coincides exactly with `useDayAnchor`'s flip, so
+the endpoints agree by construction.
+
+### `hooks/useRailHighlight.ts` (new)
+
+Owned by `DayRail` — no prop threading through `page.tsx`. Its own passive
+rAF-throttled scroll listener. Chip geometry (`left`/`width` per index) is
+measured in one pass and cached, recomputed only when the chip list or size
+changes. Per frame it does reads-then-writes, never interleaved, so no layout
+thrash.
+
+### DOM
+
+```
+<div ref=strip class="overflow-x-auto">                              scroller
+  <div class="relative flex gap-1 w-max">                            content
+    <div ref=pill  class="absolute bg-blue-600 rounded-md" />        z-0
+    {chips}                                                          z-10  base colours
+    <div ref=clip aria-hidden class="absolute inset-0 flex gap-1
+         text-white pointer-events-none" style="clip-path: inset()"> z-20  duplicate row
+      {chips as divs, not buttons}
+    </div>
+  </div>
+</div>
+```
+
+Both layers share one `scrollLeft`, so they cannot desync.
+
+**The pill and the clip layer live in content coordinates**, computed from
+`f` alone and never touched by `scrollLeft`. `scrollLeft` is a wholly
+separate, suspendable policy. This is what makes the peek gesture cost
+nothing to support.
+
+Per frame: `pill.style.transform`, `clip.style.clipPath`, and (unless
+suspended) `strip.scrollLeft`.
+
+The pill sits at the strip's centre until `stripScrollLeft` clamps at either
+end of the season, at which point it drifts off-centre and pins on its own —
+the ends-of-range case falls out of the same clamp rather than needing a
+branch.
+
+`bg-blue-600` comes off the anchor chip; the highlight is now the pill plus
+the clipped white copy.
+
+### Programmatic jumps
+
+Tapping a chip does an instant `window.scrollBy`, so `scrollLeft` would
+teleport across many days. When the target moves more than 1.5 days in one
+frame, tween `scrollLeft` over ~220ms ease-out instead of snapping; any
+gesture cancels it.
+
+That tween is the only self-moving animation here, so it is the only thing
+`prefers-reduced-motion` turns off. The scroll-linked motion is 1:1 with the
+reader's own gesture and stays as-is.
+
+## Testing
+
+- **Pure** (`railPosition`): ramp floor on a one-event day, clamping at both
+  ends of the season, `f` continuity across the flip.
+- **Hook** (`useRailHighlight`): stubbed rects, following the existing
+  `useDayAnchor.test.ts` pattern. Suspension on `pointerdown`/`wheel`; resume
+  on anchor change.
+- **Component** (`DayRail`): clip layer is `aria-hidden`, contains nothing
+  focusable, `aria-current` still lands on the anchor.
+- **Browser, mandatory.** Chrome on a phone viewport, with a GIF of a slow
+  drag *stopped mid-transition* showing the half-and-half chip. This is the
+  acceptance criterion and no test can reach it — phase 3a shipped eleven
+  green task reviews with a rail that did not stick.
+
+Existing rail tests assert `aria-current` and "the strip writes its own
+`scrollLeft`". Both stay true, so test churn is minimal.
+
+## Risks to verify early in the browser
+
+1. Whether `clip-path` on the absolutely-positioned layer resolves against
+   its own border box (expected) rather than the scroller's.
+2. Whether the duplicated row's ~64 extra nodes cost anything measurable on a
+   phone.
+3. Whether the browser's native axis-locking on `overflow-x-auto` keeps a
+   diagonal drag near the screen's top edge from stealing vertical page
+   scroll.
+
+## Files
+
+| File | Change |
+|---|---|
+| `frontend/src/lib/utils/railPosition.ts` | new, pure |
+| `frontend/src/hooks/useRailHighlight.ts` | new |
+| `frontend/src/hooks/useDayAnchor.ts` | swap in `resolveAnchor` |
+| `frontend/src/components/calendar/DayRail.tsx` | layers; delete the centring effect |
+| tests for each | new / updated |

--- a/frontend/e2e/verify-filter-reveal.mjs
+++ b/frontend/e2e/verify-filter-reveal.mjs
@@ -26,8 +26,27 @@ const check = (name, ok, detail) => {
 const browser = await chromium.launch();
 
 async function phone({ reducedMotion } = {}) {
+  // Chautauqua's own timezone, pinned rather than inherited from the runner.
+  //
+  // Event `startDate`s are Institution-local and carry no offset, so the app
+  // effectively treats the browser's clock as event-time. CI runs UTC, which
+  // in the afternoon Eastern means the app believes the day's programming has
+  // already ended — under the default `Now` scope today then has no upcoming
+  // events, and `11c ⟳ Now hides once back on today` fails because the anchor
+  // cannot land on today. Reproduced by A/B: this suite passes in Eastern and
+  // fails in UTC on `main` as well as on any branch, so `browser-checks` was
+  // failing for everyone after roughly 20:00 UTC and passing earlier in the
+  // day. Pinning makes every date-sensitive check here independent of the
+  // wall-clock hour and of where it is run.
+  //
+  // This pins the TEST's clock, not the app's. Whether `now` ought to be
+  // evaluated in the Institution's timezone rather than the device's is a real
+  // product question — a visitor on a non-Eastern device late in their local
+  // day sees today's events as already past — and is deliberately left alone
+  // here rather than answered by a test harness.
   const ctx = await browser.newContext({
     viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
+    timezoneId: 'America/New_York',
     ...(reducedMotion ? { reducedMotion: 'reduce' } : {}),
   });
   const page = await ctx.newPage();

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -20,7 +20,28 @@ function check(name, ok, detail) {
 const browser = await chromium.launch();
 
 async function newPage({ width = 900, height = 900, storage } = {}) {
-  const ctx = await browser.newContext({ viewport: { width, height } });
+  // Chautauqua's own timezone, pinned rather than inherited from the runner.
+  //
+  // Event `startDate`s are Institution-local and carry no offset, so the app
+  // effectively treats the browser's clock as event-time. CI runs UTC, which
+  // in the afternoon Eastern means the app believes the day's programming has
+  // already ended — under the default `Now` scope today then has no upcoming
+  // events, and `11c ⟳ Now hides once back on today` fails because the anchor
+  // cannot land on today. Reproduced by A/B: this suite passes in Eastern and
+  // fails in UTC on `main` as well as on any branch, so `browser-checks` was
+  // failing for everyone after roughly 20:00 UTC and passing earlier in the
+  // day. Pinning makes every date-sensitive check here independent of the
+  // wall-clock hour and of where it is run.
+  //
+  // This pins the TEST's clock, not the app's. Whether `now` ought to be
+  // evaluated in the Institution's timezone rather than the device's is a real
+  // product question — a visitor on a non-Eastern device late in their local
+  // day sees today's events as already past — and is deliberately left alone
+  // here rather than answered by a test harness.
+  const ctx = await browser.newContext({
+    viewport: { width, height },
+    timezoneId: 'America/New_York',
+  });
   const page = await ctx.newPage();
   if (storage) {
     await page.addInitScript(([k, v]) => localStorage.setItem(k, v), storage);

--- a/frontend/src/__tests__/components/calendar/DayRail.test.tsx
+++ b/frontend/src/__tests__/components/calendar/DayRail.test.tsx
@@ -255,9 +255,28 @@ describe('DayRail', () => {
     it('puts nothing extra in the tab order', () => {
       const { container } = renderRailIn();
       const copy = container.querySelector<HTMLElement>('[data-rail-clip]')!;
-      const focusable = Array.from(copy.querySelectorAll('button'));
-      expect(focusable.length).toBeGreaterThan(0); // it really does render chips
-      expect(focusable.every(b => b.getAttribute('tabindex') === '-1')).toBe(true);
+      expect(copy.children.length).toBeGreaterThan(0); // it really does render chips
+      expect(copy.querySelectorAll('button, a, [tabindex], [contenteditable]')).toHaveLength(0);
+    });
+
+    // Regression, caught by `e2e/verify-rail.mjs` and by nothing else. The
+    // copy's chips were `<button>` (chosen for box-metric parity) and carry
+    // no `data-chip`, which made them match the rail's own chevron selector
+    // `button:not([data-chip])`. Playwright then aimed a chevron click at
+    // inert paint and the real chip beneath intercepted it, timing out.
+    //
+    // Asserted as the selector rather than as "they are divs", because the
+    // selector is the thing that has to keep working — the e2e suite's other
+    // family, `[data-day-rail] [data-chip]`, is covered by the count guard
+    // above, and between them they pin both ways the copy could collide with
+    // a real control.
+    it('contributes nothing to the rail\'s chevron selector', () => {
+      const { container } = renderRailIn();
+      const rail = container.querySelector<HTMLElement>('[data-day-rail]')!;
+      const nonChipButtons = rail.querySelectorAll('button:not([data-chip])');
+      // The two chevrons, and nothing else. No `⟳ Now` (anchor is today) and
+      // no Filters toggle (no `filtersToggle` prop).
+      expect(nonChipButtons).toHaveLength(2);
     });
 
     it('starts fully clipped, so it cannot flash before the first measurement', () => {

--- a/frontend/src/__tests__/components/calendar/DayRail.test.tsx
+++ b/frontend/src/__tests__/components/calendar/DayRail.test.tsx
@@ -344,6 +344,22 @@ describe('DayRail', () => {
     }
   });
 
+  it('listens to nothing while it is rendering nothing', () => {
+    // With no strip, every scroll frame would schedule a rAF only for the
+    // highlight's `sync` to bail on null refs. The listeners go on when the
+    // elements do — see the scope-resolves test above.
+    const raf = vi.fn(() => 0);
+    vi.stubGlobal('requestAnimationFrame', raf);
+    try {
+      renderRailIn({ scopeHasWindow: false });
+      act(() => { window.dispatchEvent(new Event('scroll')); });
+      act(() => { window.dispatchEvent(new Event('resize')); });
+      expect(raf).not.toHaveBeenCalled();
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('renders nothing when there are no days to show', () => {
     const { container } = render(
       <DayRail chips={[]} anchorDay={null} prevDay={null} nextDay={null} scopeHasWindow todayKey={null} windowDayKeys={[]}

--- a/frontend/src/__tests__/components/calendar/DayRail.test.tsx
+++ b/frontend/src/__tests__/components/calendar/DayRail.test.tsx
@@ -291,6 +291,59 @@ describe('DayRail', () => {
     });
   });
 
+  // A returning visitor with `'this-week'` restored from localStorage while
+  // the current date is off-season gets `scopeHasWindow === false`, so the
+  // rail renders nothing on its very first commit — chips and all. The
+  // highlight's listeners must still find the strip when it appears later.
+  //
+  // This is a distinct route to the same null render as "events have not
+  // loaded yet", and the one a real reader actually hits. It is also why the
+  // hook keys its listener effect on the elements rather than on
+  // `chips.length > 0`: chips are non-empty here throughout, so a chip-count
+  // signal would never flip and the listeners would never attach.
+  it('attaches the highlight to a strip that appears only after the scope resolves', () => {
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0; });
+    try {
+      const { container, rerender } = renderRailIn({ scopeHasWindow: false });
+      expect(container.querySelector('[data-rail-strip]')).toBeNull();
+
+      act(() => {
+        rerender(
+          <DayRail
+            chips={chips} anchorDay="2026-07-05" prevDay="2026-07-04" nextDay={null}
+            scopeHasWindow todayKey="2026-07-05"
+            windowDayKeys={['2026-07-04', '2026-07-05', '2026-07-06']}
+            onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()}
+          />
+        );
+      });
+
+      const strip = container.querySelector<HTMLElement>('[data-rail-strip]')!;
+      const writes: number[] = [];
+      let value = 0;
+      Object.defineProperty(strip, 'scrollLeft', {
+        configurable: true,
+        get: () => value,
+        set: (v: number) => { value = v; writes.push(v); },
+      });
+
+      act(() => { window.dispatchEvent(new Event('scroll')); });
+      expect(writes.length).toBeGreaterThan(0); // the highlight is driving it
+
+      // The reader pans the strip. This is only detectable if the strip's own
+      // scroll listener attached to the element that appeared after mount.
+      act(() => {
+        strip.scrollLeft = 500;
+        strip.dispatchEvent(new Event('scroll'));
+      });
+      writes.length = 0;
+      act(() => { window.dispatchEvent(new Event('scroll')); });
+      expect(writes).toEqual([]);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
   it('renders nothing when there are no days to show', () => {
     const { container } = render(
       <DayRail chips={[]} anchorDay={null} prevDay={null} nextDay={null} scopeHasWindow todayKey={null} windowDayKeys={[]}

--- a/frontend/src/__tests__/components/calendar/DayRail.test.tsx
+++ b/frontend/src/__tests__/components/calendar/DayRail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/preact';
+import { render, screen, fireEvent, act } from '@testing-library/preact';
 import { DayRail } from '@/components/calendar/DayRail';
 import { dayChips } from '@/lib/utils/dayWindow';
 
@@ -15,11 +15,25 @@ function renderRail(overrides: Partial<Parameters<typeof DayRail>[0]> = {}) {
   const props = {
     chips, anchorDay: '2026-07-05', prevDay: '2026-07-04', nextDay: null as string | null,
     scopeHasWindow: true, todayKey: '2026-07-05',
+    windowDayKeys: ['2026-07-04', '2026-07-05', '2026-07-06'],
     onSelectDay: vi.fn(), onStepDay: vi.fn(), onGoToToday: vi.fn(),
     ...overrides,
   };
   render(<DayRail {...props} />);
   return props;
+}
+
+/** As `renderRail`, but returning the container for the layer queries below. */
+function renderRailIn(overrides: Partial<Parameters<typeof DayRail>[0]> = {}) {
+  return render(
+    <DayRail
+      chips={chips} anchorDay="2026-07-05" prevDay="2026-07-04" nextDay={null}
+      scopeHasWindow todayKey="2026-07-05"
+      windowDayKeys={['2026-07-04', '2026-07-05', '2026-07-06']}
+      onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()}
+      {...overrides}
+    />
+  );
 }
 
 // The day chip that carries `key`. Queried by `data-chip` rather than by
@@ -206,15 +220,61 @@ describe('DayRail', () => {
   it('renders nothing when the scope resolves to no window at all', () => {
     const { container } = render(
       <DayRail chips={chips} anchorDay={null} prevDay={null} nextDay={null}
-        scopeHasWindow={false} todayKey={null}
+        scopeHasWindow={false} todayKey={null} windowDayKeys={[]}
         onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()} />
     );
     expect(container.firstChild).toBeNull();
   });
 
+  // The highlight is painted by duplicating the whole chip row in the
+  // highlighted colour and clipping it to the pill. That copy is paint: it
+  // must not be announced, must not be reachable, and must not be clickable,
+  // or the rail silently doubles every day for a screen-reader or keyboard
+  // reader.
+  describe('the highlighted copy of the row', () => {
+    it('is hidden from assistive technology', () => {
+      const { container } = renderRailIn();
+      const copy = container.querySelector<HTMLElement>('[data-rail-clip]')!;
+      expect(copy.getAttribute('aria-hidden')).toBe('true');
+      expect(copy.className).toContain('pointer-events-none');
+    });
+
+    it('adds no announced buttons', () => {
+      renderRail();
+      // Every button the rail exposes, counted outright: 3 day chips + 2
+      // chevrons. No `⟳ Now` (the anchor already is today) and no Filters
+      // toggle (no `filtersToggle` prop).
+      //
+      // Deliberately NOT filtered to `[data-chip]`: the copy's chips carry
+      // no `data-chip`, so such a filter would exclude exactly the elements
+      // this test exists to catch and could never fail. Falsified by
+      // removing `aria-hidden` from the copy, which takes this to 8.
+      expect(screen.getAllByRole('button')).toHaveLength(5);
+    });
+
+    it('puts nothing extra in the tab order', () => {
+      const { container } = renderRailIn();
+      const copy = container.querySelector<HTMLElement>('[data-rail-clip]')!;
+      const focusable = Array.from(copy.querySelectorAll('button'));
+      expect(focusable.length).toBeGreaterThan(0); // it really does render chips
+      expect(focusable.every(b => b.getAttribute('tabindex') === '-1')).toBe(true);
+    });
+
+    it('starts fully clipped, so it cannot flash before the first measurement', () => {
+      const { container } = renderRailIn();
+      const copy = container.querySelector<HTMLElement>('[data-rail-clip]')!;
+      const pill = container.querySelector<HTMLElement>('[data-rail-pill]')!;
+      // jsdom runs the layout effect against zero-size rects, so the pill
+      // settles at zero width rather than staying at the initial opacity 0 —
+      // what matters here is that neither starts painted across the row.
+      expect(pill.style.width === '' || pill.style.width === '0px').toBe(true);
+      expect(copy.style.clipPath).toMatch(/^inset\(/);
+    });
+  });
+
   it('renders nothing when there are no days to show', () => {
     const { container } = render(
-      <DayRail chips={[]} anchorDay={null} prevDay={null} nextDay={null} scopeHasWindow todayKey={null}
+      <DayRail chips={[]} anchorDay={null} prevDay={null} nextDay={null} scopeHasWindow todayKey={null} windowDayKeys={[]}
         onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()} />
     );
     expect(container.firstChild).toBeNull();
@@ -228,19 +288,33 @@ describe('DayRail', () => {
   // `scrollIntoView` is never called, and the strip's own `scrollLeft` is
   // written, which is the only kind of scroll this control is allowed to
   // cause.
+  //
+  // The trigger moved with the scroll-linked highlight: the strip used to be
+  // repositioned by an effect on `anchorDay`, and is now repositioned on
+  // scroll, continuously. The property being guarded did not move, so this
+  // test drives it the new way rather than being retired — a rail that
+  // reached for `scrollIntoView` again would still be the same defect.
+  // Geometry lives in `useRailHighlight.test.tsx`, which states it.
   it('keeps the anchor chip in view by moving the strip, never by scrolling the page', () => {
     const scrollIntoView = vi.fn();
     const original = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = scrollIntoView;
+    // The highlight measures inside a rAF, which jsdom defers to a timer, so
+    // an unstubbed frame lands after this test's assertions. Returning 0 is
+    // required: the hook throttles with `if (frame) return; frame = rAF(...)`
+    // and an inline callback clears `frame` before that assignment, so a
+    // truthy handle would be written back afterwards and latch the throttle
+    // shut. Real rAF assigns before the callback runs and is unaffected.
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0; });
     try {
-      const { rerender } = render(
-        <DayRail chips={chips} anchorDay="2026-07-04" prevDay={null} nextDay="2026-07-05" scopeHasWindow todayKey="2026-07-05"
+      const { container } = render(
+        <DayRail chips={chips} anchorDay="2026-07-04" prevDay={null} nextDay="2026-07-05" scopeHasWindow todayKey="2026-07-05" windowDayKeys={['2026-07-04', '2026-07-05', '2026-07-06']}
           onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()} />
       );
-      // Stubbed only after mount: the effect that centres the *initial*
-      // anchor has already run by the time `render()` returns, so the
-      // rerender below is what re-triggers it under observation.
-      const strip = chipButton('2026-07-04').parentElement as HTMLElement;
+      // Stubbed only after mount: the layout effect that places the initial
+      // highlight has already run by the time `render()` returns, so the
+      // scroll below is what re-triggers it under observation.
+      const strip = container.querySelector<HTMLElement>('[data-rail-strip]')!;
       const scrollLeftWrites: number[] = [];
       Object.defineProperty(strip, 'scrollLeft', {
         configurable: true,
@@ -248,15 +322,13 @@ describe('DayRail', () => {
         set: (v: number) => { scrollLeftWrites.push(v); },
       });
 
-      rerender(
-        <DayRail chips={chips} anchorDay="2026-07-06" prevDay="2026-07-05" nextDay={null} scopeHasWindow todayKey="2026-07-05"
-          onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()} />
-      );
+      act(() => { window.dispatchEvent(new Event('scroll')); });
 
       expect(scrollIntoView).not.toHaveBeenCalled();
       expect(scrollLeftWrites.length).toBeGreaterThan(0);
     } finally {
       Element.prototype.scrollIntoView = original;
+      vi.unstubAllGlobals();
     }
   });
 
@@ -270,7 +342,7 @@ describe('DayRail', () => {
   it('gives rootRef the same element that is data-day-rail and sticky — no wrapper', () => {
     const ref: { current: HTMLElement | null } = { current: null };
     render(
-      <DayRail chips={chips} anchorDay="2026-07-05" prevDay="2026-07-04" nextDay={null} scopeHasWindow todayKey="2026-07-05"
+      <DayRail chips={chips} anchorDay="2026-07-05" prevDay="2026-07-04" nextDay={null} scopeHasWindow todayKey="2026-07-05" windowDayKeys={['2026-07-04', '2026-07-05', '2026-07-06']}
         onSelectDay={vi.fn()} onStepDay={vi.fn()} onGoToToday={vi.fn()}
         rootRef={(el) => { ref.current = el; }} />
     );

--- a/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
+++ b/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
@@ -233,22 +233,38 @@ describe('useRailHighlight', () => {
   });
 
   describe('peeking', () => {
-    it('stops driving the strip once the reader takes hold of it', () => {
+    /** The reader moves the strip themselves, and the browser fires `scroll`. */
+    function readerPans(strip: HTMLElement, to: number) {
+      act(() => {
+        strip.scrollLeft = to;
+        strip.dispatchEvent(new Event('scroll'));
+      });
+    }
+
+    it('stops driving the strip once the reader has moved it', () => {
       const { strip } = mount(atRest);
       scroll();
+      readerPans(strip, 500);
       scrollWrites.length = 0;
-      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
       scroll();
       expect(scrollWrites).toEqual([]);
     });
 
-    it('stops driving the strip on a trackpad pan, which fires no pointer event', () => {
+    // Browser-measured regression. Suspending on `wheel`/`pointerdown` over
+    // the strip also caught a plain vertical page scroll with the pointer
+    // resting on the rail — which on a phone is exactly where the rail is.
+    // One vertical wheel then 120px of page scroll moved the strip 0px.
+    it('keeps driving the strip through a page scroll that merely passed over the rail', () => {
       const { strip } = mount(atRest);
       scroll();
+      act(() => {
+        strip.dispatchEvent(new WheelEvent('wheel', { deltaY: 120, deltaX: 0 }));
+        strip.dispatchEvent(new Event('pointerdown'));
+      });
       scrollWrites.length = 0;
-      act(() => { strip.dispatchEvent(new Event('wheel')); });
       scroll();
-      expect(scrollWrites).toEqual([]);
+      // Neither event moved the strip, so neither is a peek.
+      expect(scrollWrites.length).toBeGreaterThan(0);
     });
 
     it('keeps the pill glued to its day while the reader peeks', () => {
@@ -256,7 +272,7 @@ describe('useRailHighlight', () => {
       // being read, rather than catching whichever chip is dragged under it.
       const { strip, pill } = mount(atRest);
       scroll();
-      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      readerPans(strip, 500);
       scroll();
       expect(pillLeft(pill)).toBe(PITCH);
       expect(pill.style.opacity).toBe('1');
@@ -269,7 +285,7 @@ describe('useRailHighlight', () => {
       };
       const { strip } = mount(spec);
       scroll();
-      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      readerPans(strip, 500);
       scrollWrites.length = 0;
       // Still on d2 — the peek survives scrolling around within the day.
       scroll();
@@ -285,7 +301,7 @@ describe('useRailHighlight', () => {
       // else would hand the strip back.
       const { strip, api } = mount(atRest);
       scroll();
-      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      readerPans(strip, 500);
       scrollWrites.length = 0;
       act(() => { api().resume(); });
       scroll();

--- a/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
+++ b/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
@@ -26,10 +26,21 @@ interface LayoutSpec {
   clientWidth?: number;
 }
 
+/**
+ * The genuine implementation, captured once at module load.
+ *
+ * `installLayout` runs per `mount()`, and reading the "original" off the
+ * prototype at that point would capture the previous *stub* — seventeen
+ * mounts would nest seventeen stubs, each delegating to the last. Holding the
+ * real one here keeps the fallback one call deep and gives `afterEach`
+ * something true to restore, so the stub cannot leak into other test files
+ * sharing this worker.
+ */
+const REAL_RECT = Element.prototype.getBoundingClientRect;
+
 function installLayout(spec: LayoutSpec) {
   const contentWidth = spec.chips.length * PITCH;
   const chipLeft = (key: string) => spec.chips.indexOf(key) * PITCH;
-  const original = Element.prototype.getBoundingClientRect;
 
   Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
     const el = this as HTMLElement;
@@ -53,7 +64,7 @@ function installLayout(spec: LayoutSpec) {
       const key = owner?.getAttribute(DAY_SECTION_ATTR) ?? '';
       return { top: 0, height: spec.sections[key]?.headerHeight ?? 36, left: 0, width: 400 } as DOMRect;
     }
-    return original.call(this);
+    return REAL_RECT.call(this);
   };
 
   document.documentElement.style.setProperty('--day-rail-h', `${RAIL_H}px`);
@@ -72,6 +83,8 @@ function Harness({ chips, windowDayKeys, onApi }: {
 }) {
   const api = useRailHighlight(chips, windowDayKeys);
   onApi(api);
+  // Mirrors `DayRail`, which returns null until it has days to show.
+  if (chips.length === 0) return null;
   return (
     <div ref={api.stripRef} data-rail-strip>
       <div ref={api.contentRef} data-rail-content>
@@ -83,16 +96,29 @@ function Harness({ chips, windowDayKeys, onApi }: {
   );
 }
 
-function mount(spec: LayoutSpec, windowDayKeys?: string[]) {
+function mount(spec: LayoutSpec, windowDayKeys?: string[], startEmpty = false) {
   installLayout(spec);
   let api!: RailHighlight;
   const utils = render(
     <Harness
-      chips={spec.chips}
-      windowDayKeys={windowDayKeys ?? Object.keys(spec.sections)}
+      chips={startEmpty ? [] : spec.chips}
+      windowDayKeys={startEmpty ? [] : (windowDayKeys ?? Object.keys(spec.sections))}
       onApi={(a) => { api = a; }}
     />
   );
+  if (startEmpty) {
+    // The real load order: `DayRail` renders nothing until events arrive, so
+    // the strip and its content do not exist on the first mount.
+    act(() => {
+      utils.rerender(
+        <Harness
+          chips={spec.chips}
+          windowDayKeys={windowDayKeys ?? Object.keys(spec.sections)}
+          onApi={(a) => { api = a; }}
+        />
+      );
+    });
+  }
   const strip = utils.container.querySelector<HTMLElement>('[data-rail-strip]')!;
   // jsdom reports 0 for all three and ignores writes to scrollLeft.
   Object.defineProperty(strip, 'clientWidth', { value: spec.clientWidth ?? 240, configurable: true });
@@ -141,6 +167,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  Element.prototype.getBoundingClientRect = REAL_RECT;
   document.body.innerHTML = '';
   document.documentElement.style.removeProperty('--day-rail-h');
   vi.unstubAllGlobals();
@@ -325,6 +352,27 @@ describe('useRailHighlight', () => {
       scroll();
       expect(scrollWrites.length).toBeGreaterThan(0);
     });
+  });
+
+  // The strip does not exist on the first mount — `DayRail` renders nothing
+  // until events have loaded. A listener effect scoped to mount would attach
+  // nothing and never re-run, leaving peek detection dead in production while
+  // every other test here, which mounts with chips already present, passed.
+  it('attaches its listeners to elements that appear after the first mount', () => {
+    const spec: LayoutSpec = {
+      chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+      sections: { d1: { top: -900 }, d2: { top: -100 }, d3: { top: 700 } },
+    };
+    const { strip } = mount(spec, undefined, /* startEmpty */ true);
+    scroll();
+    // A peek is only detectable if the strip's own scroll listener attached.
+    act(() => {
+      strip.scrollLeft = 500;
+      strip.dispatchEvent(new Event('scroll'));
+    });
+    scrollWrites.length = 0;
+    scroll();
+    expect(scrollWrites).toEqual([]);
   });
 
   describe('catching up after a jump', () => {

--- a/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
+++ b/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
@@ -296,6 +296,24 @@ describe('useRailHighlight', () => {
       expect(scrollWrites.length).toBeGreaterThan(0);
     });
 
+    // `resume` has to re-baseline, not just clear the flag. A `scroll` event
+    // still in flight from the reader's pan is delivered after the click that
+    // called `resume`, and compares the strip's position against whatever we
+    // last wrote — which is not where the reader left it. Without the
+    // re-baseline that comparison diverges and re-suspends immediately,
+    // silently undoing the resume.
+    it('survives a scroll event still in flight from the pan it just lifted', () => {
+      const { strip, api } = mount(atRest);
+      scroll();
+      readerPans(strip, 500);
+      act(() => { api().resume(); });
+      // The straggler: same position, dispatched after resume.
+      act(() => { strip.dispatchEvent(new Event('scroll')); });
+      scrollWrites.length = 0;
+      scroll();
+      expect(scrollWrites.length).toBeGreaterThan(0);
+    });
+
     it('lifts the peek on an explicit commit to the day already being read', () => {
       // Tapping the current day's own chip changes no anchor, so nothing
       // else would hand the strip back.

--- a/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
+++ b/frontend/src/__tests__/hooks/useRailHighlight.test.tsx
@@ -1,0 +1,330 @@
+import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
+import { render, act } from '@testing-library/preact';
+import { useRailHighlight, type RailHighlight } from '@/hooks/useRailHighlight';
+import { DAY_SECTION_ATTR, DAY_HEADER_ATTR } from '@/lib/utils/daySections';
+import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
+
+/**
+ * jsdom has no layout, so every measurement this hook makes has to be stated
+ * outright. A test that skipped this would pass on all-zero rects whether or
+ * not the hook worked — which is exactly how the rail shipped a highlight
+ * that never moved.
+ *
+ * Chips are laid out on a 48px pitch (44px wide, 4px gap), matching the real
+ * `min-w-11 gap-1` row.
+ */
+const CHIP_W = 44;
+const PITCH = 48;
+const RAIL_H = 60;
+
+interface LayoutSpec {
+  /** Viewport-relative top per day section, plus that section's own height. */
+  sections: Record<string, { top: number; height?: number; headerHeight?: number }>;
+  /** Chip keys in row order; extents are derived from the pitch. */
+  chips: string[];
+  /** The strip's visible width. */
+  clientWidth?: number;
+}
+
+function installLayout(spec: LayoutSpec) {
+  const contentWidth = spec.chips.length * PITCH;
+  const chipLeft = (key: string) => spec.chips.indexOf(key) * PITCH;
+  const original = Element.prototype.getBoundingClientRect;
+
+  Element.prototype.getBoundingClientRect = function (this: Element): DOMRect {
+    const el = this as HTMLElement;
+    const chip = el.dataset?.chip;
+    if (chip && spec.chips.includes(chip)) {
+      // Content coordinates are `chipRect.left - contentRect.left`, so an
+      // arbitrary non-zero content origin is used deliberately: a stub with
+      // the content at 0 would let a hook that forgot to subtract still pass.
+      return { left: 1000 + chipLeft(chip), width: CHIP_W, top: 0, height: 50 } as DOMRect;
+    }
+    if (el.hasAttribute?.('data-rail-content')) {
+      return { left: 1000, width: contentWidth, top: 0, height: 50 } as DOMRect;
+    }
+    const sectionKey = el.getAttribute?.(DAY_SECTION_ATTR);
+    if (sectionKey && spec.sections[sectionKey]) {
+      const s = spec.sections[sectionKey];
+      return { top: s.top, height: s.height ?? 800, left: 0, width: 400 } as DOMRect;
+    }
+    if (el.hasAttribute?.(DAY_HEADER_ATTR)) {
+      const owner = el.closest(`[${DAY_SECTION_ATTR}]`);
+      const key = owner?.getAttribute(DAY_SECTION_ATTR) ?? '';
+      return { top: 0, height: spec.sections[key]?.headerHeight ?? 36, left: 0, width: 400 } as DOMRect;
+    }
+    return original.call(this);
+  };
+
+  document.documentElement.style.setProperty('--day-rail-h', `${RAIL_H}px`);
+  document.body.innerHTML = Object.keys(spec.sections)
+    .map(k => `<div ${DAY_SECTION_ATTR}="${k}"><div ${DAY_HEADER_ATTR}></div></div>`)
+    .join('');
+}
+
+/** Captured `scrollLeft` writes — jsdom's own is not a real scroll position. */
+let scrollWrites: number[] = [];
+
+function Harness({ chips, windowDayKeys, onApi }: {
+  chips: string[];
+  windowDayKeys: string[];
+  onApi: (api: RailHighlight) => void;
+}) {
+  const api = useRailHighlight(chips, windowDayKeys);
+  onApi(api);
+  return (
+    <div ref={api.stripRef} data-rail-strip>
+      <div ref={api.contentRef} data-rail-content>
+        <div ref={api.pillRef} data-rail-pill />
+        {chips.map(k => <button key={k} type="button" data-chip={k} />)}
+        <div ref={api.clipRef} data-rail-clip />
+      </div>
+    </div>
+  );
+}
+
+function mount(spec: LayoutSpec, windowDayKeys?: string[]) {
+  installLayout(spec);
+  let api!: RailHighlight;
+  const utils = render(
+    <Harness
+      chips={spec.chips}
+      windowDayKeys={windowDayKeys ?? Object.keys(spec.sections)}
+      onApi={(a) => { api = a; }}
+    />
+  );
+  const strip = utils.container.querySelector<HTMLElement>('[data-rail-strip]')!;
+  // jsdom reports 0 for all three and ignores writes to scrollLeft.
+  Object.defineProperty(strip, 'clientWidth', { value: spec.clientWidth ?? 240, configurable: true });
+  Object.defineProperty(strip, 'scrollWidth', { value: spec.chips.length * PITCH, configurable: true });
+  let scrollLeft = 0;
+  Object.defineProperty(strip, 'scrollLeft', {
+    configurable: true,
+    get: () => scrollLeft,
+    set: (v: number) => { scrollLeft = v; scrollWrites.push(v); },
+  });
+  return {
+    api: () => api,
+    strip,
+    pill: utils.container.querySelector<HTMLElement>('[data-rail-pill]')!,
+    clip: utils.container.querySelector<HTMLElement>('[data-rail-clip]')!,
+  };
+}
+
+function scroll() {
+  act(() => { window.dispatchEvent(new Event('scroll')); });
+}
+
+/** The pill's content-coordinate left, read back off the written transform. */
+function pillLeft(pill: HTMLElement): number {
+  const m = /translateX\(([-\d.]+)px\)/.exec(pill.style.transform);
+  return m ? Number.parseFloat(m[1]) : Number.NaN;
+}
+
+beforeEach(() => {
+  installResizeObserverMock();
+  scrollWrites = [];
+  // rAF runs inline so a dispatched scroll is measured within the same act().
+  //
+  // It must return 0. The hook throttles with `if (frame) return; frame =
+  // requestAnimationFrame(...)`, and an inline rAF runs the callback — which
+  // clears `frame` — *before* the assignment, so any truthy handle would be
+  // written back afterwards and latch the throttle shut for the rest of the
+  // test. Real rAF is asynchronous and assigns before the callback runs, so
+  // this is an artefact of running it inline, not a defect in the hook.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => { cb(0); return 0; });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+  // Reduced motion by default, so the catch-up tween resolves to a single
+  // assignment and the geometry assertions below are not racing an easing
+  // curve. The tween itself is covered explicitly at the end of this file.
+  vi.stubGlobal('matchMedia', () => ({ matches: true, addEventListener() {}, removeEventListener() {} }));
+});
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  document.documentElement.style.removeProperty('--day-rail-h');
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('useRailHighlight', () => {
+  // d2 is the anchor (top above the rail); d3 is 700px away, well beyond any
+  // ramp, so the handover has not begun.
+  const atRest: LayoutSpec = {
+    chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+    sections: { d1: { top: -900 }, d2: { top: -100 }, d3: { top: 700 } },
+  };
+
+  it('places the pill exactly on the anchor chip when no handover is in flight', () => {
+    const { pill } = mount(atRest);
+    scroll();
+    expect(pillLeft(pill)).toBe(PITCH); // d2 is index 1
+    expect(pill.style.width).toBe(`${CHIP_W}px`);
+    expect(pill.style.opacity).toBe('1');
+  });
+
+  it('clips the highlighted copy to exactly the pill', () => {
+    const { pill, clip } = mount(atRest);
+    scroll();
+    const left = pillLeft(pill);
+    const right = atRest.chips.length * PITCH - (left + CHIP_W);
+    expect(clip.style.clipPath).toBe(`inset(0 ${right}px 0 ${left}px)`);
+  });
+
+  it('centres the anchor chip in the strip', () => {
+    const { strip } = mount(atRest);
+    scroll();
+    // d2's centre is 48 + 22 = 70; centring it in a 240 strip wants -50,
+    // which clamps to 0 at the start of the season.
+    expect(strip.scrollLeft).toBe(0);
+  });
+
+  it('slides the pill between two chips part-way through the handover', () => {
+    // d3's section is 800 tall, so the ramp is 200. With d3's top 160 above
+    // the limit's 61, 99 of that 200 remains → just past halfway.
+    const { pill } = mount({
+      chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+      sections: { d1: { top: -900 }, d2: { top: -100, height: 800 }, d3: { top: 161 } },
+    });
+    scroll();
+    // ramp 200, remaining 161 - 61 = 100 → progress 0.5 → halfway between
+    // chip d2 (48) and chip d3 (96).
+    expect(pillLeft(pill)).toBeCloseTo(72, 5);
+  });
+
+  it('lands the pill on the next chip exactly as the handover completes', () => {
+    const { pill } = mount({
+      chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+      sections: { d1: { top: -900 }, d2: { top: -100, height: 800 }, d3: { top: 61 } },
+    });
+    scroll();
+    // progress 1 on d2 puts the pill on d3's chip — the same place the very
+    // next frame will put it once resolveAnchor flips. That coincidence is
+    // what makes the motion continuous rather than merely smooth either side.
+    expect(pillLeft(pill)).toBe(2 * PITCH);
+  });
+
+  it('holds the pill still while the reader is inside a long day', () => {
+    const { pill } = mount({
+      chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+      sections: { d1: { top: -900 }, d2: { top: -2000, height: 4000 }, d3: { top: 1800 } },
+    });
+    scroll();
+    expect(pillLeft(pill)).toBe(PITCH);
+  });
+
+  it('lets the pill sit off-centre at the end of the season', () => {
+    const { strip, pill } = mount({
+      chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+      sections: { d1: { top: -900 }, d6: { top: -100 } },
+    }, ['d1', 'd6']);
+    scroll();
+    // d6's centre is 5*48 + 22 = 262; centring wants 142, but maxScroll is
+    // 288 - 240 = 48, so the strip stops and the pill drifts right of centre.
+    expect(strip.scrollLeft).toBe(48);
+    expect(pillLeft(pill)).toBe(5 * PITCH);
+  });
+
+  it('blanks the highlight when no day is resolvable', () => {
+    const { pill, clip } = mount({ chips: ['d1', 'd2'], sections: {} }, []);
+    scroll();
+    expect(pill.style.opacity).toBe('0');
+    expect(clip.style.clipPath).toBe('inset(0 100% 0 0)');
+  });
+
+  describe('peeking', () => {
+    it('stops driving the strip once the reader takes hold of it', () => {
+      const { strip } = mount(atRest);
+      scroll();
+      scrollWrites.length = 0;
+      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      scroll();
+      expect(scrollWrites).toEqual([]);
+    });
+
+    it('stops driving the strip on a trackpad pan, which fires no pointer event', () => {
+      const { strip } = mount(atRest);
+      scroll();
+      scrollWrites.length = 0;
+      act(() => { strip.dispatchEvent(new Event('wheel')); });
+      scroll();
+      expect(scrollWrites).toEqual([]);
+    });
+
+    it('keeps the pill glued to its day while the reader peeks', () => {
+      // The whole point of the peek: the highlight still reports the day
+      // being read, rather than catching whichever chip is dragged under it.
+      const { strip, pill } = mount(atRest);
+      scroll();
+      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      scroll();
+      expect(pillLeft(pill)).toBe(PITCH);
+      expect(pill.style.opacity).toBe('1');
+    });
+
+    it('lifts the peek once the reader scrolls into a different day', () => {
+      const spec: LayoutSpec = {
+        chips: ['d1', 'd2', 'd3', 'd4', 'd5', 'd6'],
+        sections: { d1: { top: -900 }, d2: { top: -100 }, d3: { top: 700 } },
+      };
+      const { strip } = mount(spec);
+      scroll();
+      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      scrollWrites.length = 0;
+      // Still on d2 — the peek survives scrolling around within the day.
+      scroll();
+      expect(scrollWrites).toEqual([]);
+      // Now d3 has passed the rail, so the anchor changes and the peek ends.
+      spec.sections.d3.top = -50;
+      scroll();
+      expect(scrollWrites.length).toBeGreaterThan(0);
+    });
+
+    it('lifts the peek on an explicit commit to the day already being read', () => {
+      // Tapping the current day's own chip changes no anchor, so nothing
+      // else would hand the strip back.
+      const { strip, api } = mount(atRest);
+      scroll();
+      act(() => { strip.dispatchEvent(new Event('pointerdown')); });
+      scrollWrites.length = 0;
+      act(() => { api().resume(); });
+      scroll();
+      expect(scrollWrites.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('catching up after a jump', () => {
+    it('eases rather than teleporting when the strip is far out of position', () => {
+      vi.stubGlobal('matchMedia', () => ({ matches: false, addEventListener() {}, removeEventListener() {} }));
+      let now = 0;
+      vi.spyOn(performance, 'now').mockImplementation(() => now);
+      // rAF that advances the clock, so the easing terminates.
+      vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        now += 40;
+        cb(now);
+        return 0; // see the note in beforeEach
+      });
+      // Anchor far along the rail, so centring wants a large scrollLeft.
+      const { strip } = mount({
+        chips: Array.from({ length: 40 }, (_, i) => `c${i}`),
+        sections: { c0: { top: -900 }, c30: { top: -100 } },
+      }, ['c0', 'c30']);
+      scroll();
+      // Intermediate positions were written, not one assignment.
+      expect(scrollWrites.length).toBeGreaterThan(2);
+      expect(strip.scrollLeft).toBe(30 * PITCH + CHIP_W / 2 - 120);
+    });
+
+    it('teleports instead of easing under prefers-reduced-motion', () => {
+      // matchMedia already reports reduced motion in this file's default
+      // setup — this asserts that is what produces the single write.
+      const { strip } = mount({
+        chips: Array.from({ length: 40 }, (_, i) => `c${i}`),
+        sections: { c0: { top: -900 }, c30: { top: -100 } },
+      }, ['c0', 'c30']);
+      scroll();
+      expect(scrollWrites).toEqual([30 * PITCH + CHIP_W / 2 - 120]);
+      expect(strip.scrollLeft).toBe(30 * PITCH + CHIP_W / 2 - 120);
+    });
+  });
+});

--- a/frontend/src/__tests__/lib/utils/railPosition.test.ts
+++ b/frontend/src/__tests__/lib/utils/railPosition.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveAnchor,
+  rampDistance,
+  dayProgress,
+  stripScrollLeft,
+  pillGeometry,
+  lerp,
+  RAMP_MAX_PX,
+  RAMP_SECTION_FRACTION,
+} from '@/lib/utils/railPosition';
+
+/**
+ * A `topOf` lookup backed by a plain map, so these tests describe geometry
+ * without a DOM. A key absent from the map stands for a day inside the view
+ * window whose section is not mounted — the render window's subset is
+ * smaller than the view window's day list, which is the case
+ * `daySectionElement` returning null covers in the real hook.
+ */
+function tops(map: Record<string, number>) {
+  return (key: string) => (key in map ? map[key] : null);
+}
+
+describe('resolveAnchor', () => {
+  const keys = ['d1', 'd2', 'd3', 'd4'];
+
+  it('returns null when there are no days', () => {
+    expect(resolveAnchor([], 60, tops({}))).toBeNull();
+  });
+
+  it('keeps the last day whose top has passed the limit, and names the next', () => {
+    // d1 and d2 are above the line, d3 is still below it.
+    const at = resolveAnchor(keys, 60, tops({ d1: -900, d2: -200, d3: 400, d4: 1500 }));
+    expect(at).toEqual({ key: 'd2', nextKey: 'd3', nextTop: 400 });
+  });
+
+  it('treats a top exactly at the limit as passed', () => {
+    const at = resolveAnchor(keys, 60, tops({ d1: -900, d2: 60, d3: 400 }));
+    expect(at?.key).toBe('d2');
+  });
+
+  it('falls back to the first day before anything has scrolled past', () => {
+    // Nothing has passed the line, so the reader is plainly at the top of the
+    // list. There is no handover in progress, so no next day and no ramp —
+    // without this, `nextKey` would be d1 itself and progress would be
+    // computed between a day and itself.
+    const at = resolveAnchor(keys, 60, tops({ d1: 300, d2: 1200 }));
+    expect(at).toEqual({ key: 'd1', nextKey: null, nextTop: null });
+  });
+
+  it('reports no next day once the last mounted section has passed', () => {
+    const at = resolveAnchor(keys, 60, tops({ d1: -2000, d2: -1200, d3: -400 }));
+    expect(at).toEqual({ key: 'd3', nextKey: null, nextTop: null });
+  });
+
+  it('skips days that are in the window but not mounted', () => {
+    // d2 and d3 have no section yet; the handover in flight is d1 -> d4.
+    const at = resolveAnchor(keys, 60, tops({ d1: -300, d4: 500 }));
+    expect(at).toEqual({ key: 'd1', nextKey: 'd4', nextTop: 500 });
+  });
+
+  it('does not let an unmounted first day strand the anchor', () => {
+    const at = resolveAnchor(keys, 60, tops({ d2: -300, d3: 500 }));
+    expect(at).toEqual({ key: 'd2', nextKey: 'd3', nextTop: 500 });
+  });
+});
+
+describe('rampDistance', () => {
+  it('spans a quarter of an ordinary day section', () => {
+    expect(rampDistance(600, 36)).toBe(600 * RAMP_SECTION_FRACTION);
+  });
+
+  it('caps at RAMP_MAX_PX so a very long day does not ramp forever', () => {
+    expect(rampDistance(10_000, 36)).toBe(RAMP_MAX_PX);
+  });
+
+  it('never drops below the header height, so a one-event day still hands over', () => {
+    // A quarter of 80px is 20px, which is shorter than the header itself —
+    // the ramp would finish before the title had begun to move.
+    expect(rampDistance(80, 36)).toBe(36);
+  });
+
+  it('survives an unmeasured section', () => {
+    expect(rampDistance(0, 36)).toBe(36);
+    expect(rampDistance(Number.NaN, 36)).toBe(36);
+  });
+
+  it('returns 0 when nothing has been measured at all', () => {
+    // Both inputs unmeasured — `dayProgress` treats a zero ramp as "no
+    // handover in progress" rather than dividing by it.
+    expect(rampDistance(0, 0)).toBe(0);
+  });
+});
+
+describe('dayProgress', () => {
+  it('is 0 while the next day is further away than the ramp', () => {
+    expect(dayProgress(1000, 60, 200)).toBe(0);
+    // Exactly at the start of the ramp.
+    expect(dayProgress(260, 60, 200)).toBe(0);
+  });
+
+  it('rises linearly across the ramp', () => {
+    expect(dayProgress(160, 60, 200)).toBeCloseTo(0.5);
+    expect(dayProgress(110, 60, 200)).toBeCloseTo(0.75);
+  });
+
+  it('reaches 1 exactly as the next day meets the limit', () => {
+    // This is the instant `resolveAnchor` flips to the next day, which is
+    // what makes the value continuous across the handover: progress hits 1
+    // on the old anchor in the same frame it would restart at 0 on the new
+    // one.
+    expect(dayProgress(60, 60, 200)).toBe(1);
+  });
+
+  it('clamps rather than overshooting if the flip is measured a frame late', () => {
+    expect(dayProgress(-40, 60, 200)).toBe(1);
+  });
+
+  it('is 0 when there is no ramp to travel', () => {
+    expect(dayProgress(100, 60, 0)).toBe(0);
+    expect(dayProgress(100, 60, -5)).toBe(0);
+  });
+});
+
+describe('stripScrollLeft', () => {
+  it('centres the pill in the strip', () => {
+    expect(stripScrollLeft(500, 300, 2000)).toBe(350);
+  });
+
+  it('clamps at the start of the season, letting the pill sit left of centre', () => {
+    // The strip cannot scroll before its own beginning, so the highlight
+    // pins near the left edge on its own — no separate branch for the ends
+    // of the range.
+    expect(stripScrollLeft(20, 300, 2000)).toBe(0);
+  });
+
+  it('clamps at the end of the season, letting the pill sit right of centre', () => {
+    // Content 2300 wide in a 300 viewport, so maxScroll is 2000 and the last
+    // chip's centre sits at 2280. Centring it would want scrollLeft 2130,
+    // which is past the end.
+    expect(stripScrollLeft(2280, 300, 2000)).toBe(2000);
+  });
+
+  it('stays at 0 when the whole strip fits with nothing to scroll', () => {
+    expect(stripScrollLeft(120, 400, 0)).toBe(0);
+    // A negative max (content narrower than the viewport) is still 0.
+    expect(stripScrollLeft(120, 400, -50)).toBe(0);
+  });
+});
+
+describe('pillGeometry', () => {
+  const a = { left: 100, width: 44 };
+  const b = { left: 148, width: 44 };
+
+  it('sits exactly on the anchor chip at rest', () => {
+    expect(pillGeometry(a, b, 0)).toEqual({ left: 100, width: 44 });
+  });
+
+  it('sits exactly on the next chip when the handover completes', () => {
+    expect(pillGeometry(a, b, 1)).toEqual({ left: 148, width: 44 });
+  });
+
+  it('straddles both chips mid-handover', () => {
+    // The half-and-half state: stop scrolling here and the pill covers the
+    // right half of one chip and the left half of the next.
+    expect(pillGeometry(a, b, 0.5)).toEqual({ left: 124, width: 44 });
+  });
+
+  it('interpolates width too, for chips that are not the same size', () => {
+    expect(pillGeometry({ left: 0, width: 40 }, { left: 60, width: 60 }, 0.5))
+      .toEqual({ left: 30, width: 50 });
+  });
+
+  it('stays on the anchor when there is no next chip', () => {
+    expect(pillGeometry(a, null, 0.8)).toEqual({ left: 100, width: 44 });
+  });
+
+  it('returns null when the anchor chip has no geometry', () => {
+    expect(pillGeometry(null, b, 0.5)).toBeNull();
+  });
+});
+
+describe('lerp', () => {
+  it('interpolates between the endpoints', () => {
+    expect(lerp(0, 10, 0)).toBe(0);
+    expect(lerp(0, 10, 1)).toBe(10);
+    expect(lerp(0, 10, 0.25)).toBe(2.5);
+  });
+
+  it('lands exactly on the far endpoint rather than near it', () => {
+    // Guards the pill against settling a subpixel short of the chip it is
+    // supposed to be sitting on.
+    expect(lerp(148, 196, 1)).toBe(196);
+  });
+});

--- a/frontend/src/__tests__/lib/utils/railPosition.test.ts
+++ b/frontend/src/__tests__/lib/utils/railPosition.test.ts
@@ -188,8 +188,25 @@ describe('lerp', () => {
   });
 
   it('lands exactly on the far endpoint rather than near it', () => {
-    // Guards the pill against settling a subpixel short of the chip it is
-    // supposed to be sitting on.
+    // Integer coordinates cannot catch this — `a + (b - a) * t` happens to be
+    // exact for them, so the previous version of this test could never have
+    // failed. These are fractional, as `DOMRect` values are under browser
+    // text zoom, and this specific pair returns 63.529707595868686 (high by
+    // 7.1e-15) without the endpoint returned outright.
+    expect(lerp(14.338952280847916, 63.52970759586868, 1)).toBe(63.52970759586868);
     expect(lerp(148, 196, 1)).toBe(196);
+  });
+
+  it('lands exactly on the near endpoint too', () => {
+    expect(lerp(14.338952280847916, 63.52970759586868, 0)).toBe(14.338952280847916);
+  });
+
+  it('places the pill exactly on the next chip when a handover completes', () => {
+    // The property `lerp`'s endpoint handling exists to protect: at progress
+    // 1 the pill must sit on the next chip, not 7e-15 past it, because the
+    // clip layer's inset is derived from the same number.
+    const a = { left: 14.338952280847916, width: 44.5 };
+    const b = { left: 63.52970759586868, width: 44.5 };
+    expect(pillGeometry(a, b, 1)).toEqual(b);
   });
 });

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -559,6 +559,10 @@ function HomeContent() {
           <DayRail
             chips={railChips}
             anchorDay={anchorDay}
+            // The same array `useDayAnchor` walks, so the rail's continuous
+            // highlight and this hook's discrete anchor resolve identical
+            // input through the same `resolveAnchor`.
+            windowDayKeys={windowDayKeys}
             prevDay={prevDay}
             nextDay={nextDay}
             // Off-season 'this-week' restored from localStorage resolves to no

--- a/frontend/src/components/calendar/DayRail.tsx
+++ b/frontend/src/components/calendar/DayRail.tsx
@@ -227,10 +227,12 @@ export function DayRail({
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     const content = contentRef.current;
     if (!content) return;
-    // `:scope >` matters: the highlighted copy of the row lives inside this
-    // same element and carries the same `data-chip` keys, so an unscoped
-    // query would walk focus through every chip twice — and half of those
-    // are `tabIndex={-1}` decorations that must never receive focus.
+    // `:scope >` restricts the walk to the real chip row. The highlighted
+    // copy below carries no `data-chip` and holds no focusable elements, so
+    // this is defence in depth rather than the only thing keeping the copy
+    // out — but it is the cheap half of that pair, and it keeps the walk
+    // correct against any future descendant of `content` that does carry a
+    // chip key.
     const buttons = Array.from(content.querySelectorAll<HTMLElement>(':scope > [data-chip]'));
     const current = buttons.indexOf(document.activeElement as HTMLElement);
     if (current < 0) return;
@@ -347,18 +349,26 @@ export function DayRail({
             style={{ clipPath: 'inset(0 100% 0 0)' }}
           >
             {chips.map((chip) => (
-              // Buttons, not divs: this row must match the real one's box
-              // metrics exactly, and a `<div>` does not inherit the same UA
-              // and preflight rules a `<button>` does. Not focusable, not
-              // announced, not clickable — it is paint.
-              <button
-                key={chip.key}
-                type="button"
-                tabIndex={-1}
-                className={chipBoxClass(chip.count === 0)}
-              >
+              // Divs, not buttons, and carrying no `data-chip`. This row is
+              // paint: it must not be a control, and it must not answer to a
+              // selector looking for one.
+              //
+              // Both halves of that are load-bearing, and each was learned the
+              // hard way. `<button>` here (chosen originally for box-metric
+              // parity) made the copy match the rail's own
+              // `button:not([data-chip])` chevron selector, so a click landed
+              // on inert paint with the real chip intercepting beneath it —
+              // caught by `e2e/verify-rail.mjs`, not by any unit test. Adding
+              // `data-chip` to fix *that* would instead double every
+              // `[data-day-rail] [data-chip]` query in the same suite. A plain
+              // `<div>` is the only shape that satisfies both, and it is the
+              // honest one. Tailwind's preflight normalises a button's font,
+              // padding, border and margin to a div's, so the box metrics are
+              // identical anyway — browser-measured at 0px worst delta across
+              // all 251 pairs.
+              <div key={chip.key} className={chipBoxClass(chip.count === 0)}>
                 <ChipFace chip={chip} />
-              </button>
+              </div>
             ))}
           </div>
         </div>

--- a/frontend/src/components/calendar/DayRail.tsx
+++ b/frontend/src/components/calendar/DayRail.tsx
@@ -1,6 +1,37 @@
-import { useEffect, useRef } from 'react';
+import { useMemo } from 'react';
 import type { DayChip } from '@/lib/utils/dayWindow';
 import { FiltersIcon } from '@/components/filters/FiltersIcon';
+import { useRailHighlight } from '@/hooks/useRailHighlight';
+
+/**
+ * Everything that decides a chip's box, shared verbatim by the two layers.
+ *
+ * The highlighted copy of the row has to lay out pixel-identically to the
+ * real one — it is positioned on top of it and clipped, so a single pixel of
+ * width difference shows up as a seam through the middle of a digit. Sharing
+ * one string is what makes that a compile-time guarantee rather than a thing
+ * two class lists happen to agree on, and it is why the empty-day border is
+ * here (1px, and it must be 1px on both) while the dimming that goes with it
+ * is not (paint only, and the copy is clipped away over an empty day anyway).
+ */
+function chipBoxClass(isEmpty: boolean): string {
+  return `shrink-0 min-h-11 min-w-11 px-2 py-1 rounded-md text-center leading-tight ${
+    isEmpty ? 'border border-dashed border-gray-300 dark:border-gray-600' : 'border border-transparent'
+  }`;
+}
+
+/** A chip's three lines. Rendered identically into both layers. */
+function ChipFace({ chip }: { chip: DayChip }) {
+  return (
+    <>
+      {chip.month && (
+        <span className="block text-[10px] font-semibold uppercase opacity-70" aria-hidden="true">{chip.month}</span>
+      )}
+      <span className="block text-[10px] uppercase opacity-70" aria-hidden="true">{chip.weekday}</span>
+      <span className="block text-sm font-semibold" aria-hidden="true">{chip.dayOfMonth}</span>
+    </>
+  );
+}
 
 export interface DayRailProps {
   chips: DayChip[];
@@ -67,6 +98,18 @@ export interface DayRailProps {
    * math anywhere else has to learn about it.
    */
   filtersToggle?: DayRailFiltersToggleProps;
+  /**
+   * The view window's day list, in order — the same array `useDayAnchor` is
+   * given in `page.tsx`.
+   *
+   * Passed rather than derived from `chips` so both the discrete anchor and
+   * this component's continuous highlight walk *identical* input through the
+   * same `resolveAnchor`. `chips` spans the navigable bounds, a superset, and
+   * walking it here would in practice agree — but "in practice agrees" is
+   * exactly the property that lets `aria-current` and the painted highlight
+   * drift onto different days the first time the two ranges diverge.
+   */
+  windowDayKeys: string[];
 }
 
 export interface DayRailFiltersToggleProps {
@@ -108,9 +151,16 @@ export interface DayRailFiltersToggleProps {
  * The day rail — the fine-grained half of D4's two strips, sticky beneath
  * the week strip.
  *
- * Purely presentational: chips in, callbacks out. Scroll position lives in
- * `useDayAnchor`, the window lives in `useFilterState`, and the rail knows
- * about neither — which is what lets it be tested without a layout stub.
+ * Chips in, callbacks out. The window lives in `useFilterState` and the
+ * *discrete* anchor in `useDayAnchor`; the rail owns neither, and still
+ * decides nothing about which day is current.
+ *
+ * It is no longer layout-free, though, and the old claim that it could be
+ * tested without a layout stub no longer holds: `useRailHighlight` measures
+ * the chip row and the day sections to place the highlight continuously. The
+ * chips, the labels, the keyboard walk and the disabled states all still
+ * test on plain markup; anything about *where the highlight is* needs stated
+ * geometry, which is what `useRailHighlight.test.tsx` provides.
  *
  * It spans the navigable bounds, **not** the current scope. It is a
  * navigation surface, not a filter readout: in `Today` scope it still shows
@@ -135,9 +185,11 @@ export interface DayRailFiltersToggleProps {
  */
 export function DayRail({
   chips, anchorDay, prevDay, nextDay, scopeHasWindow, todayKey,
-  onSelectDay, onStepDay, onGoToToday, rootRef, filtersToggle,
+  onSelectDay, onStepDay, onGoToToday, rootRef, filtersToggle, windowDayKeys,
 }: DayRailProps) {
-  const stripRef = useRef<HTMLDivElement>(null);
+  const chipKeys = useMemo(() => chips.map(c => c.key), [chips]);
+  const { stripRef, contentRef, pillRef, clipRef, resume } =
+    useRailHighlight(chipKeys, windowDayKeys);
 
   // Reachability, not adjacency: `chips` spans every calendar day in the
   // navigable bounds, so `anchorIdx ± 1` is enabled on days a step cannot
@@ -163,40 +215,23 @@ export function DayRail({
   // null anchor would leave the whole strip unreachable from the keyboard.
   const tabStopKey = chips.some(c => c.key === anchorDay) ? anchorDay : chips[0]?.key;
 
-  // Keep the highlighted chip in view as the reader scrolls the list. The
-  // rail scrolls itself horizontally; it never scrolls the page.
-  //
-  // Deliberately NOT `chip.scrollIntoView(...)`. `block: 'nearest'` minimises
-  // vertical movement but does not forbid it — with the rail scrolled
-  // partway off-screen (an ordinary scroll position, not a bug), that call
-  // drags the whole page to bring the chip's vertical position into view,
-  // which is exactly the page-scroll this control must never cause. Setting
-  // the strip's own `scrollLeft` can only move the strip.
-  useEffect(() => {
-    if (!anchorDay) return;
-    const strip = stripRef.current;
-    const chip = strip?.querySelector<HTMLElement>(`[data-chip="${anchorDay}"]`);
-    if (!strip || !chip) return;
-    // `offsetLeft` is relative to the nearest positioned ancestor, which is
-    // not reliably `strip` (the sticky root above it is itself positioned).
-    // Bounding rects sidestep that: `chipRect.left - stripRect.left` is the
-    // chip's edge relative to the strip's edge as currently painted, and
-    // adding back the strip's own `scrollLeft` converts that into a
-    // scroll-independent, content-relative position.
-    const stripRect = strip.getBoundingClientRect();
-    const chipRect = chip.getBoundingClientRect();
-    const chipCenter = (chipRect.left - stripRect.left) + chipRect.width / 2 + strip.scrollLeft;
-    strip.scrollLeft = chipCenter - strip.clientWidth / 2;
-  }, [anchorDay]);
+  // The highlight — where it sits, and what moves the strip — now lives in
+  // `useRailHighlight`, driven continuously from scroll position rather than
+  // from `anchorDay` changing. `anchorDay` is still what this component
+  // *announces* (`aria-current` below); it is no longer what it paints.
 
   // Left/Right move focus along the rail, Home jumps to today. Focus only —
   // activating is Enter/Space on the focused chip, which a <button> already
   // does. Moving the window on mere focus would make arrowing through the
   // rail refilter the list on every keystroke.
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const strip = stripRef.current;
-    if (!strip) return;
-    const buttons = Array.from(strip.querySelectorAll<HTMLElement>('[data-chip]'));
+    const content = contentRef.current;
+    if (!content) return;
+    // `:scope >` matters: the highlighted copy of the row lives inside this
+    // same element and carries the same `data-chip` keys, so an unscoped
+    // query would walk focus through every chip twice — and half of those
+    // are `tabIndex={-1}` decorations that must never receive focus.
+    const buttons = Array.from(content.querySelectorAll<HTMLElement>(':scope > [data-chip]'));
     const current = buttons.indexOf(document.activeElement as HTMLElement);
     if (current < 0) return;
     let next = -1;
@@ -237,61 +272,103 @@ export function DayRail({
         type="button"
         aria-label={prevLabel}
         disabled={!canStepBack}
-        onClick={() => onStepDay(-1)}
+        onClick={() => { resume(); onStepDay(-1); }}
         className="shrink-0 inline-flex min-h-11 min-w-11 items-center justify-center px-2 py-1 text-gray-600 dark:text-gray-300 disabled:opacity-30 disabled:cursor-default"
       >
         ‹
       </button>
 
-      <div ref={stripRef} className="flex-1 flex items-center gap-1 overflow-x-auto scrollbar-hide">
-        {chips.map((chip) => {
-          const isAnchor = chip.key === anchorDay;
-          // A day with nothing on it is not a destination. It keeps its
-          // place on the strip — the rail is a calendar and a gap is
-          // information — and it keeps its focusability, but it is announced
-          // and painted as unavailable rather than offering a trip that
-          // cannot happen.
-          const isEmpty = chip.count === 0;
-          return (
-            <button
-              key={chip.key}
-              type="button"
-              data-chip={chip.key}
-              aria-label={chip.label}
-              aria-current={isAnchor ? 'date' : undefined}
-              aria-disabled={isEmpty || undefined}
-              // One tab stop for the whole strip: a season is ~64 chips, and
-              // every one of them being a tab stop between the filters and
-              // the list is what the ArrowLeft/ArrowRight/Home handler above
-              // exists to replace.
-              tabIndex={chip.key === tabStopKey ? 0 : -1}
-              onClick={() => { if (!isEmpty) onSelectDay(chip.key); }}
-              className={`shrink-0 min-h-11 min-w-11 px-2 py-1 rounded-md text-center leading-tight transition-colors ${
-                isAnchor
-                  ? 'bg-blue-600 text-white'
-                  : 'text-gray-700 dark:text-gray-300 hover:bg-blue-50 dark:hover:bg-gray-700'
-              } ${
-                // The dashed border says "nothing here", mirroring iOS's
-                // MyDayChipContent.isEmpty; the dimming says "and so there is
-                // nothing to press".
-                isEmpty ? 'border border-dashed border-gray-300 dark:border-gray-600 opacity-50 cursor-default' : 'border border-transparent'
-              }`}
-            >
-              {chip.month && (
-                <span className="block text-[10px] font-semibold uppercase opacity-70" aria-hidden="true">{chip.month}</span>
-              )}
-              <span className="block text-[10px] uppercase opacity-70" aria-hidden="true">{chip.weekday}</span>
-              <span className="block text-sm font-semibold" aria-hidden="true">{chip.dayOfMonth}</span>
-            </button>
-          );
-        })}
+      {/*
+        Three stacked layers inside one scroller, so all of them share a
+        single `scrollLeft` and cannot desync:
+
+          chips (static)  — the real, interactive row
+          pill  (z-10)    — the highlight, painted OVER the chips' own
+                            backgrounds and text
+          copy  (z-20)    — the same row again in the highlighted colour,
+                            clipped to exactly the pill
+
+        The pill sitting above the chips rather than behind them is what
+        keeps `hover:bg-blue-50` from painting over the highlight on the
+        current day; the copy above the pill is what puts legible text back.
+        A chip straddling the pill's edge is therefore genuinely split — the
+        left half in the base colour, the right half white — which is the
+        half-and-half state the reader sees if they stop mid-scroll.
+      */}
+      <div ref={stripRef} data-rail-strip className="flex-1 overflow-x-auto scrollbar-hide">
+        <div ref={contentRef} data-rail-content className="relative flex items-center gap-1 w-max">
+          {chips.map((chip) => {
+            // A day with nothing on it is not a destination. It keeps its
+            // place on the strip — the rail is a calendar and a gap is
+            // information — and it keeps its focusability, but it is
+            // announced and painted as unavailable rather than offering a
+            // trip that cannot happen.
+            const isEmpty = chip.count === 0;
+            return (
+              <button
+                key={chip.key}
+                type="button"
+                data-chip={chip.key}
+                aria-label={chip.label}
+                aria-current={chip.key === anchorDay ? 'date' : undefined}
+                aria-disabled={isEmpty || undefined}
+                // One tab stop for the whole strip: a season is ~64 chips,
+                // and every one of them being a tab stop between the filters
+                // and the list is what the ArrowLeft/ArrowRight/Home handler
+                // above exists to replace.
+                tabIndex={chip.key === tabStopKey ? 0 : -1}
+                onClick={() => { if (!isEmpty) { resume(); onSelectDay(chip.key); } }}
+                className={`${chipBoxClass(isEmpty)} text-gray-700 dark:text-gray-300 ${
+                  // The dimming says "nothing to press" — paint only, so it
+                  // stays out of the shared box class.
+                  isEmpty ? 'opacity-50 cursor-default' : 'hover:bg-blue-50 dark:hover:bg-gray-700'
+                }`}
+              >
+                <ChipFace chip={chip} />
+              </button>
+            );
+          })}
+
+          <div
+            ref={pillRef}
+            data-rail-pill
+            aria-hidden="true"
+            className="absolute inset-y-0 left-0 z-10 rounded-md bg-blue-600 pointer-events-none"
+            // Placed before first paint by `useRailHighlight`'s layout
+            // effect; hidden until then so it cannot flash at x=0.
+            style={{ opacity: 0 }}
+          />
+
+          <div
+            ref={clipRef}
+            data-rail-clip
+            aria-hidden="true"
+            className="absolute inset-0 z-20 flex items-center gap-1 text-white pointer-events-none"
+            style={{ clipPath: 'inset(0 100% 0 0)' }}
+          >
+            {chips.map((chip) => (
+              // Buttons, not divs: this row must match the real one's box
+              // metrics exactly, and a `<div>` does not inherit the same UA
+              // and preflight rules a `<button>` does. Not focusable, not
+              // announced, not clickable — it is paint.
+              <button
+                key={chip.key}
+                type="button"
+                tabIndex={-1}
+                className={chipBoxClass(chip.count === 0)}
+              >
+                <ChipFace chip={chip} />
+              </button>
+            ))}
+          </div>
+        </div>
       </div>
 
       <button
         type="button"
         aria-label={nextLabel}
         disabled={!canStepForward}
-        onClick={() => onStepDay(1)}
+        onClick={() => { resume(); onStepDay(1); }}
         className="shrink-0 inline-flex min-h-11 min-w-11 items-center justify-center px-2 py-1 text-gray-600 dark:text-gray-300 disabled:opacity-30 disabled:cursor-default"
       >
         ›
@@ -308,7 +385,7 @@ export function DayRail({
         <button
           type="button"
           aria-label="Go to today"
-          onClick={onGoToToday}
+          onClick={() => { resume(); onGoToToday(); }}
           className="shrink-0 inline-flex min-h-11 items-center justify-center px-2 py-1 text-sm rounded-md bg-blue-50 dark:bg-gray-700 text-blue-600 dark:text-blue-400 hover:bg-blue-100 dark:hover:bg-gray-600"
         >
           ⟳ Now

--- a/frontend/src/components/calendar/DayRail.tsx
+++ b/frontend/src/components/calendar/DayRail.tsx
@@ -188,7 +188,7 @@ export function DayRail({
   onSelectDay, onStepDay, onGoToToday, rootRef, filtersToggle, windowDayKeys,
 }: DayRailProps) {
   const chipKeys = useMemo(() => chips.map(c => c.key), [chips]);
-  const { stripRef, contentRef, pillRef, clipRef, resume } =
+  const { stripRef, contentRef, pillRef, clipRef, contentEl, resume } =
     useRailHighlight(chipKeys, windowDayKeys);
 
   // Reachability, not adjacency: `chips` spans every calendar day in the
@@ -225,7 +225,7 @@ export function DayRail({
   // does. Moving the window on mere focus would make arrowing through the
   // rail refilter the list on every keystroke.
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    const content = contentRef.current;
+    const content = contentEl.current;
     if (!content) return;
     // `:scope >` restricts the walk to the real chip row. The highlighted
     // copy below carries no `data-chip` and holds no focusable elements, so

--- a/frontend/src/components/calendar/EventListView.tsx
+++ b/frontend/src/components/calendar/EventListView.tsx
@@ -3,7 +3,7 @@ import type { WeekTheme } from '@/hooks/useWeeklyThemes';
 import type { ArticleLink } from '@/hooks/useArticleLinks';
 import type { ProgramLink } from '@/hooks/useProgramLinks';
 import { downloadICS } from '@/lib/utils/icsHelpers';
-import { DAY_SECTION_ATTR } from '@/lib/utils/daySections';
+import { DAY_SECTION_ATTR, DAY_HEADER_ATTR } from '@/lib/utils/daySections';
 import { EventCard } from './EventCard';
 import { WeekBadge } from './WeekBadge';
 
@@ -54,6 +54,7 @@ export function EventListView({
           style={{ scrollMarginTop: 'var(--day-rail-h)' }}
         >
           <div
+            {...{ [DAY_HEADER_ATTR]: '' }}
             className="sticky bg-white dark:bg-gray-800 z-10 border-b border-gray-200 dark:border-gray-700 pb-1 sm:pb-2 mb-2 sm:mb-4"
             // `top-0` is dropped from the class list in favour of this: two
             // sticky layers both pinned at 0 overlap, and the header is the

--- a/frontend/src/hooks/useDayAnchor.ts
+++ b/frontend/src/hooks/useDayAnchor.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { daySectionElement, dayRailHeightPx } from '@/lib/utils/daySections';
+import { daySectionElement, daySectionTop, dayRailHeightPx } from '@/lib/utils/daySections';
+import { resolveAnchor } from '@/lib/utils/railPosition';
 
 /**
  * How far below the viewport top a day header counts as "the one I'm reading".
@@ -45,22 +46,17 @@ export function useDayAnchor(windowDayKeys: string[]): {
     let frame = 0;
     const measure = () => {
       frame = 0;
-      const limit = stickyOffset() + 1;
-      // Walk forward and keep the last one that has passed the chrome. The
-      // first day in the window is the fallback: before any scroll, nothing
-      // has passed, and the reader is plainly looking at the top of the list.
+      // The walk itself lives in `railPosition.resolveAnchor`, shared with
+      // the rail's scroll-linked highlight. Sharing it is load-bearing
+      // rather than tidy: the highlight's pill and this hook's `aria-current`
+      // must never name different days, and one walk cannot disagree with
+      // itself the way two copies could drift.
+      //
       // `windowDayKeys` is the view window's full day list, not the render
-      // window's mounted subset — a day this loop reaches may have no
-      // section yet, which is exactly what `daySectionElement` returning
-      // null below is for.
-      let next = windowDayKeys[0];
-      for (const key of windowDayKeys) {
-        const el = daySectionElement(key);
-        if (!el) continue;
-        if (el.getBoundingClientRect().top <= limit) next = key;
-        else break;
-      }
-      setAnchorDay(next);
+      // window's mounted subset — a day the walk reaches may have no section
+      // yet, which is what `daySectionTop` returning null is for.
+      const resolved = resolveAnchor(windowDayKeys, stickyOffset() + 1, daySectionTop);
+      if (resolved) setAnchorDay(resolved.key);
     };
 
     const onScroll = () => {

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -336,10 +336,19 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
 
   // Measure and place before paint: a pill positioned in a passive effect
   // would flash at x=0 on the first frame.
+  //
+  // `nodeGeneration` is a dependency for the same reason the listener effect
+  // below has it, and missing it here is subtler: the chip row can appear
+  // without the chip *list* changing at all. `DayRail` renders nothing while
+  // `scopeHasWindow` is false — an off-season `'this-week'` restored from
+  // localStorage — with `chips` populated the whole time. When the scope then
+  // resolves, `chipsId` and `keysId` are unchanged, so without this the row
+  // would never be measured, `extents` would stay empty, and the pill would
+  // not paint at all.
   useLayoutEffect(() => {
     measureChips();
     sync();
-  }, [chipsId, keysId, measureChips, sync]);
+  }, [chipsId, keysId, nodeGeneration, measureChips, sync]);
 
   // `sync` and `measureChips` are reached through a ref so the listener
   // effect below does not depend on them. Both are recreated whenever the day

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
 import { daySectionTop, daySectionMetrics, dayRailHeightPx } from '@/lib/utils/daySections';
 import {
@@ -20,15 +20,30 @@ export const JUMP_CHIPS = 1.5;
 /** Fallback chip pitch, used only before anything has been measured. */
 const FALLBACK_PITCH = 48;
 
+/**
+ * Callback refs, not ref objects.
+ *
+ * The listener effect below has to re-run when these elements actually
+ * appear, and a ref object mutating gives it nothing to depend on. `DayRail`
+ * renders nothing at all until events have loaded, so the elements are null
+ * on first mount and arrive later — an effect that missed that moment would
+ * leave the strip's own `scroll` listener and the content `ResizeObserver`
+ * permanently unattached, silently disabling peek detection in production
+ * while every test that mounts with chips already present still passed.
+ */
+export type RailNodeRef = (el: HTMLDivElement | null) => void;
+
 export interface RailHighlight {
   /** The horizontally scrolling element. */
-  stripRef: RefObject<HTMLDivElement | null>;
+  stripRef: RailNodeRef;
   /** The content inside it — the positioning context for pill and clip. */
-  contentRef: RefObject<HTMLDivElement | null>;
+  contentRef: RailNodeRef;
   /** The highlight itself. */
-  pillRef: RefObject<HTMLDivElement | null>;
+  pillRef: RailNodeRef;
   /** The duplicated, highlighted copy of the chip row. */
-  clipRef: RefObject<HTMLDivElement | null>;
+  clipRef: RailNodeRef;
+  /** The content element, for the caller's own keyboard walk. */
+  contentEl: RefObject<HTMLDivElement | null>;
   /** Hand `scrollLeft` back to the highlight after an explicit commit. */
   resume: () => void;
 }
@@ -73,6 +88,21 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
   const contentRef = useRef<HTMLDivElement | null>(null);
   const pillRef = useRef<HTMLDivElement | null>(null);
   const clipRef = useRef<HTMLDivElement | null>(null);
+
+  // Bumped only when an element attaches or detaches — once on load, not per
+  // render and never per frame. This is what the listener effect depends on,
+  // so it re-runs exactly when there is something new to listen to.
+  const [nodeGeneration, setNodeGeneration] = useState(0);
+  const nodeSetter = (ref: RefObject<HTMLDivElement | null>): RailNodeRef =>
+    (el) => {
+      if (ref.current === el) return;
+      ref.current = el;
+      setNodeGeneration(n => n + 1);
+    };
+  const setStrip = useCallback(nodeSetter(stripRef), []);
+  const setContent = useCallback(nodeSetter(contentRef), []);
+  const setPill = useCallback(nodeSetter(pillRef), []);
+  const setClip = useCallback(nodeSetter(clipRef), []);
 
   /** Chip extents in content coordinates, rebuilt only when the row changes. */
   const extents = useRef<Map<string, ChipExtent>>(new Map());
@@ -365,9 +395,16 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
       strip?.removeEventListener('scroll', onStripScroll);
       observer?.disconnect();
     };
-    // Deliberately mount-scoped: the elements these attach to are created once
-    // by `DayRail` and live as long as this hook does.
-  }, [cancelTween]);
+    // Keyed on the elements, not on the day list. `chipsId`/`keysId` change on
+    // every filter, scope and window change and would tear down and rebuild
+    // every listener for nothing — none of this wiring depends on the chip or
+    // day contents, only `sync`'s closure does, and that is reached through
+    // `latest`. But it cannot be mount-scoped either: the elements do not
+    // exist on first mount.
+  }, [nodeGeneration, cancelTween]);
 
-  return { stripRef, contentRef, pillRef, clipRef, resume };
+  return {
+    stripRef: setStrip, contentRef: setContent, pillRef: setPill, clipRef: setClip,
+    contentEl: contentRef, resume,
+  };
 }

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -81,6 +81,22 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
 
   /** True while the reader owns `scrollLeft` — see `resume` below. */
   const suspended = useRef(false);
+  /**
+   * The last `scrollLeft` this hook wrote, read back after writing.
+   *
+   * This is how a peek is detected: if the strip's position ever differs from
+   * what we last put there, something other than us moved it. That is a
+   * direct observation rather than an inference from event types, and it was
+   * arrived at by watching the inference fail — suspending on `wheel` or
+   * `pointerdown` over the strip also fires for a plain *vertical* page
+   * scroll with the pointer resting on the rail, which on a phone is exactly
+   * where the rail is. Browser-measured: one vertical wheel over the rail,
+   * then 120px of page scroll, moved the strip 0px. Divergence cannot make
+   * that mistake, and it catches every way the reader can move the strip —
+   * touch drag, trackpad pan, scrollbar, keyboard — rather than the two the
+   * event list happened to name.
+   */
+  const lastWritten = useRef(0);
   /** The anchor as of the last frame, so a change of day can lift a peek. */
   const lastAnchor = useRef<string | null>(null);
   const tween = useRef<{ to: number; raf: number } | null>(null);
@@ -111,6 +127,19 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
   const resume = useCallback(() => { suspended.current = false; }, []);
 
   /**
+   * The one place `scrollLeft` is written.
+   *
+   * Reads the value back rather than recording what was asked for: the
+   * browser clamps to the scrollable range, so storing the request would
+   * leave `lastWritten` permanently disagreeing with reality at either end of
+   * the season and read as a peek that never happened.
+   */
+  const writeScrollLeft = useCallback((strip: HTMLElement, value: number) => {
+    strip.scrollLeft = value;
+    lastWritten.current = strip.scrollLeft;
+  }, []);
+
+  /**
    * Ease the strip to a destination it cannot simply track.
    *
    * A tap scrolls the page instantly, so `scrollLeft` would otherwise
@@ -122,7 +151,7 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     cancelTween();
     const from = strip.scrollLeft;
     if (prefersReducedMotion() || Math.abs(to - from) < 1) {
-      strip.scrollLeft = to;
+      writeScrollLeft(strip, to);
       return;
     }
     const t0 = performance.now();
@@ -132,13 +161,13 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     const step = () => {
       if (tween.current !== self) return;
       const progress = Math.min(1, (performance.now() - t0) / TWEEN_MS);
-      strip.scrollLeft = lerp(from, to, easeOutCubic(progress));
+      writeScrollLeft(strip, lerp(from, to, easeOutCubic(progress)));
       if (progress < 1) self.raf = requestAnimationFrame(step);
       else tween.current = null;
     };
     tween.current = self;
     self.raf = requestAnimationFrame(step);
-  }, [cancelTween]);
+  }, [cancelTween, writeScrollLeft]);
 
   /**
    * Re-measure the chip row.
@@ -248,8 +277,8 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
       return;
     }
     if (Math.abs(desired - strip.scrollLeft) > threshold) startTween(strip, desired);
-    else strip.scrollLeft = desired;
-  }, [keysId, hide, startTween]);
+    else writeScrollLeft(strip, desired);
+  }, [keysId, hide, startTween, writeScrollLeft]);
 
   // Measure and place before paint: a pill positioned in a passive effect
   // would flash at x=0 on the first frame.
@@ -269,17 +298,24 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     };
     const onResize = () => { measureChips(); onScroll(); };
 
-    // The reader taking hold of the rail suspends our writes until they
-    // scroll into a different day. `wheel` as well as `pointerdown`: a
-    // trackpad two-finger horizontal pan fires no pointer event at all, and
-    // would otherwise be fought by the per-frame `scrollLeft` write.
-    const takeOver = () => { suspended.current = true; cancelTween(); };
+    // The reader moved the strip themselves — suspend until they scroll into
+    // a different day or commit explicitly. Detected by the strip's position
+    // diverging from the last value we put there, which is the only signal
+    // that distinguishes a genuine pan from a vertical page scroll that
+    // merely passed over the rail. The 1px tolerance absorbs the subpixel
+    // rounding browsers apply to a fractional `scrollLeft`.
+    const onStripScroll = () => {
+      if (!strip) return;
+      if (Math.abs(strip.scrollLeft - lastWritten.current) > 1) {
+        suspended.current = true;
+        cancelTween();
+      }
+    };
 
     // Passive throughout: none of these may delay a scroll.
     window.addEventListener('scroll', onScroll, { passive: true });
     window.addEventListener('resize', onResize, { passive: true });
-    strip?.addEventListener('pointerdown', takeOver, { passive: true });
-    strip?.addEventListener('wheel', takeOver, { passive: true });
+    strip?.addEventListener('scroll', onStripScroll, { passive: true });
 
     // The chip row can change width without the window resizing — `⟳ Now`
     // and the Filters toggle appear and disappear beside it. Absent in some
@@ -293,8 +329,7 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
       cancelTween();
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onResize);
-      strip?.removeEventListener('pointerdown', takeOver);
-      strip?.removeEventListener('wheel', takeOver);
+      strip?.removeEventListener('scroll', onStripScroll);
       observer?.disconnect();
     };
   }, [chipsId, keysId, sync, measureChips, cancelTween]);

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -270,6 +270,17 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     const clip = clipRef.current;
     if (!strip || !pill || !clip) return;
 
+    // This repeats the walk `useDayAnchor` also performs each frame, and that
+    // duplication is a deliberate trade rather than an oversight. Measured in
+    // Chromium against production data: 0.034ms per walk at a typical render
+    // window (3 mounted day sections) and 0.335ms at a large one (16 sections,
+    // 321 event cards) — so both hooks together cost 0.4% of a 16.7ms frame
+    // typically and 4% at the large end. Sharing one measurement would mean
+    // either threading a subscription from `useDayAnchor` through `page.tsx`
+    // into this component, or hoisting a third hook that both depend on;
+    // both trade a measured 4% worst case for a new coupling across the
+    // boundary this design keeps clean. Revisit if the render window ever
+    // stops being bounded — that, not the day list, is what sets this cost.
     const limit = dayRailHeightPx() + 1;
     const resolved = resolveAnchor(windowDayKeys, limit, daySectionTop);
     if (!resolved) {
@@ -334,21 +345,33 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     else writeScrollLeft(strip, desired);
   }, [keysId, hide, startTween, writeScrollLeft]);
 
-  // Measure and place before paint: a pill positioned in a passive effect
-  // would flash at x=0 on the first frame.
+  // `nodeGeneration` is a dependency on both effects below for the same
+  // reason the listener effect has it, and missing it is subtler here: the
+  // chip row can appear without the chip *list* changing at all. `DayRail`
+  // renders nothing while `scopeHasWindow` is false — an off-season
+  // `'this-week'` restored from localStorage — with `chips` populated the
+  // whole time. When the scope then resolves, `chipsId` and `keysId` are
+  // unchanged, so without this the row would never be measured, `extents`
+  // would stay empty, and the pill would not paint at all.
+  // Two effects, not one, and the split is not cosmetic: `measureChips` walks
+  // every chip in the row calling `getBoundingClientRect` — 251 of them in a
+  // full season — and the row's geometry depends on the *chips*, never on the
+  // day window. Measuring on `keysId` too meant a forced layout and 251 rect
+  // reads on every filter and scope change, for a row that had not moved.
   //
-  // `nodeGeneration` is a dependency for the same reason the listener effect
-  // below has it, and missing it here is subtler: the chip row can appear
-  // without the chip *list* changing at all. `DayRail` renders nothing while
-  // `scopeHasWindow` is false — an off-season `'this-week'` restored from
-  // localStorage — with `chips` populated the whole time. When the scope then
-  // resolves, `chipsId` and `keysId` are unchanged, so without this the row
-  // would never be measured, `extents` would stay empty, and the pill would
-  // not paint at all.
+  // Declaration order is the contract: measure runs before sync in the same
+  // commit, so a commit that changes both the chips and the window still
+  // places the pill against fresh extents.
   useLayoutEffect(() => {
     measureChips();
+  }, [chipsId, nodeGeneration, measureChips]);
+
+  // Placement before paint — in a passive effect the pill would flash at x=0
+  // on the first frame. This one does follow the day window: the anchor moves
+  // when the window does, even with the chip row untouched.
+  useLayoutEffect(() => {
     sync();
-  }, [chipsId, keysId, nodeGeneration, measureChips, sync]);
+  }, [chipsId, keysId, nodeGeneration, sync]);
 
   // `sync` and `measureChips` are reached through a ref so the listener
   // effect below does not depend on them. Both are recreated whenever the day

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -362,6 +362,12 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
   useEffect(() => {
     const strip = stripRef.current;
     const content = contentRef.current;
+    // Nothing rendered — `DayRail` returns null while it has no days, or
+    // while the scope resolves to no window at all. Attaching global scroll
+    // and resize listeners now would schedule a rAF on every frame of every
+    // scroll only for `sync` to bail on the same null refs. `nodeGeneration`
+    // brings us straight back here the moment the elements exist.
+    if (!strip || !content) return;
 
     let frame = 0;
     const onScroll = () => {
@@ -377,7 +383,6 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     // merely passed over the rail. The 1px tolerance absorbs the subpixel
     // rounding browsers apply to a fractional `scrollLeft`.
     const onStripScroll = () => {
-      if (!strip) return;
       if (Math.abs(strip.scrollLeft - lastWritten.current) > 1) {
         suspended.current = true;
         cancelTween();
@@ -387,21 +392,21 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     // Passive throughout: none of these may delay a scroll.
     window.addEventListener('scroll', onScroll, { passive: true });
     window.addEventListener('resize', onResize, { passive: true });
-    strip?.addEventListener('scroll', onStripScroll, { passive: true });
+    strip.addEventListener('scroll', onStripScroll, { passive: true });
 
     // The chip row can change width without the window resizing — `⟳ Now`
     // and the Filters toggle appear and disappear beside it. Absent in some
     // older browsers and in jsdom without a stub; skipping it there only
     // loses a re-measure, which is better than throwing on mount.
     const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(onResize);
-    if (content) observer?.observe(content);
+    observer?.observe(content);
 
     return () => {
       if (frame) cancelAnimationFrame(frame);
       cancelTween();
       window.removeEventListener('scroll', onScroll);
       window.removeEventListener('resize', onResize);
-      strip?.removeEventListener('scroll', onStripScroll);
+      strip.removeEventListener('scroll', onStripScroll);
       observer?.disconnect();
     };
     // Keyed on the elements, not on the day list. `chipsId`/`keysId` change on

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -95,6 +95,16 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
    * that mistake, and it catches every way the reader can move the strip —
    * touch drag, trackpad pan, scrollbar, keyboard — rather than the two the
    * event list happened to name.
+   *
+   * The comparison rests on one ordering assumption, stated here rather than
+   * left implicit: a `scroll` event is dispatched no earlier than the task
+   * that caused it, and its handler reads the *live* `scrollLeft` at dispatch
+   * time. So by the time our own write's event is delivered, `lastWritten`
+   * has already been updated to that same value and the two compare equal —
+   * even mid-tween, where a write happens every frame. Every mainstream
+   * engine defers scroll dispatch by at least a task. If one did not, our own
+   * writes would read as peeks and the highlight would stop centring after
+   * the first frame.
    */
   const lastWritten = useRef(0);
   /** The anchor as of the last frame, so a change of day can lift a peek. */
@@ -124,7 +134,15 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
    * tapping the chip for the day already being read changes no anchor, and
    * without this the strip would stay wherever the reader had panned it.
    */
-  const resume = useCallback(() => { suspended.current = false; }, []);
+  const resume = useCallback(() => {
+    suspended.current = false;
+    // Re-baseline before handing control back. `lastWritten` still points at
+    // wherever *we* last wrote, which is not where the reader left the strip,
+    // so a `scroll` event still in flight from their pan would compare
+    // divergent and re-suspend immediately — silently undoing this call.
+    const strip = stripRef.current;
+    if (strip) lastWritten.current = strip.scrollLeft;
+  }, []);
 
   /**
    * The one place `scrollLeft` is written.
@@ -185,9 +203,13 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     contentWidth.current = contentRect.width;
     const next = new Map<string, ChipExtent>();
     const lefts: number[] = [];
-    // `:scope >` matters: the highlighted copy of the row is a descendant of
-    // this same element and carries the same `data-chip` keys, so an
-    // unscoped query would measure every chip twice.
+    // `:scope >` restricts the measurement to the real chip row. The
+    // highlighted copy is a descendant of this same element; it carries no
+    // `data-chip` today, so this is defence in depth rather than the only
+    // thing keeping it out of the map — but an unscoped query would silently
+    // start measuring every chip twice the day anything under `content`
+    // gained a chip key, and the failure would be a mispositioned pill
+    // rather than an error.
     for (const el of Array.from(content.querySelectorAll<HTMLElement>(':scope > [data-chip]'))) {
       const key = el.dataset.chip;
       if (!key || next.has(key)) continue;
@@ -232,6 +254,8 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     // mistaken for a change of day.
     if (lastAnchor.current !== null && resolved.key !== lastAnchor.current) {
       suspended.current = false;
+      // Re-baseline for the same reason `resume` does — see there.
+      lastWritten.current = strip.scrollLeft;
     }
     lastAnchor.current = resolved.key;
 
@@ -287,6 +311,15 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     sync();
   }, [chipsId, keysId, measureChips, sync]);
 
+  // `sync` and `measureChips` are reached through a ref so the listener
+  // effect below does not depend on them. Both are recreated whenever the day
+  // list changes, and wiring the listeners to them directly tore down and
+  // rebuilt every `window` listener and the `ResizeObserver` on every filter,
+  // scope and window change — churn that buys nothing, since none of the
+  // wiring itself depends on the chip or day contents.
+  const latest = useRef({ sync, measureChips });
+  latest.current = { sync, measureChips };
+
   useEffect(() => {
     const strip = stripRef.current;
     const content = contentRef.current;
@@ -294,9 +327,9 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     let frame = 0;
     const onScroll = () => {
       if (frame) return;
-      frame = requestAnimationFrame(() => { frame = 0; sync(); });
+      frame = requestAnimationFrame(() => { frame = 0; latest.current.sync(); });
     };
-    const onResize = () => { measureChips(); onScroll(); };
+    const onResize = () => { latest.current.measureChips(); onScroll(); };
 
     // The reader moved the strip themselves — suspend until they scroll into
     // a different day or commit explicitly. Detected by the strip's position
@@ -332,7 +365,9 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
       strip?.removeEventListener('scroll', onStripScroll);
       observer?.disconnect();
     };
-  }, [chipsId, keysId, sync, measureChips, cancelTween]);
+    // Deliberately mount-scoped: the elements these attach to are created once
+    // by `DayRail` and live as long as this hook does.
+  }, [cancelTween]);
 
   return { stripRef, contentRef, pillRef, clipRef, resume };
 }

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -1,0 +1,303 @@
+import { useCallback, useEffect, useLayoutEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import { daySectionTop, daySectionMetrics, dayRailHeightPx } from '@/lib/utils/daySections';
+import {
+  resolveAnchor, rampDistance, dayProgress, stripScrollLeft, pillGeometry, lerp,
+  type ChipExtent,
+} from '@/lib/utils/railPosition';
+
+/** How long the strip takes to catch up after a tap, a chevron, or `⟳ Now`. */
+export const TWEEN_MS = 220;
+
+/**
+ * How far the strip has to be out of position before catching up is treated
+ * as a jump to be animated rather than a scroll to be tracked.
+ *
+ * Measured in chips, not pixels, so it stays right at any text zoom.
+ */
+export const JUMP_CHIPS = 1.5;
+
+/** Fallback chip pitch, used only before anything has been measured. */
+const FALLBACK_PITCH = 48;
+
+export interface RailHighlight {
+  /** The horizontally scrolling element. */
+  stripRef: RefObject<HTMLDivElement | null>;
+  /** The content inside it — the positioning context for pill and clip. */
+  contentRef: RefObject<HTMLDivElement | null>;
+  /** The highlight itself. */
+  pillRef: RefObject<HTMLDivElement | null>;
+  /** The duplicated, highlighted copy of the chip row. */
+  clipRef: RefObject<HTMLDivElement | null>;
+  /** Hand `scrollLeft` back to the highlight after an explicit commit. */
+  resume: () => void;
+}
+
+function easeOutCubic(t: number): number {
+  return 1 - Math.pow(1 - t, 3);
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Drives the rail's highlight from scroll position, without re-rendering.
+ *
+ * The day the reader is on is a *fraction*, not a key: it advances
+ * continuously as the list's own sticky day title hands over, so the
+ * highlight tracks the reader's finger and stops half-done when they stop.
+ * That fraction deliberately never becomes React state — `page.tsx` is the
+ * whole application, and putting a per-frame value in `useState` would
+ * re-render it sixty times a second. Everything here is measured in a
+ * rAF-throttled callback and written straight to three DOM properties.
+ *
+ * The discrete anchor stays where it was, in `useDayAnchor`: it drives
+ * `aria-current`, the chevron targets and `⟳ Now`, none of which want a
+ * fractional day. Both resolve through the same `resolveAnchor`, so the pill
+ * and the announced current day cannot name different days.
+ *
+ * **The invariant this rests on:** the anchor is derived from page scroll and
+ * nothing else. This hook only ever reads it. Dragging the rail sideways is a
+ * peek — it moves the reader's view of the season and never the page — so the
+ * pill stays glued to the day being read and drifts off centre rather than
+ * catching whatever chip is dragged under it.
+ *
+ * The four refs are created here rather than accepted as an argument so their
+ * identity is stable: a caller passing a fresh `{ strip, pill, ... }` object
+ * each render would re-subscribe every listener on every render.
+ */
+export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): RailHighlight {
+  const stripRef = useRef<HTMLDivElement | null>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const pillRef = useRef<HTMLDivElement | null>(null);
+  const clipRef = useRef<HTMLDivElement | null>(null);
+
+  /** Chip extents in content coordinates, rebuilt only when the row changes. */
+  const extents = useRef<Map<string, ChipExtent>>(new Map());
+  const contentWidth = useRef(0);
+  const pitch = useRef(FALLBACK_PITCH);
+
+  /** True while the reader owns `scrollLeft` — see `resume` below. */
+  const suspended = useRef(false);
+  /** The anchor as of the last frame, so a change of day can lift a peek. */
+  const lastAnchor = useRef<string | null>(null);
+  const tween = useRef<{ to: number; raf: number } | null>(null);
+
+  // Serialized so the effects below re-run when the *contents* change rather
+  // than on every render that hands down a new array identity. (NOTE for
+  // humans, not a real eslint-disable: this repo has no
+  // eslint-plugin-react-hooks, so a literal `react-hooks/exhaustive-deps`
+  // disable comment is a hard ESLint 9 error rather than a silenced warning.)
+  const chipsId = chipKeys.join(',');
+  const keysId = windowDayKeys.join(',');
+
+  const cancelTween = useCallback(() => {
+    if (tween.current) {
+      cancelAnimationFrame(tween.current.raf);
+      tween.current = null;
+    }
+  }, []);
+
+  /**
+   * Hand `scrollLeft` back to the highlight.
+   *
+   * Called on any explicit commit — a chip, a chevron, `⟳ Now`. Scrolling the
+   * page into a different day lifts a peek on its own (see `sync` below), but
+   * tapping the chip for the day already being read changes no anchor, and
+   * without this the strip would stay wherever the reader had panned it.
+   */
+  const resume = useCallback(() => { suspended.current = false; }, []);
+
+  /**
+   * Ease the strip to a destination it cannot simply track.
+   *
+   * A tap scrolls the page instantly, so `scrollLeft` would otherwise
+   * teleport across a week of chips. This is the only self-moving animation
+   * in the rail — everything else is 1:1 with the reader's own gesture — so
+   * it is the only thing `prefers-reduced-motion` turns off.
+   */
+  const startTween = useCallback((strip: HTMLElement, to: number) => {
+    cancelTween();
+    const from = strip.scrollLeft;
+    if (prefersReducedMotion() || Math.abs(to - from) < 1) {
+      strip.scrollLeft = to;
+      return;
+    }
+    const t0 = performance.now();
+    // Identity, not a boolean: a frame belonging to a superseded tween must
+    // not null out the tween that replaced it.
+    const self = { to, raf: 0 };
+    const step = () => {
+      if (tween.current !== self) return;
+      const progress = Math.min(1, (performance.now() - t0) / TWEEN_MS);
+      strip.scrollLeft = lerp(from, to, easeOutCubic(progress));
+      if (progress < 1) self.raf = requestAnimationFrame(step);
+      else tween.current = null;
+    };
+    tween.current = self;
+    self.raf = requestAnimationFrame(step);
+  }, [cancelTween]);
+
+  /**
+   * Re-measure the chip row.
+   *
+   * Rects rather than `offsetLeft`: the content element is the offset parent
+   * today, but `offsetLeft` silently re-points at whatever positioned
+   * ancestor appears above it later, and `chipRect.left - contentRect.left`
+   * cannot. The content element scrolls with its chips, so that difference is
+   * already scroll-independent — no `scrollLeft` term needed.
+   */
+  const measureChips = useCallback(() => {
+    const content = contentRef.current;
+    if (!content) return;
+    const contentRect = content.getBoundingClientRect();
+    contentWidth.current = contentRect.width;
+    const next = new Map<string, ChipExtent>();
+    const lefts: number[] = [];
+    // `:scope >` matters: the highlighted copy of the row is a descendant of
+    // this same element and carries the same `data-chip` keys, so an
+    // unscoped query would measure every chip twice.
+    for (const el of Array.from(content.querySelectorAll<HTMLElement>(':scope > [data-chip]'))) {
+      const key = el.dataset.chip;
+      if (!key || next.has(key)) continue;
+      const rect = el.getBoundingClientRect();
+      const left = rect.left - contentRect.left;
+      next.set(key, { left, width: rect.width });
+      lefts.push(left);
+    }
+    extents.current = next;
+    // Pitch from the first gap rather than an average: chips are uniform, and
+    // one subtraction cannot be skewed by a partially-laid-out row.
+    if (lefts.length >= 2 && lefts[1] > lefts[0]) pitch.current = lefts[1] - lefts[0];
+  }, []);
+
+  /** Blank the highlight rather than leave it parked on a stale day. */
+  const hide = useCallback(() => {
+    if (pillRef.current) pillRef.current.style.opacity = '0';
+    if (clipRef.current) clipRef.current.style.clipPath = 'inset(0 100% 0 0)';
+  }, []);
+
+  /**
+   * Measure, compute, write. Every read is taken before any write, so a frame
+   * never interleaves them and forces a synchronous re-layout.
+   */
+  const sync = useCallback(() => {
+    const strip = stripRef.current;
+    const pill = pillRef.current;
+    const clip = clipRef.current;
+    if (!strip || !pill || !clip) return;
+
+    const limit = dayRailHeightPx() + 1;
+    const resolved = resolveAnchor(windowDayKeys, limit, daySectionTop);
+    if (!resolved) {
+      hide();
+      lastAnchor.current = null;
+      return;
+    }
+
+    // Scrolling into a different day lifts a peek: the reader has moved on
+    // from whatever they had panned the rail to look at. Guarded on a
+    // non-null previous anchor so the very first measured frame is not
+    // mistaken for a change of day.
+    if (lastAnchor.current !== null && resolved.key !== lastAnchor.current) {
+      suspended.current = false;
+    }
+    lastAnchor.current = resolved.key;
+
+    const metrics = daySectionMetrics(resolved.key);
+    const ramp = metrics ? rampDistance(metrics.height, metrics.headerHeight) : 0;
+    const progress = resolved.nextTop === null ? 0 : dayProgress(resolved.nextTop, limit, ramp);
+
+    const geometry = pillGeometry(
+      extents.current.get(resolved.key) ?? null,
+      resolved.nextKey ? extents.current.get(resolved.nextKey) ?? null : null,
+      progress,
+    );
+    // The anchor day has no chip — reachable if the view window and the
+    // navigable bounds ever disagree. Nothing to highlight.
+    if (!geometry) { hide(); return; }
+
+    const { left, width } = geometry;
+    const right = Math.max(0, contentWidth.current - (left + width));
+
+    pill.style.opacity = '1';
+    pill.style.width = `${width}px`;
+    pill.style.transform = `translateX(${left}px)`;
+    // The clip layer is `inset-0` inside the content element, so its own box
+    // is the content box and these insets are already in the same coordinate
+    // space as `left` and `width`.
+    clip.style.clipPath = `inset(0 ${right}px 0 ${left}px)`;
+
+    // The reader is panning the rail. The pill above still tracks its day —
+    // that is the point of the peek — but the strip stays where they put it.
+    if (suspended.current) return;
+
+    const desired = stripScrollLeft(
+      left + width / 2,
+      strip.clientWidth,
+      strip.scrollWidth - strip.clientWidth,
+    );
+    const threshold = pitch.current * JUMP_CHIPS;
+
+    if (tween.current) {
+      // Let a running tween finish unless the destination has genuinely
+      // moved — a second tap while the first is still travelling.
+      if (Math.abs(desired - tween.current.to) > threshold) startTween(strip, desired);
+      return;
+    }
+    if (Math.abs(desired - strip.scrollLeft) > threshold) startTween(strip, desired);
+    else strip.scrollLeft = desired;
+  }, [keysId, hide, startTween]);
+
+  // Measure and place before paint: a pill positioned in a passive effect
+  // would flash at x=0 on the first frame.
+  useLayoutEffect(() => {
+    measureChips();
+    sync();
+  }, [chipsId, keysId, measureChips, sync]);
+
+  useEffect(() => {
+    const strip = stripRef.current;
+    const content = contentRef.current;
+
+    let frame = 0;
+    const onScroll = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => { frame = 0; sync(); });
+    };
+    const onResize = () => { measureChips(); onScroll(); };
+
+    // The reader taking hold of the rail suspends our writes until they
+    // scroll into a different day. `wheel` as well as `pointerdown`: a
+    // trackpad two-finger horizontal pan fires no pointer event at all, and
+    // would otherwise be fought by the per-frame `scrollLeft` write.
+    const takeOver = () => { suspended.current = true; cancelTween(); };
+
+    // Passive throughout: none of these may delay a scroll.
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onResize, { passive: true });
+    strip?.addEventListener('pointerdown', takeOver, { passive: true });
+    strip?.addEventListener('wheel', takeOver, { passive: true });
+
+    // The chip row can change width without the window resizing — `⟳ Now`
+    // and the Filters toggle appear and disappear beside it. Absent in some
+    // older browsers and in jsdom without a stub; skipping it there only
+    // loses a re-measure, which is better than throwing on mount.
+    const observer = typeof ResizeObserver === 'undefined' ? null : new ResizeObserver(onResize);
+    if (content) observer?.observe(content);
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame);
+      cancelTween();
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onResize);
+      strip?.removeEventListener('pointerdown', takeOver);
+      strip?.removeEventListener('wheel', takeOver);
+      observer?.disconnect();
+    };
+  }, [chipsId, keysId, sync, measureChips, cancelTween]);
+
+  return { stripRef, contentRef, pillRef, clipRef, resume };
+}

--- a/frontend/src/lib/utils/daySections.ts
+++ b/frontend/src/lib/utils/daySections.ts
@@ -17,8 +17,38 @@
  */
 export const DAY_SECTION_ATTR = 'data-day-key';
 
+/**
+ * The sticky title inside a day section.
+ *
+ * Declared rather than reached for via `firstElementChild` because the rail's
+ * highlight ramp is floored at this element's height — the distance the title
+ * itself takes to hand over — and a wrapper introduced above the header later
+ * would silently re-point that floor at something else. Named, it is a
+ * compile-time-visible contract like `DAY_SECTION_ATTR`; positional, it is a
+ * bug that only shows up as a ramp that feels wrong.
+ */
+export const DAY_HEADER_ATTR = 'data-day-header';
+
 export function daySectionElement(key: string): HTMLElement | null {
   return document.querySelector<HTMLElement>(`[${DAY_SECTION_ATTR}="${key}"]`);
+}
+
+/**
+ * A day section's own height and the height of its sticky title.
+ *
+ * Both read through `getBoundingClientRect` rather than `offsetHeight`: it is
+ * the measurement the rest of this file already uses, it reports fractional
+ * pixels at browser text zoom, and it is the one every test in this repo
+ * already knows how to state for a layout-free jsdom.
+ */
+export function daySectionMetrics(key: string): { height: number; headerHeight: number } | null {
+  const el = daySectionElement(key);
+  if (!el) return null;
+  const header = el.querySelector<HTMLElement>(`[${DAY_HEADER_ATTR}]`);
+  return {
+    height: el.getBoundingClientRect().height,
+    headerHeight: header ? header.getBoundingClientRect().height : 0,
+  };
 }
 
 /**

--- a/frontend/src/lib/utils/railPosition.ts
+++ b/frontend/src/lib/utils/railPosition.ts
@@ -1,0 +1,174 @@
+/**
+ * The geometry behind the day rail's scroll-linked highlight.
+ *
+ * Every function here is pure and takes its measurements as arguments, so
+ * the whole model is testable without a layout. That is deliberate: the rail
+ * has already shipped one bug that eleven green task reviews missed because
+ * the failure lived in the seam between a measurement and the DOM. Keeping
+ * the arithmetic out of the DOM does not test the seam — only a browser does
+ * — but it does mean a seam bug cannot hide inside arithmetic that was never
+ * checked.
+ */
+
+/** A chip's horizontal extent in the strip's own content coordinates. */
+export interface ChipExtent {
+  left: number;
+  width: number;
+}
+
+export interface AnchorResolution {
+  /** The day the reader is currently on. */
+  key: string;
+  /**
+   * The day being handed over to, or null when no handover is in progress —
+   * the reader is above the first day, or past the last mounted one.
+   */
+  nextKey: string | null;
+  /** `nextKey`'s viewport-relative top, or null alongside a null `nextKey`. */
+  nextTop: number | null;
+}
+
+/**
+ * How much of a day section the highlight travels across, as a fraction.
+ *
+ * A quarter is long enough to be visible at flick speed (~200px is roughly
+ * twelve frames) and short enough that the rail is unambiguously at rest for
+ * most of a day's worth of reading.
+ */
+export const RAMP_SECTION_FRACTION = 0.25;
+
+/**
+ * The longest the handover may take, in pixels of scroll.
+ *
+ * Without a cap, a day with sixty events would start the rail moving
+ * thousands of pixels before the title it is tracking does, and the two
+ * would visibly disagree about which day the reader is in.
+ */
+export const RAMP_MAX_PX = 200;
+
+/**
+ * The day the reader is on, and the one being handed over to.
+ *
+ * The forward walk — "keep the last section whose top has passed the
+ * chrome" — is the same question `useDayAnchor` has always asked, and this
+ * is now the only place that asks it. Both the discrete anchor (which drives
+ * `aria-current`) and the continuous highlight resolve through this
+ * function, so the pill and the announced current day cannot name different
+ * days. Two copies of the walk could drift; one cannot.
+ *
+ * `topOf` returns null for a day that is in the view window but has no
+ * mounted section — the render window's subset is smaller than the view
+ * window's day list — and such days are skipped rather than ending the walk.
+ */
+export function resolveAnchor(
+  keys: string[],
+  limit: number,
+  topOf: (key: string) => number | null,
+): AnchorResolution | null {
+  if (keys.length === 0) return null;
+
+  // The first day is the fallback: before any scroll nothing has passed the
+  // chrome, and the reader is plainly looking at the top of the list.
+  let key = keys[0];
+  let anchored = false;
+
+  for (const candidate of keys) {
+    const top = topOf(candidate);
+    if (top === null) continue;
+    if (top <= limit) {
+      key = candidate;
+      anchored = true;
+      continue;
+    }
+    // The first section still below the line. It is the handover target only
+    // if something has actually passed: otherwise the reader is above the
+    // first day, this candidate *is* the fallback anchor, and reporting it
+    // as the next day would ask for progress between a day and itself.
+    return anchored
+      ? { key, nextKey: candidate, nextTop: top }
+      : { key, nextKey: null, nextTop: null };
+  }
+
+  // Everything mounted has passed — the last day of the list.
+  return { key, nextKey: null, nextTop: null };
+}
+
+/**
+ * How much scroll the highlight takes to travel from one day to the next.
+ *
+ * Floored at the header height so a one-event day still hands over across at
+ * least the distance its own title takes to move; a quarter of an 80px
+ * section is 20px, which would finish before the title had begun.
+ */
+export function rampDistance(sectionHeight: number, headerHeight: number): number {
+  const header = Number.isFinite(headerHeight) && headerHeight > 0 ? headerHeight : 0;
+  const section = Number.isFinite(sectionHeight) && sectionHeight > 0 ? sectionHeight : 0;
+  return Math.max(header, Math.min(section * RAMP_SECTION_FRACTION, RAMP_MAX_PX));
+}
+
+/**
+ * How far the handover to the next day has got, from 0 to 1.
+ *
+ * Reaches 1 at the exact moment `resolveAnchor` flips to the next day, which
+ * is what makes the value continuous across the flip rather than merely
+ * smooth on either side of it.
+ *
+ * A ramp of 0 means nothing has been measured yet; that is "no handover in
+ * progress", not a division to perform.
+ */
+export function dayProgress(nextTop: number, limit: number, ramp: number): number {
+  if (!(ramp > 0)) return 0;
+  const remaining = nextTop - limit;
+  if (remaining >= ramp) return 0;
+  if (remaining <= 0) return 1;
+  return (ramp - remaining) / ramp;
+}
+
+/**
+ * Where the strip should be scrolled to keep the highlight centred.
+ *
+ * The clamp is what gives the ends of the season their behaviour for free:
+ * the strip cannot scroll past its own bounds, so near the first or last day
+ * the pill simply stops being centred and pins toward that edge. No separate
+ * branch, and nothing to keep in step with the centred case.
+ */
+export function stripScrollLeft(
+  pillCentre: number,
+  clientWidth: number,
+  maxScroll: number,
+): number {
+  const upper = Math.max(0, maxScroll);
+  return Math.min(upper, Math.max(0, pillCentre - clientWidth / 2));
+}
+
+/**
+ * The highlight's extent, interpolated between the two chips it is between.
+ *
+ * Width is interpolated as well as position: chips are near enough uniform
+ * today (`min-w-11` dominates a two-digit label) but nothing enforces that,
+ * and a pill that kept one chip's width while sliding onto a wider one would
+ * clip the label it is supposed to be highlighting.
+ */
+export function pillGeometry(
+  anchor: ChipExtent | null,
+  next: ChipExtent | null,
+  progress: number,
+): ChipExtent | null {
+  if (!anchor) return null;
+  if (!next) return { left: anchor.left, width: anchor.width };
+  return {
+    left: lerp(anchor.left, next.left, progress),
+    width: lerp(anchor.width, next.width, progress),
+  };
+}
+
+/**
+ * Interpolate, landing exactly on the endpoints.
+ *
+ * `a + (b - a) * t` rather than `a * (1 - t) + b * t`: the latter can settle
+ * a subpixel short of `b` at `t === 1`, which would leave the pill not quite
+ * on the chip it has finished travelling to.
+ */
+export function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}

--- a/frontend/src/lib/utils/railPosition.ts
+++ b/frontend/src/lib/utils/railPosition.ts
@@ -165,10 +165,29 @@ export function pillGeometry(
 /**
  * Interpolate, landing exactly on the endpoints.
  *
- * `a + (b - a) * t` rather than `a * (1 - t) + b * t`: the latter can settle
- * a subpixel short of `b` at `t === 1`, which would leave the pill not quite
- * on the chip it has finished travelling to.
+ * The endpoints are returned outright rather than computed. `a + (b - a) * t`
+ * is exact at `t === 0` but *not* at `t === 1`: `b - a` rounds first, and
+ * adding that back to `a` need not reproduce `b`. Measured over 200,000
+ * random pairs with realistic chip geometry, it misses in about 0.025% of
+ * them — e.g. `lerp(14.338952280847916, 63.52970759586868, 1)` returns
+ * `63.529707595868686`, high by 7.1e-15.
+ *
+ * An earlier version of this comment asserted the opposite — that
+ * `a * (1 - t) + b * t` was the form that drifts. That was backwards: at
+ * `t === 1` it evaluates `a * 0 + b * 1`, which is exactly `b`, and it missed
+ * in 0 of the same 200,000 pairs. Either form is fine once the endpoints are
+ * returned directly, which is what this now does, and the reasoning is
+ * recorded because the wrong version of it was written down confidently once
+ * already.
+ *
+ * The error is far below a device pixel and nothing rendered could show it.
+ * It is fixed anyway because `pillGeometry` promises the pill sits *exactly*
+ * on the chip it has finished travelling to, and a promise that holds only
+ * for integer coordinates is one that quietly stops holding under browser
+ * text zoom, where `DOMRect` values are fractional.
  */
 export function lerp(a: number, b: number, t: number): number {
+  if (t <= 0) return a;
+  if (t >= 1) return b;
   return a + (b - a) * t;
 }


### PR DESCRIPTION
## The problem

The rail's highlight arrived in two discrete jumps that disagreed with each other:

- `useDayAnchor` emitted a **day key**, flipping the instant a section's top crossed the sticky line.
- `DayRail`'s effect fired on `[anchorDay]` and teleported `strip.scrollLeft` to centre that chip.
- Meanwhile a CSS `transition-colors` crossfaded the colour on its own timer.

Reported as: *"the highlight changes to the other date and then moves to the centre location."*

## The mechanism

The day-title replacement in the list is **scroll-linked, not time-linked** — sticky headers handing over across a fixed distance of scroll, which is why they track your finger and stop half-done when you stop. The rail now works the same way: the current day is a *fraction*, ramped over `max(headerHeight, min(25% of the section, 200px))` at the day's trailing edge. Crisp while reading, visibly continuous at flick speed.

**The fraction never becomes React state.** `page.tsx` is the whole application, so a per-frame `useState` would re-render it 60×/second. Everything is measured in a rAF and written to three DOM properties. Zero re-renders while scrolling.

## Interaction model

| Gesture | Page | Rail `scrollLeft` | Pill |
|---|---|---|---|
| Scroll the list | moves | follows, keeping the pill centred | tracks `f`, glides day→day |
| Drag the rail sideways | **still** | reader owns it; sync suspended | stays glued to its day, drifts off-centre |
| Tap a chip / `‹` `›` / `⟳ Now` | scrolls | resumes, tweens ~220ms | eases to centre |
| Scroll into a new day after a peek | moves | sync resumes here | re-centres |

**Dragging a day into the centre does not make it current.** The pill isn't a selector parked at the centre — it's attached to the day being read, and only *appears* centred because the rail auto-scrolls to keep it there. Drag peeks; tap commits. That keeps every commit an explicit button activation, so assistive tech still hears "Go to Saturday, July 4, 12 events" on every navigation — a release-to-commit drag announces nothing.

The invariant behind all of it: **`anchorDay` is derived from page scroll and nothing else.** The rail only ever reads it.

## Painting

Three layers in one scroller, so they share a single `scrollLeft` and cannot desync. The pill sits **above** the chips (below it, a chip's `hover:bg-blue-50` paints over the highlight on the current day), and a clipped copy of the row in the highlighted colour sits above the pill. A chip straddling the edge is genuinely split — left half base colour, right half white.

## Browser verification

390×844 Chromium against real production data. **This is where the one real defect was found — the branch was green on all 1029 tests at the time.**

Suspending on `wheel`/`pointerdown` over the strip infers intent from event type, and that inference is wrong for the most ordinary gesture there is: a plain **vertical** page scroll with a finger resting on the rail — which, since the rail is sticky at the top of a phone, is where swipes start. Measured: one vertical wheel, then 120px of page scroll, moved the strip **0px**; centring stayed dead until the next day boundary. Replaced with divergence detection (every write reads its value back; a strip scroll landing somewhere we didn't put it means the reader moved it). Same measurement after: **24px**. Strictly more accurate in both directions, and it now covers scrollbar drags and keyboard too.

Also measured:

- **Layer alignment** across all 251 chip pairs: **0px** worst delta.
- **Cost of the duplicated row**: none. Median frame 8.3ms with the copy, 8.3ms with it `display:none` (p95 9.9 vs 10.0). The rail turned out to span **251 chips**, not the ~64 the design estimated, so the copy is 502 buttons over a 12044px strip.
- **`clip-path` coordinate space**: resolves against the layer's own border box. Mid-handover `inset(0 1079.88px 0 10920.1px)` on a 12044px box; 10920.1 + 44 + 1079.88 = 12043.98.
- **Continuity**: 13 distinct pill positions across the 200px ramp, and the last pre-flip position *equals* the post-flip one (10896 + 48 = 10944) — continuous **across** the anchor change, not merely smooth either side of it.
- **Commit**: tapping six days ahead eases the strip through 24 distinct positions over ~400ms; under `prefers-reduced-motion`, 2.

### Not verified

Native axis-locking on a diagonal touch drag starting on the rail — headless Chromium doesn't arbitrate real touch gestures, so this needs a device or simulator pass. Low risk (ordinary `overflow-x-auto`, no `touch-action` override), but it's untested rather than passing.

## Tests

1029 passing. 29 pure geometry cases, 15 hook cases against stated layout, 4 component guards on the copy being paint-only — **each falsified by breaking the code**, including one guard I had to rewrite because it filtered on `[data-chip]`, which the copy doesn't carry, and so could never have failed.

One existing `DayRail` test was re-pointed at the new trigger rather than retired: it guards "never `scrollIntoView`", which didn't change.

## Notes for review

- `resolveAnchor` is now shared by `useDayAnchor` and the highlight. That's load-bearing, not tidiness: the pill and `aria-current` must never name different days, and one walk cannot disagree with itself. `DayRail` takes `windowDayKeys` for the same reason — both walks get identical input rather than input that happens to agree.
- Adds `DAY_HEADER_ATTR` so the ramp's floor reads a declared element rather than `firstElementChild`.
- Design and findings: `docs/plans/2026-08-17-day-rail-scroll-linked-highlight.md`.

[skip-screenshots: web-only change, touches no ios/ paths]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyVVFZYXXcmS6RrqtA2igP