### PR TITLE
fix(ci): park the sticky-stack check where a day header is actually stuck

### DIFF
--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -228,24 +228,79 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     await page.evaluate(z => { document.documentElement.style.fontSize = `${16 * z}px`; }, zoom);
     await page.waitForTimeout(600);
   }
-  await page.mouse.wheel(0, 1800);
-  await page.waitForTimeout(600);
-  const geom = await page.evaluate(() => {
+
+  // Park deliberately inside a day whose header is genuinely stuck, rather
+  // than scrolling a fixed distance and measuring whatever is there.
+  //
+  // `mouse.wheel(0, 1800)` used to do the latter, and where 1800px lands
+  // depends on how many events the current scope is showing — so it depended
+  // on the wall-clock hour. At 200% zoom it landed in the gap between two
+  // days: the outgoing header was being pushed up by the end of its own
+  // section (correct `position: sticky` behaviour, bounded by its containing
+  // block) while the next day's header had not reached the rail yet. Nothing
+  // was stuck, so there was nothing for the assertion below to be about, and
+  // it failed on `main` as well as on every branch.
+  //
+  // Iterated rather than scrolled once: the render window mounts more days as
+  // the reader descends, which moves the target out from under a single
+  // computed delta. Loop until the section is actually in position, then stop.
+  const parked = await page.evaluate(async () => {
+    const frame = () => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const railBottom = () => document.querySelector('[data-day-rail]').getBoundingClientRect().bottom;
+    const headerOf = (sec) => sec.querySelector('.sticky');
+
+    // A day tall enough that its header is still stuck once we are inside it:
+    // it must outlast the rail, its own header, and the margin we park at.
+    const MARGIN = 120;
+    const roomy = () => [...document.querySelectorAll('[data-day-key]')].find((e) => {
+      const header = headerOf(e);
+      if (!header) return false;
+      return e.getBoundingClientRect().height
+        > railBottom() + header.getBoundingClientRect().height + MARGIN * 2;
+    });
+
+    const target = roomy();
+    if (!target) return null;
+    const key = target.dataset.dayKey;
+
+    for (let i = 0; i < 25; i++) {
+      const sec = document.querySelector(`[data-day-key="${key}"]`);
+      if (!sec) return null;
+      // Aim to sit MARGIN pixels past the section's start, so the header has
+      // stuck and the section has not yet begun pushing it back out.
+      const delta = sec.getBoundingClientRect().top - railBottom() + MARGIN;
+      if (Math.abs(delta) <= 2) return key;
+      window.scrollBy(0, delta);
+      await frame();
+    }
+    return null;
+  });
+  await page.waitForTimeout(300);
+
+  const geom = parked === null ? null : await page.evaluate((key) => {
     const rail = document.querySelector('[data-day-rail]');
-    const railH = rail.getBoundingClientRect().bottom;
-    // The stuck header belongs to the section spanning the viewport top. The
-    // FIRST section's header legitimately scrolls away once you are past it,
-    // so measuring that one tests nothing.
-    const sec = [...document.querySelectorAll('[data-day-key]')]
-      .find(e => { const r = e.getBoundingClientRect(); return r.top <= railH + 1 && r.bottom > railH + 1; });
+    const sec = document.querySelector(`[data-day-key="${key}"]`);
     const header = sec?.querySelector('.sticky');
     if (!rail || !header) return null;
     const r = rail.getBoundingClientRect(), h = header.getBoundingClientRect();
-    return { railBottom: r.bottom, headerTop: h.top, headerText: header.textContent.trim().slice(0, 30) };
-  });
-  if (!geom) { check(`12 sticky stack @ ${label}`, false, 'rail or header missing'); await page.close(); continue; }
-  check(`12 header clears the rail @ ${label}`, geom.headerTop >= geom.railBottom - 2,
-    `railBottom=${geom.railBottom.toFixed(1)} headerTop=${geom.headerTop.toFixed(1)}`);
+    return { day: key, railBottom: r.bottom, headerTop: h.top, headerText: header.textContent.trim().slice(0, 30) };
+  }, parked);
+
+  if (!geom) {
+    // Said out loud rather than skipped: "no day was tall enough to park in"
+    // is a fact about the fixture the next reader needs, not a pass.
+    check(`12 sticky stack @ ${label}`, false, 'could not park inside a day with a stuck header');
+    await page.close();
+    continue;
+  }
+  // Stuck AT the rail's bottom edge, not merely somewhere below it.
+  // `headerTop >= railBottom - 2` was the old form and is satisfied by a
+  // header sitting a thousand pixels down the page, having never stuck at
+  // all — so it could pass while proving nothing. Equality is the property
+  // this check exists for: the day title comes to rest flush under the rail
+  // rather than sliding beneath it.
+  check(`12 header clears the rail @ ${label}`, Math.abs(geom.headerTop - geom.railBottom) <= 2,
+    `day=${geom.day} railBottom=${geom.railBottom.toFixed(1)} headerTop=${geom.headerTop.toFixed(1)}`);
   const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
   check(`12 no horizontal page overflow @ ${label}`, overflow <= 1, `${overflow}px`);
   await page.close();

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -246,8 +246,20 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
   // computed delta. Loop until the section is actually in position, then stop.
   const parked = await page.evaluate(async () => {
     const frame = () => new Promise(r => requestAnimationFrame(() => requestAnimationFrame(r)));
-    const railBottom = () => document.querySelector('[data-day-rail]').getBoundingClientRect().bottom;
-    const headerOf = (sec) => sec.querySelector('.sticky');
+    // Null-returning rather than throwing: an exception inside `evaluate`
+    // aborts the whole script, where every other failure in this harness is
+    // reported as a named check with the value it measured.
+    const railBottom = () => {
+      const rail = document.querySelector('[data-day-rail]');
+      return rail ? rail.getBoundingClientRect().bottom : null;
+    };
+    // `[data-day-header]` rather than `.sticky`: the attribute is the declared
+    // DOM contract (`DAY_SECTION_ATTR`'s neighbour in `daySections.ts`), while
+    // the class is a Tailwind utility that would silently match any other
+    // sticky descendant a section gained later.
+    const headerOf = (sec) => sec.querySelector('[data-day-header]');
+
+    if (railBottom() === null) return { ok: false, why: 'no day rail on the page' };
 
     // A day tall enough that its header is still stuck once we are inside it:
     // it must outlast the rail, its own header, and the margin we park at.
@@ -255,8 +267,10 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     const roomy = () => [...document.querySelectorAll('[data-day-key]')].find((e) => {
       const header = headerOf(e);
       if (!header) return false;
+      const bottom = railBottom();
+      if (bottom === null) return false;
       return e.getBoundingClientRect().height
-        > railBottom() + header.getBoundingClientRect().height + MARGIN * 2;
+        > bottom + header.getBoundingClientRect().height + MARGIN * 2;
     });
 
     // Search as the window grows, not once before it has.
@@ -289,9 +303,11 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     for (let i = 0; i < 25; i++) {
       const sec = document.querySelector(`[data-day-key="${key}"]`);
       if (!sec) return { ok: false, why: `target day ${key} left the DOM while homing in on it` };
+      const bottom = railBottom();
+      if (bottom === null) return { ok: false, why: 'the day rail left the page while homing in' };
       // Aim to sit MARGIN pixels past the section's start, so the header has
       // stuck and the section has not yet begun pushing it back out.
-      const delta = sec.getBoundingClientRect().top - railBottom() + MARGIN;
+      const delta = sec.getBoundingClientRect().top - bottom + MARGIN;
       if (Math.abs(delta) <= 2) return { ok: true, key };
       window.scrollBy(0, delta);
       await frame();
@@ -306,7 +322,7 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
   const geom = !parked.ok ? null : await page.evaluate((key) => {
     const rail = document.querySelector('[data-day-rail]');
     const sec = document.querySelector(`[data-day-key="${key}"]`);
-    const header = sec?.querySelector('.sticky');
+    const header = sec?.querySelector('[data-day-header]');
     if (!rail || !header) return null;
     const r = rail.getBoundingClientRect(), h = header.getBoundingClientRect();
     return { day: key, railBottom: r.bottom, headerTop: h.top, headerText: header.textContent.trim().slice(0, 30) };

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -325,7 +325,7 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     const header = sec?.querySelector('[data-day-header]');
     if (!rail || !header) return null;
     const r = rail.getBoundingClientRect(), h = header.getBoundingClientRect();
-    return { day: key, railBottom: r.bottom, headerTop: h.top, headerText: header.textContent.trim().slice(0, 30) };
+    return { day: key, railBottom: r.bottom, headerTop: h.top };
   }, parked.key);
 
   if (!geom) {

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -259,37 +259,63 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
         > railBottom() + header.getBoundingClientRect().height + MARGIN * 2;
     });
 
-    const target = roomy();
-    if (!target) return null;
-    const key = target.dataset.dayKey;
+    // Search as the window grows, not once before it has.
+    //
+    // The day list is lazily windowed: the first render mounts only enough
+    // days to reach RENDER_BATCH_EVENTS, and more arrive as an
+    // IntersectionObserver on a bottom sentinel is tripped. Choosing the
+    // target from the initially-mounted set alone would make this check
+    // depend on whether the first batch happens to contain a tall day —
+    // a property of whatever the season is showing today, which is the exact
+    // class of data-dependence this whole change exists to remove. So the
+    // search is retried as the window grows, and only a genuine exhaustion
+    // of the list is reported as a failure.
+    let target = roomy();
+    for (let grow = 0; grow < 20 && !target; grow++) {
+      const before = document.querySelectorAll('[data-day-key]').length;
+      window.scrollBy(0, window.innerHeight);
+      await frame();
+      await frame();
+      target = roomy();
+      // The window stopped growing and still has nothing tall enough — more
+      // scrolling cannot help, so stop rather than spin out the loop.
+      if (!target && document.querySelectorAll('[data-day-key]').length === before) break;
+    }
+    if (!target) {
+      return { ok: false, why: 'no mounted day was tall enough to hold a stuck header, even after growing the render window' };
+    }
 
+    const key = target.dataset.dayKey;
     for (let i = 0; i < 25; i++) {
       const sec = document.querySelector(`[data-day-key="${key}"]`);
-      if (!sec) return null;
+      if (!sec) return { ok: false, why: `target day ${key} left the DOM while homing in on it` };
       // Aim to sit MARGIN pixels past the section's start, so the header has
       // stuck and the section has not yet begun pushing it back out.
       const delta = sec.getBoundingClientRect().top - railBottom() + MARGIN;
-      if (Math.abs(delta) <= 2) return key;
+      if (Math.abs(delta) <= 2) return { ok: true, key };
       window.scrollBy(0, delta);
       await frame();
     }
-    return null;
+    // Distinct from the search failure above: a day WAS found, the scroll just
+    // never settled on it. Worth telling apart — one is about the fixture, the
+    // other about the page moving under the scroll.
+    return { ok: false, why: `scroll did not settle on ${key} within 25 attempts` };
   });
   await page.waitForTimeout(300);
 
-  const geom = parked === null ? null : await page.evaluate((key) => {
+  const geom = !parked.ok ? null : await page.evaluate((key) => {
     const rail = document.querySelector('[data-day-rail]');
     const sec = document.querySelector(`[data-day-key="${key}"]`);
     const header = sec?.querySelector('.sticky');
     if (!rail || !header) return null;
     const r = rail.getBoundingClientRect(), h = header.getBoundingClientRect();
     return { day: key, railBottom: r.bottom, headerTop: h.top, headerText: header.textContent.trim().slice(0, 30) };
-  }, parked);
+  }, parked.key);
 
   if (!geom) {
     // Said out loud rather than skipped: "no day was tall enough to park in"
     // is a fact about the fixture the next reader needs, not a pass.
-    check(`12 sticky stack @ ${label}`, false, 'could not park inside a day with a stuck header');
+    check(`12 header clears the rail @ ${label}`, false, parked.why ?? 'rail or header missing');
     await page.close();
     continue;
   }


### PR DESCRIPTION
## `main` is red, and it is the check, not the code

`browser-checks` fails on `main` at `12 header clears the rail @ 200% zoom` with `railBottom=105.0 headerTop=41.0`. The same check failed with **byte-identical numbers** at `f9e8a31`, before the recent rail work, so this predates #241 and is not a regression from it.

## Why it fails

The check scrolled a fixed `mouse.wheel(0, 1800)` and measured whatever happened to be under the rail. Where 1800px lands depends on how many events the current scope is showing — so it depended on the wall-clock hour, the same root cause as `11c` in #241.

At 200% zoom it landed in the **gap between two days**: the outgoing header was being pushed up by the end of its own section — `position: sticky` behaving correctly against its containing block — while the next day's header had not yet reached the rail. Nothing was stuck, so there was nothing for the assertion to be about.

Reproduced locally 4/4, deterministically:

```
railBottom=105  --day-rail-h=105px  header position=sticky  top=105px
headerTop=41    <- being pushed out by the end of its own section
```

Note `--day-rail-h` was **correct** at 105px and the header genuinely had `top: 105px`. This was never a measurement race.

## The fix

Park deliberately inside a day tall enough to hold a stuck header, instead of scrolling a fixed distance and hoping.

**Iterated, not computed once.** The render window mounts more days as the reader descends, which moves the target out from under a single delta. Measured on an intermediate attempt: one `scrollBy` left the header **512px** and **1044px** from the rail rather than on it.

**Assertion tightened** from `headerTop >= railBottom - 2` to `|headerTop - railBottom| <= 2`. The old form is satisfied by a header sitting a thousand pixels down the page having never stuck at all — and during this fix it did exactly that, reporting `PASS` for a header 1044px away. Equality is the property the check exists for: the day title comes to rest flush under the rail rather than sliding beneath it.

**Unparkable is a failure, not a skip.** "No day was tall enough to park in" is a fact about the fixture the next reader needs.

## Verification

| | result |
|---|---|
| Local, 3 consecutive runs | 36/36 and 34/34 |
| Under `TZ=UTC` | 36/36 |
| At 320px | `railBottom=64.0 headerTop=64.0` |
| At 200% zoom | `railBottom=105.0 headerTop=105.0` |

**Falsified** by reintroducing the defect the check exists for — the day header sticking at `top: 0` instead of below the rail — which it catches at both viewports:

```
FAIL  12 header clears the rail @ 320px      railBottom=64.0   headerTop=0.0
FAIL  12 header clears the rail @ 200% zoom  railBottom=105.0  headerTop=0.0
```

Worth recording: that falsification needed `vite build` directly. `npm run build` runs the unit suite, which **already catches this defect** and correctly refused to produce the broken bundle — so my first falsification attempt silently tested a stale bundle and reported a false PASS.

## Scope

One file, `frontend/e2e/verify-rail.mjs`, check 12 only. No application code changes.

[skip-screenshots: e2e harness only, no ios/ paths and no pixel a user can see]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyVVFZYXXcmS6RrqtA2igP