### PR TITLE
fix(e2e): pin the rail suite's clock so browser-checks stops going red at night

### DIFF
--- a/frontend/e2e/fixedNow.mjs
+++ b/frontend/e2e/fixedNow.mjs
@@ -1,0 +1,35 @@
+/**
+ * One pinned instant, shared by the browser checks that care what time it is.
+ *
+ * These suites run against live production data, so "today" has to stay the
+ * real today — hardcode a date and every assertion about which days carry
+ * events goes stale the moment the feed moves on. What is removed is only the
+ * *hour*, which is the part that was making CI red at night and green in the
+ * morning on the same commit.
+ *
+ * `14:00Z` is 10:00 EDT in season and 09:00 EST out of it. Both are
+ * comfortably mid-morning — late enough that the day's programming is under
+ * way, early enough that it has not run out — which is all these checks need,
+ * and it buys that without offset arithmetic to get wrong twice a year.
+ *
+ * Lives in its own module so the suites cannot drift apart on what "now"
+ * means; two copies of this rule would eventually disagree.
+ */
+
+/** Mid-morning Institution time on the run's own calendar day. */
+export const FIXED_NOW = new Date(
+  `${new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date())}T14:00:00Z`
+);
+
+/**
+ * Pins `page`'s clock. Call before `goto`.
+ *
+ * `setFixedTime`, not `install`: it pins what `Date.now()`/`new Date()` report
+ * while **leaving every timer running**. The app leans on real timers — the
+ * search debounce, the render window's observers, the rail's scroll settling —
+ * so faking those as well would break the very interactions these suites
+ * drive.
+ */
+export async function pinClock(page) {
+  await page.clock.setFixedTime(FIXED_NOW);
+}

--- a/frontend/e2e/verify-filter-reveal.mjs
+++ b/frontend/e2e/verify-filter-reveal.mjs
@@ -26,24 +26,21 @@ const check = (name, ok, detail) => {
 const browser = await chromium.launch();
 
 async function phone({ reducedMotion } = {}) {
-  // Chautauqua's own timezone, pinned rather than inherited from the runner.
+  // Chautauqua's own timezone, kept for belt-and-braces — it is not
+  // load-bearing. The paragraph that used to be here claimed the app "treats
+  // the browser's clock as event-time" and that whether `now` should be
+  // evaluated in the Institution's timezone was an open product question. Both
+  // were true when written and #243 ("resolve every date in the Institution's
+  // timezone") made them false: `parseEventDate` reads a naive `startDate` as
+  // Institution wall time, `dayKeyOf` resolves the day key in `CHQ_ZONE`, and
+  // `chqDateAt` builds instants from Institution parts. `verify-timezone.mjs`
+  // holds the standing proof across `America/New_York`, `UTC`,
+  // `America/Los_Angeles` and `Asia/Tokyo`.
   //
-  // Event `startDate`s are Institution-local and carry no offset, so the app
-  // effectively treats the browser's clock as event-time. CI runs UTC, which
-  // in the afternoon Eastern means the app believes the day's programming has
-  // already ended — under the default `Now` scope today then has no upcoming
-  // events, and `11c ⟳ Now hides once back on today` fails because the anchor
-  // cannot land on today. Reproduced by A/B: this suite passes in Eastern and
-  // fails in UTC on `main` as well as on any branch, so `browser-checks` was
-  // failing for everyone after roughly 20:00 UTC and passing earlier in the
-  // day. Pinning makes every date-sensitive check here independent of the
-  // wall-clock hour and of where it is run.
-  //
-  // This pins the TEST's clock, not the app's. Whether `now` ought to be
-  // evaluated in the Institution's timezone rather than the device's is a real
-  // product question — a visitor on a non-Eastern device late in their local
-  // day sees today's events as already past — and is deliberately left alone
-  // here rather than answered by a test harness.
+  // The identical stale paragraph in `verify-rail.mjs` outlived its truth long
+  // enough to convince a later reader there was an unfixed product bug, which
+  // is why this copy is corrected rather than left to do the same. This suite
+  // is not hour-sensitive, so unlike that one it needs no pinned clock.
   const ctx = await browser.newContext({
     viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true,
     timezoneId: 'America/New_York',

--- a/frontend/e2e/verify-filter-reveal.mjs
+++ b/frontend/e2e/verify-filter-reveal.mjs
@@ -50,6 +50,10 @@ async function phone({ reducedMotion } = {}) {
     ...(reducedMotion ? { reducedMotion: 'reduce' } : {}),
   });
   const page = await ctx.newPage();
+  // Tie the context's lifetime to the page's. Callers only ever `page.close()`,
+  // so without this every check leaks a whole `BrowserContext` — roughly twenty
+  // of them across a run, each holding its own browser process resources.
+  page.once('close', () => { ctx.close().catch(() => {}); });
   await page.goto(URL, { waitUntil: 'networkidle' });
   await page.waitForSelector('[data-day-key]');
   return page;

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -19,6 +19,20 @@ function check(name, ok, detail) {
 
 const browser = await chromium.launch();
 
+// Mid-morning Institution time on the run's **own** calendar day.
+//
+// Deliberately not a hardcoded date: these checks run against live production
+// data, so "today" has to stay the real today or every assertion about which
+// days carry events goes stale the moment the feed moves on. What is removed
+// is only the *hour* — the suite now behaves the same at 02:00 as at 14:00.
+//
+// 14:00Z is 10:00 EDT in season and 09:00 EST out of it; both are comfortably
+// mid-morning, which is all this needs, so it buys determinism without any
+// offset arithmetic to get wrong twice a year.
+const FIXED_NOW = new Date(
+  `${new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date())}T14:00:00Z`
+);
+
 async function newPage({ width = 900, height = 900, storage } = {}) {
   // Chautauqua's own timezone, pinned rather than inherited from the runner.
   //
@@ -30,8 +44,33 @@ async function newPage({ width = 900, height = 900, storage } = {}) {
   // cannot land on today. Reproduced by A/B: this suite passes in Eastern and
   // fails in UTC on `main` as well as on any branch, so `browser-checks` was
   // failing for everyone after roughly 20:00 UTC and passing earlier in the
-  // day. Pinning makes every date-sensitive check here independent of the
-  // wall-clock hour and of where it is run.
+  // day.
+  //
+  // **The timezone pin alone was not enough**, and the original version of
+  // this comment claimed otherwise. It fixed the afternoon-*UTC* case and left
+  // the genuine late-evening-*Eastern* one: once the last event of the day has
+  // passed in Chautauqua, today really has no upcoming events under `Now`, the
+  // anchor really does move to tomorrow, and `11c` really cannot pass. Seen on
+  // `main` at 01:31Z, reproduced identically on a re-run at 01:58Z, and the
+  // same commit passed at 10:17Z — deterministic, not flaky.
+  //
+  // Reproduced locally by pinning the clock to CI's exact failing instant,
+  // which reports:
+  //
+  //     today=2026-08-19 anchor=2026-08-27
+  //     mounted=2026-08-20,2026-08-21,2026-08-22 button=1
+  //
+  // Today is not mounted at all, so ⟳ Now cannot land on it and stays visible
+  // — the app is right and the check's assumption was wrong.
+  //
+  // The boundary is not an hour of the clock but **today's last event plus
+  // `Now`'s one-hour grace**, so it moves with the day's programming: pinned
+  // to 01:30Z that same night, `2026-08-19` is still mounted and this passes;
+  // one minute later at 01:31Z it is gone and this fails. That is why hunting
+  // for a fixed "fails after N o'clock" rule never converged.
+  //
+  // So the clock is pinned too, below, and that is what actually makes these
+  // checks independent of the hour.
   //
   // This pins the TEST's clock, not the app's. Whether `now` ought to be
   // evaluated in the Institution's timezone rather than the device's is a real
@@ -43,6 +82,12 @@ async function newPage({ width = 900, height = 900, storage } = {}) {
     timezoneId: 'America/New_York',
   });
   const page = await ctx.newPage();
+  // `setFixedTime`, not `install`: it pins what `Date.now()`/`new Date()`
+  // report while **leaving every timer running**. The app leans on real
+  // timers — the search debounce, the render window's observers, the rail's
+  // scroll settling — so faking those as well would break the very
+  // interactions these checks drive.
+  await page.clock.setFixedTime(FIXED_NOW);
   if (storage) {
     await page.addInitScript(([k, v]) => localStorage.setItem(k, v), storage);
   }
@@ -216,7 +261,22 @@ for (const scrolled of [false, true]) {
     const scopeAfter = await page.$$eval('button[aria-pressed]', els =>
       els.map(e => `${e.textContent.trim()}=${e.getAttribute('aria-pressed')}`).join(','));
     check('11b ⟳ Now changes no filter', scopeBefore === scopeAfter, scopeAfter);
-    check('11c ⟳ Now hides once back on today', (await page.getByRole('button', { name: 'Go to today' }).count()) === 0);
+
+    // Reported with its state on purpose. `11c` has failed on `main` at night
+    // and passed the same commit in the morning, and every previous
+    // investigation had to guess at the cause because this check printed
+    // nothing but its own name — the log line was `11c ⟳ Now hides once back
+    // on today:` with an empty detail. Whatever the cause turns out to be,
+    // the next failure should be able to state it: what the app thinks today
+    // is, where the anchor actually landed, and which days are mounted.
+    const stillThere = await page.getByRole('button', { name: 'Go to today' }).count();
+    const landedOn = await anchorChip(page);
+    const [appToday, mountedNow] = await page.evaluate(() => [
+      new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date()),
+      [...document.querySelectorAll('[data-day-key]')].slice(0, 3).map(e => e.dataset.dayKey),
+    ]);
+    check('11c ⟳ Now hides once back on today', stillThere === 0,
+      `today=${appToday} anchor=${landedOn} mounted=${mountedNow.join(',')} button=${stillThere}`);
   }
   await page.close();
 }

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -255,7 +255,11 @@ for (const scrolled of [false, true]) {
     const landedOn = await anchorChip(page);
     const [appToday, mountedNow] = await page.evaluate(() => [
       new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date()),
-      [...document.querySelectorAll('[data-day-key]')].slice(0, 3).map(e => e.dataset.dayKey),
+      // Not sliced. A capped list defeats the point: if the render window ever
+      // mounts more days, `today` lands past the cap and is truncated away in
+      // exactly the failure this exists to explain. It is a short array of day
+      // keys, so printing all of them costs nothing.
+      [...document.querySelectorAll('[data-day-key]')].map(e => e.dataset.dayKey),
     ]);
     check('11c ⟳ Now hides once back on today', stillThere === 0,
       `today=${appToday} anchor=${landedOn} mounted=${mountedNow.join(',')} button=${stillThere}`);

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -9,6 +9,7 @@
  * server on :3000.
  */
 import { chromium } from 'playwright';
+import { pinClock } from './fixedNow.mjs';
 
 const URL = process.env.URL ?? 'http://localhost:3000/';
 const results = [];
@@ -19,82 +20,52 @@ function check(name, ok, detail) {
 
 const browser = await chromium.launch();
 
-// Mid-morning Institution time on the run's **own** calendar day.
-//
-// Deliberately not a hardcoded date: these checks run against live production
-// data, so "today" has to stay the real today or every assertion about which
-// days carry events goes stale the moment the feed moves on. What is removed
-// is only the *hour* — the suite now behaves the same at 02:00 as at 14:00.
-//
-// 14:00Z is 10:00 EDT in season and 09:00 EST out of it; both are comfortably
-// mid-morning, which is all this needs, so it buys determinism without any
-// offset arithmetic to get wrong twice a year.
-const FIXED_NOW = new Date(
-  `${new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date())}T14:00:00Z`
-);
 
 async function newPage({ width = 900, height = 900, storage } = {}) {
-  // Chautauqua's own timezone, pinned rather than inherited from the runner.
+  // Chautauqua's own timezone, kept for belt-and-braces — it is no longer
+  // load-bearing. The paragraph that used to be here claimed the app "treats
+  // the browser's clock as event-time" because `startDate`s are
+  // Institution-local and carry no offset. True when written; #243 ("resolve
+  // every date in the Institution's timezone") made it false — `parseEventDate`
+  // reads a naive `startDate` as Institution wall time, `dayKeyOf` resolves the
+  // day key in `CHQ_ZONE`, `chqDateAt` builds instants from Institution parts.
+  // Confirmed by running this whole suite under `Asia/Tokyo`: 36/36, identical
+  // to Eastern. It is recorded as wrong rather than deleted because it
+  // outlived its truth long enough to convince a later reader there was an
+  // unfixed product bug.
   //
-  // **Kept for belt-and-braces only — it is no longer load-bearing, and the
-  // paragraph that used to be here was wrong.** It claimed the app "treats the
-  // browser's clock as event-time" because `startDate`s are Institution-local
-  // and carry no offset. That was true when it was written and #243 ("resolve
-  // every date in the Institution's timezone") made it false: `parseEventDate`
-  // now reads a naive `startDate` as Institution wall time, `dayKeyOf` resolves
-  // the day key in `CHQ_ZONE`, and `chqDateAt` builds instants from
-  // Institution parts. Verified by running this whole suite under
-  // `Asia/Tokyo`: 36/36, identical to Eastern.
-  //
-  // The stale claim outlived its truth long enough to mislead a later reader
-  // of this file into believing there was an unfixed product bug, so it is
-  // recorded here as wrong rather than quietly deleted.
-  //
-  // **The timezone pin alone was not enough**, and the original version of
-  // this comment claimed otherwise. It fixed the afternoon-*UTC* case and left
-  // the genuine late-evening-*Eastern* one: once the last event of the day has
-  // passed in Chautauqua, today really has no upcoming events under `Now`, the
-  // anchor really does move to tomorrow, and `11c` really cannot pass. Seen on
-  // `main` at 01:31Z, reproduced identically on a re-run at 01:58Z, and the
-  // same commit passed at 10:17Z — deterministic, not flaky.
-  //
-  // Reproduced locally by pinning the clock to CI's exact failing instant,
-  // which reports:
+  // The *hour*, though, was load-bearing, and pinning the timezone never
+  // addressed it. `11c ⟳ Now hides once back on today` failed on `main` at
+  // 01:31Z, again at 01:58Z on a re-run, and passed on the same commit at
+  // 10:17Z. Pinning the clock to that failing instant reproduces it exactly:
   //
   //     today=2026-08-19 anchor=2026-08-27
   //     mounted=2026-08-20,2026-08-21,2026-08-22 button=1
   //
-  // Today is not mounted at all, so ⟳ Now cannot land on it and stays visible
-  // — the app is right and the check's assumption was wrong.
+  // Today is not mounted at all — once today's last event plus `Now`'s
+  // one-hour grace has passed, today leaves the window, so ⟳ Now cannot land
+  // on it and correctly stays visible. The app was right; the check's
+  // assumption that today is always reachable was wrong.
   //
-  // The boundary is not an hour of the clock but **today's last event plus
-  // `Now`'s one-hour grace**, so it moves with the day's programming: pinned
-  // to 01:30Z that same night, `2026-08-19` is still mounted and this passes;
-  // one minute later at 01:31Z it is gone and this fails. That is why hunting
-  // for a fixed "fails after N o'clock" rule never converged.
+  // The boundary tracks the day's programming rather than the clock, which is
+  // why no fixed "fails after N o'clock" rule ever fit: pinned to 01:30Z that
+  // night `2026-08-19` is still mounted and `11c` passes; at 01:31Z it is gone
+  // and it fails.
   //
-  // So the clock is pinned too, below, and that is what actually makes these
-  // checks independent of the hour.
-  //
-  // This pins the TEST's clock, not the app's, and it fixes a test-harness
-  // problem rather than a product one. The product question this used to raise
-  // — should `now` be evaluated in the Institution's timezone rather than the
-  // device's — is already answered in the app: it is. `verify-timezone.mjs`
-  // holds the standing proof, asserting that `America/New_York`, `UTC`,
-  // `America/Los_Angeles` and `Asia/Tokyo` all agree on the days shown, the
-  // day headers, the event times, which day is today, and which events are
-  // upcoming.
+  // So the clock is pinned below, and that — not the timezone — is what makes
+  // these checks independent of when they run. It fixes a harness problem, not
+  // a product one: whether `now` is evaluated in the Institution's timezone is
+  // already settled in the app, and `verify-timezone.mjs` holds the standing
+  // proof across `America/New_York`, `UTC`, `America/Los_Angeles` and
+  // `Asia/Tokyo`.
   const ctx = await browser.newContext({
     viewport: { width, height },
     timezoneId: 'America/New_York',
   });
   const page = await ctx.newPage();
-  // `setFixedTime`, not `install`: it pins what `Date.now()`/`new Date()`
-  // report while **leaving every timer running**. The app leans on real
-  // timers — the search debounce, the render window's observers, the rail's
-  // scroll settling — so faking those as well would break the very
-  // interactions these checks drive.
-  await page.clock.setFixedTime(FIXED_NOW);
+  // Shared with `verify-timezone.mjs`; see `fixedNow.mjs` for what is pinned
+  // and, more importantly, what deliberately is not.
+  await pinClock(page);
   if (storage) {
     await page.addInitScript(([k, v]) => localStorage.setItem(k, v), storage);
   }

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -66,6 +66,10 @@ async function newPage({ width = 900, height = 900, storage } = {}) {
   // Shared with `verify-timezone.mjs`; see `fixedNow.mjs` for what is pinned
   // and, more importantly, what deliberately is not.
   await pinClock(page);
+  // Tie the context's lifetime to the page's. Callers only ever `page.close()`,
+  // so without this every check leaks a whole `BrowserContext` — roughly twenty
+  // of them across a run, each holding its own browser process resources.
+  page.once('close', () => { ctx.close().catch(() => {}); });
   if (storage) {
     await page.addInitScript(([k, v]) => localStorage.setItem(k, v), storage);
   }

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -36,15 +36,19 @@ const FIXED_NOW = new Date(
 async function newPage({ width = 900, height = 900, storage } = {}) {
   // Chautauqua's own timezone, pinned rather than inherited from the runner.
   //
-  // Event `startDate`s are Institution-local and carry no offset, so the app
-  // effectively treats the browser's clock as event-time. CI runs UTC, which
-  // in the afternoon Eastern means the app believes the day's programming has
-  // already ended — under the default `Now` scope today then has no upcoming
-  // events, and `11c ⟳ Now hides once back on today` fails because the anchor
-  // cannot land on today. Reproduced by A/B: this suite passes in Eastern and
-  // fails in UTC on `main` as well as on any branch, so `browser-checks` was
-  // failing for everyone after roughly 20:00 UTC and passing earlier in the
-  // day.
+  // **Kept for belt-and-braces only — it is no longer load-bearing, and the
+  // paragraph that used to be here was wrong.** It claimed the app "treats the
+  // browser's clock as event-time" because `startDate`s are Institution-local
+  // and carry no offset. That was true when it was written and #243 ("resolve
+  // every date in the Institution's timezone") made it false: `parseEventDate`
+  // now reads a naive `startDate` as Institution wall time, `dayKeyOf` resolves
+  // the day key in `CHQ_ZONE`, and `chqDateAt` builds instants from
+  // Institution parts. Verified by running this whole suite under
+  // `Asia/Tokyo`: 36/36, identical to Eastern.
+  //
+  // The stale claim outlived its truth long enough to mislead a later reader
+  // of this file into believing there was an unfixed product bug, so it is
+  // recorded here as wrong rather than quietly deleted.
   //
   // **The timezone pin alone was not enough**, and the original version of
   // this comment claimed otherwise. It fixed the afternoon-*UTC* case and left
@@ -72,11 +76,14 @@ async function newPage({ width = 900, height = 900, storage } = {}) {
   // So the clock is pinned too, below, and that is what actually makes these
   // checks independent of the hour.
   //
-  // This pins the TEST's clock, not the app's. Whether `now` ought to be
-  // evaluated in the Institution's timezone rather than the device's is a real
-  // product question — a visitor on a non-Eastern device late in their local
-  // day sees today's events as already past — and is deliberately left alone
-  // here rather than answered by a test harness.
+  // This pins the TEST's clock, not the app's, and it fixes a test-harness
+  // problem rather than a product one. The product question this used to raise
+  // — should `now` be evaluated in the Institution's timezone rather than the
+  // device's — is already answered in the app: it is. `verify-timezone.mjs`
+  // holds the standing proof, asserting that `America/New_York`, `UTC`,
+  // `America/Los_Angeles` and `Asia/Tokyo` all agree on the days shown, the
+  // day headers, the event times, which day is today, and which events are
+  // upcoming.
   const ctx = await browser.newContext({
     viewport: { width, height },
     timezoneId: 'America/New_York',

--- a/frontend/e2e/verify-timezone.mjs
+++ b/frontend/e2e/verify-timezone.mjs
@@ -8,6 +8,7 @@
  * property is agreement.
  */
 import { chromium } from 'playwright';
+import { pinClock } from './fixedNow.mjs';
 
 const URL = process.env.URL ?? 'http://localhost:3000/';
 const ZONES = ['America/New_York', 'UTC', 'America/Los_Angeles', 'Asia/Tokyo'];
@@ -22,6 +23,7 @@ const browser = await chromium.launch();
 async function readUnder(timezoneId) {
   const ctx = await browser.newContext({ viewport: { width: 900, height: 900 }, timezoneId });
   const page = await ctx.newPage();
+  await pinClock(page);
   await page.goto(URL, { waitUntil: 'networkidle' });
   await page.waitForSelector('[data-day-key]', { timeout: 30000 });
   const out = await page.evaluate(() => ({
@@ -36,50 +38,43 @@ async function readUnder(timezoneId) {
   return out;
 }
 
-// The baseline is read once before the other three contexts and again after
-// — `today` and `nowVisible` are wall-clock sensitive, so a run that crosses
-// a minute or day boundary mid-flight must not be reported as a false
-// mismatch against the other zones. Both baseline readings are compared
-// against every zone, and a value must match one of them — matching neither
-// is a real cross-zone disagreement, not clock skew, and still fails.
-const baselineFirst = await readUnder(ZONES[0]);
-check('0 baseline rendered something to compare', baselineFirst.days.length > 0,
-  `${baselineFirst.days.length} days, first=${baselineFirst.days[0]}`);
+// One baseline, compared strictly.
+//
+// This used to read the baseline twice — before and after the other zones —
+// and accept a value matching *either*, because `today` and `nowVisible` are
+// wall-clock sensitive and a run crossing a minute or day boundary mid-flight
+// would otherwise report a false mismatch. Every read now happens at one
+// pinned instant (`fixedNow.mjs`), so there is exactly one right answer and
+// the tolerance is not merely unnecessary but harmful: it would let a genuine
+// cross-zone disagreement pass whenever it happened to match the second read.
+const baseline = await readUnder(ZONES[0]);
+check('0 baseline rendered something to compare', baseline.days.length > 0,
+  `${baseline.days.length} days, first=${baseline.days[0]}`);
 
 const zoneResults = [];
 for (const zone of ZONES.slice(1)) {
   zoneResults.push({ zone, got: await readUnder(zone) });
 }
 
-const baselineLast = await readUnder(ZONES[0]);
-const clockMoved = JSON.stringify(baselineFirst.today) !== JSON.stringify(baselineLast.today)
-  || baselineFirst.nowVisible !== baselineLast.nowVisible;
-
-function agreesWithEitherBaseline(value, pick) {
-  return value === pick(baselineFirst) || value === pick(baselineLast);
-}
-
 for (const { zone, got } of zoneResults) {
   check(`1 same days under ${zone}`,
-    JSON.stringify(got.days) === JSON.stringify(baselineFirst.days),
-    `${got.days[0]}..${got.days.at(-1)} vs ${baselineFirst.days[0]}..${baselineFirst.days.at(-1)}`);
+    JSON.stringify(got.days) === JSON.stringify(baseline.days),
+    `${got.days[0]}..${got.days.at(-1)} vs ${baseline.days[0]}..${baseline.days.at(-1)}`);
   check(`2 same day headers under ${zone}`,
-    JSON.stringify(got.headers) === JSON.stringify(baselineFirst.headers),
+    JSON.stringify(got.headers) === JSON.stringify(baseline.headers),
     got.headers[0] ?? '(none)');
   check(`3 same event times under ${zone}`,
-    JSON.stringify(got.times) === JSON.stringify(baselineFirst.times),
+    JSON.stringify(got.times) === JSON.stringify(baseline.times),
     got.times.slice(0, 3).join(', '));
 
-  // A moving clock explains a value drifting between the two baseline reads.
-  // It does not explain a value matching neither — that is a real cross-zone
-  // disagreement, and this file exists to catch exactly that, so it must
-  // still fail rather than being swallowed as clock skew.
+  // The two the pinned clock exists for: which day the app calls today, and
+  // how much it considers still upcoming. Both are exact comparisons now.
   check(`4 same day is today under ${zone}`,
-    agreesWithEitherBaseline(got.today, b => b.today),
-    `${got.today} vs ${baselineFirst.today}/${baselineLast.today}${clockMoved ? ' (clock moved mid-run)' : ''}`);
+    got.today === baseline.today,
+    `${got.today} vs ${baseline.today}`);
   check(`5 same events are upcoming under ${zone}`,
-    agreesWithEitherBaseline(got.nowVisible, b => b.nowVisible),
-    `${got.nowVisible} vs ${baselineFirst.nowVisible}/${baselineLast.nowVisible}${clockMoved ? ' (clock moved mid-run)' : ''}`);
+    got.nowVisible === baseline.nowVisible,
+    `${got.nowVisible} vs ${baseline.nowVisible}`);
 }
 
 await browser.close();

--- a/frontend/e2e/verify-timezone.mjs
+++ b/frontend/e2e/verify-timezone.mjs
@@ -67,8 +67,9 @@ for (const { zone, got } of zoneResults) {
     JSON.stringify(got.times) === JSON.stringify(baseline.times),
     got.times.slice(0, 3).join(', '));
 
-  // The two the pinned clock exists for: which day the app calls today, and
-  // how much it considers still upcoming. Both are exact comparisons now.
+  // The two checks the pinned clock exists for: which day the app calls
+  // today, and how much it considers still upcoming. Both are exact
+  // comparisons now.
   check(`4 same day is today under ${zone}`,
     got.today === baseline.today,
     `${got.today} vs ${baseline.today}`);


### PR DESCRIPTION
`browser-checks` has been red on `main` every night and green every morning **on the same commit**: failing at 01:31Z, again at 01:58Z on a re-run, passing at 10:17Z. Deterministic, not flaky — and it will keep happening regardless of what anyone merges.

## The cause

Reproduced locally by pinning the browser clock to CI's exact failing instant. With the new diagnostic in place, `11c` now says:

```
today=2026-08-19 anchor=2026-08-27 mounted=2026-08-20,2026-08-21,2026-08-22 button=1
```

Today is not mounted at all. Once today's last event plus `Now`'s one-hour grace has passed, today leaves the `Now` window — so the anchor cannot return to it, and `⟳ Now` correctly stays visible. **The app is right; the check's assumption that today is always reachable is what was wrong.**

The boundary tracks the day's programming rather than the clock, which is why no fixed "fails after N o'clock" rule ever fit the history: pinned to `01:30Z` that night, `2026-08-19` is still mounted and `11c` passes; one minute later at `01:31Z` it is gone and `11c` fails. The earlier timezone pin (#241/#242) fixed the afternoon-**UTC** version of this and could not fix the late-evening-**Eastern** one.

## The fix

Pin the browser clock to mid-morning Institution time **on the run's own calendar day**.

- `setFixedTime`, not `install` — it pins what `Date.now()`/`new Date()` report while leaving every timer running. The app leans on real timers for the search debounce, the render window's observers and the rail's scroll settling; faking those would break the interactions these checks drive.
- The date stays the real today, so every assertion about which days carry events stays valid against live production data. Only the *hour* is removed.
- `14:00Z` is 10:00 EDT in season and 09:00 EST out of it — both comfortably mid-morning, so it buys determinism without offset arithmetic to get wrong twice a year.

## `11c` now explains itself

Every previous investigation into this check had to guess, because the failure line was `11c ⟳ Now hides once back on today:` with an empty detail. It now reports what the app thinks today is, where the anchor landed, and which days are mounted — so the next failure states its own cause.

## Verification

| | result |
|---|---|
| pinned mid-morning (the fix) | 36/36 |
| pinned to CI's failing instant | 35/36 — the exact CI failure, reproduced on demand |
| full `test:browser` suite | 36/36, 34/34, 16/16 |

The middle row is the falsification: the check can still fail, and fails for exactly the reason CI failed.

Found while merging #245, which touched **zero** frontend files — it only surfaced this by triggering a run after the boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dxr9zVJLDHofJBEs26bUw4
