### PR TITLE
feat(web): resolve every date in the Institution's timezone

### DIFF
--- a/docs/plans/2026-08-18-institution-timezone-design.md
+++ b/docs/plans/2026-08-18-institution-timezone-design.md
@@ -145,13 +145,29 @@ technique, which must be tested at both DST transitions
 
 ## Testing, and one corrected proposal
 
-**A second unit-test leg under `TZ=UTC` does not work.** `vitest.config.ts`
-already pins `env: { TZ: 'America/New_York' }` on purpose — without it the
-DST-transition tests in `dayWindow.test.ts` stop discriminating a DST-safe
-implementation from naive millisecond arithmetic, because GitHub runners are
-UTC where 2026-03-08 and 2026-11-01 are not transitions. The pin overrides
-the environment: the full suite passes unchanged under `UTC`,
+**Unit tests cannot prove device-independence here.** `vitest.config.ts` pins
+`env: { TZ: 'America/New_York' }` on purpose — without it the DST-transition
+tests in `dayWindow.test.ts` stop discriminating a DST-safe implementation
+from naive millisecond arithmetic, because GitHub runners are UTC where
+2026-03-08 and 2026-11-01 are not transitions. That pin overrides the `TZ`
+environment variable, so the suite passes unchanged under `UTC`,
 `America/Los_Angeles`, `Asia/Tokyo` and `Pacific/Kiritimati`. Verified.
+
+*Correction, found during execution:* a second vitest **config file** does
+replace the pin, where the env var could not. Running the suite that way under
+`Asia/Tokyo` fails widely — but the failures are overwhelmingly test **fixture**
+zone-dependence, not code defects: tests that build inputs with a device-local
+`new Date(y, m, d)` and assert an Institution-time answer are only valid while
+the device is Eastern. Making the whole suite zone-independent would mean
+rewriting dozens of fixtures across many files, so it is deliberately out of
+scope.
+
+The consequence is load-bearing and must not be forgotten: **with the pin in
+place, a unit test cannot distinguish correct Institution-anchored code from
+the device-local code it replaced.** Every unit test in this migration pins
+intended semantics and guards against regression; none of them proves the
+migration happened. The browser check below is the only automated proof, and
+is therefore not optional.
 
 The safeguard instead has two parts:
 

--- a/docs/plans/2026-08-18-institution-timezone-design.md
+++ b/docs/plans/2026-08-18-institution-timezone-design.md
@@ -1,0 +1,176 @@
+# All times in the Institution's timezone
+
+**Status:** Design, approved in conversation. Not yet implemented.
+**Branch:** `feat/institution-timezone`
+
+## The decision
+
+> All times and dates, including "now", should be in the timezone of the
+> Institution (America/New_York).
+
+Times are **not labelled**. `7:00 PM` stays `7:00 PM` for everyone; no "ET"
+suffix, no per-viewer variation.
+
+## The data, and what must not change
+
+Every event in the feed looks like this:
+
+```json
+{ "startDate": "2026-07-27 12:45:00",
+  "endDate":   "2026-07-27 12:45:00",
+  "timezone":  "America/New_York" }
+```
+
+Surveyed across all **3,246** events: the `startDate` format is uniform
+(space-separated, naive, no offset, zero exceptions) and `timezone` is
+`America/New_York` for every single one. The web has never read the
+`timezone` field.
+
+**This change touches `frontend/src/**` only.** No backend handler, no
+`syncHandler`, nothing in the ingest path. `all-events.json` stays
+byte-identical, so an old web bundle or the shipped iOS app fetches the same
+bytes and runs the code it shipped with — unaffected by construction, not
+merely in practice. The implementation diff must contain zero files outside
+`frontend/`, and that is checkable rather than assertable.
+
+Stored state is unaffected too: localStorage holds `dateFilter` (a string
+enum), `selectedWeeks` (numbers) and day keys. Day keys are already
+timezone-independent (see below). No instants are persisted, so there is
+nothing to migrate.
+
+### Why the fix is not in the data
+
+Emitting offsets (`2026-07-27T12:45:00-04:00`) would fix every client at
+once, including old ones. It is the wrong move here:
+
+- The **shipped iOS app** parses with two fixed-format `DateFormatter`s,
+  `"yyyy-MM-dd HH:mm:ss"` and `"yyyy-MM-dd'T'HH:mm:ss"`. A trailing offset
+  is outside both. Whether `DateFormatter` tolerates trailing characters is
+  not something to gamble on against a binary already on people's phones
+  that cannot be patched retroactively.
+- The **backend itself** assumes the naive shape — `articleMatcher`
+  regex-matches `[T ](\d{2}):(\d{2})`.
+- Blast radius: a data change reaches every client of every age plus backend
+  services; a client change reaches one deployable that can be rolled back.
+
+If offsets are ever wanted in the feed, the ordering is forced: ship iOS
+parsers that accept both shapes, wait for adoption, *then* change the data.
+Separate project.
+
+## What is actually broken
+
+Measured, not reasoned — the app's real logic run under four device zones
+against one event (`2026-07-27 12:45:00`) and one fixed instant (12:50 EDT,
+five minutes *after* it):
+
+| Device TZ | Displayed | Day group | "Upcoming?" | "Today" |
+|---|---|---|---|---|
+| `America/New_York` | 12:45 PM | 2026-07-27 | no | 2026-07-27 |
+| `UTC` | 12:45 PM | 2026-07-27 | no | 2026-07-27 |
+| `America/Los_Angeles` | 12:45 PM | 2026-07-27 | **yes** ❌ | 2026-07-27 |
+| `Asia/Tokyo` | 12:45 PM | 2026-07-27 | no | **2026-07-28** ❌ |
+
+Display and day-grouping are **identical everywhere**, because parsing a
+naive string as device-local and reading device-local components back is an
+identity round-trip. The ICS export is correct for the same reason.
+
+What breaks is comparison against the true current instant:
+
+- **The `Now` scope.** West of Eastern, events look later than they are — an
+  event that ended five minutes ago still reads as upcoming.
+- **`todayKey`.** East of Eastern, "today" can be tomorrow, so `⟳ Now`, the
+  day rail's anchor and the Today scope land on the wrong day.
+
+This is the same defect that made CI's `⟳ Now` check fail after 20:00 UTC
+(see [[browser-checks-e2e-time-dependence]]).
+
+## The part that is easy to get wrong
+
+An earlier draft of this design listed grouping, week assignment, display and
+ICS as things to fix. That was wrong: each is **already correct**. But they
+are correct only because everything — parsing, day keys, week boundaries,
+formatting — is consistently device-local, so the offsets cancel.
+
+The moment parsing moves to Institution time, that cancellation stops
+holding. So those call sites must move too, not because they are broken but
+because leaving them behind would break them:
+
+| Site | Broken today? | Must change? | Why |
+|---|---|---|---|
+| Event parsing | yes (wrong instant) | yes | the root |
+| `Now` scope / now-comparisons | **yes** | yes | user-visible defect |
+| `todayKey` | **yes** | yes | user-visible defect |
+| Day keys / grouping | no | **yes** | must read NY components off an NY instant |
+| Season week boundaries | no | **yes** | Saturday *noon at Chautauqua* |
+| Time display | no | **yes** | must format an NY instant in NY |
+| ICS export | no | **yes** | must keep its round-trip property |
+
+**It is all-or-nothing.** A partial migration leaves mixed semantics, which
+is strictly worse than today's consistent-but-shifted state.
+
+## The module
+
+`frontend/src/lib/utils/chqTime.ts`, mirroring iOS's `ChqTime` rather than
+inventing a second model — the two apps should agree about what a day is.
+
+```
+CHQ_ZONE = 'America/New_York'
+
+parseEventDate(s)         naive "yyyy-MM-dd HH:mm:ss" | "...T..." -> instant
+chqDayKey(instant)        the Chautauqua calendar day of an instant
+chqStartOfDay(dayKey)     -> instant
+chqDateAt(y, m, d, h, min)  Chautauqua wall time -> instant
+formatChqTime(instant)    "7:00 PM", unlabelled
+chqParts(instant)         { year, month, day, hour, minute } in CHQ_ZONE
+```
+
+Built on `Intl.DateTimeFormat` with `timeZone` — no new dependency, correct
+across DST. Wall-time-to-instant uses the standard offset-lookup-and-correct
+technique, which must be tested at both DST transitions
+(2026-03-08, 2026-11-01).
+
+## Call sites
+
+- `lib/utils/dateHelpers.ts` — `getChautauquaSeasonWeeks` (the noon
+  boundaries), `isInChautauquaWeek`, `isWeekInPast`, `getCurrentWeekNumber`,
+  `getWeekNumberForDate`, `getAdaptiveEndDate`
+- `lib/utils/dayWindow.ts` — `dayKeyOf`, `startOfDay`, `dayAfter`, `addDays`
+- `lib/utils/eventHelpers.ts` — day grouping and sorting
+- `lib/utils/filterHelpers.ts` — the window containment test
+- `lib/utils/icsHelpers.ts` — preserve the round-trip
+- `lib/constants.ts` — `getDefaultYear`'s October-1 turnover
+- `app/page.tsx` — the two `now: new Date()` sites and `todayKey`
+- `components/calendar/EventCard.tsx` — time display
+- `components/layout/CountdownBanner.tsx`
+
+## Testing, and one corrected proposal
+
+**A second unit-test leg under `TZ=UTC` does not work.** `vitest.config.ts`
+already pins `env: { TZ: 'America/New_York' }` on purpose — without it the
+DST-transition tests in `dayWindow.test.ts` stop discriminating a DST-safe
+implementation from naive millisecond arithmetic, because GitHub runners are
+UTC where 2026-03-08 and 2026-11-01 are not transitions. The pin overrides
+the environment: the full suite passes unchanged under `UTC`,
+`America/Los_Angeles`, `Asia/Tokyo` and `Pacific/Kiritimati`. Verified.
+
+The safeguard instead has two parts:
+
+1. **Unit** — `chqTime` tested directly, including both DST transitions, and
+   the existing suites extended where behaviour is now pinned rather than
+   incidental (day keys, ICS round-trip).
+2. **Browser** — the e2e already sets `timezoneId` per context (added in
+   #241). Add a pass that drives the app under a **non-Eastern** zone and
+   asserts the same days, the same grouping and the same rendered times as
+   the Eastern pass. That tests the actual property — "the app shows
+   Chautauqua's day regardless of the device" — at the layer where it
+   matters, and no config pin can defeat it.
+
+Every new guard proved by breaking the code first; see
+[[falsify-guards-and-suspect-the-harness]] for the trap that a browser-check
+falsification needs `npx vite build`, not `npm run build`.
+
+## Out of scope
+
+- Any backend or data change (see above).
+- iOS — already correct via `ChqTime`.
+- Timezone labels in the UI — explicitly declined.

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -1,0 +1,1106 @@
+# Institution Timezone Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every time and date the web app computes — including "now" and "today" — resolve in the Chautauqua Institution's timezone, `America/New_York`, regardless of the reader's device.
+
+**Architecture:** One new pure module, `chqTime.ts`, converts between naive Institution wall-clock strings and absolute instants using `Intl.DateTimeFormat`. Every existing site that today reads or builds device-local calendar fields is migrated to it in one coherent sweep. The migration is all-or-nothing: display, day grouping and ICS are *correct today* only because everything is consistently device-local and the offsets cancel; moving parsing alone would break them.
+
+**Tech Stack:** TypeScript 5, Vite 7, Preact 10, Vitest 4, Playwright (e2e). No new runtime dependency — `Intl.DateTimeFormat` only.
+
+**Spec:** `docs/plans/2026-08-18-institution-timezone-design.md`
+
+## Global Constraints
+
+- **Zero files outside `frontend/`.** `git diff --stat main...HEAD` must list only `frontend/` paths. The feed, the backend and `all-events.json` are untouched, so old web bundles and the shipped iOS app are unaffected by construction.
+- **Timezone identifier is exactly `America/New_York`.** Never a fixed offset, never `EST`/`EDT`.
+- **Times are unlabelled.** `7:00 PM` stays `7:00 PM`. No "ET" suffix anywhere, no per-viewer variation.
+- **Half-open windows.** `start <= x < endExclusive`. Never an inclusive bound with a subtracted epsilon.
+- **Day keys are `yyyy-mm-dd`,** zero-padded, lexicographically chronological, byte-identical to iOS `ChqTime.dayKey`.
+- **Do not change `vitest.config.ts`'s `env: { TZ: 'America/New_York' }`.** It exists so the DST-transition tests keep discriminating on UTC runners.
+- Run `npm run validate` (type-check + lint) before every commit. Frontend commands run from `frontend/`.
+
+---
+
+### Task 1: The `chqTime` module
+
+**Files:**
+- Create: `frontend/src/lib/utils/chqTime.ts`
+- Test: `frontend/src/__tests__/lib/utils/chqTime.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `CHQ_ZONE: string`, `chqParts(d: Date): ChqParts`, `chqDayKey(d: Date): string`, `chqDateAt(y: number, mo: number, d: number, h?: number, mi?: number, s?: number, ms?: number): Date`, `parseEventDate(s: string): Date`, `formatChqTime(d: Date): string`, `formatChqDayLabel(d: Date): string`, and `interface ChqParts { year: number; month: number; day: number; hour: number; minute: number; second: number; weekday: number }`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/__tests__/lib/utils/chqTime.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import {
+  CHQ_ZONE, chqParts, chqDayKey, chqDateAt, parseEventDate,
+  formatChqTime, formatChqDayLabel,
+} from '@/lib/utils/chqTime';
+
+describe('CHQ_ZONE', () => {
+  it('is the Institution zone, never a fixed offset', () => {
+    expect(CHQ_ZONE).toBe('America/New_York');
+  });
+});
+
+describe('chqParts', () => {
+  it('reads calendar fields in Institution time, not the device zone', () => {
+    // 2026-07-27T03:45:00Z is 23:45 on 2026-07-26 at Chautauqua (EDT, -4).
+    const p = chqParts(new Date('2026-07-27T03:45:00Z'));
+    expect(p).toMatchObject({ year: 2026, month: 7, day: 26, hour: 23, minute: 45 });
+  });
+
+  it('reads winter instants in EST', () => {
+    // 2026-01-15T18:30:00Z is 13:30 EST (-5).
+    const p = chqParts(new Date('2026-01-15T18:30:00Z'));
+    expect(p).toMatchObject({ year: 2026, month: 1, day: 15, hour: 13, minute: 30 });
+  });
+
+  it('reports midnight as hour 0, never 24', () => {
+    // 2026-07-27T04:00:00Z is exactly midnight EDT.
+    expect(chqParts(new Date('2026-07-27T04:00:00Z')).hour).toBe(0);
+  });
+});
+
+describe('chqDayKey', () => {
+  it('gives the Institution calendar day of an instant', () => {
+    expect(chqDayKey(new Date('2026-07-27T03:45:00Z'))).toBe('2026-07-26');
+    expect(chqDayKey(new Date('2026-07-27T16:45:00Z'))).toBe('2026-07-27');
+  });
+
+  it('zero-pads to yyyy-mm-dd', () => {
+    expect(chqDayKey(new Date('2026-01-05T17:00:00Z'))).toBe('2026-01-05');
+  });
+});
+
+describe('chqDateAt', () => {
+  it('builds an instant from Institution wall time in summer', () => {
+    // Noon EDT on 2026-07-27 is 16:00Z.
+    expect(chqDateAt(2026, 7, 27, 12).toISOString()).toBe('2026-07-27T16:00:00.000Z');
+  });
+
+  it('builds an instant from Institution wall time in winter', () => {
+    // Noon EST on 2026-01-15 is 17:00Z.
+    expect(chqDateAt(2026, 1, 15, 12).toISOString()).toBe('2026-01-15T17:00:00.000Z');
+  });
+
+  it('round-trips through chqParts across the spring DST transition', () => {
+    // 2026-03-08: 02:00 does not exist; 03:00 EDT is 07:00Z.
+    const d = chqDateAt(2026, 3, 8, 3);
+    expect(chqParts(d)).toMatchObject({ year: 2026, month: 3, day: 8, hour: 3 });
+  });
+
+  it('round-trips through chqParts across the autumn DST transition', () => {
+    // 2026-11-01: 01:00 occurs twice. Either instant must read back as 01:00.
+    const d = chqDateAt(2026, 11, 1, 1);
+    expect(chqParts(d)).toMatchObject({ year: 2026, month: 11, day: 1, hour: 1 });
+  });
+
+  it('round-trips every hour of both DST transition days', () => {
+    for (const [mo, day] of [[3, 8], [11, 1]] as const) {
+      for (let h = 0; h < 24; h++) {
+        const p = chqParts(chqDateAt(2026, mo, day, h));
+        // The spring-forward hour 02:00 does not exist; it normalises to 03:00.
+        const expected = mo === 3 && h === 2 ? 3 : h;
+        expect({ h, got: p.hour }).toEqual({ h, got: expected });
+      }
+    }
+  });
+});
+
+describe('parseEventDate', () => {
+  it('reads the feed\'s space-separated form as Institution wall time', () => {
+    expect(parseEventDate('2026-07-27 12:45:00').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('reads the T-separated form the publisher feeds use', () => {
+    expect(parseEventDate('2026-07-27T12:45:00').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('reads a winter date in EST', () => {
+    expect(parseEventDate('2026-01-15 12:00:00').toISOString()).toBe('2026-01-15T17:00:00.000Z');
+  });
+
+  it('tolerates a missing seconds field', () => {
+    expect(parseEventDate('2026-07-27 12:45').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('returns an Invalid Date for an unparseable string', () => {
+    // groupEventsByDay relies on this to emit its NaN-NaN-NaN key.
+    expect(Number.isNaN(parseEventDate('not a date').getTime())).toBe(true);
+  });
+});
+
+describe('formatChqTime', () => {
+  it('renders Institution wall time, unlabelled', () => {
+    expect(formatChqTime(new Date('2026-07-27T23:00:00Z'))).toBe('7:00 PM');
+  });
+
+  it('carries no timezone suffix', () => {
+    expect(formatChqTime(new Date('2026-07-27T23:00:00Z'))).not.toMatch(/ET|EDT|EST|GMT|UTC/);
+  });
+});
+
+describe('formatChqDayLabel', () => {
+  it('names the Institution day, not the device day', () => {
+    // 03:45Z is still the 26th at Chautauqua.
+    expect(formatChqDayLabel(new Date('2026-07-27T03:45:00Z')))
+      .toBe('Sunday, July 26, 2026');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/chqTime.test.ts`
+Expected: FAIL — `Failed to resolve import "@/lib/utils/chqTime"`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `frontend/src/lib/utils/chqTime.ts`:
+
+```ts
+/**
+ * Institution-anchored time.
+ *
+ * Every date the calendar reasons about belongs to the Chautauqua
+ * Institution, whose season runs on Eastern time, and the feed's timestamps
+ * carry no offset of their own (`"2026-07-27 12:45:00"`, with a sibling
+ * `timezone` field that has said `America/New_York` for all 3,246 events).
+ * Reading them in the device's zone made the app agree with a reader
+ * standing on the grounds and disagree with everyone else.
+ *
+ * Mirrors iOS's `ChqTime` deliberately: the two apps should not hold
+ * different opinions about which day an event is on.
+ */
+
+/** Never a fixed offset — the season spans a DST transition in most years. */
+export const CHQ_ZONE = 'America/New_York';
+
+export interface ChqParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  /** 0 = Sunday, matching `Date.prototype.getDay`. */
+  weekday: number;
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const partsFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHQ_ZONE,
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+  weekday: 'short', hour12: false,
+});
+
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHQ_ZONE, hour: 'numeric', minute: '2-digit', hour12: true,
+});
+
+const dayLabelFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHQ_ZONE,
+  weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+});
+
+/** An instant's calendar fields as they read at Chautauqua. */
+export function chqParts(d: Date): ChqParts {
+  const found: Record<string, string> = {};
+  for (const { type, value } of partsFormatter.formatToParts(d)) {
+    found[type] = value;
+  }
+  return {
+    year: Number(found.year),
+    month: Number(found.month),
+    day: Number(found.day),
+    // `hourCycle: h23` still renders midnight as "24" in some engines.
+    hour: Number(found.hour) % 24,
+    minute: Number(found.minute),
+    second: Number(found.second),
+    weekday: Math.max(0, WEEKDAYS.indexOf(found.weekday)),
+  };
+}
+
+/** The Chautauqua calendar day an instant falls on, as `yyyy-mm-dd`. */
+export function chqDayKey(d: Date): string {
+  const { year, month, day } = chqParts(d);
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/**
+ * The instant at which the Chautauqua clock reads the given wall time.
+ *
+ * Offset-lookup-and-correct, applied twice. A single correction is wrong
+ * when the guess and the answer straddle a DST boundary: the offset used to
+ * make the guess is not the offset in force at the result. The second pass
+ * re-reads the offset at the corrected instant and settles it. Ambiguous
+ * times (the repeated hour each autumn) resolve to the first occurrence,
+ * and nonexistent ones (the skipped hour each spring) to the instant after
+ * the gap — both matching `Calendar` on iOS.
+ */
+export function chqDateAt(
+  y: number, mo: number, d: number,
+  h = 0, mi = 0, s = 0, ms = 0,
+): Date {
+  const asUTC = Date.UTC(y, mo - 1, d, h, mi, s, ms);
+  let guess = new Date(asUTC);
+  for (let pass = 0; pass < 2; pass++) {
+    const p = chqParts(guess);
+    const readBack = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second, ms);
+    const drift = readBack - asUTC;
+    if (drift === 0) break;
+    guess = new Date(guess.getTime() - drift);
+  }
+  return guess;
+}
+
+/**
+ * A feed timestamp — naive Institution wall time — as an absolute instant.
+ *
+ * Accepts the space-separated form the CHQ feed emits and the T-separated
+ * form publisher feeds use, with or without seconds. Anything else yields an
+ * Invalid Date, which `groupEventsByDay` turns into its `NaN-NaN-NaN` key
+ * rather than crashing.
+ */
+export function parseEventDate(s: string): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/.exec(s ?? '');
+  if (!m) return new Date(NaN);
+  return chqDateAt(
+    Number(m[1]), Number(m[2]), Number(m[3]),
+    Number(m[4]), Number(m[5]), Number(m[6] ?? 0),
+  );
+}
+
+/** `"7:00 PM"` at Chautauqua. Deliberately unlabelled — see the design doc. */
+export function formatChqTime(d: Date): string {
+  return timeFormatter.format(d);
+}
+
+/** `"Sunday, July 26, 2026"` at Chautauqua. */
+export function formatChqDayLabel(d: Date): string {
+  return dayLabelFormatter.format(d);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/chqTime.test.ts`
+Expected: PASS, all cases.
+
+- [ ] **Step 5: Prove the DST tests bite**
+
+Temporarily replace the body of `chqDateAt` with the naive version:
+
+```ts
+  return new Date(Date.UTC(y, mo - 1, d, h, mi, s, ms));
+```
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/chqTime.test.ts`
+Expected: FAIL on the summer/winter and both DST round-trip cases. Restore the real implementation and re-run to PASS.
+
+- [ ] **Step 6: Validate and commit**
+
+```bash
+cd frontend && npm run validate
+cd .. && git add frontend/src/lib/utils/chqTime.ts frontend/src/__tests__/lib/utils/chqTime.test.ts
+git commit -m "feat(web): add Institution-anchored time helpers"
+```
+
+---
+
+### Task 2: Day keys and window boundaries
+
+**Files:**
+- Modify: `frontend/src/lib/utils/dayWindow.ts` — `dayKeyOf`, `startOfDay`, `dayAfter`, `lastDayCovered`, `addDays`, `isDayKey`
+- Test: `frontend/src/__tests__/lib/utils/dayWindow.test.ts` (existing — add to it)
+
+**Interfaces:**
+- Consumes: `chqDayKey`, `chqDateAt`, `chqParts` from Task 1.
+- Produces: the same exported signatures as today — `dayKeyOf(d: Date): DayKey`, `startOfDay(key: DayKey): Date`, `dayAfter(key: DayKey): Date`, `lastDayCovered(endExclusive: Date): DayKey`, `addDays(key: DayKey, n: number): DayKey`. Only their *meaning* changes: Institution time rather than device time.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/__tests__/lib/utils/dayWindow.test.ts`:
+
+```ts
+describe('Institution-anchored day boundaries', () => {
+  it('files an instant under the Institution day, not the device day', () => {
+    // 03:45Z on the 27th is 23:45 on the 26th at Chautauqua.
+    expect(dayKeyOf(new Date('2026-07-27T03:45:00Z'))).toBe('2026-07-26');
+  });
+
+  it('starts a day at Institution midnight', () => {
+    expect(startOfDay('2026-07-27').toISOString()).toBe('2026-07-27T04:00:00.000Z');
+  });
+
+  it('starts a winter day at Institution midnight', () => {
+    expect(startOfDay('2026-01-15').toISOString()).toBe('2026-01-15T05:00:00.000Z');
+  });
+
+  it('ends a day at the next Institution midnight', () => {
+    expect(dayAfter('2026-07-27').toISOString()).toBe('2026-07-28T04:00:00.000Z');
+  });
+
+  it('tiles exactly: one day\'s end is the next day\'s start', () => {
+    expect(dayAfter('2026-03-07').getTime()).toBe(startOfDay('2026-03-08').getTime());
+    expect(dayAfter('2026-10-31').getTime()).toBe(startOfDay('2026-11-01').getTime());
+  });
+
+  it('treats Institution midnight as midnight for lastDayCovered', () => {
+    // 04:00Z is midnight EDT, so the window does not show that day.
+    expect(lastDayCovered(new Date('2026-07-28T04:00:00.000Z'))).toBe('2026-07-27');
+  });
+
+  it('keeps the final day when a window ends mid-day at Chautauqua', () => {
+    // Noon EDT Saturday — 'this-week' ends here and that morning has events.
+    expect(lastDayCovered(new Date('2026-07-25T16:00:00.000Z'))).toBe('2026-07-25');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/dayWindow.test.ts -t "Institution-anchored"`
+Expected: FAIL — the device-local implementations return `2026-07-27` and midnight-local instants.
+
+- [ ] **Step 3: Write the implementation**
+
+In `frontend/src/lib/utils/dayWindow.ts`, add the import and replace the five functions.
+
+Import:
+
+```ts
+import { chqDateAt, chqDayKey, chqParts } from '@/lib/utils/chqTime';
+```
+
+Update the `DayKey` doc comment's first line from `in local time` to:
+
+```ts
+/**
+ * A calendar day as `yyyy-mm-dd`, zero-padded, in Institution time.
+ *
+```
+
+Replace the function bodies:
+
+```ts
+export function dayKeyOf(d: Date): DayKey {
+  return chqDayKey(d);
+}
+
+export function startOfDay(key: DayKey): Date {
+  const [y, m, d] = partsOf(key);
+  return chqDateAt(y, m, d, 0, 0, 0, 0);
+}
+
+export function dayAfter(key: DayKey): Date {
+  const [y, m, d] = partsOf(key);
+  // Built by adding a calendar day, never 86,400,000ms: a DST transition day
+  // is 23 or 25 hours long, and millisecond arithmetic lands an hour out.
+  return chqDateAt(y, m, d + 1, 0, 0, 0, 0);
+}
+
+export function lastDayCovered(endExclusive: Date): DayKey {
+  const p = chqParts(endExclusive);
+  const isMidnight = p.hour === 0 && p.minute === 0 && p.second === 0;
+  const key = dayKeyOf(endExclusive);
+  return isMidnight ? addDays(key, -1) : key;
+}
+
+export function addDays(key: DayKey, n: number): DayKey {
+  const [y, m, d] = partsOf(key);
+  return dayKeyOf(chqDateAt(y, m, d + n, 12, 0, 0, 0));
+}
+```
+
+Also replace `isDayKey`'s body, which validated against a device-local `Date`:
+
+```ts
+function isDayKey(key: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) return false;
+  const [y, m, d] = partsOf(key);
+  // Noon, not midnight: a date that does not exist rolls over, and noon is
+  // far enough from any DST edge that only a genuine rollover moves the day.
+  return dayKeyOf(chqDateAt(y, m, d, 12)) === key;
+}
+```
+
+Note the deliberate `12` in `addDays` and `isDayKey`: `chqDateAt` normalises the nonexistent 02:00 on a spring-forward day to 03:00, so anchoring at noon keeps the arithmetic away from the boundary entirely.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/dayWindow.test.ts`
+Expected: PASS — both the new cases and every pre-existing case in the file, including the DST-transition tests.
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+cd frontend && npm run validate
+cd .. && git add frontend/src/lib/utils/dayWindow.ts frontend/src/__tests__/lib/utils/dayWindow.test.ts
+git commit -m "feat(web): anchor day keys and day boundaries to Institution time"
+```
+
+---
+
+### Task 3: Event parsing, grouping, and filtering
+
+**Files:**
+- Modify: `frontend/src/lib/utils/eventHelpers.ts:95-136` — `weekNumbersForCalendarDate`, `groupEventsByDay`
+- Modify: `frontend/src/lib/utils/filterHelpers.ts:39`
+- Test: `frontend/src/__tests__/lib/utils/eventHelpers.test.ts` (existing — add to it)
+
+**Interfaces:**
+- Consumes: `parseEventDate`, `formatChqDayLabel`, `chqParts`, `chqDateAt` from Task 1; `dayKeyOf` from Task 2.
+- Produces: unchanged signatures — `groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): DayGroup[]`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/__tests__/lib/utils/eventHelpers.test.ts`:
+
+```ts
+import { groupEventsByDay } from '@/lib/utils/eventHelpers';
+import type { Event } from '@/lib/types';
+
+describe('groupEventsByDay in Institution time', () => {
+  const ev = (id: string, startDate: string): Event =>
+    ({ id, title: id, startDate } as Event);
+
+  it('files a late-evening event under the Institution day it belongs to', () => {
+    const groups = groupEventsByDay([ev('a', '2026-07-26 23:45:00')], []);
+    expect(groups[0].key).toBe('2026-07-26');
+  });
+
+  it('labels the group with the Institution day', () => {
+    const groups = groupEventsByDay([ev('a', '2026-07-26 23:45:00')], []);
+    expect(groups[0].baseLabel).toBe('Sunday, July 26, 2026');
+  });
+
+  it('keeps an unparseable date out of the real days rather than crashing', () => {
+    const groups = groupEventsByDay([ev('bad', 'not a date')], []);
+    expect(groups[0].key).toBe('NaN-NaN-NaN');
+  });
+
+  it('sorts within a day by true instant', () => {
+    const groups = groupEventsByDay([
+      ev('late', '2026-07-27 19:00:00'),
+      ev('early', '2026-07-27 09:00:00'),
+    ], []);
+    expect(groups[0].events.map(e => e.id)).toEqual(['early', 'late']);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/eventHelpers.test.ts -t "Institution time"`
+Expected: FAIL — `baseLabel` renders in the device zone and, under the pinned test TZ, the key is right for the wrong reason.
+
+- [ ] **Step 3: Write the implementation**
+
+In `frontend/src/lib/utils/eventHelpers.ts`, add:
+
+```ts
+import { chqDateAt, chqParts, formatChqDayLabel, parseEventDate } from '@/lib/utils/chqTime';
+```
+
+Replace `weekNumbersForCalendarDate` (line 95):
+
+```ts
+function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]): number[] {
+  const { year, month, day } = chqParts(date);
+  const dayStart = chqDateAt(year, month, day, 0, 0, 0, 0);
+  // Half-open against the next Institution midnight, so a DST day of 23 or
+  // 25 hours needs no special case.
+  const dayEnd = chqDateAt(year, month, day + 1, 0, 0, 0, 0);
+  const numbers: number[] = [];
+  for (const w of seasonWeeks) {
+    if (w.start < dayEnd && w.end > dayStart) {
+      numbers.push(w.number);
+    }
+  }
+  return numbers;
+}
+```
+
+In `groupEventsByDay`, replace the two `new Date(...)` reads:
+
+```ts
+    const eventDate = parseEventDate(event.startDate);
+```
+
+```ts
+      const baseLabel = formatChqDayLabel(eventDate);
+```
+
+and the sort:
+
+```ts
+    group.events.sort(
+      (a, b) => parseEventDate(a.startDate).getTime() - parseEventDate(b.startDate).getTime()
+    );
+```
+
+In `frontend/src/lib/utils/filterHelpers.ts`, add the import and replace line 39:
+
+```ts
+import { parseEventDate } from '@/lib/utils/chqTime';
+```
+
+```ts
+  filtered = filtered.filter((event) => windowContains(dateWindow, parseEventDate(event.startDate)));
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/eventHelpers.test.ts src/__tests__/lib/utils/filterHelpers.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+cd frontend && npm run validate
+cd .. && git add frontend/src/lib/utils/eventHelpers.ts frontend/src/lib/utils/filterHelpers.ts frontend/src/__tests__/lib/utils/eventHelpers.test.ts
+git commit -m "feat(web): parse, group and filter events in Institution time"
+```
+
+---
+
+### Task 4: Season weeks and "now"
+
+**Files:**
+- Modify: `frontend/src/lib/utils/dateHelpers.ts` — `getChautauquaSeasonWeeks`, `isInChautauquaWeek`, `isWeekInPast`, `getCurrentWeekNumber`, `getAdaptiveEndDate`
+- Test: `frontend/src/__tests__/lib/utils/dateHelpers.test.ts` (existing — add to it)
+
+**Interfaces:**
+- Consumes: `parseEventDate`, `chqDateAt`, `chqParts` from Task 1.
+- Produces: unchanged signatures — `getChautauquaSeasonWeeks(year: number): SeasonWeek[]`, `isInChautauquaWeek(dateString: string, weekNumber: number, seasonWeeks: SeasonWeek[]): boolean`, `isWeekInPast(weekNumber: number, seasonWeeks: SeasonWeek[]): boolean`, `getCurrentWeekNumber(seasonWeeks: SeasonWeek[]): number | null`, `getAdaptiveEndDate(events: Event[], startDate: Date, minEvents: number): Date`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/__tests__/lib/utils/dateHelpers.test.ts`:
+
+```ts
+describe('season weeks in Institution time', () => {
+  it('starts week 1 at Saturday noon at Chautauqua, not noon on the device', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    // 2026's 4th Sunday of June is the 28th; the Saturday before is the 27th.
+    // Noon EDT on 2026-06-27 is 16:00Z.
+    expect(weeks[0].start.toISOString()).toBe('2026-06-27T16:00:00.000Z');
+  });
+
+  it('runs each week exactly seven calendar days, noon to noon', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    expect(weeks[0].end.toISOString()).toBe('2026-07-04T16:00:00.000Z');
+    expect(weeks).toHaveLength(9);
+  });
+
+  it('tiles: each week ends where the next begins', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    for (let i = 1; i < weeks.length; i++) {
+      expect(weeks[i].start.getTime()).toBe(weeks[i - 1].end.getTime());
+    }
+  });
+
+  it('places an event by its Institution instant', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    // 11:00 on the Saturday is still the previous week; 13:00 is the next.
+    expect(isInChautauquaWeek('2026-07-04 11:00:00', 1, weeks)).toBe(true);
+    expect(isInChautauquaWeek('2026-07-04 13:00:00', 1, weeks)).toBe(false);
+    expect(isInChautauquaWeek('2026-07-04 13:00:00', 2, weeks)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/dateHelpers.test.ts -t "Institution time"`
+Expected: FAIL — the weeks are built with device-local `new Date(year, 5, 1)` and `setHours(12, ...)`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `frontend/src/lib/utils/dateHelpers.ts`, add:
+
+```ts
+import { chqDateAt, chqParts, parseEventDate } from '@/lib/utils/chqTime';
+```
+
+Replace `getChautauquaSeasonWeeks` (lines 3-49):
+
+```ts
+export function getChautauquaSeasonWeeks(year: number): SeasonWeek[] {
+  // The 4th Sunday of June, found by walking Institution calendar days.
+  // Anchored at noon throughout: a DST transition never falls at midday, so
+  // the walk cannot be knocked onto a neighbouring day.
+  let sundayCount = 0;
+  let fourthSundayDay: number | null = null;
+  for (let day = 1; day <= 30; day++) {
+    if (chqParts(chqDateAt(year, 6, day, 12)).weekday === 0) {
+      sundayCount++;
+      if (sundayCount === 4) { fourthSundayDay = day; break; }
+    }
+  }
+  // June always contains four Sundays, so this cannot be null — but a
+  // silent NaN downstream would be far worse than an explicit throw.
+  if (fourthSundayDay === null) {
+    throw new Error(`no 4th Sunday of June ${year}`);
+  }
+
+  const weeks: SeasonWeek[] = [];
+  for (let i = 0; i < 9; i++) {
+    // Week 1 starts at noon on the Saturday before, i.e. the day before the
+    // 4th Sunday. `chqDateAt` normalises out-of-range days, so subtracting
+    // one and adding 7i needs no month arithmetic here.
+    const startDayOfJune = fourthSundayDay - 1 + i * 7;
+    const start = chqDateAt(year, 6, startDayOfJune, 12);
+    const end = chqDateAt(year, 6, startDayOfJune + 7, 12);
+    weeks.push({
+      number: i + 1,
+      start,
+      end,
+      label: `Week ${i + 1} (${formatWeekEdge(start)} 12pm - ${formatWeekEdge(end)} 12pm)`,
+    });
+  }
+  return weeks;
+}
+
+const weekEdgeFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York', month: 'short', day: 'numeric',
+});
+
+/** `"Jun 27"` at Chautauqua — the week label's edges. */
+function formatWeekEdge(d: Date): string {
+  return weekEdgeFormatter.format(d);
+}
+```
+
+Replace `isInChautauquaWeek`'s parse:
+
+```ts
+export function isInChautauquaWeek(dateString: string, weekNumber: number, seasonWeeks: SeasonWeek[]): boolean {
+  const eventDate = parseEventDate(dateString);
+  const week = seasonWeeks[weekNumber - 1];
+  return eventDate >= week.start && eventDate < week.end;
+}
+```
+
+`isWeekInPast` and `getCurrentWeekNumber` compare `new Date()` — a true instant — against `week.start`/`week.end`, which are now true instants. **Leave both unchanged**; they become correct automatically once the week boundaries are right.
+
+In `getAdaptiveEndDate`, replace the three event parses and the day arithmetic:
+
+```ts
+  const futureEvents = events
+    .filter(e => parseEventDate(e.startDate) >= startDate)
+    .sort((a, b) => parseEventDate(a.startDate).getTime() - parseEventDate(b.startDate).getTime());
+
+  if (futureEvents.length === 0) {
+    const p = chqParts(startDate);
+    return chqDateAt(p.year, p.month, p.day + 91, 0, 0, 0, 0);
+  }
+```
+
+and inside the loop:
+
+```ts
+  for (const event of futureEvents) {
+    const eventDate = parseEventDate(event.startDate);
+    const p = chqParts(eventDate);
+    const eventDay = chqDateAt(p.year, p.month, p.day, 0, 0, 0, 0);
+
+    if (!currentDayDate || eventDay.getTime() !== currentDayDate.getTime()) {
+      if (currentDayDate) {
+        // Exclusive end-of-day: the next Institution midnight, so a 23- or
+        // 25-hour DST day needs no special case.
+        const c = chqParts(currentDayDate);
+        lastCompleteDayEnd = chqDateAt(c.year, c.month, c.day + 1, 0, 0, 0, 0);
+        if (accumulated >= minEvents) {
+          return lastCompleteDayEnd;
+        }
+      }
+      currentDayDate = eventDay;
+    }
+    accumulated++;
+  }
+
+  const last = chqParts(currentDayDate!);
+  return chqDateAt(last.year, last.month, last.day + 1, 0, 0, 0, 0);
+```
+
+Note this converts `getAdaptiveEndDate` from an inclusive `23:59:59.999` bound to an exclusive next-midnight bound, matching the half-open rule in Global Constraints.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/dateHelpers.test.ts`
+Expected: PASS. If a pre-existing case asserts `23:59:59.999`, update it to the next Institution midnight and note the half-open change in the commit message — do not weaken the assertion.
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+cd frontend && npm run validate
+cd .. && git add frontend/src/lib/utils/dateHelpers.ts frontend/src/__tests__/lib/utils/dateHelpers.test.ts
+git commit -m "feat(web): build season weeks on Institution noon boundaries"
+```
+
+---
+
+### Task 5: Display, countdown, today, and the default year
+
+**Files:**
+- Modify: `frontend/src/components/calendar/EventCard.tsx:52-56`
+- Modify: `frontend/src/components/layout/CountdownBanner.tsx:12,21-25`
+- Modify: `frontend/src/lib/constants.ts:19-23` — `getDefaultYear`
+- Modify: `frontend/src/app/page.tsx:312` — `todayKey`
+- Test: `frontend/src/__tests__/lib/constants.test.ts` (create if absent), `frontend/src/__tests__/components/calendar/EventCard.test.tsx` (existing)
+
+**Interfaces:**
+- Consumes: `formatChqTime`, `chqParts`, `parseEventDate` from Task 1; `dayKeyOf` from Task 2.
+- Produces: `getDefaultYear(): number` unchanged in signature.
+
+- [ ] **Step 1: Write the failing test**
+
+Create or append to `frontend/src/__tests__/lib/constants.test.ts`:
+
+```ts
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { getDefaultYear } from '@/lib/constants';
+
+afterEach(() => { vi.useRealTimers(); });
+
+describe('getDefaultYear', () => {
+  it('turns over on October 1 at Chautauqua, not on the device', () => {
+    // 2026-10-01T03:00:00Z is still 23:00 on September 30 at Chautauqua,
+    // so the season year must not have turned over yet.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-10-01T03:00:00Z'));
+    expect(getDefaultYear()).toBe(2026);
+  });
+
+  it('turns over once Chautauqua reaches October', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-10-01T05:00:00Z')); // 01:00 EDT, Oct 1
+    expect(getDefaultYear()).toBe(2027);
+  });
+});
+```
+
+Append to `frontend/src/__tests__/components/calendar/EventCard.test.tsx`:
+
+```ts
+describe('event time display', () => {
+  it('shows the Institution wall time, unlabelled', () => {
+    // 23:00Z is 7:00 PM EDT.
+    render(<EventCard {...baseProps} event={{ ...baseProps.event, startDate: '2026-07-27 19:00:00' }} />);
+    expect(screen.getByText(/7:00 PM/)).toBeTruthy();
+    expect(screen.queryByText(/ET|EDT|EST/)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/constants.test.ts`
+Expected: FAIL on the first case — device-local `getMonth()` already reads October.
+
+- [ ] **Step 3: Write the implementation**
+
+`frontend/src/lib/constants.ts`:
+
+```ts
+import { chqParts } from '@/lib/utils/chqTime';
+
+/**
+ * The default season year, turning over on October 1 — at Chautauqua.
+ *
+ * Read in Institution time so a reader east of Eastern does not see next
+ * season a few hours early on September 30.
+ */
+export function getDefaultYear(): number {
+  const { year, month } = chqParts(new Date());
+  return month >= 10 ? year + 1 : year;
+}
+```
+
+`frontend/src/components/calendar/EventCard.tsx` — add the import and replace the time expression:
+
+```ts
+import { formatChqTime, parseEventDate } from '@/lib/utils/chqTime';
+```
+
+```tsx
+              🕐 {formatChqTime(parseEventDate(event.startDate))}
+```
+
+`frontend/src/components/layout/CountdownBanner.tsx` — `now` is a true instant and `seasonWeeks[0].start` is now a true instant, so the comparison is already right. Only the *rendered date* needs the zone. Add the import and replace the formatter:
+
+```ts
+import { CHQ_ZONE } from '@/lib/utils/chqTime';
+```
+
+```ts
+  const dateStr = seasonStart.toLocaleDateString('en-US', {
+    timeZone: CHQ_ZONE,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+```
+
+`frontend/src/app/page.tsx:312` needs no edit — `dayKeyOf(new Date())` became Institution-anchored in Task 2. Confirm by reading the line; leave it alone if it already reads `dayKeyOf(isCurrentYear ? ... : null)`.
+
+The two `now: new Date()` sites (`page.tsx:114,156`) also need no edit: they pass a true instant, and every value they are compared against is now a true instant.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/constants.test.ts src/__tests__/components/calendar/EventCard.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+cd frontend && npm run validate
+cd .. && git add frontend/src/lib/constants.ts frontend/src/components/calendar/EventCard.tsx frontend/src/components/layout/CountdownBanner.tsx frontend/src/__tests__/lib/constants.test.ts frontend/src/__tests__/components/calendar/EventCard.test.tsx
+git commit -m "feat(web): render times and the season turnover in Institution time"
+```
+
+---
+
+### Task 6: Preserve the ICS export
+
+**Files:**
+- Modify: `frontend/src/lib/utils/icsHelpers.ts:33-43` — `formatICSDate`
+- Test: `frontend/src/__tests__/lib/utils/icsHelpers.test.ts` (existing — add to it)
+
+**Interfaces:**
+- Consumes: `chqParts`, `parseEventDate` from Task 1.
+- Produces: `generateICS(event: Event): string` unchanged.
+
+This task changes no behaviour. `formatICSDate` is correct today by accident — it parses naive-as-device-local and reads device-local components back, an identity round-trip — and the file declares `DTSTART;TZID=America/New_York`. Once Task 3 has moved parsing, that accident no longer holds, so the reader must move with it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/__tests__/lib/utils/icsHelpers.test.ts`:
+
+```ts
+describe('ICS times are Institution wall time', () => {
+  it('emits the feed\'s wall clock verbatim under TZID America/New_York', () => {
+    const ics = generateICS({ id: 'x', title: 'T', startDate: '2026-07-27 12:45:00', endDate: '2026-07-27 13:45:00' } as Event);
+    expect(ics).toContain('DTSTART;TZID=America/New_York:20260727T124500');
+    expect(ics).toContain('DTEND;TZID=America/New_York:20260727T134500');
+  });
+
+  it('round-trips a winter date without shifting an hour', () => {
+    const ics = generateICS({ id: 'x', title: 'T', startDate: '2026-01-15 09:30:00', endDate: '2026-01-15 10:30:00' } as Event);
+    expect(ics).toContain('DTSTART;TZID=America/New_York:20260115T093000');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/icsHelpers.test.ts -t "Institution wall time"`
+Expected: FAIL after Task 3 — the naive `new Date(dateStr)` no longer matches how the rest of the app reads that string. If it passes, the test is not yet discriminating; check Task 3 landed first.
+
+- [ ] **Step 3: Write the implementation**
+
+In `frontend/src/lib/utils/icsHelpers.ts`, add the import and replace `formatICSDate`:
+
+```ts
+import { chqParts, parseEventDate } from '@/lib/utils/chqTime';
+```
+
+```ts
+/**
+ * An ICS local datetime, `YYYYMMDDTHHMMSS`, in Institution time.
+ *
+ * Paired with `DTSTART;TZID=America/New_York`, so the components written
+ * here must be Chautauqua's wall clock — which is exactly the wall clock the
+ * feed gave us. The round trip is therefore an identity, and this function
+ * existed in a device-local form that was correct only because parsing was
+ * device-local too.
+ */
+function formatICSDate(dateStr: string): string {
+  const { year, month, day, hour, minute, second } = chqParts(parseEventDate(dateStr));
+  const p2 = (n: number) => String(n).padStart(2, '0');
+  return `${year}${p2(month)}${p2(day)}T${p2(hour)}${p2(minute)}${p2(second)}`;
+}
+```
+
+Leave `formatICSTimestamp` unchanged — `DTSTAMP` is correctly UTC per RFC 5545.
+
+Find the "+1 hour" default (`const endDate = new Date(event.startDate);` near line 80) and replace its parse:
+
+```ts
+    const endDate = parseEventDate(event.startDate);
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/icsHelpers.test.ts`
+Expected: PASS, including every pre-existing case.
+
+- [ ] **Step 5: Validate and commit**
+
+```bash
+cd frontend && npm run validate
+cd .. && git add frontend/src/lib/utils/icsHelpers.ts frontend/src/__tests__/lib/utils/icsHelpers.test.ts
+git commit -m "fix(web): keep the ICS export on Institution wall time"
+```
+
+---
+
+### Task 7: Prove it in a browser, from a non-Eastern device
+
+**Files:**
+- Modify: `frontend/e2e/verify-rail.mjs` — parameterise the context timezone
+- Create: `frontend/e2e/verify-timezone.mjs`
+- Modify: `frontend/package.json` — the `test:browser` script
+
+**Interfaces:**
+- Consumes: the running app.
+- Produces: a `test:browser` script that also runs `verify-timezone.mjs`.
+
+A unit-level `TZ` sweep cannot prove this: `vitest.config.ts` pins `TZ: 'America/New_York'` on purpose, and the whole suite passes unchanged under `UTC`, `America/Los_Angeles`, `Asia/Tokyo` and `Pacific/Kiritimati`. Playwright's per-context `timezoneId` is not defeated that way.
+
+- [ ] **Step 1: Write the failing check**
+
+Create `frontend/e2e/verify-timezone.mjs`:
+
+```js
+/**
+ * The app shows Chautauqua's day and Chautauqua's clock regardless of where
+ * the reader's device thinks it is.
+ *
+ * Asserted by rendering the same page under four device timezones and
+ * requiring the results to be identical, rather than by hardcoding an
+ * expected day — the fixture is live production data, so the only stable
+ * property is agreement.
+ */
+import { chromium } from 'playwright';
+
+const URL = process.env.URL ?? 'http://localhost:3000/';
+const ZONES = ['America/New_York', 'UTC', 'America/Los_Angeles', 'Asia/Tokyo'];
+
+const results = [];
+function check(name, ok, detail) {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const browser = await chromium.launch();
+
+async function readUnder(timezoneId) {
+  const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, timezoneId });
+  const page = await ctx.newPage();
+  await page.goto(URL, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-day-key]', { timeout: 30000 });
+  const out = await page.evaluate(() => ({
+    days: [...document.querySelectorAll('[data-day-key)'.replace(')', ']'))].map(e => e.dataset.dayKey).slice(0, 6),
+    headers: [...document.querySelectorAll('[data-day-header]')].map(e => e.textContent.trim()).slice(0, 6),
+    times: [...document.querySelectorAll('.event-card')].slice(0, 12)
+      .map(e => (e.textContent.match(/\d{1,2}:\d{2}\s?[AP]M/) ?? [''])[0]),
+    today: document.querySelector('[data-chip][aria-current="date"]')?.dataset.chip ?? null,
+    nowVisible: document.querySelectorAll('.event-card').length,
+  }));
+  await ctx.close();
+  return out;
+}
+
+const baseline = await readUnder(ZONES[0]);
+check('0 baseline rendered something to compare', baseline.days.length > 0,
+  `${baseline.days.length} days, first=${baseline.days[0]}`);
+
+for (const zone of ZONES.slice(1)) {
+  const got = await readUnder(zone);
+  check(`1 same days under ${zone}`,
+    JSON.stringify(got.days) === JSON.stringify(baseline.days),
+    `${got.days[0]}..${got.days.at(-1)} vs ${baseline.days[0]}..${baseline.days.at(-1)}`);
+  check(`2 same day headers under ${zone}`,
+    JSON.stringify(got.headers) === JSON.stringify(baseline.headers),
+    got.headers[0] ?? '(none)');
+  check(`3 same event times under ${zone}`,
+    JSON.stringify(got.times) === JSON.stringify(baseline.times),
+    got.times.slice(0, 3).join(', '));
+  check(`4 same day is today under ${zone}`,
+    got.today === baseline.today, `${got.today} vs ${baseline.today}`);
+  check(`5 same events are upcoming under ${zone}`,
+    got.nowVisible === baseline.nowVisible, `${got.nowVisible} vs ${baseline.nowVisible}`);
+}
+
+await browser.close();
+const failed = results.filter(r => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) {
+  console.log('FAILED:');
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}
+```
+
+Fix the deliberate obfuscation on the `days` selector line before running — it must read:
+
+```js
+    days: [...document.querySelectorAll('[data-day-key]')].map(e => e.dataset.dayKey).slice(0, 6),
+```
+
+- [ ] **Step 2: Run it against the pre-change build to verify it fails**
+
+```bash
+cd frontend && git stash && npm run build && (npm run preview &)
+until curl -sf http://localhost:3000/ -o /dev/null; do sleep 1; done
+node e2e/verify-timezone.mjs
+```
+
+Expected: FAIL on `4 same day is today under Asia/Tokyo` and `5 same events are upcoming under America/Los_Angeles`.
+Then: `pkill -f "vite preview"; git stash pop`.
+
+- [ ] **Step 3: Wire it into the suite**
+
+In `frontend/package.json`, extend the script:
+
+```json
+    "test:browser": "node e2e/verify-rail.mjs && node e2e/verify-filter-reveal.mjs && node e2e/verify-timezone.mjs"
+```
+
+- [ ] **Step 4: Run it against the changed build to verify it passes**
+
+```bash
+cd frontend && npm run build && (npm run preview &)
+until curl -sf http://localhost:3000/ -o /dev/null; do sleep 1; done
+npm run test:browser
+pkill -f "vite preview"
+```
+
+Expected: PASS — all three suites, including every zone comparison.
+
+- [ ] **Step 5: Confirm the Global Constraint and commit**
+
+```bash
+cd .. && git diff --stat main...HEAD -- . ':(exclude)frontend'
+```
+
+Expected: empty output. If anything is listed, a file outside `frontend/` was touched and must be reverted.
+
+```bash
+git add frontend/e2e/verify-timezone.mjs frontend/package.json
+git commit -m "test(web): prove the app shows Chautauqua's day from any device timezone"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section of the design maps to a task: the module (1), day keys and boundaries (2), parsing/grouping/filtering (3), season weeks and now-comparisons (4), display/countdown/today/default-year (5), ICS (6), the browser safeguard (7). The "all-or-nothing" table in the spec is covered row by row — parsing (3), now-comparisons (4), `todayKey` (2, via `dayKeyOf`), day keys (2), week boundaries (4), display (5), ICS (6). The client-only constraint is enforced by an explicit check in Task 7 Step 5.
+
+**Placeholders.** None. Every code step carries the actual code; the one deliberate defect is the obfuscated selector in Task 7 Step 1, which Step 1 itself instructs the implementer to fix.
+
+**Type consistency.** `chqParts` returns `ChqParts` with `year/month/day/hour/minute/second/weekday`, used with those exact names in Tasks 2-6. `chqDateAt(y, mo, d, h?, mi?, s?, ms?)` is called with 1-based months throughout. `parseEventDate` returns `Date` and is the only parser used after Task 3. `dayKeyOf` keeps its signature; only its meaning changes.
+
+**Known risk carried into execution.** Tasks 2-4 change values that existing tests assert. Where a pre-existing assertion encodes the old device-local answer, update it and say so in the commit — never weaken it. Where one encodes the inclusive `23:59:59.999` bound, Task 4 converts it to the next Institution midnight deliberately.

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -1070,10 +1070,22 @@ function formatICSDate(dateStr: string): string {
 
 Leave `formatICSTimestamp` unchanged — `DTSTAMP` is correctly UTC per RFC 5545.
 
-Find the "+1 hour" default (`const endDate = new Date(event.startDate);` near line 80) and replace its parse:
+Find the "+1 hour" default (`const endDate = new Date(event.startDate);` near
+line 80). Replacing only the parse is **not enough** and would reintroduce the
+bug this task exists to remove: the following `setHours` mutates in the
+*device's* zone whatever instant the `Date` holds, so a naive swap relocates
+the device dependence rather than removing it.
+
+Add the hour in Institution wall-clock terms instead — read the parts,
+increment, rebuild:
 
 ```ts
-    const endDate = parseEventDate(event.startDate);
+    const p = chqParts(parseEventDate(event.startDate));
+    // One hour of Chautauqua wall clock, not 3,600,000ms. `chqDateAt`
+    // normalises both the 24-hour overflow and the spring-forward gap, so an
+    // event at 01:30 on a transition day ends at 03:30 — a one-hour block in
+    // any calendar client, which is what "default to an hour" means.
+    const endDate = chqDateAt(p.year, p.month, p.day, p.hour + 1, p.minute, p.second);
 ```
 
 - [ ] **Step 4: Run the tests to verify they pass**

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -460,6 +460,133 @@ git commit -m "feat(web): anchor day keys and day boundaries to Institution time
 
 ---
 
+### Task 2b: The rest of `dayWindow.ts`
+
+**Files:**
+- Modify: `frontend/src/lib/utils/dayWindow.ts` — `navigableBounds`, `eventDayKeys`, `eventCountsByDay`, `formatDayLabel`, `formatDayRange`, `dayChips`
+- Test: `frontend/src/__tests__/lib/utils/dayWindow.test.ts` (existing — add to it)
+
+**Interfaces:**
+- Consumes: `parseEventDate`, `chqParts`, `CHQ_ZONE` from Task 1; `startOfDay`, `dayKeyOf` from Task 2.
+- Produces: unchanged signatures throughout.
+
+**Why this task exists.** Task 2 changed `startOfDay(key)` from returning
+device-local midnight to returning *Institution* midnight. Six functions in
+the same file still read that instant with device-zone accessors, and they
+were correct before only because the two coincided. They now disagree on any
+device west of Eastern.
+
+Measured on the instant `startOfDay('2026-07-27')` returns
+(`2026-07-27T04:00:00.000Z`):
+
+| Device zone | chip label | `dayOfMonth` |
+|---|---|---|
+| `America/New_York` | Mon, Jul 27 | 27 |
+| `America/Chicago` | Sun, Jul 26 | **26** |
+| `America/Los_Angeles` | Sun, Jul 26 | **26** |
+| `Pacific/Honolulu` | Sun, Jul 26 | **26** |
+
+A rail chip would render "26" while its own `key` is `2026-07-27`, so tapping
+it navigates to a day the chip does not name. This is the day rail shipped in
+#241.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `frontend/src/__tests__/lib/utils/dayWindow.test.ts`:
+
+```ts
+describe('day chips and labels read Institution time', () => {
+  it('names the chip after its own key', () => {
+    const chips = dayChips(['2026-07-27'], new Map([['2026-07-27', 3]]));
+    expect(chips[0].dayOfMonth).toBe('27');
+    expect(chips[0].weekday).toBe('Mon');
+    expect(chips[0].month).toBe('Jul');
+    expect(chips[0].label).toBe('Go to Monday, July 27, 3 events');
+  });
+
+  it('names a chip on the far side of a DST transition correctly', () => {
+    const chips = dayChips(['2026-11-01'], new Map());
+    expect(chips[0].dayOfMonth).toBe('1');
+    expect(chips[0].label).toBe('Sunday, November 1, no events');
+  });
+
+  it('labels a day by its Institution date', () => {
+    expect(formatDayLabel('2026-07-27')).toContain('July 27');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/dayWindow.test.ts -t "Institution time"`
+
+Expected: PASS, not FAIL — the pinned test timezone (`America/New_York`) makes
+the device zone equal the Institution zone, so these cannot discriminate here.
+That is known and ruled; write them anyway as regression pins. Prove the fix
+instead in Step 4 with the explicit-zone check, which does discriminate.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to the existing import from `@/lib/utils/chqTime`: `CHQ_ZONE`, `chqParts`,
+`parseEventDate`.
+
+Replace all three bare event parses (in `navigableBounds`, `eventDayKeys`, and
+`eventCountsByDay`) — each currently reads `const parsed = new Date(event.startDate);`:
+
+```ts
+    const parsed = parseEventDate(event.startDate);
+```
+
+In `formatDayLabel` and `formatDayRange`, add the zone to every
+`startOfDay(key).toLocaleDateString('en-US', { ... })` call — the option
+object gains one entry, nothing else changes:
+
+```ts
+    timeZone: CHQ_ZONE,
+```
+
+In `dayChips`, add `timeZone: CHQ_ZONE` to all three `toLocaleDateString`
+option objects (`month`, `spoken`, `weekday`), and replace the day-of-month:
+
+```ts
+      dayOfMonth: String(chqParts(date).day),
+```
+
+- [ ] **Step 4: Prove the fix under a non-Eastern device zone**
+
+The unit tests cannot discriminate, so verify directly. Run this and paste the
+output into your report:
+
+```bash
+cd frontend && cat > /tmp/chip-probe.mjs <<'EOF'
+const inst = new Date('2026-07-27T04:00:00.000Z'); // what startOfDay('2026-07-27') returns
+for (const tz of ['America/New_York', 'America/Los_Angeles', 'Pacific/Honolulu']) {
+  const withZone = new Intl.DateTimeFormat('en-US', { timeZone: 'America/New_York', day: 'numeric' }).format(inst);
+  const withoutZone = new Intl.DateTimeFormat('en-US', { timeZone: tz, day: 'numeric' }).format(inst);
+  console.log(tz.padEnd(22), 'pinned:', withZone, ' device-zone:', withoutZone);
+}
+EOF
+node /tmp/chip-probe.mjs; rm -f /tmp/chip-probe.mjs
+```
+
+Expected: the pinned column reads `27` for every row; the device-zone column
+reads `26` for the two western zones. That difference is exactly what adding
+`timeZone: CHQ_ZONE` removes.
+
+- [ ] **Step 5: Run the full file and validate**
+
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/dayWindow.test.ts && npm run validate`
+Expected: PASS, all cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/lib/utils/dayWindow.ts frontend/src/__tests__/lib/utils/dayWindow.test.ts
+git commit -m "fix(web): read day chips and labels in Institution time"
+```
+
+---
+
 ### Task 3: Event parsing, grouping, and filtering
 
 **Files:**

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -12,7 +12,7 @@
 
 ## Global Constraints
 
-- **Zero files outside `frontend/`.** `git diff --stat main...HEAD` must list only `frontend/` paths. The feed, the backend and `all-events.json` are untouched, so old web bundles and the shipped iOS app are unaffected by construction.
+- **Zero code outside `frontend/`.** The only non-`frontend/` paths this branch may touch are its own `docs/plans/*.md`. No backend, no `infrastructure/`, no `ios/`, nothing in the ingest path. `all-events.json` stays byte-identical, so old web bundles and the shipped iOS app are unaffected by construction. Task 7 Step 5 checks this rather than trusting it.
 - **Timezone identifier is exactly `America/New_York`.** Never a fixed offset, never `EST`/`EDT`.
 - **Times are unlabelled.** `7:00 PM` stays `7:00 PM`. No "ET" suffix anywhere, no per-viewer variation.
 - **Half-open windows.** `start <= x < endExclusive`. Never an inclusive bound with a subtracted epsilon.
@@ -1077,10 +1077,10 @@ Expected: PASS — all three suites, including every zone comparison.
 - [ ] **Step 5: Confirm the Global Constraint and commit**
 
 ```bash
-cd .. && git diff --stat main...HEAD -- . ':(exclude)frontend'
+cd .. && git diff --stat main...HEAD -- . ':(exclude)frontend' ':(exclude)docs/plans'
 ```
 
-Expected: empty output. If anything is listed, a file outside `frontend/` was touched and must be reverted.
+Expected: empty output. Anything listed is a file this change had no business touching — revert it. The exclusions are deliberate and narrow: `frontend/` is the change, `docs/plans/` is this branch's own design and plan.
 
 ```bash
 git add frontend/e2e/verify-timezone.mjs frontend/package.json

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -252,15 +252,24 @@ export function chqDateAt(
   h = 0, mi = 0, s = 0, ms = 0,
 ): Date {
   const asUTC = Date.UTC(y, mo - 1, d, h, mi, s, ms);
-  let guess = new Date(asUTC);
-  for (let pass = 0; pass < 2; pass++) {
+
+  const correct = (guess: Date): Date => {
     const p = chqParts(guess);
     const readBack = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second, ms);
-    const drift = readBack - asUTC;
-    if (drift === 0) break;
-    guess = new Date(guess.getTime() - drift);
-  }
-  return guess;
+    return new Date(guess.getTime() - (readBack - asUTC));
+  };
+
+  const firstPass = correct(new Date(asUTC));
+  const secondPass = correct(firstPass);
+
+  // The second pass settles a DST straddle, but in the spring-forward gap the
+  // requested wall time does not exist at all, so no instant can read it back
+  // and the second pass overshoots backward past the gap. The first pass lands
+  // on the instant just after the gap, which is the intended normalisation.
+  const p = chqParts(secondPass);
+  const matches = p.year === y && p.month === mo && p.day === d
+    && p.hour === h && p.minute === mi && p.second === s;
+  return matches ? secondPass : firstPass;
 }
 
 /**

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -511,7 +511,7 @@ describe('day chips and labels read Institution time', () => {
   });
 
   it('labels a day by its Institution date', () => {
-    expect(formatDayLabel('2026-07-27')).toContain('July 27');
+    expect(formatDayLabel('2026-07-27')).toContain('Jul 27');
   });
 });
 ```

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -456,7 +456,7 @@ git commit -m "feat(web): anchor day keys and day boundaries to Institution time
 **Files:**
 - Modify: `frontend/src/lib/utils/eventHelpers.ts:95-136` — `weekNumbersForCalendarDate`, `groupEventsByDay`
 - Modify: `frontend/src/lib/utils/filterHelpers.ts:39`
-- Test: `frontend/src/__tests__/lib/utils/eventHelpers.test.ts` (existing — add to it)
+- Test: `frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts` (existing — add to it)
 
 **Interfaces:**
 - Consumes: `parseEventDate`, `formatChqDayLabel`, `chqParts`, `chqDateAt` from Task 1; `dayKeyOf` from Task 2.
@@ -464,15 +464,11 @@ git commit -m "feat(web): anchor day keys and day boundaries to Institution time
 
 - [ ] **Step 1: Write the failing test**
 
-Append to `frontend/src/__tests__/lib/utils/eventHelpers.test.ts`:
+Append to `frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts`. It already imports `groupEventsByDay` and `Event` and defines a local `evt(id, startDate)` fixture builder — reuse them rather than redeclaring:
 
 ```ts
-import { groupEventsByDay } from '@/lib/utils/eventHelpers';
-import type { Event } from '@/lib/types';
-
 describe('groupEventsByDay in Institution time', () => {
-  const ev = (id: string, startDate: string): Event =>
-    ({ id, title: id, startDate } as Event);
+  const ev = evt; // the file's existing fixture builder
 
   it('files a late-evening event under the Institution day it belongs to', () => {
     const groups = groupEventsByDay([ev('a', '2026-07-26 23:45:00')], []);
@@ -501,7 +497,7 @@ describe('groupEventsByDay in Institution time', () => {
 
 - [ ] **Step 2: Run the test to verify it fails**
 
-Run: `cd frontend && npx vitest run src/__tests__/lib/utils/eventHelpers.test.ts -t "Institution time"`
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/groupEventsByDay.test.ts -t "Institution time"`
 Expected: FAIL — `baseLabel` renders in the device zone and, under the pinned test TZ, the key is right for the wrong reason.
 
 - [ ] **Step 3: Write the implementation**
@@ -561,14 +557,14 @@ import { parseEventDate } from '@/lib/utils/chqTime';
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `cd frontend && npx vitest run src/__tests__/lib/utils/eventHelpers.test.ts src/__tests__/lib/utils/filterHelpers.test.ts`
+Run: `cd frontend && npx vitest run src/__tests__/lib/utils/groupEventsByDay.test.ts src/__tests__/lib/utils/filterHelpers.test.ts`
 Expected: PASS.
 
 - [ ] **Step 5: Validate and commit**
 
 ```bash
 cd frontend && npm run validate
-cd .. && git add frontend/src/lib/utils/eventHelpers.ts frontend/src/lib/utils/filterHelpers.ts frontend/src/__tests__/lib/utils/eventHelpers.test.ts
+cd .. && git add frontend/src/lib/utils/eventHelpers.ts frontend/src/lib/utils/filterHelpers.ts frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts
 git commit -m "feat(web): parse, group and filter events in Institution time"
 ```
 
@@ -758,7 +754,7 @@ git commit -m "feat(web): build season weeks on Institution noon boundaries"
 - Modify: `frontend/src/components/layout/CountdownBanner.tsx:12,21-25`
 - Modify: `frontend/src/lib/constants.ts:19-23` — `getDefaultYear`
 - Modify: `frontend/src/app/page.tsx:312` — `todayKey`
-- Test: `frontend/src/__tests__/lib/constants.test.ts` (create if absent), `frontend/src/__tests__/components/calendar/EventCard.test.tsx` (existing)
+- Test: `frontend/src/__tests__/lib/constants.test.ts` (existing — add to it), `frontend/src/__tests__/components/calendar/EventCard.time.test.tsx` (create — EventCard suites are split per concern: `EventCard.articleLinks`, `EventCard.programLinks`, `EventCard.publisherSource`)
 
 **Interfaces:**
 - Consumes: `formatChqTime`, `chqParts`, `parseEventDate` from Task 1; `dayKeyOf` from Task 2.
@@ -766,32 +762,35 @@ git commit -m "feat(web): build season weeks on Institution noon boundaries"
 
 - [ ] **Step 1: Write the failing test**
 
-Create or append to `frontend/src/__tests__/lib/constants.test.ts`:
+Append two cases to the existing `describe('getDefaultYear', ...)` in
+`frontend/src/__tests__/lib/constants.test.ts`. **Use `await import(...)`, not a
+static import** — every existing case in that file does, because fake timers
+must be set before the module evaluates (`constants.ts` computes `ACTIVE_YEAR`
+at load time):
 
 ```ts
-import { describe, it, expect, vi, afterEach } from 'vitest';
-import { getDefaultYear } from '@/lib/constants';
-
-afterEach(() => { vi.useRealTimers(); });
-
-describe('getDefaultYear', () => {
-  it('turns over on October 1 at Chautauqua, not on the device', () => {
+  it('turns over on October 1 at Chautauqua, not on the device', async () => {
     // 2026-10-01T03:00:00Z is still 23:00 on September 30 at Chautauqua,
     // so the season year must not have turned over yet.
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-10-01T03:00:00Z'));
+    const { getDefaultYear } = await import('@/lib/constants');
     expect(getDefaultYear()).toBe(2026);
   });
 
-  it('turns over once Chautauqua reaches October', () => {
+  it('turns over once Chautauqua reaches October', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-10-01T05:00:00Z')); // 01:00 EDT, Oct 1
+    const { getDefaultYear } = await import('@/lib/constants');
     expect(getDefaultYear()).toBe(2027);
   });
-});
 ```
 
-Append to `frontend/src/__tests__/components/calendar/EventCard.test.tsx`:
+The file's existing cases build instants with `new Date(2026, 5, 15)`, a
+device-local constructor. Under the pinned test TZ that already *is*
+Institution time, so they keep passing unchanged — leave them alone.
+
+Create `frontend/src/__tests__/components/calendar/EventCard.time.test.tsx`, following the render/props setup used by `EventCard.articleLinks.test.tsx` in the same directory:
 
 ```ts
 describe('event time display', () => {
@@ -859,14 +858,14 @@ The two `now: new Date()` sites (`page.tsx:114,156`) also need no edit: they pas
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `cd frontend && npx vitest run src/__tests__/lib/constants.test.ts src/__tests__/components/calendar/EventCard.test.tsx`
+Run: `cd frontend && npx vitest run src/__tests__/lib/constants.test.ts src/__tests__/components/calendar/EventCard.time.test.tsx`
 Expected: PASS.
 
 - [ ] **Step 5: Validate and commit**
 
 ```bash
 cd frontend && npm run validate
-cd .. && git add frontend/src/lib/constants.ts frontend/src/components/calendar/EventCard.tsx frontend/src/components/layout/CountdownBanner.tsx frontend/src/__tests__/lib/constants.test.ts frontend/src/__tests__/components/calendar/EventCard.test.tsx
+cd .. && git add frontend/src/lib/constants.ts frontend/src/components/calendar/EventCard.tsx frontend/src/components/layout/CountdownBanner.tsx frontend/src/__tests__/lib/constants.test.ts frontend/src/__tests__/components/calendar/EventCard.time.test.tsx
 git commit -m "feat(web): render times and the season turnover in Institution time"
 ```
 
@@ -959,7 +958,6 @@ git commit -m "fix(web): keep the ICS export on Institution wall time"
 ### Task 7: Prove it in a browser, from a non-Eastern device
 
 **Files:**
-- Modify: `frontend/e2e/verify-rail.mjs` — parameterise the context timezone
 - Create: `frontend/e2e/verify-timezone.mjs`
 - Modify: `frontend/package.json` — the `test:browser` script
 

--- a/docs/plans/2026-08-18-institution-timezone-plan.md
+++ b/docs/plans/2026-08-18-institution-timezone-plan.md
@@ -1002,7 +1002,7 @@ async function readUnder(timezoneId) {
   await page.goto(URL, { waitUntil: 'networkidle' });
   await page.waitForSelector('[data-day-key]', { timeout: 30000 });
   const out = await page.evaluate(() => ({
-    days: [...document.querySelectorAll('[data-day-key)'.replace(')', ']'))].map(e => e.dataset.dayKey).slice(0, 6),
+    days: [...document.querySelectorAll('[data-day-key]')].map(e => e.dataset.dayKey).slice(0, 6),
     headers: [...document.querySelectorAll('[data-day-header]')].map(e => e.textContent.trim()).slice(0, 6),
     times: [...document.querySelectorAll('.event-card')].slice(0, 12)
       .map(e => (e.textContent.match(/\d{1,2}:\d{2}\s?[AP]M/) ?? [''])[0]),
@@ -1042,12 +1042,6 @@ if (failed.length) {
   for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
   process.exit(1);
 }
-```
-
-Fix the deliberate obfuscation on the `days` selector line before running — it must read:
-
-```js
-    days: [...document.querySelectorAll('[data-day-key]')].map(e => e.dataset.dayKey).slice(0, 6),
 ```
 
 - [ ] **Step 2: Run it against the pre-change build to verify it fails**
@@ -1099,7 +1093,7 @@ git commit -m "test(web): prove the app shows Chautauqua's day from any device t
 
 **Spec coverage.** Every section of the design maps to a task: the module (1), day keys and boundaries (2), parsing/grouping/filtering (3), season weeks and now-comparisons (4), display/countdown/today/default-year (5), ICS (6), the browser safeguard (7). The "all-or-nothing" table in the spec is covered row by row — parsing (3), now-comparisons (4), `todayKey` (2, via `dayKeyOf`), day keys (2), week boundaries (4), display (5), ICS (6). The client-only constraint is enforced by an explicit check in Task 7 Step 5.
 
-**Placeholders.** None. Every code step carries the actual code; the one deliberate defect is the obfuscated selector in Task 7 Step 1, which Step 1 itself instructs the implementer to fix.
+**Placeholders.** None. Every code step carries the actual code, ready to run as written.
 
 **Type consistency.** `chqParts` returns `ChqParts` with `year/month/day/hour/minute/second/weekday`, used with those exact names in Tasks 2-6. `chqDateAt(y, mo, d, h?, mi?, s?, ms?)` is called with 1-based months throughout. `parseEventDate` returns `Date` and is the only parser used after Task 3. `dayKeyOf` keeps its signature; only its meaning changes.
 

--- a/frontend/e2e/verify-timezone.mjs
+++ b/frontend/e2e/verify-timezone.mjs
@@ -1,0 +1,68 @@
+/**
+ * The app shows Chautauqua's day and Chautauqua's clock regardless of where
+ * the reader's device thinks it is.
+ *
+ * Asserted by rendering the same page under four device timezones and
+ * requiring the results to be identical, rather than by hardcoding an
+ * expected day — the fixture is live production data, so the only stable
+ * property is agreement.
+ */
+import { chromium } from 'playwright';
+
+const URL = process.env.URL ?? 'http://localhost:3000/';
+const ZONES = ['America/New_York', 'UTC', 'America/Los_Angeles', 'Asia/Tokyo'];
+
+const results = [];
+function check(name, ok, detail) {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+const browser = await chromium.launch();
+
+async function readUnder(timezoneId) {
+  const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, timezoneId });
+  const page = await ctx.newPage();
+  await page.goto(URL, { waitUntil: 'networkidle' });
+  await page.waitForSelector('[data-day-key]', { timeout: 30000 });
+  const out = await page.evaluate(() => ({
+    days: [...document.querySelectorAll('[data-day-key]')].map(e => e.dataset.dayKey).slice(0, 6),
+    headers: [...document.querySelectorAll('[data-day-header]')].map(e => e.textContent.trim()).slice(0, 6),
+    times: [...document.querySelectorAll('.event-card')].slice(0, 12)
+      .map(e => (e.textContent.match(/\d{1,2}:\d{2}\s?[AP]M/) ?? [''])[0]),
+    today: document.querySelector('[data-chip][aria-current="date"]')?.dataset.chip ?? null,
+    nowVisible: document.querySelectorAll('.event-card').length,
+  }));
+  await ctx.close();
+  return out;
+}
+
+const baseline = await readUnder(ZONES[0]);
+check('0 baseline rendered something to compare', baseline.days.length > 0,
+  `${baseline.days.length} days, first=${baseline.days[0]}`);
+
+for (const zone of ZONES.slice(1)) {
+  const got = await readUnder(zone);
+  check(`1 same days under ${zone}`,
+    JSON.stringify(got.days) === JSON.stringify(baseline.days),
+    `${got.days[0]}..${got.days.at(-1)} vs ${baseline.days[0]}..${baseline.days.at(-1)}`);
+  check(`2 same day headers under ${zone}`,
+    JSON.stringify(got.headers) === JSON.stringify(baseline.headers),
+    got.headers[0] ?? '(none)');
+  check(`3 same event times under ${zone}`,
+    JSON.stringify(got.times) === JSON.stringify(baseline.times),
+    got.times.slice(0, 3).join(', '));
+  check(`4 same day is today under ${zone}`,
+    got.today === baseline.today, `${got.today} vs ${baseline.today}`);
+  check(`5 same events are upcoming under ${zone}`,
+    got.nowVisible === baseline.nowVisible, `${got.nowVisible} vs ${baseline.nowVisible}`);
+}
+
+await browser.close();
+const failed = results.filter(r => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed`);
+if (failed.length) {
+  console.log('FAILED:');
+  for (const f of failed) console.log(`  - ${f.name}: ${f.detail}`);
+  process.exit(1);
+}

--- a/frontend/e2e/verify-timezone.mjs
+++ b/frontend/e2e/verify-timezone.mjs
@@ -17,6 +17,11 @@ function check(name, ok, detail) {
   results.push({ name, ok, detail });
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
 }
+/** Not a failure — the clock moved during the run so this comparison isn't meaningful. */
+function skip(name, detail) {
+  results.push({ name, ok: true, detail });
+  console.log(`SKIP  ${name}${detail ? ` — ${detail}` : ''}`);
+}
 
 const browser = await chromium.launch();
 
@@ -37,25 +42,67 @@ async function readUnder(timezoneId) {
   return out;
 }
 
-const baseline = await readUnder(ZONES[0]);
-check('0 baseline rendered something to compare', baseline.days.length > 0,
-  `${baseline.days.length} days, first=${baseline.days[0]}`);
+// The baseline is read once before the other three contexts and again after
+// — `today` and `nowVisible` are wall-clock sensitive, so a run that crosses
+// a minute or day boundary mid-flight must not be reported as a false
+// mismatch against the other zones. Both baseline readings are compared
+// against every zone; if the two baseline readings disagree with *each
+// other*, the clock moved during the run and the wall-clock-sensitive
+// checks are reported as skipped rather than failed, without weakening what
+// they assert when the clock holds still.
+const baselineFirst = await readUnder(ZONES[0]);
+check('0 baseline rendered something to compare', baselineFirst.days.length > 0,
+  `${baselineFirst.days.length} days, first=${baselineFirst.days[0]}`);
 
+const zoneResults = [];
 for (const zone of ZONES.slice(1)) {
-  const got = await readUnder(zone);
+  zoneResults.push({ zone, got: await readUnder(zone) });
+}
+
+const baselineLast = await readUnder(ZONES[0]);
+const clockMoved = JSON.stringify(baselineFirst.today) !== JSON.stringify(baselineLast.today)
+  || baselineFirst.nowVisible !== baselineLast.nowVisible;
+
+function agreesWithEitherBaseline(value, pick) {
+  return value === pick(baselineFirst) || value === pick(baselineLast);
+}
+
+for (const { zone, got } of zoneResults) {
   check(`1 same days under ${zone}`,
-    JSON.stringify(got.days) === JSON.stringify(baseline.days),
-    `${got.days[0]}..${got.days.at(-1)} vs ${baseline.days[0]}..${baseline.days.at(-1)}`);
+    JSON.stringify(got.days) === JSON.stringify(baselineFirst.days),
+    `${got.days[0]}..${got.days.at(-1)} vs ${baselineFirst.days[0]}..${baselineFirst.days.at(-1)}`);
   check(`2 same day headers under ${zone}`,
-    JSON.stringify(got.headers) === JSON.stringify(baseline.headers),
+    JSON.stringify(got.headers) === JSON.stringify(baselineFirst.headers),
     got.headers[0] ?? '(none)');
   check(`3 same event times under ${zone}`,
-    JSON.stringify(got.times) === JSON.stringify(baseline.times),
+    JSON.stringify(got.times) === JSON.stringify(baselineFirst.times),
     got.times.slice(0, 3).join(', '));
-  check(`4 same day is today under ${zone}`,
-    got.today === baseline.today, `${got.today} vs ${baseline.today}`);
-  check(`5 same events are upcoming under ${zone}`,
-    got.nowVisible === baseline.nowVisible, `${got.nowVisible} vs ${baseline.nowVisible}`);
+
+  if (!clockMoved) {
+    check(`4 same day is today under ${zone}`,
+      got.today === baselineFirst.today, `${got.today} vs ${baselineFirst.today}`);
+    check(`5 same events are upcoming under ${zone}`,
+      got.nowVisible === baselineFirst.nowVisible, `${got.nowVisible} vs ${baselineFirst.nowVisible}`);
+    continue;
+  }
+
+  // The clock moved mid-run. Still require agreement — just against
+  // whichever baseline reading (first or last) the clock hadn't yet moved
+  // past — before giving up and reporting a skip instead of a failure.
+  if (agreesWithEitherBaseline(got.today, b => b.today)) {
+    check(`4 same day is today under ${zone}`, true,
+      `${got.today} (clock moved mid-run: baseline was ${baselineFirst.today} then ${baselineLast.today})`);
+  } else {
+    skip(`4 same day is today under ${zone}`,
+      `clock moved mid-run: baseline was ${baselineFirst.today} then ${baselineLast.today}, got ${got.today}`);
+  }
+  if (agreesWithEitherBaseline(got.nowVisible, b => b.nowVisible)) {
+    check(`5 same events are upcoming under ${zone}`, true,
+      `${got.nowVisible} (clock moved mid-run: baseline was ${baselineFirst.nowVisible} then ${baselineLast.nowVisible})`);
+  } else {
+    skip(`5 same events are upcoming under ${zone}`,
+      `clock moved mid-run: baseline was ${baselineFirst.nowVisible} then ${baselineLast.nowVisible}, got ${got.nowVisible}`);
+  }
 }
 
 await browser.close();

--- a/frontend/e2e/verify-timezone.mjs
+++ b/frontend/e2e/verify-timezone.mjs
@@ -17,12 +17,6 @@ function check(name, ok, detail) {
   results.push({ name, ok, detail });
   console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
 }
-/** Not a failure — the clock moved during the run so this comparison isn't meaningful. */
-function skip(name, detail) {
-  results.push({ name, ok: true, detail });
-  console.log(`SKIP  ${name}${detail ? ` — ${detail}` : ''}`);
-}
-
 const browser = await chromium.launch();
 
 async function readUnder(timezoneId) {
@@ -46,10 +40,8 @@ async function readUnder(timezoneId) {
 // — `today` and `nowVisible` are wall-clock sensitive, so a run that crosses
 // a minute or day boundary mid-flight must not be reported as a false
 // mismatch against the other zones. Both baseline readings are compared
-// against every zone; if the two baseline readings disagree with *each
-// other*, the clock moved during the run and the wall-clock-sensitive
-// checks are reported as skipped rather than failed, without weakening what
-// they assert when the clock holds still.
+// against every zone, and a value must match one of them — matching neither
+// is a real cross-zone disagreement, not clock skew, and still fails.
 const baselineFirst = await readUnder(ZONES[0]);
 check('0 baseline rendered something to compare', baselineFirst.days.length > 0,
   `${baselineFirst.days.length} days, first=${baselineFirst.days[0]}`);
@@ -78,31 +70,16 @@ for (const { zone, got } of zoneResults) {
     JSON.stringify(got.times) === JSON.stringify(baselineFirst.times),
     got.times.slice(0, 3).join(', '));
 
-  if (!clockMoved) {
-    check(`4 same day is today under ${zone}`,
-      got.today === baselineFirst.today, `${got.today} vs ${baselineFirst.today}`);
-    check(`5 same events are upcoming under ${zone}`,
-      got.nowVisible === baselineFirst.nowVisible, `${got.nowVisible} vs ${baselineFirst.nowVisible}`);
-    continue;
-  }
-
-  // The clock moved mid-run. Still require agreement — just against
-  // whichever baseline reading (first or last) the clock hadn't yet moved
-  // past — before giving up and reporting a skip instead of a failure.
-  if (agreesWithEitherBaseline(got.today, b => b.today)) {
-    check(`4 same day is today under ${zone}`, true,
-      `${got.today} (clock moved mid-run: baseline was ${baselineFirst.today} then ${baselineLast.today})`);
-  } else {
-    skip(`4 same day is today under ${zone}`,
-      `clock moved mid-run: baseline was ${baselineFirst.today} then ${baselineLast.today}, got ${got.today}`);
-  }
-  if (agreesWithEitherBaseline(got.nowVisible, b => b.nowVisible)) {
-    check(`5 same events are upcoming under ${zone}`, true,
-      `${got.nowVisible} (clock moved mid-run: baseline was ${baselineFirst.nowVisible} then ${baselineLast.nowVisible})`);
-  } else {
-    skip(`5 same events are upcoming under ${zone}`,
-      `clock moved mid-run: baseline was ${baselineFirst.nowVisible} then ${baselineLast.nowVisible}, got ${got.nowVisible}`);
-  }
+  // A moving clock explains a value drifting between the two baseline reads.
+  // It does not explain a value matching neither — that is a real cross-zone
+  // disagreement, and this file exists to catch exactly that, so it must
+  // still fail rather than being swallowed as clock skew.
+  check(`4 same day is today under ${zone}`,
+    agreesWithEitherBaseline(got.today, b => b.today),
+    `${got.today} vs ${baselineFirst.today}/${baselineLast.today}${clockMoved ? ' (clock moved mid-run)' : ''}`);
+  check(`5 same events are upcoming under ${zone}`,
+    agreesWithEitherBaseline(got.nowVisible, b => b.nowVisible),
+    `${got.nowVisible} vs ${baselineFirst.nowVisible}/${baselineLast.nowVisible}${clockMoved ? ' (clock moved mid-run)' : ''}`);
 }
 
 await browser.close();

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "about:screenshots:ios": "node scripts/prepare-about-screenshots.mjs",
     "about:screenshots:web": "node scripts/capture-web-screenshots.mjs",
     "about:screenshots": "npm run about:screenshots:ios && npm run about:screenshots:web",
-    "test:browser": "node e2e/verify-rail.mjs && node e2e/verify-filter-reveal.mjs"
+    "test:browser": "node e2e/verify-rail.mjs && node e2e/verify-filter-reveal.mjs && node e2e/verify-timezone.mjs"
   },
   "dependencies": {
     "preact": "^10.28.4"

--- a/frontend/src/__tests__/components/calendar/EventCard.time.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventCard.time.test.tsx
@@ -1,0 +1,43 @@
+/// <reference types="vitest/globals" />
+import { render, screen } from '@testing-library/preact';
+import { EventCard } from '@/components/calendar/EventCard';
+import type { Event } from '@/lib/types';
+
+const baseEvent: Event = {
+  id: 'e1',
+  title: 'Interfaith Lecture',
+  description: 'A talk about peace.',
+  startDate: '2026-07-15T14:00:00',
+  endDate: '2026-07-15T15:00:00',
+  location: 'Hall of Philosophy',
+};
+
+function renderCard(overrides: Partial<Parameters<typeof EventCard>[0]> = {}) {
+  return render(
+    <EventCard
+      event={baseEvent}
+      index={0}
+      isExpanded={false}
+      onToggleDescription={vi.fn()}
+      onToggleTag={vi.fn()}
+      isTagSelected={() => false}
+      isFavorite={false}
+      onToggleFavorite={vi.fn()}
+      onDownloadICS={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+// The pinned test TZ (America/New_York, see vitest.config.ts) makes device
+// time and Institution time coincide, so this cannot by itself distinguish
+// Institution-anchored formatting from the device-local code it replaced.
+// It stands as a regression pin, not proof of the timezone fix.
+describe('event time display', () => {
+  it('shows the Institution wall time, unlabelled', () => {
+    // 23:00Z is 7:00 PM EDT.
+    renderCard({ event: { ...baseEvent, startDate: '2026-07-27 19:00:00' } });
+    expect(screen.getByText(/7:00 PM/)).toBeTruthy();
+    expect(screen.queryByText(/ET|EDT|EST/)).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/lib/constants.test.ts
+++ b/frontend/src/__tests__/lib/constants.test.ts
@@ -48,4 +48,20 @@ describe('getDefaultYear', () => {
     const { getDefaultYear } = await import('@/lib/constants');
     expect(getDefaultYear()).toBe(2027);
   });
+
+  it('turns over on October 1 at Chautauqua, not on the device', async () => {
+    // 2026-10-01T03:00:00Z is still 23:00 on September 30 at Chautauqua,
+    // so the season year must not have turned over yet.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-10-01T03:00:00Z'));
+    const { getDefaultYear } = await import('@/lib/constants');
+    expect(getDefaultYear()).toBe(2026);
+  });
+
+  it('turns over once Chautauqua reaches October', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-10-01T05:00:00Z')); // 01:00 EDT, Oct 1
+    const { getDefaultYear } = await import('@/lib/constants');
+    expect(getDefaultYear()).toBe(2027);
+  });
 });

--- a/frontend/src/__tests__/lib/utils/calendarUrls.test.ts
+++ b/frontend/src/__tests__/lib/utils/calendarUrls.test.ts
@@ -140,3 +140,75 @@ describe('isDesktop', () => {
     expect(isDesktop()).toBe(false);
   });
 });
+
+// Institution-anchored dates (F1): both providers must read `startDate`
+// through `parseEventDate`/`chqParts` rather than device-local `Date`
+// accessors, so naive feed timestamps and offset-bearing publisher
+// timestamps (any zone) agree with each other and with the ICS export.
+function makeTzEvent(startDate: string, endDate: string): Event {
+  return { id: 'evt-tz', title: 'TZ Event', startDate, endDate };
+}
+
+function googleDatesParam(event: Event): string {
+  const url = new URL(getGoogleCalendarUrl(event));
+  return url.searchParams.get('dates') ?? '';
+}
+
+function outlookStartdt(event: Event): string {
+  const url = new URL(getOutlookCalendarUrl(event));
+  return url.searchParams.get('startdt') ?? '';
+}
+
+describe('getGoogleCalendarUrl institution-anchored dates', () => {
+  it('sets ctz=America/New_York', () => {
+    const url = new URL(getGoogleCalendarUrl(makeTzEvent('2026-07-27 12:45:00', '2026-07-27 13:45:00')));
+    expect(url.searchParams.get('ctz')).toBe('America/New_York');
+  });
+
+  it('renders a naive feed timestamp as Institution wall time', () => {
+    const dates = googleDatesParam(makeTzEvent('2026-07-27 12:45:00', '2026-07-27 13:45:00'));
+    expect(dates.split('/')[0]).toBe('20260727T124500');
+  });
+
+  it('renders an offset-bearing timestamp already in Eastern unchanged', () => {
+    const dates = googleDatesParam(makeTzEvent('2026-07-04T18:00:00-04:00', '2026-07-04T19:00:00-04:00'));
+    expect(dates.split('/')[0]).toBe('20260704T180000');
+  });
+
+  it('converts an offset-bearing timestamp from a different zone to the Institution equivalent', () => {
+    // 18:00+09:00 is 09:00Z, which is 05:00 EDT the same morning.
+    const dates = googleDatesParam(makeTzEvent('2026-07-04T18:00:00+09:00', '2026-07-04T19:00:00+09:00'));
+    expect(dates.split('/')[0]).toBe('20260704T050000');
+  });
+});
+
+describe('getOutlookCalendarUrl institution-anchored dates', () => {
+  it('appends the Institution EDT offset for a naive summer timestamp', () => {
+    expect(outlookStartdt(makeTzEvent('2026-07-27 12:45:00', '2026-07-27 13:45:00')))
+      .toBe('2026-07-27T12:45:00-04:00');
+  });
+
+  it('appends the Institution EST offset for a naive winter timestamp', () => {
+    expect(outlookStartdt(makeTzEvent('2026-01-15 09:30:00', '2026-01-15 10:30:00')))
+      .toBe('2026-01-15T09:30:00-05:00');
+  });
+
+  it('renders an offset-bearing timestamp already in Eastern as the same wall time it names, not shifted', () => {
+    expect(outlookStartdt(makeTzEvent('2026-07-04T18:00:00-04:00', '2026-07-04T19:00:00-04:00')))
+      .toBe('2026-07-04T18:00:00-04:00');
+  });
+
+  it('converts an offset-bearing timestamp from a different zone to the Institution equivalent', () => {
+    // 18:00+09:00 is 09:00Z, which is 05:00 EDT the same morning.
+    expect(outlookStartdt(makeTzEvent('2026-07-04T18:00:00+09:00', '2026-07-04T19:00:00+09:00')))
+      .toBe('2026-07-04T05:00:00-04:00');
+  });
+});
+
+describe('Google and Outlook agree with each other on the same event', () => {
+  it('both name the same Institution wall time for a naive timestamp', () => {
+    const event = makeTzEvent('2026-07-27 12:45:00', '2026-07-27 13:45:00');
+    expect(googleDatesParam(event).split('/')[0]).toBe('20260727T124500');
+    expect(outlookStartdt(event)).toBe('2026-07-27T12:45:00-04:00');
+  });
+});

--- a/frontend/src/__tests__/lib/utils/chqTime.test.ts
+++ b/frontend/src/__tests__/lib/utils/chqTime.test.ts
@@ -3,6 +3,7 @@ import {
   CHQ_ZONE, chqParts, chqDayKey, chqDateAt, parseEventDate,
   formatChqTime, formatChqDayLabel,
 } from '@/lib/utils/chqTime';
+import { startOfDay, dayAfter, windowContains } from '@/lib/utils/dayWindow';
 
 describe('CHQ_ZONE', () => {
   it('is the Institution zone, never a fixed offset', () => {
@@ -107,6 +108,29 @@ describe('parseEventDate', () => {
 
   it('still reads the feed\'s naive form as Institution wall time', () => {
     expect(parseEventDate('2026-07-27 12:45:00').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('reads a date-only string as Institution midnight of that day', () => {
+    expect(parseEventDate('2026-07-27').toISOString()).toBe('2026-07-27T04:00:00.000Z');
+  });
+
+  it('keeps a date-only event visible in a window covering that day', () => {
+    const d = parseEventDate('2026-07-27');
+    const window = {
+      startDay: '2026-07-27', endDay: '2026-07-27',
+      start: startOfDay('2026-07-27'), endExclusive: dayAfter('2026-07-27'),
+    };
+    expect(windowContains(window, d)).toBe(true);
+  });
+
+  it('falls through to the naive path on a malformed offset rather than throwing', () => {
+    // `+25:99` passes the trailing-offset shape check but is not a value
+    // `Date` can parse, so the offset parse silently fails and the string is
+    // re-read as naive Institution wall time, ignoring the bad suffix. This
+    // is documented behaviour, not a validated design — pinned here so a
+    // future change to the fallthrough is a deliberate decision.
+    expect(parseEventDate('2026-07-27T12:45:00+25:99').toISOString())
+      .toBe('2026-07-27T16:45:00.000Z');
   });
 });
 

--- a/frontend/src/__tests__/lib/utils/chqTime.test.ts
+++ b/frontend/src/__tests__/lib/utils/chqTime.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CHQ_ZONE, chqParts, chqDayKey, chqDateAt, parseEventDate,
+  formatChqTime, formatChqDayLabel,
+} from '@/lib/utils/chqTime';
+
+describe('CHQ_ZONE', () => {
+  it('is the Institution zone, never a fixed offset', () => {
+    expect(CHQ_ZONE).toBe('America/New_York');
+  });
+});
+
+describe('chqParts', () => {
+  it('reads calendar fields in Institution time, not the device zone', () => {
+    // 2026-07-27T03:45:00Z is 23:45 on 2026-07-26 at Chautauqua (EDT, -4).
+    const p = chqParts(new Date('2026-07-27T03:45:00Z'));
+    expect(p).toMatchObject({ year: 2026, month: 7, day: 26, hour: 23, minute: 45 });
+  });
+
+  it('reads winter instants in EST', () => {
+    // 2026-01-15T18:30:00Z is 13:30 EST (-5).
+    const p = chqParts(new Date('2026-01-15T18:30:00Z'));
+    expect(p).toMatchObject({ year: 2026, month: 1, day: 15, hour: 13, minute: 30 });
+  });
+
+  it('reports midnight as hour 0, never 24', () => {
+    // 2026-07-27T04:00:00Z is exactly midnight EDT.
+    expect(chqParts(new Date('2026-07-27T04:00:00Z')).hour).toBe(0);
+  });
+});
+
+describe('chqDayKey', () => {
+  it('gives the Institution calendar day of an instant', () => {
+    expect(chqDayKey(new Date('2026-07-27T03:45:00Z'))).toBe('2026-07-26');
+    expect(chqDayKey(new Date('2026-07-27T16:45:00Z'))).toBe('2026-07-27');
+  });
+
+  it('zero-pads to yyyy-mm-dd', () => {
+    expect(chqDayKey(new Date('2026-01-05T17:00:00Z'))).toBe('2026-01-05');
+  });
+});
+
+describe('chqDateAt', () => {
+  it('builds an instant from Institution wall time in summer', () => {
+    // Noon EDT on 2026-07-27 is 16:00Z.
+    expect(chqDateAt(2026, 7, 27, 12).toISOString()).toBe('2026-07-27T16:00:00.000Z');
+  });
+
+  it('builds an instant from Institution wall time in winter', () => {
+    // Noon EST on 2026-01-15 is 17:00Z.
+    expect(chqDateAt(2026, 1, 15, 12).toISOString()).toBe('2026-01-15T17:00:00.000Z');
+  });
+
+  it('round-trips through chqParts across the spring DST transition', () => {
+    // 2026-03-08: 02:00 does not exist; 03:00 EDT is 07:00Z.
+    const d = chqDateAt(2026, 3, 8, 3);
+    expect(chqParts(d)).toMatchObject({ year: 2026, month: 3, day: 8, hour: 3 });
+  });
+
+  it('round-trips through chqParts across the autumn DST transition', () => {
+    // 2026-11-01: 01:00 occurs twice. Either instant must read back as 01:00.
+    const d = chqDateAt(2026, 11, 1, 1);
+    expect(chqParts(d)).toMatchObject({ year: 2026, month: 11, day: 1, hour: 1 });
+  });
+
+  it('round-trips every hour of both DST transition days', () => {
+    for (const [mo, day] of [[3, 8], [11, 1]] as const) {
+      for (let h = 0; h < 24; h++) {
+        const p = chqParts(chqDateAt(2026, mo, day, h));
+        // The spring-forward hour 02:00 does not exist; it normalises to 03:00.
+        const expected = mo === 3 && h === 2 ? 3 : h;
+        expect({ h, got: p.hour }).toEqual({ h, got: expected });
+      }
+    }
+  });
+});
+
+describe('parseEventDate', () => {
+  it('reads the feed\'s space-separated form as Institution wall time', () => {
+    expect(parseEventDate('2026-07-27 12:45:00').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('reads the T-separated form the publisher feeds use', () => {
+    expect(parseEventDate('2026-07-27T12:45:00').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('reads a winter date in EST', () => {
+    expect(parseEventDate('2026-01-15 12:00:00').toISOString()).toBe('2026-01-15T17:00:00.000Z');
+  });
+
+  it('tolerates a missing seconds field', () => {
+    expect(parseEventDate('2026-07-27 12:45').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
+
+  it('returns an Invalid Date for an unparseable string', () => {
+    // groupEventsByDay relies on this to emit its NaN-NaN-NaN key.
+    expect(Number.isNaN(parseEventDate('not a date').getTime())).toBe(true);
+  });
+});
+
+describe('formatChqTime', () => {
+  it('renders Institution wall time, unlabelled', () => {
+    expect(formatChqTime(new Date('2026-07-27T23:00:00Z'))).toBe('7:00 PM');
+  });
+
+  it('carries no timezone suffix', () => {
+    expect(formatChqTime(new Date('2026-07-27T23:00:00Z'))).not.toMatch(/ET|EDT|EST|GMT|UTC/);
+  });
+});
+
+describe('formatChqDayLabel', () => {
+  it('names the Institution day, not the device day', () => {
+    // 03:45Z is still the 26th at Chautauqua.
+    expect(formatChqDayLabel(new Date('2026-07-27T03:45:00Z')))
+      .toBe('Sunday, July 26, 2026');
+  });
+});

--- a/frontend/src/__tests__/lib/utils/chqTime.test.ts
+++ b/frontend/src/__tests__/lib/utils/chqTime.test.ts
@@ -96,6 +96,18 @@ describe('parseEventDate', () => {
     // groupEventsByDay relies on this to emit its NaN-NaN-NaN key.
     expect(Number.isNaN(parseEventDate('not a date').getTime())).toBe(true);
   });
+
+  it('honours an explicit Z rather than re-reading it as Institution time', () => {
+    expect(parseEventDate('2026-07-27T12:45:00Z').toISOString()).toBe('2026-07-27T12:45:00.000Z');
+  });
+
+  it('honours an explicit offset', () => {
+    expect(parseEventDate('2026-07-27T12:45:00+09:00').toISOString()).toBe('2026-07-27T03:45:00.000Z');
+  });
+
+  it('still reads the feed\'s naive form as Institution wall time', () => {
+    expect(parseEventDate('2026-07-27 12:45:00').toISOString()).toBe('2026-07-27T16:45:00.000Z');
+  });
 });
 
 describe('formatChqTime', () => {

--- a/frontend/src/__tests__/lib/utils/chqTime.test.ts
+++ b/frontend/src/__tests__/lib/utils/chqTime.test.ts
@@ -127,3 +127,21 @@ describe('formatChqDayLabel', () => {
       .toBe('Sunday, July 26, 2026');
   });
 });
+
+describe('unparseable dates degrade rather than throw', () => {
+  const bad = parseEventDate('not a date');
+
+  it('yields NaN parts instead of throwing', () => {
+    expect(() => chqParts(bad)).not.toThrow();
+    expect(Number.isNaN(chqParts(bad).year)).toBe(true);
+  });
+
+  it('produces the documented NaN-NaN-NaN day key', () => {
+    expect(chqDayKey(bad)).toBe('NaN-NaN-NaN');
+  });
+
+  it('formats as Invalid Date rather than throwing', () => {
+    expect(formatChqTime(bad)).toBe('Invalid Date');
+    expect(formatChqDayLabel(bad)).toBe('Invalid Date');
+  });
+});

--- a/frontend/src/__tests__/lib/utils/dateHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/dateHelpers.test.ts
@@ -1,4 +1,4 @@
-import { getAdaptiveEndDate, getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
+import { getAdaptiveEndDate, getChautauquaSeasonWeeks, isInChautauquaWeek } from '@/lib/utils/dateHelpers';
 import type { Event } from '@/lib/types';
 
 function makeEvent(dateStr: string, id?: string): Event {
@@ -30,51 +30,57 @@ describe('getAdaptiveEndDate', () => {
     ),
   ];
 
-  it('returns end-of-day boundary', () => {
+  // getAdaptiveEndDate now returns an exclusive bound — the Institution
+  // midnight immediately after the last included day — rather than an
+  // inclusive 23:59:59.999 on that day, matching the half-open
+  // `start <= x < end` convention used throughout. These assertions were
+  // updated from the old inclusive values (Task 4).
+  it('returns the exclusive next-midnight boundary', () => {
     const startDate = new Date('2026-06-30T07:00:00');
     const endDate = getAdaptiveEndDate(events, startDate, 5);
-    expect(endDate.getHours()).toBe(23);
-    expect(endDate.getMinutes()).toBe(59);
+    expect(endDate.getHours()).toBe(0);
+    expect(endDate.getMinutes()).toBe(0);
   });
 
   it('includes enough full days to meet minEvents', () => {
     const startDate = new Date('2026-06-30T07:00:00');
     // Need 20 events. Day 1 has 10 (< 20, not enough).
-    // Day 1 + Day 2 = 25 (>= 20, enough). Return end of Day 2.
+    // Day 1 + Day 2 = 25 (>= 20, enough). Return the midnight after Day 2.
     const endDate = getAdaptiveEndDate(events, startDate, 20);
-    // End date should be end of Jul 1 (Day 2 complete, accumulated 25 >= 20)
+    // End date should be the start of Jul 2 (Day 2 complete, accumulated 25 >= 20)
     expect(endDate.getMonth()).toBe(6); // July = month 6
-    expect(endDate.getDate()).toBe(1);
+    expect(endDate.getDate()).toBe(2);
   });
 
   it('handles when first day has enough events', () => {
     const startDate = new Date('2026-06-30T07:00:00');
     // minEvents = 5, Day 1 has 10 events.
-    // After completing Day 1, accumulated=10 >= 5, return end of Day 1
+    // After completing Day 1, accumulated=10 >= 5, return the midnight after Day 1
     const endDate = getAdaptiveEndDate(events, startDate, 5);
-    expect(endDate.getMonth()).toBe(5); // June = month 5
-    expect(endDate.getDate()).toBe(30);
+    expect(endDate.getMonth()).toBe(6); // July = month 6
+    expect(endDate.getDate()).toBe(1);
   });
 
-  it('returns last event day if not enough events exist', () => {
+  it('returns the day after the last event day if not enough events exist', () => {
     const startDate = new Date('2026-06-30T07:00:00');
     const endDate = getAdaptiveEndDate(events, startDate, 1000);
-    // Should return end of last event's day (Jul 3)
+    // Should return the midnight after the last event's day (Jul 3 -> Jul 4)
     expect(endDate.getMonth()).toBe(6);
-    expect(endDate.getDate()).toBe(3);
+    expect(endDate.getDate()).toBe(4);
   });
 
-  it('returns 90-day fallback for empty events array', () => {
+  it('returns a 91-day-later fallback for empty events array', () => {
     const startDate = new Date('2026-06-30T07:00:00');
     const endDate = getAdaptiveEndDate([], startDate, 50);
-    // Fallback adds 90 days from start and sets to end-of-day
+    // Fallback: 91 days from start, at midnight (exclusive equivalent of the
+    // old "90 days later, end of day" inclusive bound).
     const expectedDate = new Date(startDate);
-    expectedDate.setDate(expectedDate.getDate() + 90);
+    expectedDate.setDate(expectedDate.getDate() + 91);
     expect(endDate.getFullYear()).toBe(expectedDate.getFullYear());
     expect(endDate.getMonth()).toBe(expectedDate.getMonth());
     expect(endDate.getDate()).toBe(expectedDate.getDate());
-    expect(endDate.getHours()).toBe(23);
-    expect(endDate.getMinutes()).toBe(59);
+    expect(endDate.getHours()).toBe(0);
+    expect(endDate.getMinutes()).toBe(0);
   });
 
   it('filters out events before startDate', () => {
@@ -84,9 +90,9 @@ describe('getAdaptiveEndDate', () => {
     // Need 20 events. Jul 1 has 15 events (< 20, not enough).
     // Jul 1 + Jul 2 = 35 events (>= 20, enough).
     // When transitioning to Jul 3, we see accumulated=35 >= 20,
-    // and return end of Jul 2 (the last completed day).
+    // and return the midnight after Jul 2 (the last completed day).
     expect(endDate.getMonth()).toBe(6); // July
-    expect(endDate.getDate()).toBe(2); // End of Jul 2
+    expect(endDate.getDate()).toBe(3); // Start of Jul 3
   });
 });
 
@@ -104,5 +110,35 @@ describe('getChautauquaSeasonWeeks', () => {
       const diff = week.end.getTime() - week.start.getTime();
       expect(diff).toBe(7 * 24 * 60 * 60 * 1000);
     });
+  });
+});
+
+describe('season weeks in Institution time', () => {
+  it('starts week 1 at Saturday noon at Chautauqua, not noon on the device', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    // 2026's 4th Sunday of June is the 28th; the Saturday before is the 27th.
+    // Noon EDT on 2026-06-27 is 16:00Z.
+    expect(weeks[0].start.toISOString()).toBe('2026-06-27T16:00:00.000Z');
+  });
+
+  it('runs each week exactly seven calendar days, noon to noon', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    expect(weeks[0].end.toISOString()).toBe('2026-07-04T16:00:00.000Z');
+    expect(weeks).toHaveLength(9);
+  });
+
+  it('tiles: each week ends where the next begins', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    for (let i = 1; i < weeks.length; i++) {
+      expect(weeks[i].start.getTime()).toBe(weeks[i - 1].end.getTime());
+    }
+  });
+
+  it('places an event by its Institution instant', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    // 11:00 on the Saturday is still the previous week; 13:00 is the next.
+    expect(isInChautauquaWeek('2026-07-04 11:00:00', 1, weeks)).toBe(true);
+    expect(isInChautauquaWeek('2026-07-04 13:00:00', 1, weeks)).toBe(false);
+    expect(isInChautauquaWeek('2026-07-04 13:00:00', 2, weeks)).toBe(true);
   });
 });

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -719,6 +719,12 @@ describe('Institution-anchored day boundaries', () => {
     // Noon EDT Saturday — 'this-week' ends here and that morning has events.
     expect(lastDayCovered(new Date('2026-07-25T16:00:00.000Z'))).toBe('2026-07-25');
   });
+
+  it('keeps the final day when the bound is 400ms after midnight (regression: ChqParts has no ms field)', () => {
+    // 04:00:00.400Z is 400ms past Institution midnight on the 28th — not
+    // midnight itself, so the 28th must be kept, not dropped.
+    expect(lastDayCovered(new Date('2026-07-28T04:00:00.400Z'))).toBe('2026-07-28');
+  });
 });
 
 describe('day chips and labels read Institution time', () => {

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -649,3 +649,37 @@ describe('eventCountsByDay', () => {
     expect(counts.get('2026-07-04')).toBe(1);
   });
 });
+
+describe('Institution-anchored day boundaries', () => {
+  it('files an instant under the Institution day, not the device day', () => {
+    // 03:45Z on the 27th is 23:45 on the 26th at Chautauqua.
+    expect(dayKeyOf(new Date('2026-07-27T03:45:00Z'))).toBe('2026-07-26');
+  });
+
+  it('starts a day at Institution midnight', () => {
+    expect(startOfDay('2026-07-27').toISOString()).toBe('2026-07-27T04:00:00.000Z');
+  });
+
+  it('starts a winter day at Institution midnight', () => {
+    expect(startOfDay('2026-01-15').toISOString()).toBe('2026-01-15T05:00:00.000Z');
+  });
+
+  it('ends a day at the next Institution midnight', () => {
+    expect(dayAfter('2026-07-27').toISOString()).toBe('2026-07-28T04:00:00.000Z');
+  });
+
+  it('tiles exactly: one day\'s end is the next day\'s start', () => {
+    expect(dayAfter('2026-03-07').getTime()).toBe(startOfDay('2026-03-08').getTime());
+    expect(dayAfter('2026-10-31').getTime()).toBe(startOfDay('2026-11-01').getTime());
+  });
+
+  it('treats Institution midnight as midnight for lastDayCovered', () => {
+    // 04:00Z is midnight EDT, so the window does not show that day.
+    expect(lastDayCovered(new Date('2026-07-28T04:00:00.000Z'))).toBe('2026-07-27');
+  });
+
+  it('keeps the final day when a window ends mid-day at Chautauqua', () => {
+    // Noon EDT Saturday — 'this-week' ends here and that morning has events.
+    expect(lastDayCovered(new Date('2026-07-25T16:00:00.000Z'))).toBe('2026-07-25');
+  });
+});

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -17,8 +17,8 @@ import {
   dayChips,
   eventCountsByDay,
 } from '@/lib/utils/dayWindow';
-import { getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
-import { parseEventDate } from '@/lib/utils/chqTime';
+import { getAdaptiveEndDate, getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
+import { chqDateAt, parseEventDate } from '@/lib/utils/chqTime';
 import type { Event } from '@/lib/types';
 
 const seasonWeeks = getChautauquaSeasonWeeks(2026);
@@ -181,13 +181,13 @@ describe('baseWindow', () => {
   });
 
   it("'next' starts one hour before now, not at midnight", () => {
-    const adaptiveEndDate = new Date(2026, 6, 17, 23, 59, 59, 999);
+    // Exclusive end of Jul 17 — what the real getAdaptiveEndDate now returns
+    // (Task 4). baseWindow uses a supplied adaptiveEndDate as-is.
+    const adaptiveEndDate = chqDateAt(2026, 7, 18, 0, 0, 0, 0);
     const w = baseWindow({
       dateFilter: 'next', seasonWeeks, currentWeekNumber, now: NOW, adaptiveEndDate, bounds,
     })!;
     expect(w.start.getTime()).toBe(new Date(2026, 6, 15, 14, 0, 0, 0).getTime());
-    // adaptiveEndDate is an inclusive 23:59:59.999; the half-open bound is
-    // the following midnight. No representable event falls in the gap.
     expect(w.endExclusive.getTime()).toBe(new Date(2026, 6, 18, 0, 0, 0, 0).getTime());
     expect(w.startDay).toBe('2026-07-15');
     expect(w.endDay).toBe('2026-07-17');
@@ -202,10 +202,30 @@ describe('baseWindow', () => {
       seasonWeeks,
       currentWeekNumber,
       now: nearMidnight,
-      adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+      // Exclusive end of Jul 17.
+      adaptiveEndDate: chqDateAt(2026, 7, 18, 0, 0, 0, 0),
       bounds,
     })!;
     expect(w.startDay).toBe('2026-07-14');
+  });
+
+  it("'next' ends where getAdaptiveEndDate said, not a day later", () => {
+    // Regression for fix-round 1, task 4: getAdaptiveEndDate now returns an
+    // already-exclusive bound (Task 4), but this 'next' case used to
+    // re-derive an exclusive bound from it as if it were still inclusive —
+    // landing a full day past the real cutoff.
+    const events = [
+      { id: 'a', title: 'a', startDate: '2026-07-01 09:00:00' },
+      { id: 'b', title: 'b', startDate: '2026-07-01 19:00:00' },
+      { id: 'c', title: 'c', startDate: '2026-07-02 09:00:00' },
+    ] as Event[];
+    const now = new Date('2026-07-01T13:00:00Z');
+    const adaptiveEndDate = getAdaptiveEndDate(events, now, 2);
+    const w = baseWindow({
+      dateFilter: 'next', seasonWeeks, currentWeekNumber, now, adaptiveEndDate, bounds,
+    })!;
+    expect(w.endDay).toBe('2026-07-01');
+    expect(w.endExclusive.toISOString()).toBe('2026-07-02T04:00:00.000Z');
   });
 
   it("'this-week' carries the week's own exclusive noon bound through", () => {
@@ -365,7 +385,8 @@ describe('viewWindow expansion', () => {
       seasonWeeks,
       currentWeekNumber,
       now: NOW,
-      adaptiveEndDate: new Date(2026, 6, 17, 23, 59, 59, 999),
+      // Exclusive end of Jul 17.
+      adaptiveEndDate: chqDateAt(2026, 7, 18, 0, 0, 0, 0),
       bounds,
       expandedStartDay: '2026-07-13',
     })!;

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -23,7 +23,16 @@ import type { Event } from '@/lib/types';
 const seasonWeeks = getChautauquaSeasonWeeks(2026);
 
 function makeEvent(id: string, date: Date): Event {
-  return { id, title: id, startDate: date.toISOString() } as Event;
+  // The real feed sends naive Institution wall time ("2026-07-27 12:45:00"),
+  // never an absolute instant with a `Z`/offset suffix — see
+  // `parseEventDate`. Built from local getters, not `toISOString()`: under
+  // the pinned test TZ (`America/New_York`, equal to `CHQ_ZONE`) those
+  // getters already read Institution wall time, so this reproduces the
+  // feed shape exactly instead of a UTC instant `parseEventDate` would
+  // reinterpret as if it were local time.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const startDate = `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+  return { id, title: id, startDate } as Event;
 }
 
 describe('day key arithmetic', () => {
@@ -681,5 +690,25 @@ describe('Institution-anchored day boundaries', () => {
   it('keeps the final day when a window ends mid-day at Chautauqua', () => {
     // Noon EDT Saturday — 'this-week' ends here and that morning has events.
     expect(lastDayCovered(new Date('2026-07-25T16:00:00.000Z'))).toBe('2026-07-25');
+  });
+});
+
+describe('day chips and labels read Institution time', () => {
+  it('names the chip after its own key', () => {
+    const chips = dayChips(['2026-07-27'], new Map([['2026-07-27', 3]]));
+    expect(chips[0].dayOfMonth).toBe('27');
+    expect(chips[0].weekday).toBe('Mon');
+    expect(chips[0].month).toBe('Jul');
+    expect(chips[0].label).toBe('Go to Monday, July 27, 3 events');
+  });
+
+  it('names a chip on the far side of a DST transition correctly', () => {
+    const chips = dayChips(['2026-11-01'], new Map());
+    expect(chips[0].dayOfMonth).toBe('1');
+    expect(chips[0].label).toBe('Sunday, November 1, no events');
+  });
+
+  it('labels a day by its Institution date', () => {
+    expect(formatDayLabel('2026-07-27')).toContain('Jul 27');
   });
 });

--- a/frontend/src/__tests__/lib/utils/dayWindow.test.ts
+++ b/frontend/src/__tests__/lib/utils/dayWindow.test.ts
@@ -18,6 +18,7 @@ import {
   eventCountsByDay,
 } from '@/lib/utils/dayWindow';
 import { getChautauquaSeasonWeeks } from '@/lib/utils/dateHelpers';
+import { parseEventDate } from '@/lib/utils/chqTime';
 import type { Event } from '@/lib/types';
 
 const seasonWeeks = getChautauquaSeasonWeeks(2026);
@@ -44,6 +45,12 @@ describe('day key arithmetic', () => {
   it('sorts lexicographically in chronological order', () => {
     const keys = ['2026-12-31', '2026-07-05', '2026-07-15'];
     expect([...keys].sort()).toEqual(['2026-07-05', '2026-07-15', '2026-12-31']);
+  });
+
+  it('does not throw on an Invalid Date, and yields the NaN-NaN-NaN key', () => {
+    const bad = parseEventDate('not a date');
+    expect(() => dayKeyOf(bad)).not.toThrow();
+    expect(dayKeyOf(bad)).toBe('NaN-NaN-NaN');
   });
 
   it('adds and subtracts days across month and year boundaries', () => {

--- a/frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts
+++ b/frontend/src/__tests__/lib/utils/groupEventsByDay.test.ts
@@ -85,3 +85,30 @@ describe('groupEventsByDay — week-number metadata on day headers', () => {
     ]);
   });
 });
+
+describe('groupEventsByDay in Institution time', () => {
+  const ev = evt; // the file's existing fixture builder
+
+  it('files a late-evening event under the Institution day it belongs to', () => {
+    const groups = groupEventsByDay([ev('a', '2026-07-26 23:45:00')], []);
+    expect(groups[0].key).toBe('2026-07-26');
+  });
+
+  it('labels the group with the Institution day', () => {
+    const groups = groupEventsByDay([ev('a', '2026-07-26 23:45:00')], []);
+    expect(groups[0].baseLabel).toBe('Sunday, July 26, 2026');
+  });
+
+  it('keeps an unparseable date out of the real days rather than crashing', () => {
+    const groups = groupEventsByDay([ev('bad', 'not a date')], []);
+    expect(groups[0].key).toBe('NaN-NaN-NaN');
+  });
+
+  it('sorts within a day by true instant', () => {
+    const groups = groupEventsByDay([
+      ev('late', '2026-07-27 19:00:00'),
+      ev('early', '2026-07-27 09:00:00'),
+    ], []);
+    expect(groups[0].events.map(e => e.id)).toEqual(['early', 'late']);
+  });
+});

--- a/frontend/src/__tests__/lib/utils/icsHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/icsHelpers.test.ts
@@ -220,3 +220,16 @@ describe('downloadICS', () => {
     expect(downloadAttr).toBe('my-event-title.ics');
   });
 });
+
+describe('ICS times are Institution wall time', () => {
+  it('emits the feed\'s wall clock verbatim under TZID America/New_York', () => {
+    const ics = generateICS({ id: 'x', title: 'T', startDate: '2026-07-27 12:45:00', endDate: '2026-07-27 13:45:00' } as Event);
+    expect(ics).toContain('DTSTART;TZID=America/New_York:20260727T124500');
+    expect(ics).toContain('DTEND;TZID=America/New_York:20260727T134500');
+  });
+
+  it('round-trips a winter date without shifting an hour', () => {
+    const ics = generateICS({ id: 'x', title: 'T', startDate: '2026-01-15 09:30:00', endDate: '2026-01-15 10:30:00' } as Event);
+    expect(ics).toContain('DTSTART;TZID=America/New_York:20260115T093000');
+  });
+});

--- a/frontend/src/components/calendar/EventCard.tsx
+++ b/frontend/src/components/calendar/EventCard.tsx
@@ -4,6 +4,7 @@ import type { ArticleLink } from '@/hooks/useArticleLinks';
 import type { ProgramLink } from '@/hooks/useProgramLinks';
 import { getCategoryDisplayName } from '@/lib/constants';
 import { isDesktop } from '@/lib/utils/calendarUrls';
+import { formatChqTime, parseEventDate } from '@/lib/utils/chqTime';
 import { CalendarPopup } from './CalendarPopup';
 
 /**
@@ -49,11 +50,7 @@ export function EventCard({ event, index, isExpanded, onToggleDescription, onTog
           {/* Time and location above title */}
           <div className="flex items-center justify-between text-xs sm:text-sm text-gray-500 dark:text-gray-400 mb-1">
             <span>
-              🕐 {new Date(event.startDate).toLocaleTimeString([], {
-                hour: 'numeric',
-                minute: '2-digit',
-                hour12: true
-              })}
+              🕐 {formatChqTime(parseEventDate(event.startDate))}
               {event.location && <span className="ml-2">📍 {event.location}</span>}
             </span>
             <span className="flex items-center flex-shrink-0 ml-2">

--- a/frontend/src/components/layout/CountdownBanner.tsx
+++ b/frontend/src/components/layout/CountdownBanner.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import type { SeasonWeek } from '@/lib/types';
+import { CHQ_ZONE } from '@/lib/utils/chqTime';
 
 interface CountdownBannerProps {
   seasonWeeks: SeasonWeek[];
@@ -19,6 +20,7 @@ export function CountdownBanner({ seasonWeeks }: CountdownBannerProps) {
 
   const seasonStart = seasonWeeks[0].start;
   const dateStr = seasonStart.toLocaleDateString('en-US', {
+    timeZone: CHQ_ZONE,
     weekday: 'long',
     month: 'long',
     day: 'numeric',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,3 +1,5 @@
+import { chqParts } from '@/lib/utils/chqTime';
+
 export const CACHE_EXPIRY_MS = 3600000; // 1 hour in milliseconds
 export const USER_STATE_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
 export const LONG_PRESS_MS = 500;
@@ -14,12 +16,14 @@ export const IOS_MIN_VERSION = 18;
 export const APP_STORE_URL = 'https://apps.apple.com/us/app/chqcalendar/id6797027562';
 export const YEARS_MANIFEST_PATH = '/cache/calendar-cache/years.json';
 /**
- * Compute the default season year based on October 1 turnover.
- * Before Oct 1: current year. On/after Oct 1: next year.
+ * The default season year, turning over on October 1 — at Chautauqua.
+ *
+ * Read in Institution time so a reader east of Eastern does not see next
+ * season a few hours early on September 30.
  */
 export function getDefaultYear(): number {
-  const now = new Date();
-  return now.getMonth() >= 9 ? now.getFullYear() + 1 : now.getFullYear();
+  const { year, month } = chqParts(new Date());
+  return month >= 10 ? year + 1 : year;
 }
 
 // Backward-compatible constant — will be removed once all consumers use getDefaultYear()

--- a/frontend/src/lib/utils/calendarUrls.ts
+++ b/frontend/src/lib/utils/calendarUrls.ts
@@ -1,7 +1,5 @@
 import type { Event } from '@/lib/types';
-import { CHQ_ZONE, chqParts, parseEventDate } from '@/lib/utils/chqTime';
-
-const p2 = (n: number) => String(n).padStart(2, '0');
+import { CHQ_ZONE, chqParts, pad2 as p2, parseEventDate } from '@/lib/utils/chqTime';
 
 /**
  * Format a Date as YYYYMMDDTHHMMSS for Google Calendar, in Institution wall

--- a/frontend/src/lib/utils/calendarUrls.ts
+++ b/frontend/src/lib/utils/calendarUrls.ts
@@ -1,56 +1,47 @@
 import type { Event } from '@/lib/types';
+import { CHQ_ZONE, chqParts, parseEventDate } from '@/lib/utils/chqTime';
+
+const p2 = (n: number) => String(n).padStart(2, '0');
 
 /**
- * Format a Date as YYYYMMDDTHHMMSS for Google Calendar.
- * Google Calendar requires dates in this format without timezone offset.
+ * Format a Date as YYYYMMDDTHHMMSS for Google Calendar, in Institution wall
+ * time. Google Calendar requires dates in this format without a timezone
+ * offset; the popup's `ctz=America/New_York` param (set below) is what tells
+ * Google how to interpret it.
  */
 function toGoogleDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
-  const seconds = String(d.getSeconds()).padStart(2, '0');
-  return `${year}${month}${day}T${hours}${minutes}${seconds}`;
+  const { year, month, day, hour, minute, second } = chqParts(parseEventDate(dateStr));
+  return `${year}${p2(month)}${p2(day)}T${p2(hour)}${p2(minute)}${p2(second)}`;
 }
 
 /**
- * Determine Eastern timezone offset (EDT or EST) for a given date.
- * US DST: second Sunday of March through first Sunday of November.
+ * The Institution's UTC offset (e.g. `-04:00`) at the instant `d` names,
+ * derived from the instant itself rather than a hardcoded DST rule. The
+ * second-Sunday-of-March / first-Sunday-of-November calculation this
+ * replaced only ever encoded the *current* US rule and would go wrong
+ * silently the day that rule changes; comparing the Institution wall clock
+ * to the same instant's UTC components is correct on both sides of every
+ * transition without knowing the rule at all.
  */
-function getEasternOffset(d: Date): string {
-  const month = d.getMonth(); // 0-indexed
-  // April through October: always EDT
-  if (month >= 3 && month <= 9) return '-04:00';
-  // December through February: always EST
-  if (month <= 1 || month === 11) return '-05:00';
-  // March: DST starts second Sunday
-  if (month === 2) {
-    const dayOfWeek = new Date(d.getFullYear(), 2, 1).getDay();
-    const secondSunday = dayOfWeek === 0 ? 8 : 15 - dayOfWeek;
-    return d.getDate() >= secondSunday ? '-04:00' : '-05:00';
-  }
-  // November: DST ends first Sunday
-  const dayOfWeek = new Date(d.getFullYear(), 10, 1).getDay();
-  const firstSunday = dayOfWeek === 0 ? 1 : 8 - dayOfWeek;
-  return d.getDate() < firstSunday ? '-04:00' : '-05:00';
+function chqOffset(d: Date): string {
+  const p = chqParts(d);
+  const wallAsUTC = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second);
+  const diffMinutes = Math.round((wallAsUTC - d.getTime()) / 60000);
+  const sign = diffMinutes < 0 ? '-' : '+';
+  const abs = Math.abs(diffMinutes);
+  return `${sign}${p2(Math.floor(abs / 60))}:${p2(abs % 60)}`;
 }
 
 /**
- * Format a Date as ISO 8601 string with Eastern offset for Outlook.
- * Outlook interprets naive times in the user's account timezone,
- * so we append the Eastern offset to ensure correct display.
+ * Format a Date as ISO 8601 string with the Institution's offset, for
+ * Outlook. Outlook interprets naive times in the user's account timezone,
+ * so the offset is appended to ensure correct display regardless of where
+ * the reader's Outlook account is set.
  */
 function toOutlookDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
-  const seconds = String(d.getSeconds()).padStart(2, '0');
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${getEasternOffset(d)}`;
+  const d = parseEventDate(dateStr);
+  const { year, month, day, hour, minute, second } = chqParts(d);
+  return `${year}-${p2(month)}-${p2(day)}T${p2(hour)}:${p2(minute)}:${p2(second)}${chqOffset(d)}`;
 }
 
 /**
@@ -63,7 +54,7 @@ export function getGoogleCalendarUrl(event: Event): string {
   params.set('action', 'TEMPLATE');
   params.set('text', event.title);
   params.set('dates', `${toGoogleDate(event.startDate)}/${toGoogleDate(event.endDate)}`);
-  params.set('ctz', 'America/New_York');
+  params.set('ctz', CHQ_ZONE);
   if (event.location) {
     params.set('location', event.location);
   }

--- a/frontend/src/lib/utils/chqTime.ts
+++ b/frontend/src/lib/utils/chqTime.ts
@@ -116,6 +116,16 @@ export function chqDateAt(
  * rather than crashing.
  */
 export function parseEventDate(s: string): Date {
+  // An explicit offset or `Z` means the string already names an absolute
+  // instant, so honour it rather than re-reading the digits as Institution
+  // wall time. The CHQ feed has never emitted one — every event carries a
+  // naive `startDate` and a sibling `timezone` field — but publisher feeds
+  // are third-party, and silently shifting a correctly-offset timestamp by
+  // four hours is a worse failure than any loud one.
+  if (/(?:Z|[+-]\d{2}:?\d{2})$/.test(s ?? '')) {
+    const absolute = new Date(s);
+    if (!Number.isNaN(absolute.getTime())) return absolute;
+  }
   const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/.exec(s ?? '');
   if (!m) return new Date(NaN);
   return chqDateAt(

--- a/frontend/src/lib/utils/chqTime.ts
+++ b/frontend/src/lib/utils/chqTime.ts
@@ -59,6 +59,15 @@ export function chqParts(d: Date): ChqParts {
   for (const { type, value } of partsFormatter.formatToParts(d)) {
     found[type] = value;
   }
+  // `partsFormatter`'s locale and options are fixed at module scope, so
+  // `found.weekday` can only ever be one of `WEEKDAYS` — this NaN path is
+  // defence in depth, not a reachable case today. Silently mapping an
+  // unrecognised abbreviation to Sunday (via `Math.max(0, indexOf(...))`)
+  // would be a wrong answer presented as a right one; NaN matches every
+  // other degradation path in this file (an Invalid Date already returns
+  // NaN for every field) and propagates as "no valid weekday" rather than
+  // masquerading as Sunday.
+  const weekdayIndex = WEEKDAYS.indexOf(found.weekday);
   return {
     year: Number(found.year),
     month: Number(found.month),
@@ -67,18 +76,26 @@ export function chqParts(d: Date): ChqParts {
     hour: Number(found.hour) % 24,
     minute: Number(found.minute),
     second: Number(found.second),
-    weekday: Math.max(0, WEEKDAYS.indexOf(found.weekday)),
+    weekday: weekdayIndex === -1 ? NaN : weekdayIndex,
   };
+}
+
+/**
+ * Zero-pads a number to (at least) two digits — `7` -> `'07'`, `12` -> `'12'`.
+ *
+ * `String(NaN).padStart(2, '0')` is `'NaN'` (already 3 chars, past the
+ * target length, so padStart is a no-op) — this degrades along with
+ * chqParts' NaN fields without a special case, matching the 'NaN-NaN-NaN'
+ * key the old device-local implementation produced.
+ */
+export function pad2(n: number): string {
+  return String(n).padStart(2, '0');
 }
 
 /** The Chautauqua calendar day an instant falls on, as `yyyy-mm-dd`. */
 export function chqDayKey(d: Date): string {
   const { year, month, day } = chqParts(d);
-  // `String(NaN).padStart(2, '0')` is `'NaN'` (already 3 chars, past the
-  // target length, so padStart is a no-op) — this falls out of chqParts'
-  // NaN fields without a special case, and is byte-identical to the
-  // 'NaN-NaN-NaN' key the old device-local implementation produced.
-  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  return `${year}-${pad2(month)}-${pad2(day)}`;
 }
 
 /**

--- a/frontend/src/lib/utils/chqTime.ts
+++ b/frontend/src/lib/utils/chqTime.ts
@@ -1,0 +1,135 @@
+/**
+ * Institution-anchored time.
+ *
+ * Every date the calendar reasons about belongs to the Chautauqua
+ * Institution, whose season runs on Eastern time, and the feed's timestamps
+ * carry no offset of their own (`"2026-07-27 12:45:00"`, with a sibling
+ * `timezone` field that has said `America/New_York` for all 3,246 events).
+ * Reading them in the device's zone made the app agree with a reader
+ * standing on the grounds and disagree with everyone else.
+ *
+ * Mirrors iOS's `ChqTime` deliberately: the two apps should not hold
+ * different opinions about which day an event is on.
+ */
+
+/** Never a fixed offset — the season spans a DST transition in most years. */
+export const CHQ_ZONE = 'America/New_York';
+
+export interface ChqParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+  /** 0 = Sunday, matching `Date.prototype.getDay`. */
+  weekday: number;
+}
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+
+const partsFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHQ_ZONE,
+  year: 'numeric', month: '2-digit', day: '2-digit',
+  hour: '2-digit', minute: '2-digit', second: '2-digit',
+  weekday: 'short', hour12: false,
+});
+
+const timeFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHQ_ZONE, hour: 'numeric', minute: '2-digit', hour12: true,
+});
+
+const dayLabelFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: CHQ_ZONE,
+  weekday: 'long', year: 'numeric', month: 'long', day: 'numeric',
+});
+
+/** An instant's calendar fields as they read at Chautauqua. */
+export function chqParts(d: Date): ChqParts {
+  const found: Record<string, string> = {};
+  for (const { type, value } of partsFormatter.formatToParts(d)) {
+    found[type] = value;
+  }
+  return {
+    year: Number(found.year),
+    month: Number(found.month),
+    day: Number(found.day),
+    // `hourCycle: h23` still renders midnight as "24" in some engines.
+    hour: Number(found.hour) % 24,
+    minute: Number(found.minute),
+    second: Number(found.second),
+    weekday: Math.max(0, WEEKDAYS.indexOf(found.weekday)),
+  };
+}
+
+/** The Chautauqua calendar day an instant falls on, as `yyyy-mm-dd`. */
+export function chqDayKey(d: Date): string {
+  const { year, month, day } = chqParts(d);
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+/**
+ * The instant at which the Chautauqua clock reads the given wall time.
+ *
+ * Offset-lookup-and-correct, applied twice. A single correction is wrong
+ * when the guess and the answer straddle a DST boundary: the offset used to
+ * make the guess is not the offset in force at the result. The second pass
+ * re-reads the offset at the corrected instant and settles it. Ambiguous
+ * times (the repeated hour each autumn) resolve to the first occurrence —
+ * the second pass converges there directly, since the pre-transition offset
+ * is still in force at the first-pass guess.
+ *
+ * Nonexistent wall times (the skipped hour each spring) have no fixed
+ * point: no instant reads back as the requested time, so blindly applying
+ * a second correction overshoots *backwards*, past the gap, into the
+ * previous offset. When the second pass still doesn't read back what was
+ * asked for, prefer the first pass's guess instead — it lands on the
+ * instant immediately after the gap, matching `Calendar` on iOS.
+ */
+export function chqDateAt(
+  y: number, mo: number, d: number,
+  h = 0, mi = 0, s = 0, ms = 0,
+): Date {
+  const asUTC = Date.UTC(y, mo - 1, d, h, mi, s, ms);
+
+  const correct = (guess: Date): Date => {
+    const p = chqParts(guess);
+    const readBack = Date.UTC(p.year, p.month - 1, p.day, p.hour, p.minute, p.second, ms);
+    return new Date(guess.getTime() - (readBack - asUTC));
+  };
+
+  const firstPass = correct(new Date(asUTC));
+  const secondPass = correct(firstPass);
+
+  const p = chqParts(secondPass);
+  const matches = p.year === y && p.month === mo && p.day === d
+    && p.hour === h && p.minute === mi && p.second === s;
+  return matches ? secondPass : firstPass;
+}
+
+/**
+ * A feed timestamp — naive Institution wall time — as an absolute instant.
+ *
+ * Accepts the space-separated form the CHQ feed emits and the T-separated
+ * form publisher feeds use, with or without seconds. Anything else yields an
+ * Invalid Date, which `groupEventsByDay` turns into its `NaN-NaN-NaN` key
+ * rather than crashing.
+ */
+export function parseEventDate(s: string): Date {
+  const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/.exec(s ?? '');
+  if (!m) return new Date(NaN);
+  return chqDateAt(
+    Number(m[1]), Number(m[2]), Number(m[3]),
+    Number(m[4]), Number(m[5]), Number(m[6] ?? 0),
+  );
+}
+
+/** `"7:00 PM"` at Chautauqua. Deliberately unlabelled — see the design doc. */
+export function formatChqTime(d: Date): string {
+  return timeFormatter.format(d);
+}
+
+/** `"Sunday, July 26, 2026"` at Chautauqua. */
+export function formatChqDayLabel(d: Date): string {
+  return dayLabelFormatter.format(d);
+}

--- a/frontend/src/lib/utils/chqTime.ts
+++ b/frontend/src/lib/utils/chqTime.ts
@@ -124,9 +124,23 @@ export function chqDateAt(
  * A feed timestamp — naive Institution wall time — as an absolute instant.
  *
  * Accepts the space-separated form the CHQ feed emits and the T-separated
- * form publisher feeds use, with or without seconds. Anything else yields an
- * Invalid Date, which `groupEventsByDay` turns into its `NaN-NaN-NaN` key
- * rather than crashing.
+ * form publisher feeds use, with or without seconds, as well as a bare
+ * `yyyy-mm-dd` date with no time component (read as Institution midnight of
+ * that day — `new Date('2026-07-27')` did the equivalent before this module
+ * existed, and losing that silently dropped date-only events from every
+ * scope rather than showing them on a possibly-wrong day).
+ *
+ * Parse-failure policy, pinned by tests rather than left to fall out of the
+ * regex by accident:
+ *  - A malformed offset (wrong digit grouping aside, an out-of-range one
+ *    like `+25:99`) fails the `Date` parse silently and falls through to the
+ *    naive path below, which reads the leading `yyyy-mm-ddThh:mm:ss` as
+ *    Institution wall time and ignores the bad offset entirely. This is a
+ *    quirk of the fallthrough, not a validated design — but it degrades
+ *    rather than throwing, which is the property that matters here.
+ *  - Anything that matches neither an offset-bearing instant nor either
+ *    naive shape yields an Invalid Date, which `groupEventsByDay` turns into
+ *    its `NaN-NaN-NaN` key rather than crashing.
  */
 export function parseEventDate(s: string): Date {
   // An explicit offset or `Z` means the string already names an absolute
@@ -140,11 +154,17 @@ export function parseEventDate(s: string): Date {
     if (!Number.isNaN(absolute.getTime())) return absolute;
   }
   const m = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?/.exec(s ?? '');
-  if (!m) return new Date(NaN);
-  return chqDateAt(
-    Number(m[1]), Number(m[2]), Number(m[3]),
-    Number(m[4]), Number(m[5]), Number(m[6] ?? 0),
-  );
+  if (m) {
+    return chqDateAt(
+      Number(m[1]), Number(m[2]), Number(m[3]),
+      Number(m[4]), Number(m[5]), Number(m[6] ?? 0),
+    );
+  }
+  const dateOnly = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s ?? '');
+  if (dateOnly) {
+    return chqDateAt(Number(dateOnly[1]), Number(dateOnly[2]), Number(dateOnly[3]));
+  }
+  return new Date(NaN);
 }
 
 /** `"7:00 PM"` at Chautauqua. Deliberately unlabelled — see the design doc. */

--- a/frontend/src/lib/utils/chqTime.ts
+++ b/frontend/src/lib/utils/chqTime.ts
@@ -46,6 +46,15 @@ const dayLabelFormatter = new Intl.DateTimeFormat('en-US', {
 
 /** An instant's calendar fields as they read at Chautauqua. */
 export function chqParts(d: Date): ChqParts {
+  // An unparseable `startDate` reaches here as an Invalid Date. The
+  // device-local accessors this replaced (getFullYear/getMonth/...) returned
+  // NaN for every field, and `daySections.ts` documents the `NaN-NaN-NaN` day
+  // key that falls out of that. `Intl.DateTimeFormat.formatToParts` throws
+  // instead of returning NaN, so that parity has to be restored explicitly —
+  // one bad row in a 3,246-event feed must not take the whole calendar down.
+  if (Number.isNaN(d.getTime())) {
+    return { year: NaN, month: NaN, day: NaN, hour: NaN, minute: NaN, second: NaN, weekday: NaN };
+  }
   const found: Record<string, string> = {};
   for (const { type, value } of partsFormatter.formatToParts(d)) {
     found[type] = value;
@@ -65,6 +74,10 @@ export function chqParts(d: Date): ChqParts {
 /** The Chautauqua calendar day an instant falls on, as `yyyy-mm-dd`. */
 export function chqDayKey(d: Date): string {
   const { year, month, day } = chqParts(d);
+  // `String(NaN).padStart(2, '0')` is `'NaN'` (already 3 chars, past the
+  // target length, so padStart is a no-op) — this falls out of chqParts'
+  // NaN fields without a special case, and is byte-identical to the
+  // 'NaN-NaN-NaN' key the old device-local implementation produced.
   return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 }
 
@@ -136,10 +149,16 @@ export function parseEventDate(s: string): Date {
 
 /** `"7:00 PM"` at Chautauqua. Deliberately unlabelled — see the design doc. */
 export function formatChqTime(d: Date): string {
+  // Matches native `Date.prototype.toLocaleTimeString`, which returns this
+  // string rather than throwing on an Invalid Date.
+  if (Number.isNaN(d.getTime())) return 'Invalid Date';
   return timeFormatter.format(d);
 }
 
 /** `"Sunday, July 26, 2026"` at Chautauqua. */
 export function formatChqDayLabel(d: Date): string {
+  // Matches native `Date.prototype.toLocaleDateString`, which returns this
+  // string rather than throwing on an Invalid Date.
+  if (Number.isNaN(d.getTime())) return 'Invalid Date';
   return dayLabelFormatter.format(d);
 }

--- a/frontend/src/lib/utils/dateHelpers.ts
+++ b/frontend/src/lib/utils/dateHelpers.ts
@@ -1,56 +1,53 @@
 import type { Event, SeasonWeek } from '@/lib/types';
+import { chqDateAt, chqParts, parseEventDate } from '@/lib/utils/chqTime';
 
 export function getChautauquaSeasonWeeks(year: number): SeasonWeek[] {
-  // Start from June 1st and find the 4th Sunday
-  const june1 = new Date(year, 5, 1); // June 1st
-  const current = new Date(june1);
+  // The 4th Sunday of June, found by walking Institution calendar days.
+  // Anchored at noon throughout: a DST transition never falls at midday, so
+  // the walk cannot be knocked onto a neighbouring day.
   let sundayCount = 0;
-  let fourthSunday = null;
-
-  // Find the 4th Sunday of June
-  while (current.getMonth() === 5) { // Still in June
-    if (current.getDay() === 0) { // Sunday
+  let fourthSundayDay: number | null = null;
+  for (let day = 1; day <= 30; day++) {
+    if (chqParts(chqDateAt(year, 6, day, 12)).weekday === 0) {
       sundayCount++;
-      if (sundayCount === 4) {
-        fourthSunday = new Date(current);
-        break;
-      }
+      if (sundayCount === 4) { fourthSundayDay = day; break; }
     }
-    current.setDate(current.getDate() + 1);
   }
-
-  if (!fourthSunday) {
-    // Fallback: if somehow we can't find 4th Sunday, use a reasonable date for the year
-    const fallbackDate = year === 2025 ? 22 : year === 2026 ? 28 : 27; // Approximate 4th Sunday
-    fourthSunday = new Date(year, 5, fallbackDate);
+  // June always contains four Sundays, so this cannot be null — but a
+  // silent NaN downstream would be far worse than an explicit throw.
+  if (fourthSundayDay === null) {
+    throw new Error(`no 4th Sunday of June ${year}`);
   }
-
-  // Find the Saturday before the 4th Sunday, and set it to noon
-  // This will be the start of Week 1 at Saturday noon
-  const firstWeekStart = new Date(fourthSunday);
-  firstWeekStart.setDate(fourthSunday.getDate() - 1); // Go back to Saturday
-  firstWeekStart.setHours(12, 0, 0, 0); // Set to noon
 
   const weeks: SeasonWeek[] = [];
   for (let i = 0; i < 9; i++) {
-    const weekStart = new Date(firstWeekStart);
-    weekStart.setDate(firstWeekStart.getDate() + (i * 7));
-    const weekEnd = new Date(weekStart);
-    weekEnd.setDate(weekStart.getDate() + 7); // Next Saturday at noon
-
+    // Week 1 starts at noon on the Saturday before, i.e. the day before the
+    // 4th Sunday. `chqDateAt` normalises out-of-range days, so subtracting
+    // one and adding 7i needs no month arithmetic here.
+    const startDayOfJune = fourthSundayDay - 1 + i * 7;
+    const start = chqDateAt(year, 6, startDayOfJune, 12);
+    const end = chqDateAt(year, 6, startDayOfJune + 7, 12);
     weeks.push({
       number: i + 1,
-      start: weekStart,
-      end: weekEnd,
-      label: `Week ${i + 1} (${weekStart.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} 12pm - ${weekEnd.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} 12pm)`
+      start,
+      end,
+      label: `Week ${i + 1} (${formatWeekEdge(start)} 12pm - ${formatWeekEdge(end)} 12pm)`,
     });
   }
-
   return weeks;
 }
 
+const weekEdgeFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/New_York', month: 'short', day: 'numeric',
+});
+
+/** `"Jun 27"` at Chautauqua — the week label's edges. */
+function formatWeekEdge(d: Date): string {
+  return weekEdgeFormatter.format(d);
+}
+
 export function isInChautauquaWeek(dateString: string, weekNumber: number, seasonWeeks: SeasonWeek[]): boolean {
-  const eventDate = new Date(dateString);
+  const eventDate = parseEventDate(dateString);
   const week = seasonWeeks[weekNumber - 1];
   return eventDate >= week.start && eventDate < week.end;
 }
@@ -84,19 +81,19 @@ export function getCurrentWeekNumber(seasonWeeks: SeasonWeek[]): number | null {
 
 /**
  * Finds the end-of-day boundary needed to include at least `minEvents` events
- * starting from `startDate`. Always returns a full day boundary (23:59:59.999).
+ * starting from `startDate`. Returns an exclusive bound — the Institution
+ * midnight immediately after the last included day — matching the half-open
+ * `start <= x < end` convention used throughout.
  * Expands day-by-day until enough events are accumulated.
  */
 export function getAdaptiveEndDate(events: Event[], startDate: Date, minEvents: number): Date {
   const futureEvents = events
-    .filter(e => new Date(e.startDate) >= startDate)
-    .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
+    .filter(e => parseEventDate(e.startDate) >= startDate)
+    .sort((a, b) => parseEventDate(a.startDate).getTime() - parseEventDate(b.startDate).getTime());
 
   if (futureEvents.length === 0) {
-    const fallback = new Date(startDate);
-    fallback.setDate(fallback.getDate() + 90);
-    fallback.setHours(23, 59, 59, 999);
-    return fallback;
+    const p = chqParts(startDate);
+    return chqDateAt(p.year, p.month, p.day + 91, 0, 0, 0, 0);
   }
 
   let accumulated = 0;
@@ -104,21 +101,16 @@ export function getAdaptiveEndDate(events: Event[], startDate: Date, minEvents: 
   let currentDayDate: Date | null = null;
 
   for (const event of futureEvents) {
-    const eventDate = new Date(event.startDate);
-    // Normalize event day to local midnight
-    const eventDay = new Date(
-      eventDate.getFullYear(),
-      eventDate.getMonth(),
-      eventDate.getDate()
-    );
+    const eventDate = parseEventDate(event.startDate);
+    const p = chqParts(eventDate);
+    const eventDay = chqDateAt(p.year, p.month, p.day, 0, 0, 0, 0);
 
     if (!currentDayDate || eventDay.getTime() !== currentDayDate.getTime()) {
       if (currentDayDate) {
-        // Mark end of previous day
-        const prevDayEnd = new Date(currentDayDate);
-        prevDayEnd.setHours(23, 59, 59, 999);
-        lastCompleteDayEnd = prevDayEnd;
-        // Finished a complete day - check if we have enough events
+        // Exclusive end-of-day: the next Institution midnight, so a 23- or
+        // 25-hour DST day needs no special case.
+        const c = chqParts(currentDayDate);
+        lastCompleteDayEnd = chqDateAt(c.year, c.month, c.day + 1, 0, 0, 0, 0);
         if (accumulated >= minEvents) {
           return lastCompleteDayEnd;
         }
@@ -128,8 +120,6 @@ export function getAdaptiveEndDate(events: Event[], startDate: Date, minEvents: 
     accumulated++;
   }
 
-  // Handle the last day
-  const lastDayEnd = new Date(currentDayDate!);
-  lastDayEnd.setHours(23, 59, 59, 999);
-  return lastDayEnd;
+  const last = chqParts(currentDayDate!);
+  return chqDateAt(last.year, last.month, last.day + 1, 0, 0, 0, 0);
 }

--- a/frontend/src/lib/utils/dateHelpers.ts
+++ b/frontend/src/lib/utils/dateHelpers.ts
@@ -88,9 +88,13 @@ export function getCurrentWeekNumber(seasonWeeks: SeasonWeek[]): number | null {
  * Expands day-by-day until enough events are accumulated.
  */
 export function getAdaptiveEndDate(events: Event[], startDate: Date, minEvents: number): Date {
+  // Parse each startDate exactly once, up front, and reuse it through the
+  // filter/sort/loop below — parseEventDate is far from free (a regex plus
+  // up to two Intl.DateTimeFormat round-trips per call).
   const futureEvents = events
-    .filter(e => parseEventDate(e.startDate) >= startDate)
-    .sort((a, b) => parseEventDate(a.startDate).getTime() - parseEventDate(b.startDate).getTime());
+    .map(e => ({ date: parseEventDate(e.startDate) }))
+    .filter(e => e.date >= startDate)
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
 
   if (futureEvents.length === 0) {
     const p = chqParts(startDate);
@@ -101,8 +105,7 @@ export function getAdaptiveEndDate(events: Event[], startDate: Date, minEvents: 
   let lastCompleteDayEnd: Date | null = null;
   let currentDayDate: Date | null = null;
 
-  for (const event of futureEvents) {
-    const eventDate = parseEventDate(event.startDate);
+  for (const { date: eventDate } of futureEvents) {
     const p = chqParts(eventDate);
     const eventDay = chqDateAt(p.year, p.month, p.day, 0, 0, 0, 0);
 

--- a/frontend/src/lib/utils/dateHelpers.ts
+++ b/frontend/src/lib/utils/dateHelpers.ts
@@ -1,5 +1,5 @@
 import type { Event, SeasonWeek } from '@/lib/types';
-import { chqDateAt, chqParts, parseEventDate } from '@/lib/utils/chqTime';
+import { CHQ_ZONE, chqDateAt, chqParts, parseEventDate } from '@/lib/utils/chqTime';
 
 export function getChautauquaSeasonWeeks(year: number): SeasonWeek[] {
   // The 4th Sunday of June, found by walking Institution calendar days.
@@ -13,7 +13,8 @@ export function getChautauquaSeasonWeeks(year: number): SeasonWeek[] {
       if (sundayCount === 4) { fourthSundayDay = day; break; }
     }
   }
-  // June always contains four Sundays, so this cannot be null — but a
+  // The loop above always breaks once the 4th Sunday is found, and June is
+  // long enough to contain at least four — so this cannot be null. But a
   // silent NaN downstream would be far worse than an explicit throw.
   if (fourthSundayDay === null) {
     throw new Error(`no 4th Sunday of June ${year}`);
@@ -38,7 +39,7 @@ export function getChautauquaSeasonWeeks(year: number): SeasonWeek[] {
 }
 
 const weekEdgeFormatter = new Intl.DateTimeFormat('en-US', {
-  timeZone: 'America/New_York', month: 'short', day: 'numeric',
+  timeZone: CHQ_ZONE, month: 'short', day: 'numeric',
 });
 
 /** `"Jun 27"` at Chautauqua — the week label's edges. */

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -1,7 +1,8 @@
 import type { Event, SeasonWeek } from '@/lib/types';
+import { chqDateAt, chqDayKey, chqParts } from '@/lib/utils/chqTime';
 
 /**
- * A calendar day as `yyyy-mm-dd`, zero-padded, in local time.
+ * A calendar day as `yyyy-mm-dd`, zero-padded, in Institution time.
  *
  * Lexicographic order is chronological, which is what makes plain string
  * comparison a correct date comparison throughout this module. Matches
@@ -15,10 +16,7 @@ const MIN_INSTANT = new Date(-8640000000000000);
 const MAX_INSTANT = new Date(8640000000000000);
 
 export function dayKeyOf(d: Date): DayKey {
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${y}-${m}-${day}`;
+  return chqDayKey(d);
 }
 
 function partsOf(key: DayKey): [number, number, number] {
@@ -28,7 +26,7 @@ function partsOf(key: DayKey): [number, number, number] {
 
 export function startOfDay(key: DayKey): Date {
   const [y, m, d] = partsOf(key);
-  return new Date(y, m - 1, d, 0, 0, 0, 0);
+  return chqDateAt(y, m, d, 0, 0, 0, 0);
 }
 
 /**
@@ -41,9 +39,9 @@ export function startOfDay(key: DayKey): Date {
  */
 export function dayAfter(key: DayKey): Date {
   const [y, m, d] = partsOf(key);
-  const date = new Date(y, m - 1, d);
-  date.setDate(date.getDate() + 1);
-  return date;
+  // Built by adding a calendar day, never 86,400,000ms: a DST transition day
+  // is 23 or 25 hours long, and millisecond arithmetic lands an hour out.
+  return chqDateAt(y, m, d + 1, 0, 0, 0, 0);
 }
 
 /**
@@ -55,9 +53,8 @@ export function dayAfter(key: DayKey): Date {
  * Saturday morning has events).
  */
 export function lastDayCovered(endExclusive: Date): DayKey {
-  const isMidnight =
-    endExclusive.getHours() === 0 && endExclusive.getMinutes() === 0 &&
-    endExclusive.getSeconds() === 0 && endExclusive.getMilliseconds() === 0;
+  const p = chqParts(endExclusive);
+  const isMidnight = p.hour === 0 && p.minute === 0 && p.second === 0;
   const key = dayKeyOf(endExclusive);
   return isMidnight ? addDays(key, -1) : key;
 }
@@ -65,24 +62,23 @@ export function lastDayCovered(endExclusive: Date): DayKey {
 /**
  * `key` shifted by `n` calendar days.
  *
- * Built from date parts and `setDate`, never from millisecond arithmetic:
+ * Built from date parts and `chqDateAt`, never from millisecond arithmetic:
  * adding 86,400,000 ms across a DST transition lands on the previous or
  * next day's 23:00/01:00 and produces the wrong key. Mirrors iOS's
  * `ChqTime.day(_:offsetBy:)`, which uses `Calendar` for the same reason.
  */
 export function addDays(key: DayKey, n: number): DayKey {
   const [y, m, d] = partsOf(key);
-  const date = new Date(y, m - 1, d);
-  date.setDate(date.getDate() + n);
-  return dayKeyOf(date);
+  return dayKeyOf(chqDateAt(y, m, d + n, 12, 0, 0, 0));
 }
 
 /** A `yyyy-mm-dd` key with a real calendar date behind it. */
 function isDayKey(key: string): boolean {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(key)) return false;
   const [y, m, d] = partsOf(key);
-  const date = new Date(y, m - 1, d);
-  return date.getFullYear() === y && date.getMonth() === m - 1 && date.getDate() === d;
+  // Noon, not midnight: a date that does not exist rolls over, and noon is
+  // far enough from any DST edge that only a genuine rollover moves the day.
+  return dayKeyOf(chqDateAt(y, m, d, 12)) === key;
 }
 
 /**

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -53,9 +53,13 @@ export function dayAfter(key: DayKey): Date {
  * Saturday morning has events).
  */
 export function lastDayCovered(endExclusive: Date): DayKey {
-  const p = chqParts(endExclusive);
-  const isMidnight = p.hour === 0 && p.minute === 0 && p.second === 0;
+  // Compared as instants, not via ChqParts fields: `ChqParts` has no
+  // milliseconds field, and hour/minute/second === 0 alone would misclassify
+  // an instant like `00:00:00.400` as midnight, silently dropping the final
+  // day. `endExclusive` is midnight exactly when it equals the start of its
+  // own day — an exact, ms-safe comparison that needs no new field.
   const key = dayKeyOf(endExclusive);
+  const isMidnight = endExclusive.getTime() === startOfDay(key).getTime();
   return isMidnight ? addDays(key, -1) : key;
 }
 

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -210,19 +210,16 @@ export function baseWindow(o: WindowOptions): ViewWindow | null {
     case 'next': {
       // One hour of grace so an event that has just begun is still "next".
       const start = new Date(o.now.getTime() - 60 * 60 * 1000);
-      // `adaptiveEndDate` is an inclusive end-of-day; the half-open
-      // equivalent is that day's exclusive end. No representable event falls
-      // in the difference — event times carry no sub-second component.
-      let inclusiveEnd = o.adaptiveEndDate;
-      if (!inclusiveEnd) {
+      // `getAdaptiveEndDate` returns an already-exclusive bound: the
+      // Institution midnight that ends the last day it decided to include.
+      // It is used directly. The fallback below is the only path that builds
+      // an inclusive instant, so it is the only one that needs converting.
+      let endExclusive = o.adaptiveEndDate;
+      if (!endExclusive) {
         const sixDaysOut = new Date(o.now.getTime() + 6 * 24 * 60 * 60 * 1000);
         const p = chqParts(sixDaysOut);
-        // The inclusive end of that Institution day. `dayAfter(dayKeyOf(...))`
-        // below converts it to the half-open bound, so land inside the day
-        // rather than on the next midnight.
-        inclusiveEnd = chqDateAt(p.year, p.month, p.day, 23, 59, 59, 999);
+        endExclusive = chqDateAt(p.year, p.month, p.day + 1, 0, 0, 0, 0);
       }
-      const endExclusive = dayAfter(dayKeyOf(inclusiveEnd));
       return {
         startDay: dayKeyOf(start),
         endDay: lastDayCovered(endExclusive),

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -215,8 +215,12 @@ export function baseWindow(o: WindowOptions): ViewWindow | null {
       // in the difference — event times carry no sub-second component.
       let inclusiveEnd = o.adaptiveEndDate;
       if (!inclusiveEnd) {
-        inclusiveEnd = new Date(o.now.getTime() + 6 * 24 * 60 * 60 * 1000);
-        inclusiveEnd.setHours(23, 59, 59, 999);
+        const sixDaysOut = new Date(o.now.getTime() + 6 * 24 * 60 * 60 * 1000);
+        const p = chqParts(sixDaysOut);
+        // The inclusive end of that Institution day. `dayAfter(dayKeyOf(...))`
+        // below converts it to the half-open bound, so land inside the day
+        // rather than on the next midnight.
+        inclusiveEnd = chqDateAt(p.year, p.month, p.day, 23, 59, 59, 999);
       }
       const endExclusive = dayAfter(dayKeyOf(inclusiveEnd));
       return {

--- a/frontend/src/lib/utils/dayWindow.ts
+++ b/frontend/src/lib/utils/dayWindow.ts
@@ -1,5 +1,5 @@
 import type { Event, SeasonWeek } from '@/lib/types';
-import { chqDateAt, chqDayKey, chqParts } from '@/lib/utils/chqTime';
+import { CHQ_ZONE, chqDateAt, chqDayKey, chqParts, parseEventDate } from '@/lib/utils/chqTime';
 
 /**
  * A calendar day as `yyyy-mm-dd`, zero-padded, in Institution time.
@@ -152,7 +152,7 @@ export function navigableBounds(
   let endDay = dayKeyOf(seasonWeeks[seasonWeeks.length - 1].end);
 
   for (const event of events) {
-    const parsed = new Date(event.startDate);
+    const parsed = parseEventDate(event.startDate);
     // An unparseable date must not poison the global bound: 'NaN-NaN-NaN'
     // sorts above every real key, so a single bad row would otherwise widen
     // endDay for the whole app. Every other call site (filterHelpers,
@@ -325,7 +325,7 @@ export function viewWindow(o: WindowOptions): ViewWindow | null {
 export function eventDayKeys(events: Event[]): DayKey[] {
   const keys = new Set<DayKey>();
   for (const event of events) {
-    const parsed = new Date(event.startDate);
+    const parsed = parseEventDate(event.startDate);
     if (Number.isNaN(parsed.getTime())) continue;
     keys.add(dayKeyOf(parsed));
   }
@@ -353,6 +353,7 @@ export function navigationTargets(
 /** `"Saturday, Aug 15"` — how a navigation control names its target. */
 export function formatDayLabel(key: DayKey): string {
   return startOfDay(key).toLocaleDateString('en-US', {
+    timeZone: CHQ_ZONE,
     weekday: 'long',
     month: 'short',
     day: 'numeric',
@@ -367,7 +368,7 @@ export function formatDayRange(from: DayKey, through: DayKey): string {
   // returns.
   if (from > through) return '';
   const fmt = (key: DayKey) =>
-    startOfDay(key).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+    startOfDay(key).toLocaleDateString('en-US', { timeZone: CHQ_ZONE, weekday: 'short', month: 'short', day: 'numeric' });
   if (from === through) return fmt(from);
   return `${fmt(from)} – ${fmt(through)}`;
 }
@@ -412,7 +413,7 @@ export interface DayChip {
 export function eventCountsByDay(events: Event[]): Map<DayKey, number> {
   const counts = new Map<DayKey, number>();
   for (const event of events) {
-    const parsed = new Date(event.startDate);
+    const parsed = parseEventDate(event.startDate);
     if (Number.isNaN(parsed.getTime())) continue;
     const key = dayKeyOf(parsed);
     counts.set(key, (counts.get(key) ?? 0) + 1);
@@ -424,19 +425,19 @@ export function dayChips(days: DayKey[], countsByDay: Map<DayKey, number>): DayC
   let lastMonth: string | null = null;
   return days.map((key) => {
     const date = startOfDay(key);
-    const month = date.toLocaleDateString('en-US', { month: 'short' });
+    const month = date.toLocaleDateString('en-US', { timeZone: CHQ_ZONE, month: 'short' });
     // The month rides the first chip and every change after it — without the
     // first-chip rule a rail scrolled to mid-July would show no month at all,
     // which is exactly the disorientation the rail exists to fix.
     const showMonth = month !== lastMonth;
     lastMonth = month;
     const count = countsByDay.get(key) ?? 0;
-    const spoken = date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric' });
+    const spoken = date.toLocaleDateString('en-US', { timeZone: CHQ_ZONE, weekday: 'long', month: 'long', day: 'numeric' });
     const events = count === 0 ? 'no events' : count === 1 ? '1 event' : `${count} events`;
     return {
       key,
-      weekday: date.toLocaleDateString('en-US', { weekday: 'short' }),
-      dayOfMonth: String(date.getDate()),
+      weekday: date.toLocaleDateString('en-US', { timeZone: CHQ_ZONE, weekday: 'short' }),
+      dayOfMonth: String(chqParts(date).day),
       month: showMonth ? month : null,
       count,
       label: count === 0 ? `${spoken}, ${events}` : `Go to ${spoken}, ${events}`,

--- a/frontend/src/lib/utils/eventHelpers.ts
+++ b/frontend/src/lib/utils/eventHelpers.ts
@@ -1,5 +1,6 @@
 import type { Event, SeasonWeek } from '@/lib/types';
 import { dayKeyOf } from '@/lib/utils/dayWindow';
+import { chqDateAt, chqParts, formatChqDayLabel, parseEventDate } from '@/lib/utils/chqTime';
 
 // Lookup table for common HTML entities found in event data
 const HTML_ENTITY_MAP: Record<string, string> = {
@@ -83,7 +84,7 @@ export function decodeEventHtmlEntities(event: Event): Event {
 }
 
 export interface DayGroup {
-  /** Stable key per calendar date (YYYY-MM-DD in local time). */
+  /** Stable key per calendar date (YYYY-MM-DD in Institution time). */
   key: string;
   /** Display label without the week part, e.g. "Saturday, July 4, 2026". */
   baseLabel: string;
@@ -93,11 +94,14 @@ export interface DayGroup {
 }
 
 function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]): number[] {
-  const dayStart = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 0, 0, 0, 0);
-  const dayEnd = new Date(date.getFullYear(), date.getMonth(), date.getDate(), 23, 59, 59, 999);
+  const { year, month, day } = chqParts(date);
+  const dayStart = chqDateAt(year, month, day, 0, 0, 0, 0);
+  // Half-open against the next Institution midnight, so a DST day of 23 or
+  // 25 hours needs no special case.
+  const dayEnd = chqDateAt(year, month, day + 1, 0, 0, 0, 0);
   const numbers: number[] = [];
   for (const w of seasonWeeks) {
-    if (w.start <= dayEnd && w.end > dayStart) {
+    if (w.start < dayEnd && w.end > dayStart) {
       numbers.push(w.number);
     }
   }
@@ -108,20 +112,23 @@ export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): Da
   const grouped = new Map<string, DayGroup>();
 
   for (const event of events) {
-    const eventDate = new Date(event.startDate);
-    const key = dayKeyOf(eventDate);
+    const eventDate = parseEventDate(event.startDate);
+    // An unparseable startDate produces an Invalid Date. chqParts/chqDayKey
+    // format it through Intl.DateTimeFormat, which throws RangeError on an
+    // Invalid Date rather than returning NaN fields — so this branch must
+    // stay out of that path entirely and build the 'NaN-NaN-NaN' key by hand,
+    // matching every other call site's contract for a bad row (dayWindow's
+    // navigableBounds/eventDayKeys/eventCountsByDay all drop such rows;
+    // groupEventsByDay is the one place that must keep it, visibly, instead).
+    const isValidDate = !Number.isNaN(eventDate.getTime());
+    const key = isValidDate ? dayKeyOf(eventDate) : 'NaN-NaN-NaN';
     let group = grouped.get(key);
     if (!group) {
-      const baseLabel = eventDate.toLocaleDateString('en-US', {
-        weekday: 'long',
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric',
-      });
+      const baseLabel = isValidDate ? formatChqDayLabel(eventDate) : 'Invalid Date';
       group = {
         key,
         baseLabel,
-        weekNumbers: weekNumbersForCalendarDate(eventDate, seasonWeeks),
+        weekNumbers: isValidDate ? weekNumbersForCalendarDate(eventDate, seasonWeeks) : [],
         events: [],
       };
       grouped.set(key, group);
@@ -130,7 +137,9 @@ export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): Da
   }
 
   for (const group of grouped.values()) {
-    group.events.sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime());
+    group.events.sort(
+      (a, b) => parseEventDate(a.startDate).getTime() - parseEventDate(b.startDate).getTime()
+    );
   }
 
   return Array.from(grouped.values()).sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));

--- a/frontend/src/lib/utils/eventHelpers.ts
+++ b/frontend/src/lib/utils/eventHelpers.ts
@@ -110,9 +110,15 @@ function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]): numb
 
 export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): DayGroup[] {
   const grouped = new Map<string, DayGroup>();
+  // Each event's startDate is parsed exactly once, here, and reused for the
+  // per-day sort below — parseEventDate is far from free (a regex plus up to
+  // two Intl.DateTimeFormat round-trips), and this loop already needs the
+  // parsed instant for the day key and week numbers.
+  const startTimes = new Map<Event, number>();
 
   for (const event of events) {
     const eventDate = parseEventDate(event.startDate);
+    startTimes.set(event, eventDate.getTime());
     const key = dayKeyOf(eventDate);
     let group = grouped.get(key);
     if (!group) {
@@ -129,9 +135,7 @@ export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): Da
   }
 
   for (const group of grouped.values()) {
-    group.events.sort(
-      (a, b) => parseEventDate(a.startDate).getTime() - parseEventDate(b.startDate).getTime()
-    );
+    group.events.sort((a, b) => startTimes.get(a)! - startTimes.get(b)!);
   }
 
   return Array.from(grouped.values()).sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));

--- a/frontend/src/lib/utils/eventHelpers.ts
+++ b/frontend/src/lib/utils/eventHelpers.ts
@@ -113,22 +113,14 @@ export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): Da
 
   for (const event of events) {
     const eventDate = parseEventDate(event.startDate);
-    // An unparseable startDate produces an Invalid Date. chqParts/chqDayKey
-    // format it through Intl.DateTimeFormat, which throws RangeError on an
-    // Invalid Date rather than returning NaN fields — so this branch must
-    // stay out of that path entirely and build the 'NaN-NaN-NaN' key by hand,
-    // matching every other call site's contract for a bad row (dayWindow's
-    // navigableBounds/eventDayKeys/eventCountsByDay all drop such rows;
-    // groupEventsByDay is the one place that must keep it, visibly, instead).
-    const isValidDate = !Number.isNaN(eventDate.getTime());
-    const key = isValidDate ? dayKeyOf(eventDate) : 'NaN-NaN-NaN';
+    const key = dayKeyOf(eventDate);
     let group = grouped.get(key);
     if (!group) {
-      const baseLabel = isValidDate ? formatChqDayLabel(eventDate) : 'Invalid Date';
+      const baseLabel = formatChqDayLabel(eventDate);
       group = {
         key,
         baseLabel,
-        weekNumbers: isValidDate ? weekNumbersForCalendarDate(eventDate, seasonWeeks) : [],
+        weekNumbers: weekNumbersForCalendarDate(eventDate, seasonWeeks),
         events: [],
       };
       grouped.set(key, group);

--- a/frontend/src/lib/utils/filterHelpers.ts
+++ b/frontend/src/lib/utils/filterHelpers.ts
@@ -1,4 +1,5 @@
 import type { Event, SeasonWeek } from '@/lib/types';
+import { parseEventDate } from '@/lib/utils/chqTime';
 import { isInChautauquaWeek } from './dateHelpers';
 import { windowContains, type ViewWindow } from './dayWindow';
 import { searchEvents } from './searchHelpers';
@@ -36,7 +37,7 @@ export function filterEvents(events: Event[], options: FilterOptions): Event[] {
   // inline 'next' arithmetic, and 'all' doing nothing) all reduce to this
   // once the scope has been turned into a window.
   const dateWindow = options.viewWindow;
-  filtered = filtered.filter((event) => windowContains(dateWindow, new Date(event.startDate)));
+  filtered = filtered.filter((event) => windowContains(dateWindow, parseEventDate(event.startDate)));
 
   // Week filter (independent of date filter)
   if (options.selectedWeeks.length > 0) {

--- a/frontend/src/lib/utils/icsHelpers.ts
+++ b/frontend/src/lib/utils/icsHelpers.ts
@@ -1,5 +1,5 @@
 import type { Event } from '@/lib/types';
-import { chqParts, chqDateAt, parseEventDate } from '@/lib/utils/chqTime';
+import { CHQ_ZONE, chqParts, chqDateAt, parseEventDate } from '@/lib/utils/chqTime';
 
 /**
  * Escape special characters in ICS text fields per RFC 5545.
@@ -111,7 +111,7 @@ export function generateICS(event: Event): string {
     'METHOD:PUBLISH',
     // VTIMEZONE for America/New_York (EDT/EST)
     'BEGIN:VTIMEZONE',
-    'TZID:America/New_York',
+    `TZID:${CHQ_ZONE}`,
     'BEGIN:DAYLIGHT',
     'TZOFFSETFROM:-0500',
     'TZOFFSETTO:-0400',
@@ -130,8 +130,8 @@ export function generateICS(event: Event): string {
     'BEGIN:VEVENT',
     `UID:${event.id}@chqcal.org`,
     `DTSTAMP:${formatICSTimestamp()}`,
-    `DTSTART;TZID=America/New_York:${dtStart}`,
-    `DTEND;TZID=America/New_York:${dtEnd}`,
+    `DTSTART;TZID=${CHQ_ZONE}:${dtStart}`,
+    `DTEND;TZID=${CHQ_ZONE}:${dtEnd}`,
     `SUMMARY:${escapeICSText(event.title)}`,
   ];
 

--- a/frontend/src/lib/utils/icsHelpers.ts
+++ b/frontend/src/lib/utils/icsHelpers.ts
@@ -1,5 +1,5 @@
 import type { Event } from '@/lib/types';
-import { CHQ_ZONE, chqParts, chqDateAt, parseEventDate } from '@/lib/utils/chqTime';
+import { CHQ_ZONE, chqParts, chqDateAt, pad2 as p2, parseEventDate } from '@/lib/utils/chqTime';
 
 /**
  * Escape special characters in ICS text fields per RFC 5545.
@@ -35,7 +35,6 @@ function foldLine(line: string): string {
  */
 function formatChqICSDate(d: Date): string {
   const { year, month, day, hour, minute, second } = chqParts(d);
-  const p2 = (n: number) => String(n).padStart(2, '0');
   return `${year}${p2(month)}${p2(day)}T${p2(hour)}${p2(minute)}${p2(second)}`;
 }
 

--- a/frontend/src/lib/utils/icsHelpers.ts
+++ b/frontend/src/lib/utils/icsHelpers.ts
@@ -1,4 +1,5 @@
 import type { Event } from '@/lib/types';
+import { chqParts, chqDateAt, parseEventDate } from '@/lib/utils/chqTime';
 
 /**
  * Escape special characters in ICS text fields per RFC 5545.
@@ -29,17 +30,26 @@ function foldLine(line: string): string {
 }
 
 /**
- * Format a date string as an ICS local datetime: YYYYMMDDTHHMMSS
+ * Format an instant as an ICS local datetime, `YYYYMMDDTHHMMSS`, in
+ * Institution time.
+ */
+function formatChqICSDate(d: Date): string {
+  const { year, month, day, hour, minute, second } = chqParts(d);
+  const p2 = (n: number) => String(n).padStart(2, '0');
+  return `${year}${p2(month)}${p2(day)}T${p2(hour)}${p2(minute)}${p2(second)}`;
+}
+
+/**
+ * An ICS local datetime, `YYYYMMDDTHHMMSS`, in Institution time.
+ *
+ * Paired with `DTSTART;TZID=America/New_York`, so the components written
+ * here must be Chautauqua's wall clock — which is exactly the wall clock the
+ * feed gave us. The round trip is therefore an identity, and this function
+ * existed in a device-local form that was correct only because parsing was
+ * device-local too.
  */
 function formatICSDate(dateStr: string): string {
-  const d = new Date(dateStr);
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
-  const seconds = String(d.getSeconds()).padStart(2, '0');
-  return `${year}${month}${day}T${hours}${minutes}${seconds}`;
+  return formatChqICSDate(parseEventDate(dateStr));
 }
 
 /**
@@ -76,10 +86,19 @@ export function generateICS(event: Event): string {
 
   let dtEnd: string;
   if (event.endDate === event.startDate) {
-    // Default to start + 1 hour when endDate equals startDate
-    const endDate = new Date(event.startDate);
-    endDate.setHours(endDate.getHours() + 1);
-    dtEnd = formatICSDate(endDate.toISOString());
+    // Default to start + 1 hour of Institution wall clock when endDate
+    // equals startDate. This must add an hour to the *Institution* clock,
+    // not to the absolute instant: on a DST transition day those disagree
+    // (a skipped or repeated hour), and `Date.prototype.setHours` only ever
+    // adds a device-local hour, which is exactly the device-dependence this
+    // migration removes. `chqDateAt` re-derives the instant for the
+    // adjusted wall-clock fields, so overflow (23:xx -> 24:xx) correctly
+    // carries into the next Institution day, and a nonexistent wall time
+    // (landing in a spring-forward gap) resolves the same way the rest of
+    // the app resolves one.
+    const p = chqParts(parseEventDate(event.startDate));
+    const endInstant = chqDateAt(p.year, p.month, p.day, p.hour + 1, p.minute, p.second);
+    dtEnd = formatChqICSDate(endInstant);
   } else {
     dtEnd = formatICSDate(event.endDate);
   }


### PR DESCRIPTION
## What and why

The web app interpreted event timestamps in the **reader's device** timezone. The feed's `startDate` is naive Institution wall time — `"2026-07-27 12:45:00"`, with a sibling `timezone` field reading `America/New_York` for all 3,246 events, which the web never read. Every date the app computes — including "now" and "today" — now resolves in `America/New_York` regardless of device, via a new `chqTime.ts` built on `Intl.DateTimeFormat`.

Mirrors iOS's existing `ChqTime`, so the two apps no longer hold different opinions about which day an event is on.

## Data safety — nothing changes for existing clients

**Zero code outside `frontend/`.** No backend, no ingest path, no `all-events.json`. Verified as a merge constraint, not an intention:

```
$ git diff --stat main...HEAD -- . ':(exclude)frontend' ':(exclude)docs/plans'
(empty)
```

Old web bundles and the shipped iOS app fetch identical bytes and run the code they shipped with — unaffected by construction. Stored state is untouched too: localStorage holds `dateFilter`, `selectedWeeks` and day keys, and day keys are timezone-independent.

**The fix is deliberately not in the data.** Emitting offsets would fix every client at once, but the shipped iOS app parses with two fixed-format `DateFormatter`s that a trailing offset falls outside — and a binary on people's phones can't be patched retroactively. Ordering is forced: ship iOS parsers that accept both shapes, wait for adoption, *then* change the feed. Separate project.

## What was actually broken

Measured across four device zones, one event, one fixed instant five minutes after it ended:

| Device TZ | Displayed | Day group | "Upcoming?" | "Today" |
|---|---|---|---|---|
| `America/New_York` | 12:45 PM | 2026-07-27 | no | 2026-07-27 |
| `UTC` | 12:45 PM | 2026-07-27 | no | 2026-07-27 |
| `America/Los_Angeles` | 12:45 PM | 2026-07-27 | **yes** ❌ | 2026-07-27 |
| `Asia/Tokyo` | 12:45 PM | 2026-07-27 | no | **2026-07-28** ❌ |

Display and grouping were already correct — parsing naive-as-device-local and reading device-local components back is an identity round-trip. What broke was comparison against the true current instant: the `Now` scope west of Eastern, and `todayKey` east of it.

That has a consequence the design leans on: **the migration is all-or-nothing.** Those already-correct sites are correct *only* while everything is consistently device-local. Once parsing moves, the cancellation stops holding, so they must move too.

## The proof

`frontend/vitest.config.ts` pins `env: { TZ: 'America/New_York' }` — deliberately, so DST-transition tests keep discriminating on UTC runners. **Consequence: no unit test in this repo can prove this migration happened.** With the device zone equal to the Institution zone, correct code and the device-local code it replaced produce identical output.

So `frontend/e2e/verify-timezone.mjs` renders the app under `America/New_York`, `UTC`, `America/Los_Angeles` and `Asia/Tokyo` and requires days, headers, times, "today" and event counts to **agree**. It compares rather than hardcoding, because the fixture is live production data.

- Against this branch: **16/16**
- Against the pre-change build: **failed 10/16**

Every unit test here is a regression pin. This is the only thing demonstrating the behaviour actually changed.

## Notable defects found during execution

Four in the plan's own text, plus one crash risk:

- **`Intl` throws where `Date` returned `NaN`.** All five Intl-backed helpers threw `RangeError` on an unparseable date, where the device-local accessors they replaced degraded gracefully into the `NaN-NaN-NaN` key `daySections.ts` documents. One malformed `startDate` in the feed would have white-screened the calendar. Fixed at the root.
- **A rail chip rendering the wrong day.** `startOfDay` moved to Institution midnight while six functions in the same file still read it with device-zone accessors — a chip labelled "26" navigating to the 27th, on every device west of Eastern, in the rail shipped in #240/#241.
- **The "Next" scope showing an extra day**, after `getAdaptiveEndDate` went inclusive → exclusive and one consumer kept the old assumption. Three fixtures hid it by hand-building the old shape.
- **Add-to-calendar links going device-dependent** for the offset-bearing `startDate` shape `docs/publisher/AUTHORING.md` requires — three buttons in one popup giving two answers. Latent today (the prod sidecar 404s), fixed anyway.

## Verification

| | |
|---|---|
| Unit | 1098 tests, 88 files |
| `npm run validate` | clean |
| `verify-rail.mjs` | 36/36 |
| `verify-filter-reveal.mjs` | 34/34 |
| `verify-timezone.mjs` | 16/16 (fails 10/16 pre-change) |

Executed as 8 reviewed tasks, each with an independent code review; then a whole-branch review, a fix wave, and a scoped re-review.

## Follow-ups (recorded, none blocking)

- Publisher/admin pages still render device-local times, so they now disagree with the calendar for the same event — notably `/publish/test/`, the dry-run a publisher uses to check their offsets.
- ICS device-independence is proven by an out-of-band run, not a repeatable test.
- `CountdownBanner`'s day count is elapsed-ms arithmetic; off by one late at night before a spring-forward. Pre-existing.

Design: `docs/plans/2026-08-18-institution-timezone-design.md`
Plan: `docs/plans/2026-08-18-institution-timezone-plan.md`

[skip-screenshots: web-only change, touches no ios/ paths]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AyVVFZYXXcmS6RrqtA2igP