### PR TITLE
feat(ios): Siri routes through the day rail (phase 4, part 1)

### DIFF
--- a/docs/superpowers/plans/2026-08-20-date-navigation-phase-4-ios-consolidation.md
+++ b/docs/superpowers/plans/2026-08-20-date-navigation-phase-4-ios-consolidation.md
@@ -1,0 +1,1603 @@
+# Date Navigation Phase 4 — iOS Consolidation and Release Prep
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the cross-platform date-navigation initiative on iOS by routing
+Siri through the same `goToDay` the day rail uses, fixing the two clipped-text
+accessibility findings from phase 3b's device pass, and preparing the 1.1.3
+release (version sweep, day-navigation screenshot, listing copy).
+
+**Architecture:** A new `DeepLink.day(key:)` case rides the deep-link pipeline
+every launch surface already funnels through (`.onOpenURL`, notification tap,
+widget `widgetURL`, App Intent via `PendingIntentLink`, Spotlight) and is
+consumed by `EventListView` through its existing `selectDay(_:)` — the same
+function a rail chip tap calls, so voice and touch land in byte-identical state.
+A new `OpenDayIntent` resolves an `IntentTimeframe` to a canonical day key,
+checks it against `ViewWindow.navigableBounds` before opening, and speaks the
+existing off-season dialog when the day is unreachable. Nothing new is invented:
+`goToDay`, `PendingIntentLink`, `PendingDayScroll` and `IntentDialogText` all
+shipped in earlier phases.
+
+**Tech Stack:** Swift 6, SwiftUI, Swift Testing (`@Test`/`#expect`), AppIntents,
+XCTest for `ChqCalendarUITests`, Xcode project settings, Python 3 for the
+screenshot pipeline.
+
+**Spec:** `docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md`
+(phase 4 is described at `:631` and in the "Obligations" section at `:669`; its
+Siri rationale is at `:481`. Task 9 amends that section to match what shipped.)
+
+## Global Constraints
+
+- **Never commit to `main`.** PR A's branch is `feat/date-nav-phase-4-siri-routing`
+  (already created). PR B branches off `main` after PR A merges.
+- **Swift version:** Swift 6 with `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor`.
+  Types the AppIntents/Shortcuts runtime queries off the main actor must be
+  declared `nonisolated` (`DeepLink`, `IntentTimeframe`, `IntentDataSource`,
+  `ChqShortcuts` all already are).
+- **The window is HALF-OPEN:** `start <= x < endExclusive`. Never inclusive with
+  a subtracted epsilon.
+- **Day keys are `"yyyy-MM-dd"` in America/New_York**, produced by
+  `ChqTime.dayKey(for:)` and validated by `ChqTime.isCanonicalDayKey(_:)`.
+  `"2026-8-9"` parses but is not canonical — validate, do not merely parse.
+- **Test command** (whole suite; UI tests run in the same invocation):
+  ```bash
+  cd ios && xcodebuild test \
+    -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+    -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+    -parallel-testing-enabled NO \
+    CODE_SIGNING_ALLOWED=NO
+  ```
+  Swap the `-destination` name/OS for an installed simulator
+  (`xcrun simctl list devices available`). `CODE_SIGNING_ALLOWED=NO` is
+  required, not cosmetic — `AppGroupTests.containerURLIsNilInTheUnitTestHost`
+  asserts there is no App Group entitlement, which is exactly what this flag
+  creates. `-parallel-testing-enabled NO` matches CI.
+- **Prove every guard by breaking the code.** After a test passes, `git stash`
+  the implementation (or invert a condition), re-run, confirm the test FAILS,
+  restore. A test that cannot fail is worse than no test. This repo has shipped
+  seven such tests across earlier phases.
+- **App Store screenshot guard.** `.github/workflows/app-store-assets.yml` fails
+  any PR touching `ios/ChqCalendar/Features/**`, `ios/ChqCalendar/App/**`,
+  `ios/ChqCalendarShared/**`, `ios/ChqCalendarWidgets/**` or
+  `ios/ChqCalendar/Assets.xcassets/**` unless
+  `docs/app-store/screenshots.manifest.json` changed since the merge-base, OR
+  the PR description carries `[skip-screenshots: <non-empty reason>]`. PR A
+  qualifies for the opt-out (see Task 6); PR B regenerates for real.
+- **`phrases[0]` of any `AppShortcut` must contain no `$`.** `SiriTipView` and
+  the Shortcuts gallery render the first phrase with parameter slots
+  *unresolved* — a `\(\.$timeframe)` there prints `${timeframe}` to users. This
+  leaked on 4 of 7 actions in #193. `ChqShortcutsTests` already asserts it for
+  every registered shortcut; do not weaken that test.
+- **New Swift files need no `project.pbxproj` edit.** The project uses
+  `PBXFileSystemSynchronizedRootGroup`, so a file created under a synced
+  directory joins its target automatically. Task 7's version sweep is the only
+  task that edits the project file.
+- **Coverage floors** are enforced per-PR (`.coverage-floor.json`,
+  `docs/coverage.md`) for the frontend/backend. This plan is iOS-only and does
+  not touch them.
+
+---
+
+## File Structure
+
+**PR A — Siri routing and accessibility**
+
+| File | Responsibility |
+|---|---|
+| `ios/ChqCalendarShared/Domain/DeepLink.swift` | Add `case day(key: String)` + parse/serialize. |
+| `ios/ChqCalendarShared/Domain/IntentTimeframe.swift` | Add `targetDayKey(now:year:)` — the one place a spoken timeframe becomes a day key. |
+| `ios/ChqCalendarShared/Domain/IntentDialogText.swift` | Add `unreachableDay(year:)`. |
+| `ios/ChqCalendar/Features/Root/RootTabView.swift` | Route `.day` to the Events tab without consuming the link. |
+| `ios/ChqCalendar/App/AppModel.swift` | Add `resolvePendingDayDeepLinkIfPossible()`. |
+| `ios/ChqCalendar/Features/Calendar/EventListView.swift` | Consume the resolved day through the existing `selectDay(_:)`; accessibility fix for the `Filters` pill. |
+| `ios/ChqCalendar/Features/Calendar/CalendarView.swift` | `-uitest-go-to-day <key>` launch arg; accessibility fix for the search prompt. |
+| `ios/ChqCalendarShared/Domain/OpenDayTarget.swift` | The intent's whole decision — day key + reachability — as a pure, testable type. |
+| `ios/ChqCalendar/Intents/EventIntents.swift` | Add `OpenDayIntent` beside `OpenEventIntent`. |
+| `ios/ChqCalendar/Intents/ChqShortcuts.swift` | Register the 8th `AppShortcut`. |
+| `ios/ChqCalendar/Features/About/AboutInfo.swift` | Add the example phrase to the About sheet. |
+| `ios/ChqCalendarTests/DeepLinkTests.swift` | Round trip, URL shape, rejection of non-canonical keys. |
+| `ios/ChqCalendarTests/AppModelTests.swift` | `resolvePendingDayDeepLinkIfPossible` behaviour. |
+| `ios/ChqCalendarTests/IntentTimeframeTests.swift` | `targetDayKey` per timeframe, including the week-9 edge. |
+| `ios/ChqCalendarTests/OpenDayTargetTests.swift` | Navigate-vs-refuse, including the season edge and off-season. |
+| `ios/ChqCalendarTests/DeepLinkTabRouteTests.swift` | `DeepLinkTabRoute.resolve(.day)`. |
+| `ios/ChqCalendarUITests/DayRailUITests.swift` | A `-uitest-go-to-day` launch lands the rail on that day. |
+
+**PR B — release prep**
+
+| File | Responsibility |
+|---|---|
+| `ios/ChqCalendar.xcodeproj/project.pbxproj` | 1.1.3 / build 6 across every target including the two test bundles. |
+| `ios/Scripts/screenshot-plan.json` | `01-season` reworked into the day-navigation shot. |
+| `docs/app-store/screenshots.manifest.json`, `docs/app-store/screenshots/review/` | Regenerated assets. |
+| `docs/app-store/listing-fields.json`, `docs/app-store/listing-copy.md` | 1.1.3 `whatsNew` and `promotionalText`. |
+| `docs/app-store/RELEASE_CHECKLIST.md` | The 1.1.3 entry. |
+| `docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md` | Phase-4 section amended to what shipped. |
+
+---
+
+# PR A — Siri routing and accessibility
+
+Branch: `feat/date-nav-phase-4-siri-routing`
+
+### Task 1: `DeepLink.day(key:)`
+
+The deep-link vocabulary gains a day. Everything downstream (the tab route, the
+model resolver, the intent) depends on this case existing, so it lands first and
+alone.
+
+**Files:**
+- Modify: `ios/ChqCalendarShared/Domain/DeepLink.swift`
+- Test: `ios/ChqCalendarTests/DeepLinkTests.swift`
+
+**Interfaces:**
+- Consumes: `ChqTime.isCanonicalDayKey(_:)` (`ChqCalendarShared/Support/ChqTime.swift:146`).
+- Produces: `DeepLink.day(key: String)`, serialising to `chqcal://day/<yyyy-MM-dd>`.
+  Tasks 2, 3, 5 and 8 all reference this exact case name and payload label.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ios/ChqCalendarTests/DeepLinkTests.swift`, inside `struct DeepLinkTests`,
+after the existing map round-trip tests:
+
+```swift
+    @Test func dayRoundTrips() {
+        let link = DeepLink.day(key: "2026-07-29")
+        #expect(DeepLink.parse(link.url) == link)
+    }
+
+    @Test func dayURLHasExpectedShape() {
+        #expect(DeepLink.day(key: "2026-07-29").url.absoluteString == "chqcal://day/2026-07-29")
+    }
+
+    /// `ChqTime.parse` is more permissive than its format string suggests —
+    /// `"2026-7-9"` reads as July 9th and `"26-07-09"` reads as year 26 — and
+    /// neither is a key `EventFilter`'s raw string comparisons will ever match.
+    /// A link carrying one must be rejected at the door rather than silently
+    /// resolving to a day the list cannot show.
+    @Test func dayWithANonCanonicalKeyIsRejected() {
+        #expect(DeepLink.parse(URL(string: "chqcal://day/2026-7-9")!) == nil)
+        #expect(DeepLink.parse(URL(string: "chqcal://day/26-07-09")!) == nil)
+        #expect(DeepLink.parse(URL(string: "chqcal://day/tomorrow")!) == nil)
+    }
+
+    @Test func dayWithNoKeyIsRejected() {
+        #expect(DeepLink.parse(URL(string: "chqcal://day")!) == nil)
+        #expect(DeepLink.parse(URL(string: "chqcal://day/")!) == nil)
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ChqCalendarTests/DeepLinkTests
+```
+
+Expected: FAIL to **compile** — `type 'DeepLink' has no member 'day'`. A
+compile failure is the correct "red" here; do not proceed until you have seen it.
+
+- [ ] **Step 3: Add the case**
+
+In `ios/ChqCalendarShared/Domain/DeepLink.swift`, extend the doc comment's
+recognized-shapes list with:
+
+```swift
+/// - `chqcal://day/<yyyy-MM-dd>` — open the Events tab on that day, growing
+///   the window if the day lies past an edge. The key must be canonical
+///   (`ChqTime.isCanonicalDayKey`); see `dayWithANonCanonicalKeyIsRejected`.
+```
+
+Add the case to the enum:
+
+```swift
+nonisolated enum DeepLink: Equatable, Sendable {
+    case event(id: String)
+    case myDay
+    case map(venue: String?)
+    case day(key: String)
+```
+
+Add to `parse`'s `switch host`, before `default`:
+
+```swift
+        case "day":
+            guard let key = pathComponents.first, ChqTime.isCanonicalDayKey(key) else { return nil }
+            return .day(key: key)
+```
+
+Add to `url`'s `switch self`:
+
+```swift
+        case .day(let key):
+            components.host = "day"
+            components.path = "/\(key)"
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command as Step 2. Expected: PASS, all 19 `DeepLinkTests` cases.
+
+- [ ] **Step 5: Prove the canonical-key guard can fail**
+
+Temporarily relax the guard to `guard let key = pathComponents.first, !key.isEmpty`,
+re-run, and confirm `dayWithANonCanonicalKeyIsRejected` FAILS. Restore the real
+guard and re-run to green. This is the guard most likely to be written as
+decoration.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ios/ChqCalendarShared/Domain/DeepLink.swift ios/ChqCalendarTests/DeepLinkTests.swift
+git commit -m "feat(ios): add a chqcal://day/<key> deep link case"
+```
+
+---
+
+### Task 2: Route and resolve a pending day link
+
+`.day` must land on the Events tab *without* the tab switch consuming the link —
+the same two-phase contract `.event` uses, because the tab switch is not the
+navigation. The list completes it once a snapshot exists.
+
+**Files:**
+- Modify: `ios/ChqCalendar/Features/Root/RootTabView.swift:38-48` (`DeepLinkTabRoute.resolve`)
+- Modify: `ios/ChqCalendar/App/AppModel.swift` (add beside `resolvePendingEventDeepLinkIfPossible`, which ends at `:650`)
+- Test: `ios/ChqCalendarTests/DeepLinkTabRouteTests.swift`, `ios/ChqCalendarTests/AppModelTests.swift`
+
+**Interfaces:**
+- Consumes: `DeepLink.day(key:)` (Task 1); `AppModel.snapshot`, `AppModel.pendingDeepLink`.
+- Produces: `AppModel.resolvePendingDayDeepLinkIfPossible() -> String?` — returns
+  the day key exactly once and clears `pendingDeepLink`, or `nil` if the pending
+  link is not a `.day` or no snapshot has arrived yet. Task 3 calls it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ios/ChqCalendarTests/DeepLinkTabRouteTests.swift`:
+
+```swift
+    /// `.day` behaves like `.event`, not like `.myDay`: selecting the Events
+    /// tab is not the navigation, so the link must survive the tab switch for
+    /// `EventListView` to consume once a snapshot exists.
+    @Test func dayLinkRoutesToEventsWithoutConsumingTheLink() {
+        let route = DeepLinkTabRoute.resolve(.day(key: "2026-07-29"))
+
+        #expect(route.tab == .events)
+        #expect(route.consumesLink == false)
+        #expect(route.mapFocusVenue == nil)
+    }
+```
+
+Append to `ios/ChqCalendarTests/AppModelTests.swift`, in the same region as the
+`goToDay` tests (they start at `:1474`):
+
+```swift
+    // MARK: - Pending day deep link
+
+    @Test func pendingDayLinkResolvesOnceASnapshotExists() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.pendingDeepLink = .day(key: "2026-08-06")
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == "2026-08-06")
+        #expect(model.pendingDeepLink == nil)
+    }
+
+    /// Idempotent: a second call must not re-deliver a link already acted on,
+    /// or every `.onChange` trigger in `EventListView` would re-scroll a reader
+    /// who has since moved.
+    @Test func pendingDayLinkIsDeliveredExactlyOnce() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.pendingDeepLink = .day(key: "2026-08-06")
+
+        _ = model.resolvePendingDayDeepLinkIfPossible()
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == nil)
+    }
+
+    /// Before the snapshot lands there are no day sections to scroll to, so
+    /// holding the link is what makes a cold launch work.
+    @Test func pendingDayLinkIsHeldUntilTheSnapshotArrives() throws {
+        let model = try makeInSeasonModel(defaults: makeDefaults())
+        model.snapshot = nil
+        model.pendingDeepLink = .day(key: "2026-08-06")
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == nil)
+        #expect(model.pendingDeepLink == .day(key: "2026-08-06"))
+    }
+
+    @Test func pendingEventLinkIsNotResolvedAsADay() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.pendingDeepLink = .event(id: "seed0")
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == nil)
+        #expect(model.pendingDeepLink == .event(id: "seed0"))
+    }
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ChqCalendarTests/DeepLinkTabRouteTests \
+  -only-testing:ChqCalendarTests/AppModelTests
+```
+
+Expected: FAIL to compile — no `resolvePendingDayDeepLinkIfPossible`, and
+`DeepLinkTabRoute.resolve` is not exhaustive over the new case.
+
+- [ ] **Step 3: Implement the route**
+
+In `ios/ChqCalendar/Features/Root/RootTabView.swift`, add to `resolve`'s switch:
+
+```swift
+        case .day:
+            return DeepLinkTabRoute(tab: .events, consumesLink: false, mapFocusVenue: nil)
+```
+
+Update the `consumesLink` doc comment (`:28-29`), which currently says `false`
+is "only for `.event`":
+
+```swift
+    /// Whether selecting `tab` fully consumes the link (clears
+    /// `pendingDeepLink`). `false` for `.event` and `.day` — both need the
+    /// Events tab's own content before the navigation is complete.
+```
+
+- [ ] **Step 4: Implement the resolver**
+
+In `ios/ChqCalendar/App/AppModel.swift`, immediately after
+`resolvePendingEventDeepLinkIfPossible()`:
+
+```swift
+    /// Resolves a pending `.day(key:)` deep link, clearing `pendingDeepLink`
+    /// and returning the key once a snapshot exists to navigate within.
+    ///
+    /// Unlike the `.event` resolver above there is no "is it present?"
+    /// question to retry: a day key needs no lookup, and `goToDay` is the
+    /// authority on whether the day is reachable. So this clears the link as
+    /// soon as the list has data, whether or not the caller's subsequent
+    /// `goToDay` accepts it — a day outside `navigableBounds` is refused, not
+    /// retried, and holding the link would make it fire again on the next
+    /// snapshot refresh.
+    ///
+    /// Waiting for `snapshot` is what makes a cold launch work: before it
+    /// lands there are no day sections mounted for `PendingDayScroll` to find.
+    func resolvePendingDayDeepLinkIfPossible() -> String? {
+        guard case .day(let key) = pendingDeepLink else { return nil }
+        guard snapshot != nil else { return nil }
+        pendingDeepLink = nil
+        return key
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Same command as Step 2. Expected: PASS.
+
+- [ ] **Step 6: Prove the hold-until-snapshot guard can fail**
+
+Delete the `guard snapshot != nil else { return nil }` line, re-run, and confirm
+`pendingDayLinkIsHeldUntilTheSnapshotArrives` FAILS. Restore and re-run to green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ios/ChqCalendar/Features/Root/RootTabView.swift ios/ChqCalendar/App/AppModel.swift \
+  ios/ChqCalendarTests/DeepLinkTabRouteTests.swift ios/ChqCalendarTests/AppModelTests.swift
+git commit -m "feat(ios): route a pending day deep link to the events tab"
+```
+
+---
+
+### Task 3: `EventListView` consumes the day link
+
+The payoff task: a day link now lands exactly where a rail chip tap lands,
+because it calls the identical function.
+
+**Files:**
+- Modify: `ios/ChqCalendar/Features/Calendar/EventListView.swift` (the modifier
+  chain ending at `:586` with `.onAppear`, and a new private helper beside
+  `selectDay` at `:377`)
+- Modify: `ios/ChqCalendar/Features/Calendar/CalendarView.swift` (the UI-test
+  hook block; `-uitest-tab` is at `:258` and is the pattern to copy)
+- Test: `ios/ChqCalendarUITests/DayRailUITests.swift`
+
+**Interfaces:**
+- Consumes: `AppModel.resolvePendingDayDeepLinkIfPossible()` (Task 2);
+  `EventListView.selectDay(_:)` (`:377`, already private in this file).
+- Produces: the `-uitest-go-to-day <yyyy-MM-dd>` launch argument, which Task 8's
+  screenshot depends on. It sets `model.pendingDeepLink = .day(key:)` — it does
+  **not** call `goToDay` directly, so the screenshot exercises the real pipeline.
+
+- [ ] **Step 1: Write the failing UI test**
+
+Append to `ios/ChqCalendarUITests/DayRailUITests.swift`, using that file's own
+`launchFixtureApp(now:extraArgs:)` helper (`ChqCalendarUITests/UITestApp.swift:17`)
+and its `day-chip-<key>` identifiers:
+
+```swift
+    /// A `chqcal://day/<key>` link — the shape `OpenDayIntent` writes — lands
+    /// the list on that day and pins the rail's highlight there, exactly as a
+    /// chip tap does. Driven through the launch argument, which feeds
+    /// `model.pendingDeepLink` rather than calling `goToDay` directly, so this
+    /// covers the whole pipeline a Siri run takes.
+    ///
+    /// The target is fifty-one days beyond `now`, outside the launch window —
+    /// the same target `testADistantChipTapLandsOnThatDay` uses, and for the
+    /// same reason: nothing here can pass by accident. The window has to grow,
+    /// the day has to mount, the list has to scroll, and the rail has to adopt
+    /// the pin. None of that is something a launch does on its own.
+    func testADayDeepLinkLandsOnThatDay() {
+        let app = launchFixtureApp(
+            now: "2026-07-01 10:00:00",
+            extraArgs: ["-uitest-go-to-day", "2026-08-21"])
+        let rail = app.scrollViews["day-rail"]
+        XCTAssertTrue(rail.waitForExistence(timeout: 20))
+
+        // 2026-08-21 is a Friday; the fixture titles every day header through
+        // ChqTime.dayTitle ("EEEE, MMMM d", en_US_POSIX, no year), same as
+        // testADistantChipTapLandsOnThatDay above.
+        let header = app.staticTexts["Friday, August 21"]
+        XCTAssertTrue(
+            header.waitForExistence(timeout: 20),
+            "The linked day never mounted — the deep link never reached selectDay, or the window did not grow")
+        XCTAssertTrue(
+            header.isHittable,
+            "The day mounted but the list never scrolled to it")
+        XCTAssertTrue(
+            app.buttons["day-chip-2026-08-21"].isSelected,
+            "The linked day is not the rail's pinned selection")
+    }
+```
+
+Read `testADistantChipTapLandsOnThatDay` (`:131`) before writing this — it is
+the same assertion shape with a tap where this has a launch argument, and
+matching the file beats matching this plan if the two ever disagree.
+
+- [ ] **Step 2: Run the UI test to verify it fails**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ChqCalendarUITests/DayRailUITests/testADayDeepLinkLandsOnThatDay
+```
+
+Expected: FAIL — the launch argument is unknown, so the app opens on the default
+day and no chip named July 30 is selected.
+
+- [ ] **Step 3: Add the launch argument**
+
+In `ios/ChqCalendar/Features/Calendar/CalendarView.swift`, in the UI-test hook
+block, immediately after the `-uitest-tab` handler (`:258-268`):
+
+```swift
+        // `-uitest-go-to-day <yyyy-MM-dd>` lands the Events list on a named
+        // day by feeding `model.pendingDeepLink` — the same channel
+        // `OpenDayIntent` writes through `PendingIntentLink`. Going through
+        // the link rather than calling `model.goToDay` directly is the point:
+        // the screenshot and the UI test then cover the real pipeline, not a
+        // shortcut around it. A non-canonical key is ignored (the link is
+        // never constructed), leaving the launch behaving as if the flag were
+        // absent.
+        if let flagIndex = arguments.firstIndex(of: "-uitest-go-to-day"),
+           arguments.index(after: flagIndex) < arguments.endIndex {
+            let key = arguments[arguments.index(after: flagIndex)]
+            if ChqTime.isCanonicalDayKey(key) {
+                model.pendingDeepLink = .day(key: key)
+            }
+        }
+```
+
+- [ ] **Step 4: Consume the link in `EventListView`**
+
+In `ios/ChqCalendar/Features/Calendar/EventListView.swift`, add beside
+`selectDay(_:)`:
+
+```swift
+    /// Completes a `chqcal://day/<key>` deep link the tab route deliberately
+    /// left pending (`DeepLinkTabRoute.resolve(.day)` sets
+    /// `consumesLink: false`).
+    ///
+    /// Routes through `selectDay` — the exact function a rail chip tap calls —
+    /// so a Siri "show me tomorrow" and a finger on tomorrow's chip leave the
+    /// app in identical state: same window expansion, same pinned selection,
+    /// same queued scroll. `selectDay` already refuses an unreachable day, so
+    /// nothing extra is needed for a link naming a day outside the season.
+    private func consumePendingDayLinkIfPossible() {
+        guard let dayKey = model.resolvePendingDayDeepLinkIfPossible() else { return }
+        selectDay(dayKey)
+    }
+```
+
+Attach it to the same modifier chain that already carries `.onChange(of: pendingScroll)`
+and `.onAppear` (`:582-587`), after `.onAppear`:
+
+```swift
+            // The link can arrive before this view exists (a cold launch from
+            // Siri), at the moment the tab switch mounts it, or later while it
+            // is already on screen — and in every case it can only be acted on
+            // once `snapshot` lands. Hence three triggers, all funnelling into
+            // one idempotent resolver: `resolvePendingDayDeepLinkIfPossible`
+            // returns the key exactly once, so extra calls cost a nil check.
+            // `snapshot?.fetchedAt` rather than `phase` for the same reason
+            // `resolvePendingEventDeepLinkIfPossible`'s callers use it: a warm
+            // launch sets `phase = .ready` immediately and never changes it
+            // again when the background refresh replaces the snapshot.
+            .onChange(of: model.pendingDeepLink) { _, _ in
+                consumePendingDayLinkIfPossible()
+            }
+            .onChange(of: model.snapshot?.fetchedAt) { _, _ in
+                consumePendingDayLinkIfPossible()
+            }
+            .onAppear {
+                consumePendingDayLinkIfPossible()
+            }
+```
+
+Note the existing `.onAppear { landPendingScroll(proxy, days: days) }` stays —
+add a second `.onAppear` rather than merging them, so the two concerns stay
+readable, or merge them into one closure if the file's style prefers that. Both
+compile; pick the one matching the surrounding code.
+
+- [ ] **Step 5: Run the UI test to verify it passes**
+
+Same command as Step 2. Expected: PASS. UI tests boot the app, so allow ~2
+minutes.
+
+- [ ] **Step 6: Run the whole suite**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS, no regressions. Phase 3b's rail tests are the ones to watch —
+the new `.onChange(of: model.pendingDeepLink)` fires on every link, including
+`.event`, where `consumePendingDayLinkIfPossible` must be a no-op.
+
+- [ ] **Step 7: Prove the consumption is real**
+
+Comment out the body of `consumePendingDayLinkIfPossible` (leave `return`),
+re-run the new UI test, confirm it FAILS. Restore and re-run to green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add ios/ChqCalendar/Features/Calendar/EventListView.swift \
+  ios/ChqCalendar/Features/Calendar/CalendarView.swift \
+  ios/ChqCalendarUITests/DayRailUITests.swift
+git commit -m "feat(ios): land a day deep link through the rail's own selectDay"
+```
+
+---
+
+### Task 4: A spoken timeframe becomes a day key
+
+Pure, shared, testable without the AppIntents runtime — the same split
+`IntentDataSource` uses so `IntentSelectionTests` can exercise selection with
+fixture events.
+
+**Files:**
+- Modify: `ios/ChqCalendarShared/Domain/IntentTimeframe.swift`
+- Modify: `ios/ChqCalendarShared/Domain/IntentDialogText.swift` (after `noTheme()` at `:58`)
+- Test: `ios/ChqCalendarTests/IntentTimeframeTests.swift`
+
+**Interfaces:**
+- Consumes: `IntentTimeframe.interval(now:year:)` (already present),
+  `ChqTime.dayKey(for:)`.
+- Produces: `IntentTimeframe.targetDayKey(now:year:) -> String` and
+  `IntentDialogText.unreachableDay(year:) -> String`. Task 5 calls both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `ios/ChqCalendarTests/IntentTimeframeTests.swift`:
+
+```swift
+    // MARK: - targetDayKey
+
+    /// The day a spoken timeframe should *land on* is the first day of the
+    /// window it means — not the whole window. "This week" opens on today, not
+    /// on Saturday: the reader asked what is happening, and the rail is right
+    /// there for the rest of the week.
+    @Test func targetDayKeyIsTheFirstDayOfTheInterval() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+
+        #expect(IntentTimeframe.today.targetDayKey(now: now, year: 2026) == "2026-07-27")
+        #expect(IntentTimeframe.tonight.targetDayKey(now: now, year: 2026) == "2026-07-27")
+        #expect(IntentTimeframe.tomorrow.targetDayKey(now: now, year: 2026) == "2026-07-28")
+        #expect(IntentTimeframe.thisWeek.targetDayKey(now: now, year: 2026) == "2026-07-27")
+    }
+
+    /// `tonight` is 5pm-anchored, so asking at 9pm must still mean today —
+    /// `interval` clamps its start to `now`, and the day key of either is the
+    /// same day. Pinned because a naive "5pm tomorrow" rewrite would pass the
+    /// morning case above and break this one.
+    @Test func targetDayKeyForTonightAskedLateIsStillToday() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 21:30:00"))
+
+        #expect(IntentTimeframe.tonight.targetDayKey(now: now, year: 2026) == "2026-07-27")
+    }
+
+    @Test func targetDayKeyForAnExplicitWeekIsThatWeeksFirstDay() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+        let week3 = SeasonCalendar.weeks(forYear: 2026)[2]
+
+        #expect(IntentTimeframe.week3.targetDayKey(now: now, year: 2026)
+                == ChqTime.dayKey(for: week3.start))
+    }
+
+    /// Week 9's "next week" is past the season: `interval` returns a
+    /// zero-length window at the season's end. A day key still comes out — it
+    /// is `OpenDayIntent`'s bounds check, not this function, that refuses it.
+    /// Pinned so a later "return nil when empty" refactor has to argue with a
+    /// test rather than silently change where the refusal lives.
+    @Test func targetDayKeyForNextWeekInWeekNineStillProducesAKey() throws {
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let inWeekNine = weeks[8].start.addingTimeInterval(3600)
+
+        let key = IntentTimeframe.nextWeek.targetDayKey(now: inWeekNine, year: 2026)
+
+        #expect(ChqTime.isCanonicalDayKey(key))
+        #expect(key == ChqTime.dayKey(for: weeks[8].end))
+    }
+
+```
+
+Do **not** add a "every timeframe produces a canonical key" loop over
+`allCases`. `ChqTime.dayKey` produces canonical output by construction, so such
+a test cannot fail no matter what `targetDayKey` does — it would read as
+coverage while proving nothing. This repo has shipped seven tests with that
+defect across earlier phases.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ChqCalendarTests/IntentTimeframeTests
+```
+
+Expected: FAIL to compile — no member `targetDayKey`.
+
+- [ ] **Step 3: Implement `targetDayKey`**
+
+In `ios/ChqCalendarShared/Domain/IntentTimeframe.swift`, after `interval(now:year:)`:
+
+```swift
+    /// The single NY day this timeframe should open the Events tab on — the
+    /// first day of `interval`, in `ChqTime.dayKey` form.
+    ///
+    /// A timeframe names a *window*; navigation needs a *day*. Taking the
+    /// window's first day is what makes "what's happening this week" and
+    /// "show me this week" agree about where the reader lands, and the day
+    /// rail carries them onward from there.
+    ///
+    /// Always returns a canonical key, including for the degenerate windows
+    /// `interval` produces off-season and for week 9's "next week" — whether
+    /// that day is *reachable* is `ViewWindow.navigableBounds`' question, and
+    /// `OpenDayIntent` asks it.
+    func targetDayKey(now: Date, year: Int) -> String {
+        ChqTime.dayKey(for: interval(now: now, year: year).start)
+    }
+```
+
+- [ ] **Step 4: Add the dialog line**
+
+In `ios/ChqCalendarShared/Domain/IntentDialogText.swift`, after `noTheme()`:
+
+```swift
+    /// Spoken when a requested day exists on the calendar but lies outside
+    /// everything navigation can reach — e.g. "show me tomorrow" asked on the
+    /// season's last day. Distinct from `offSeason`, which explains that the
+    /// *season* is not running; this explains that the *day* is not in it.
+    static func unreachableDay(year: Int) -> String {
+        "That day is outside the \(year) season."
+    }
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Same command as Step 2. Expected: PASS.
+
+- [ ] **Step 6: Prove `targetDayKeyForTonightAskedLateIsStillToday` can fail**
+
+Change `targetDayKey` to use `interval(...).end` instead of `.start`, re-run, and
+confirm at least `targetDayKeyIsTheFirstDayOfTheInterval` FAILS (`tomorrow` would
+still return 2026-07-28's end-of-day, so check the `thisWeek` case specifically).
+Restore and re-run to green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ios/ChqCalendarShared/Domain/IntentTimeframe.swift \
+  ios/ChqCalendarShared/Domain/IntentDialogText.swift \
+  ios/ChqCalendarTests/IntentTimeframeTests.swift
+git commit -m "feat(ios): resolve a spoken timeframe to a navigable day key"
+```
+
+---
+
+### Task 5: `OpenDayIntent` and the 8th shortcut
+
+The intent's *decision* is split out as a pure type, the same way
+`IntentDataSource.selectMatching` is split out of the intents that call it.
+That is not tidiness: an assertion written against `ViewWindow.navigableBounds`
+directly would pass even if the intent's guard were deleted, which is the
+unfalsifiable-test trap this project has been bitten by repeatedly. Testing
+`OpenDayTarget.resolve` tests the thing that can actually be wrong.
+
+**Files:**
+- Create: `ios/ChqCalendarShared/Domain/OpenDayTarget.swift`
+- Create: `ios/ChqCalendarTests/OpenDayTargetTests.swift`
+- Modify: `ios/ChqCalendar/Intents/EventIntents.swift` (after `OpenEventIntent`, which ends at `:58`)
+- Modify: `ios/ChqCalendar/Intents/ChqShortcuts.swift` (add an `AppShortcut`; update the doc comment's "seven shortcuts" at `:4`)
+- Modify: `ios/ChqCalendar/Features/About/AboutInfo.swift:58-66` (`siriPhrases`)
+
+**Interfaces:**
+- Consumes: `IntentTimeframe.targetDayKey(now:year:)` and
+  `IntentDialogText.unreachableDay(year:)` (Task 4); `DeepLink.day(key:)`
+  (Task 1); `PendingIntentLink.write(_:to:)` (`EventIntents.swift:25`);
+  `IntentDataSource.events(now:)` / `.defaultYear()`;
+  `ViewWindow.navigableBounds(year:events:starredDays:)` (`ViewWindow.swift:75`);
+  `IntentDialogText.offSeason(_:year:)` (`:60`) and `.coldCache()` (`:70`).
+- Produces: `OpenDayTarget.resolve(timeframe:now:year:events:) -> OpenDayTarget`,
+  an enum of `.navigate(dayKey: String)` / `.refuse(dialog: String)`; and
+  `OpenDayIntent` with `static let openAppWhenRun = true` and a
+  `@Parameter var timeframe: IntentTimeframe?`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `ios/ChqCalendarTests/OpenDayTargetTests.swift`. `makeEvent(id:start:…)`
+is a top-level function in `ios/ChqCalendarTests/TestSupport.swift:49` — every
+test file in the bundle can call it; do not write a second builder.
+
+```swift
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+/// `OpenDayIntent`'s whole decision, minus the AppIntents runtime.
+struct OpenDayTargetTests {
+    @Test func aDayInsideTheSeasonIsNavigatedTo() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-28 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .tomorrow, now: now, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: "2026-07-28"))
+    }
+
+    /// No timeframe spoken ("show me a day") means today — the same default
+    /// every other timeframe-carrying intent uses.
+    @Test func noTimeframeMeansToday() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-27 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: nil, now: now, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: "2026-07-27"))
+    }
+
+    /// The case the refusal exists for: asked on the season's last day,
+    /// "tomorrow" names a real calendar day that navigation cannot reach.
+    /// Opening the app and silently doing nothing is the behaviour this
+    /// prevents.
+    @Test func theDayAfterTheSeasonEndsIsRefusedWithADialog() throws {
+        let bounds = ViewWindow.navigableBounds(year: 2026, events: [], starredDays: [])
+        let lastDay = try #require(ChqTime.parse("\(bounds.upperBound) 09:00:00"))
+        let events = [makeEvent(id: "a", start: lastDay)]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .tomorrow, now: lastDay, year: 2026, events: events)
+
+        guard case .refuse(let dialog) = target else {
+            Issue.record("expected a refusal, got \(target)")
+            return
+        }
+        #expect(!dialog.isEmpty)
+    }
+
+    /// Out of season entirely, the refusal should explain *that* rather than
+    /// talk about a day — `IntentDialogText.offSeason` is the established
+    /// vocabulary and must win over the generic line.
+    @Test func offSeasonRefusalUsesTheOffSeasonDialog() throws {
+        let now = try #require(ChqTime.parse("2026-02-01 09:00:00"))
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .today, now: now, year: 2026, events: [])
+
+        let expected = try #require(
+            IntentDialogText.offSeason(SeasonStatus.make(now: now, year: 2026), year: 2026))
+        #expect(target == .refuse(dialog: expected))
+    }
+
+    /// A day the reader starred outside the season widens
+    /// `navigableBounds` — so reachability is a question about *this* user's
+    /// data, not about the calendar. Pinned because a "clamp to the season"
+    /// rewrite would pass every other test here.
+    @Test func aDayReachableOnlyBecauseAnEventLivesThereIsAccepted() throws {
+        let bounds = ViewWindow.navigableBounds(year: 2026, events: [], starredDays: [])
+        let dayAfter = try #require(
+            ChqTime.day(bounds.upperBound, offsetBy: 1))
+        let asked = try #require(ChqTime.parse("\(bounds.upperBound) 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("\(dayAfter) 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .tomorrow, now: asked, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: dayAfter))
+    }
+
+    @Test func aColdCacheIsRefusedWithTheColdCacheDialog() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .today, now: now, year: 2026, events: [])
+
+        #expect(target == .refuse(dialog: IntentDialogText.coldCache())
+                || target == .refuse(dialog: IntentDialogText.offSeason(
+                    SeasonStatus.make(now: now, year: 2026), year: 2026) ?? ""))
+    }
+```
+
+That last test is deliberately loose because the cold-cache and in-season paths
+overlap; decide in Step 3 which one wins for an empty event list and then
+**tighten the test to the single expected value**. A test asserting "one of two
+things" is a test that has not decided what the code should do.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO \
+  -only-testing:ChqCalendarTests/OpenDayTargetTests
+```
+
+Expected: FAIL to compile — no `OpenDayTarget`.
+
+- [ ] **Step 3: Implement `OpenDayTarget`**
+
+Create `ios/ChqCalendarShared/Domain/OpenDayTarget.swift`:
+
+```swift
+import Foundation
+
+/// `OpenDayIntent`'s decision, separated from the AppIntents runtime that
+/// delivers it — the same split `IntentDataSource.selectMatching` uses, and for
+/// the same reason: the rule is what can be wrong, and a rule in a `perform()`
+/// body can only be tested by booting Shortcuts.
+///
+/// The reachability check lives here rather than in the app because an intent
+/// that cannot navigate should *say so*. `AppModel.goToDay` already refuses an
+/// out-of-bounds day, but it refuses silently — the user would watch the app
+/// open and do nothing. Both sides ask
+/// `ViewWindow.navigableBounds(year:events:starredDays: [])`, so the two
+/// answers cannot drift.
+nonisolated enum OpenDayTarget: Equatable, Sendable {
+    case navigate(dayKey: String)
+    case refuse(dialog: String)
+
+    static func resolve(
+        timeframe: IntentTimeframe?, now: Date, year: Int, events: [Event]
+    ) -> OpenDayTarget {
+        guard !events.isEmpty else { return .refuse(dialog: IntentDialogText.coldCache()) }
+
+        let key = (timeframe ?? .today).targetDayKey(now: now, year: year)
+        let bounds = ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
+        guard bounds.contains(key) else {
+            let status = SeasonStatus.make(now: now, year: year)
+            return .refuse(
+                dialog: IntentDialogText.offSeason(status, year: year)
+                    ?? IntentDialogText.unreachableDay(year: year))
+        }
+        return .navigate(dayKey: key)
+    }
+}
+```
+
+Now tighten the last test from Step 1: with this implementation an empty event
+list is a **cold cache** refusal, so assert exactly
+`.refuse(dialog: IntentDialogText.coldCache())` and delete the `||`. Re-check
+`offSeasonRefusalUsesTheOffSeasonDialog` — it passes `events: []`, which now
+hits the cold-cache branch first. Give it a fixture event inside the season so
+it reaches the bounds check, or the test is asserting the wrong branch.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Same command as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Prove the bounds guard can fail**
+
+Delete `guard bounds.contains(key) else { … }` (return `.navigate` unconditionally),
+re-run, and confirm both `theDayAfterTheSeasonEndsIsRefusedWithADialog` and
+`offSeasonRefusalUsesTheOffSeasonDialog` FAIL. Restore and re-run to green. This
+is the whole point of extracting the type — do not skip it.
+
+- [ ] **Step 6: Implement `OpenDayIntent`**
+
+In `ios/ChqCalendar/Intents/EventIntents.swift`, after `OpenEventIntent`:
+
+```swift
+/// "Show a Day" — the Siri/Shortcuts equivalent of tapping a day chip on the
+/// rail. Closes the inconsistency #226 recorded: `IntentTimeframe` has shipped
+/// `tomorrow` and `nextWeek` as spoken targets since #193, so a user could
+/// *ask* Siri for tomorrow but, until phase 3b's rail, could not *tap* their
+/// way there. Routing this through the same `chqcal://day/<key>` link the rail
+/// resolves means voice and touch land in identical state.
+///
+/// `openAppWhenRun` brings the app forward; `perform()` hands the day off via
+/// `PendingIntentLink` rather than touching `AppModel` (see that type's doc
+/// comment — an intent can run with the app not launched at all).
+///
+/// Every decision lives in `OpenDayTarget`; this is the delivery shell.
+struct OpenDayIntent: AppIntent {
+    static let title: LocalizedStringResource = "Show a Day"
+    static let openAppWhenRun = true
+
+    @Parameter(title: "When")
+    var timeframe: IntentTimeframe?
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let now = Date()
+        let events = await IntentDataSource.events(now: now)
+        let year = await IntentDataSource.defaultYear()
+
+        switch OpenDayTarget.resolve(
+            timeframe: timeframe, now: now, year: year, events: events) {
+        case .refuse(let dialog):
+            return .result(dialog: "\(dialog)")
+        case .navigate(let dayKey):
+            PendingIntentLink.write(.day(key: dayKey), to: AppGroup.userDefaults())
+            return .result(dialog: "\((timeframe ?? .today).spokenLabel.capitalized).")
+        }
+    }
+}
+```
+
+`openAppWhenRun` is static, so the app comes forward even on the refusal path —
+that is why the refusal must speak. The success dialog uses `spokenLabel`, the
+vocabulary the other seven intents already speak; if it reads awkwardly aloud,
+change the line, not the structure.
+
+- [ ] **Step 7: Register the shortcut**
+
+In `ios/ChqCalendar/Intents/ChqShortcuts.swift`, add after the `OpenEventIntent`
+entry:
+
+```swift
+        AppShortcut(
+            intent: OpenDayIntent(),
+            phrases: [
+                "Show me a day in \(.applicationName)",
+                "Show me a day at \(.applicationName)",
+                "Show me \(\.$timeframe) in \(.applicationName)",
+                "Show me \(\.$timeframe) at \(.applicationName)",
+                "Open \(\.$timeframe) in \(.applicationName)",
+                "Open \(\.$timeframe) at \(.applicationName)",
+                "Take me to \(\.$timeframe) in \(.applicationName)",
+                "Take me to \(\.$timeframe) at \(.applicationName)"
+            ],
+            shortTitle: "Show a Day",
+            systemImageName: "calendar.day.timeline.left"
+        )
+```
+
+The first two phrases carry **no parameter slot** — that is load-bearing, not
+style. `ChqShortcutsTests` asserts `phrases[0]` contains no `$` for every
+registered shortcut, because `SiriTipView` renders it with slots unresolved.
+
+Update the type's doc comment at `:4`: "the seven shortcuts (listed in the
+Shortcuts app gallery under CHQ Calendar by their `AppIntent.title`: …)" becomes
+**eight**, with `"Show a Day"` added to the list.
+
+- [ ] **Step 8: Add the About-sheet example phrase**
+
+In `ios/ChqCalendar/Features/About/AboutInfo.swift`, append to `siriPhrases`:
+
+```swift
+        SiriPhrase(id: "show-day", phrase: "Show me tomorrow in Chautauqua?"),
+```
+
+- [ ] **Step 9: Run the whole suite**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS, including `ChqShortcutsTests` — which now covers eight
+shortcuts automatically and will fail loudly if `phrases[0]` carries a slot.
+
+- [ ] **Step 10: Prove the phrase guard covers the new shortcut**
+
+Swap the new shortcut's `phrases[0]` to `"Show me \(\.$timeframe) in \(.applicationName)"`,
+re-run `-only-testing:ChqCalendarTests/ChqShortcutsTests`, and confirm it FAILS
+naming `OpenDayIntent`. Restore the parameter-free phrase and re-run to green.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add ios/ChqCalendarShared/Domain/OpenDayTarget.swift ios/ChqCalendarTests/OpenDayTargetTests.swift \
+  ios/ChqCalendar/Intents/EventIntents.swift ios/ChqCalendar/Intents/ChqShortcuts.swift \
+  ios/ChqCalendar/Features/About/AboutInfo.swift
+git commit -m "feat(ios): add a Show a Day intent that opens the list on a spoken day"
+```
+
+---
+
+### Task 6: The two clipped-text accessibility fixes
+
+Both were found by phase 3b's on-device `performAccessibilityAudit()` and both
+are **pre-existing**, untouched by 3b's diff. Both fixes are gated on
+`dynamicTypeSize.isAccessibilitySize` so nothing at default text size moves a
+pixel — which is what makes PR A's screenshot opt-out honest.
+
+**Files:**
+- Modify: `ios/ChqCalendar/Features/Calendar/EventListView.swift:801-836` (`filterPillBar`)
+- Modify: `ios/ChqCalendar/Features/Calendar/CalendarView.swift:147-150` and `:158-161` (both `.searchable` prompts)
+
+**Interfaces:**
+- Consumes: `@Environment(\.dynamicTypeSize)`.
+- Produces: nothing other tasks depend on.
+
+- [ ] **Step 1: Reproduce both findings**
+
+Boot a simulator, set the largest accessibility text size
+(Settings › Accessibility › Display & Text Size › Larger Text, drag to maximum),
+launch the app, and capture the Events tab:
+
+```bash
+xcrun simctl boot 'iPhone 17'
+open -a Simulator
+# set the text size by hand, then:
+xcrun simctl io booted screenshot /tmp/claude-501/-Users-bernard-src-chq-chq-calendar/*/scratchpad/a11y-before.png
+```
+
+Confirm with your own eyes: the bottom `Filters` pill truncates to `…`, and the
+`Search events` placeholder clips. Do not implement a fix for a finding you have
+not seen — the audit's contrast findings on this same screen were mostly false
+(see the phase 3b write-up), and these two were verified real by a human render.
+
+- [ ] **Step 2: Fix the pill bar**
+
+In `EventListView.swift`, add the environment read beside the view's other
+`@Environment` properties:
+
+```swift
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+```
+
+Give the `Filters` label the same `fixedSize` the date label already has
+(`:815`), and let the row scroll when the two pills no longer fit:
+
+```swift
+                    Text(filterCount > 0 ? "Filters (\(filterCount))" : "Filters")
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+```
+
+and wrap the bar's `HStack` so it can scroll at accessibility sizes only:
+
+```swift
+    /// At accessibility text sizes the two pills no longer fit side by side —
+    /// the date pill is `fixedSize` (abbreviating the date is worse than
+    /// scrolling for it), so `Filters` was the one that truncated to `…`.
+    /// Scrolling the row keeps both labels whole. Gated on
+    /// `isAccessibilitySize` so the default layout — where both fit with room
+    /// to spare — keeps its `Spacer` and stays pixel-identical.
+    private var filterPillBar: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    pillRow
+                }
+            } else {
+                pillRow
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 4)
+    }
+
+    private var pillRow: some View {
+        HStack(spacing: 10) {
+            // ... the two existing pillButton calls, unchanged ...
+            Spacer(minLength: 0)
+        }
+    }
+```
+
+Move the two `.padding` modifiers to the outer `Group` as shown — leaving them
+on the inner `HStack` would inset the scroll content instead of the bar.
+
+- [ ] **Step 3: Fix the search prompt**
+
+In `CalendarView.swift`, add:
+
+```swift
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+```
+
+and a computed prompt used by **both** `.searchable` call sites (`:150` and `:161`):
+
+```swift
+    /// "Search events" clips inside the system search field at accessibility
+    /// text sizes; "Search" does not. Shortening only there keeps the more
+    /// informative placeholder for the sizes that can render it.
+    private var searchPrompt: String {
+        dynamicTypeSize.isAccessibilitySize ? "Search" : "Search events"
+    }
+```
+
+Replace `prompt: "Search events"` with `prompt: searchPrompt` at both sites.
+Both, not one — they are the compact and regular size-class containers, and
+fixing one leaves the iPad clipped.
+
+- [ ] **Step 4: Verify on device**
+
+Relaunch at the largest accessibility size and capture again:
+
+```bash
+xcrun simctl io booted screenshot /tmp/claude-501/-Users-bernard-src-chq-chq-calendar/*/scratchpad/a11y-after.png
+```
+
+Confirm the `Filters` label reads in full (scrolling the row if needed) and the
+placeholder is not clipped. Then set the text size back to **default** and
+confirm the bar looks exactly as it did before this task — the `Spacer` still
+pushes the pills left, no scroll indicator, "Search events" restored.
+
+- [ ] **Step 5: Run the whole suite**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS. Any UI test that queries the search field by its placeholder
+string will need updating — it runs at default text size, so `searchPrompt` is
+still `"Search events"` there, but check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add ios/ChqCalendar/Features/Calendar/EventListView.swift \
+  ios/ChqCalendar/Features/Calendar/CalendarView.swift
+git commit -m "fix(ios): keep the Filters pill and search prompt whole at accessibility text sizes"
+```
+
+- [ ] **Step 7: Open PR A**
+
+```bash
+git push -u origin feat/date-nav-phase-4-siri-routing
+gh pr create --title "feat(ios): Siri routes through the day rail (phase 4, part 1)" --body "$(cat <<'BODY'
+Phase 4, part 1 of the cross-platform date-navigation initiative
+(docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md:631).
+
+A new `chqcal://day/<yyyy-MM-dd>` deep link and an `OpenDayIntent` route Siri
+through the same `AppModel.goToDay` a rail chip tap uses, closing the
+inconsistency #226 recorded: you could *ask* Siri for tomorrow but not *tap*
+your way there. The link is consumed by `EventListView.selectDay` — literally
+the function a chip tap calls — so voice and touch land in identical state:
+same window expansion, same pinned selection, same queued scroll.
+
+Also fixes the two clipped-text findings from phase 3b's on-device
+accessibility audit (the `Filters` pill truncating to `…` and the `Search
+events` placeholder clipping at the largest accessibility text size). Both are
+pre-existing and both fixes are gated on `dynamicTypeSize.isAccessibilitySize`,
+so nothing at default text size changes.
+
+[skip-screenshots: every visible change is gated on accessibility text sizes or
+lives on the About sheet, neither of which any shot in ios/Scripts/screenshot-plan.json
+covers; phase 4 part 2 regenerates for the 1.1.3 submission]
+BODY
+)"
+```
+
+- [ ] **Step 8: Iterate the PR to green**
+
+Follow the project's PR-iteration rule in `CLAUDE.md`: address every review
+comment, request fresh Copilot/Claude reviews, and repeat until reviewers are
+empty, threads are resolved, checks pass and `mergeable_state` is `clean`.
+**Read Copilot's `Suppressed comments` block and its inline comments, not just
+the review summary** — it has reported "no new comments" while carrying real
+findings four passes running on this initiative, and inline comments are a
+separate surface from the summary. Do not merge; hand it to the user.
+
+---
+
+# PR B — release prep
+
+Branch off `main` **after PR A merges**:
+
+```bash
+git checkout main && git pull && git checkout -b chore/ios-1.1.3-release-prep
+```
+
+### Task 7: The 1.1.3 version sweep
+
+1.1.2 (build 5) is live in the App Store, so the next submission is a new
+version and a new build. The 1.1.2 bump was incomplete — it left the test bundle
+behind — and the UI-test target added in phase 3b has no version settings at all.
+This task closes both.
+
+**Files:**
+- Modify: `ios/ChqCalendar.xcodeproj/project.pbxproj`
+- Modify: any doc naming the current version (find them in Step 1)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `MARKETING_VERSION = 1.1.3` everywhere; `CURRENT_PROJECT_VERSION = 6`
+  for the app and widget targets. Task 9's listing copy quotes `1.1.3`.
+
+- [ ] **Step 1: Inventory every version reference**
+
+```bash
+grep -rn "MARKETING_VERSION\|CURRENT_PROJECT_VERSION" ios/ChqCalendar.xcodeproj/project.pbxproj
+grep -rn "1\.1\.2" docs/ ios/ --include='*.md' --include='*.json' | grep -v node_modules
+```
+
+Expected inventory in `project.pbxproj` before the change:
+
+| Config | Bundle id | `MARKETING_VERSION` | `CURRENT_PROJECT_VERSION` |
+|---|---|---|---|
+| `:432`/`:450` Debug | `org.chqcal.app` | 1.1.2 | 5 |
+| `:466`/`:484` Release | `org.chqcal.app` | 1.1.2 | 5 |
+| `:498`/`:501` Debug | `org.chqcal.calendarTests` | 1.1.2 | 1 |
+| `:516`/`:519` Release | `org.chqcal.calendarTests` | 1.1.2 | 1 |
+| `:591`/`:602` Debug | `org.chqcal.app.widgets` | 1.1.2 | 5 |
+| `:618`/`:629` Release | `org.chqcal.app.widgets` | 1.1.2 | 5 |
+| `:409-416` Debug, `:640-647` Release | `org.chqcal.calendarUITests` | **absent** | **absent** |
+
+Line numbers shift as you edit — re-grep rather than trusting them twice.
+
+- [ ] **Step 2: Bump the six existing configs**
+
+```bash
+cd ios
+sed -i '' 's/MARKETING_VERSION = 1\.1\.2;/MARKETING_VERSION = 1.1.3;/g' ChqCalendar.xcodeproj/project.pbxproj
+grep -c "MARKETING_VERSION = 1.1.3;" ChqCalendar.xcodeproj/project.pbxproj
+```
+
+Expected: `6`.
+
+Then bump the build number for the **app and widget targets only** — 5 is the
+build that shipped, and a new upload needs a higher one. Edit by hand rather
+than with `sed`: the two test-bundle configs also read `CURRENT_PROJECT_VERSION = 1`
+and must not be touched, and a global substitution of `= 5;` would hit unrelated
+settings. Change the four occurrences at `:432`, `:466`, `:591`, `:618` from
+`5` to `6`.
+
+```bash
+grep -n "CURRENT_PROJECT_VERSION" ChqCalendar.xcodeproj/project.pbxproj
+```
+
+Expected after: four `= 6;` (app Debug/Release, widgets Debug/Release) and two
+`= 1;` (test bundle Debug/Release).
+
+- [ ] **Step 3: Give the UI-test target version settings**
+
+Add both keys to the `org.chqcal.calendarUITests` Debug and Release
+`buildSettings` blocks, alphabetically placed among the existing keys:
+
+```
+				CURRENT_PROJECT_VERSION = 1;
+				MARKETING_VERSION = 1.1.3;
+```
+
+This is the point of the task as much as the bump is: the 1.1.2 sweep missed the
+unit-test bundle because nothing enumerated the targets, and 3b then added a
+target with no version at all. After this, every target in the project carries
+both keys and the next sweep is a grep.
+
+- [ ] **Step 4: Verify the project still builds and all targets report 1.1.3**
+
+```bash
+cd ios && xcodebuild build \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  CODE_SIGNING_ALLOWED=NO 2>&1 | tail -5
+
+xcodebuild -project ChqCalendar.xcodeproj -showBuildSettings -target ChqCalendar \
+  | grep -E "MARKETING_VERSION|CURRENT_PROJECT_VERSION"
+```
+
+Expected: build succeeds; settings report `MARKETING_VERSION = 1.1.3` and
+`CURRENT_PROJECT_VERSION = 6`.
+
+- [ ] **Step 5: Run the whole suite**
+
+```bash
+cd ios && xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
+```
+
+Expected: PASS. `AboutInfo.versionString` reads the bundle at runtime, so any
+test asserting a literal version string would fail here — there should be none
+(the tests pass explicit values), but confirm.
+
+- [ ] **Step 6: Update the doc references found in Step 1**
+
+Every `1.1.2` in `docs/` that names *the version being prepared* becomes
+`1.1.3`. Leave historical statements alone — `RELEASE_CHECKLIST.md:265-274`
+records what was folded into 1.1.2 and is a log entry, not a claim about the
+current version. Task 9 adds the 1.1.3 entry beneath it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ios/ChqCalendar.xcodeproj/project.pbxproj docs/
+git commit -m "chore(ios): sweep every target to 1.1.3 (build 6)"
+```
+
+---
+
+### Task 8: `01-season` becomes the day-navigation shot
+
+`ios/Scripts/screenshot-plan.json` is at **10 shots, which is App Store
+Connect's per-device maximum** — a new shot must displace one. `01-season`
+already frames the Events list with the rail on it, so it is reworked rather
+than replaced. It also currently captures **live production data with no clock
+pin**, the same fragility that silently produced a blank `03-search`; freezing
+its clock is a fix in its own right.
+
+**Files:**
+- Modify: `ios/Scripts/screenshot-plan.json` (the `01-season` entry)
+- Modify: `docs/app-store/screenshots.manifest.json`, `docs/app-store/screenshots/review/` (regenerated)
+
+**Interfaces:**
+- Consumes: `-uitest-go-to-day <key>` and `-uitest-freeze-now <ts>` (Task 3 and
+  `AppModel.swift:1539`).
+- Produces: the regenerated manifest that satisfies `app-store-assets.yml`.
+
+- [ ] **Step 1: Rework the shot definition**
+
+In `ios/Scripts/screenshot-plan.json`, replace the `01-season` entry with:
+
+```json
+    {
+      "id": "01-season",
+      "caption": "Jump to any day in the season.",
+      "launchArgs": [
+        "-uitest-freeze-now", "2026-07-27 09:00:00",
+        "-uitest-go-to-day", "2026-07-30"
+      ],
+      "settleSeconds": 12,
+      "deviceLaunchArgs": { "ipad-13": ["-uitest-select-event-index", "1"] }
+    }
+```
+
+Keep the **id** `01-season` — the manifest and the `review/` copies are keyed by
+it, and renaming would orphan files for no gain.
+
+Three deliberate choices: the clock is pinned so the shot is reproducible
+(2026-07-27 is a Monday in week 5, mid-season); the landed day is three days
+out so the rail shows `⟳ Now`, both chevrons and a selected future chip rather
+than sitting at an edge; and `settleSeconds` rises from 6 to 12 to match
+`03-search` — the launch now performs a deep-link resolution and a scroll
+against live production data, and a fixed 6s settle is exactly what produced a
+blank capture before.
+
+- [ ] **Step 2: Capture**
+
+```bash
+ios/Scripts/capture-screenshots.sh
+```
+
+Do not boot five simulators at once — `simctl bootstatus -b` can hang
+indefinitely under that load. If the script stalls, shut down all simulators
+(`xcrun simctl shutdown all`) and re-run.
+
+- [ ] **Step 3: Look at the capture with your own eyes**
+
+```bash
+open ios/Scripts/out/iphone-6.9/01-season.png
+```
+
+Confirm: real events are listed (not a blank or spinner), the day rail is
+visible, and Thursday July 30 is the selected chip. **A green script exit is not
+evidence the shot is right** — the 3b pass found the pipeline producing a blank
+`03-search` while exiting 0. If the capture is wrong, raise `settleSeconds`
+before changing anything else.
+
+- [ ] **Step 4: Compose and check**
+
+```bash
+python3 ios/Scripts/compose-screenshots.py
+python3 ios/Scripts/check-screenshots.py
+```
+
+Then open the composed `01-season` for both devices and confirm the caption
+renders in full and does not collide with the rail.
+
+- [ ] **Step 5: Commit the regenerated assets**
+
+```bash
+git add ios/Scripts/screenshot-plan.json docs/app-store/screenshots.manifest.json \
+  docs/app-store/screenshots/review/
+git commit -m "chore(app-store): make the lead screenshot show day navigation"
+```
+
+Confirm `docs/app-store/screenshots.manifest.json` is actually in the diff —
+`app-store-assets.yml` checks that this file changed since the merge-base, and
+a compose run that changed nothing means the capture did not land.
+
+---
+
+### Task 9: Listing copy and the spec amendment
+
+**Files:**
+- Modify: `docs/app-store/listing-fields.json` (`whatsNew`, `promotionalText`)
+- Modify: `docs/app-store/listing-copy.md`
+- Modify: `docs/app-store/RELEASE_CHECKLIST.md`
+- Modify: `docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md`
+
+**Interfaces:**
+- Consumes: the shipped behaviour of PR A and Tasks 7–8.
+- Produces: submission-ready copy for 1.1.3.
+
+- [ ] **Step 1: Re-read the current copy against what shipped**
+
+```bash
+python3 -c "import json; d=json.load(open('docs/app-store/listing-fields.json')); print(d['description'])"
+python3 ios/Scripts/render-listing-copy.py 2>/dev/null || cat docs/app-store/listing-copy.md
+```
+
+List every claim the date-navigation work invalidated or that is now
+understated — in particular anything describing how a reader moves through the
+season, and the `whatsNew` block still describing 1.1.2. Note them before
+writing; the failure mode this step exists for is a description promising a
+feature that changed shape.
+
+- [ ] **Step 2: Write the 1.1.3 `whatsNew`**
+
+Replace the `whatsNew` value in `docs/app-store/listing-fields.json`. Lead with
+the rail — it is the release. Keep the house style visible in the 1.1.2 entry:
+a one-line opener, then ALL-CAPS section headings with `•` bullets.
+
+```
+Version 1.1.3 is about moving through the season.
+
+A DAY AT A TIME
+• A day rail sits above the events list — tap any day to jump straight to it
+• Step a day at a time with the chevrons, or tap ⟳ Now to come back to today
+• The list grows as you reach its edges instead of stopping at the end
+• Each day names how many events it holds, so an empty day is visible before you tap it
+
+ASK FOR A DAY
+• "Show me tomorrow in Chautauqua" now opens the app on tomorrow
+• Siri and the day rail land in exactly the same place
+
+ACCESSIBILITY
+• The Filters button and the search field no longer clip their labels at the largest text sizes
+```
+
+Do not claim anything you have not seen running. If the on-device pass in
+Step 5 contradicts a bullet, change the bullet.
+
+- [ ] **Step 3: Refresh `promotionalText`**
+
+`promotionalText` is the **one field changeable without a review cycle**, which
+is what it is for. Replace the 1.1.2 text with something short and true of
+1.1.3, e.g.:
+
+```
+New in 1.1.3: a day rail above the events list — tap any day to jump straight to it, or ask Siri to show you tomorrow.
+```
+
+- [ ] **Step 4: Mirror the changes into `listing-copy.md` and the checklist**
+
+`docs/app-store/listing-copy.md` carries the same copy in prose form — update it
+so the two do not drift. In `docs/app-store/RELEASE_CHECKLIST.md`, add a 1.1.3
+entry beneath the 1.1.2 log recording what this version contains and noting that
+**further features may land before submission** — this copy is a first pass, not
+the final submission artifact.
+
+- [ ] **Step 5: On-device pass before calling the copy done**
+
+Launch the app on a simulator and walk every bullet you wrote:
+
+```bash
+xcrun simctl boot 'iPhone 17' && open -a Simulator
+```
+
+- Tap a distant day chip → the list lands there.
+- Tap `⟳ Now` → back to today.
+- Reach the end of the list → it grows.
+- Run "Show me tomorrow in Chautauqua" from the Shortcuts app → the app opens on
+  tomorrow. (Siri proper needs a device; the Shortcuts app runs the same intent.)
+- Set the largest accessibility text size → `Filters` and the search placeholder
+  read in full.
+
+Anything that does not behave as written is a bug or a wrong bullet — decide
+which, and fix that one, before continuing.
+
+- [ ] **Step 6: Amend the spec's phase-4 section**
+
+In `docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md`:
+
+- Update the **Status** banner (`:3-17`) to record phase 4 as complete and name
+  what shipped.
+- Correct the stale claim at `:678-684` that "the app and widget targets are at
+  `1.1.3`" — they were at 1.1.2 until Task 7, and the test bundle was too.
+  Replace it with what is now true: every target, including both test bundles,
+  is at 1.1.3, app and widgets at build 6.
+- In the Siri section (`:481-489`), record that routing landed as
+  `OpenDayIntent` + `chqcal://day/<key>` consumed by `EventListView.selectDay`,
+  and that the reachability refusal lives in the intent so it can be *spoken*.
+- Record the constraint that shaped Task 8: the shot list is at App Store
+  Connect's 10-shot maximum, so a new shot displaces an existing one.
+- Record that the `this-week` off-season divergence is **deliberately left
+  standing** (documented in `ViewWindow.swift`): null on web, a rolling 7-day
+  window on iOS.
+
+- [ ] **Step 7: Commit and open PR B**
+
+```bash
+git add docs/
+git commit -m "docs(app-store): 1.1.3 listing copy and the phase 4 spec amendment"
+git push -u origin chore/ios-1.1.3-release-prep
+gh pr create --title "chore(ios): 1.1.3 release prep (phase 4, part 2)" --body "$(cat <<'BODY'
+Phase 4, part 2: the release side of the cross-platform date-navigation
+initiative.
+
+- Every target swept to 1.1.3; app and widgets to build 6 (build 5 is the one
+  live in the store). The unit-test bundle was still on 1.1.2 — the same
+  incompleteness as the 1.1.2 bump — and the UI-test target added in phase 3b
+  had no version settings at all. Both fixed, so the next sweep is a grep.
+- The lead screenshot now shows day navigation rather than a static list, and
+  its clock is pinned: it was the last shot capturing live production data with
+  no `-uitest-freeze-now`, the same fragility that once produced a blank
+  `03-search`. The shot list is at App Store Connect's 10-shot maximum, so this
+  is a rework rather than an eleventh shot.
+- 1.1.3 `whatsNew` and `promotionalText`, verified bullet by bullet against a
+  running app.
+
+The listing copy is a first pass — further features are expected before
+submission.
+BODY
+)"
+```
+
+- [ ] **Step 8: Iterate PR B to green**
+
+Same rule as PR A. Do not merge; hand it to the user.
+
+---
+
+## After both PRs merge
+
+Not part of this plan, listed so nothing is dropped:
+
+- **The user archives and uploads 1.1.3 (build 6)** and submits for review.
+  `docs/app-store/RELEASE_CHECKLIST.md` carries the procedure and the App Store
+  Connect icon troubleshooting.
+- **Siri on a real device.** `SiriTipView` phrase rendering and spoken
+  invocation cannot be verified in the simulator; the #193 checklist applies to
+  the new "Show a Day" action too.
+- **The `this-week` off-season divergence** stays documented in
+  `ViewWindow.swift`, by decision.
+- **The remaining 3b accessibility debt** — the 21 "Dynamic Type font sizes are
+  partially unsupported" warnings — is untouched here. The contrast findings
+  from that audit were mostly false (see the phase 3b write-up before acting on
+  any of them).

--- a/docs/superpowers/plans/2026-08-20-date-navigation-phase-4-ios-consolidation.md
+++ b/docs/superpowers/plans/2026-08-20-date-navigation-phase-4-ios-consolidation.md
@@ -3,9 +3,13 @@
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Close the cross-platform date-navigation initiative on iOS by routing
-Siri through the same `goToDay` the day rail uses, fixing the two clipped-text
-accessibility findings from phase 3b's device pass, and preparing the 1.1.3
-release (version sweep, day-navigation screenshot, listing copy).
+Siri through the same `goToDay` the day rail uses, fixing the `Filters` pill
+truncation from phase 3b's device pass, and preparing the 1.1.3 release
+(version sweep, day-navigation screenshot, listing copy). Phase 3b's device
+pass also flagged a `Search events` placeholder clip at maximum accessibility
+text size; it did not reproduce across five configurations during this phase's
+own repro pass, so no fix was written and `CalendarView` still uses
+`prompt: "Search events"` at both `.searchable` sites.
 
 **Architecture:** A new `DeepLink.day(key:)` case rides the deep-link pipeline
 every launch surface already funnels through (`.onOpenURL`, notification tap,
@@ -90,7 +94,7 @@ Siri rationale is at `:481`. Task 9 amends that section to match what shipped.)
 | `ios/ChqCalendar/Features/Root/RootTabView.swift` | Route `.day` to the Events tab without consuming the link. |
 | `ios/ChqCalendar/App/AppModel.swift` | Add `resolvePendingDayDeepLinkIfPossible()`. |
 | `ios/ChqCalendar/Features/Calendar/EventListView.swift` | Consume the resolved day through the existing `selectDay(_:)`; accessibility fix for the `Filters` pill. |
-| `ios/ChqCalendar/Features/Calendar/CalendarView.swift` | `-uitest-go-to-day <key>` launch arg; accessibility fix for the search prompt. |
+| `ios/ChqCalendar/Features/Calendar/CalendarView.swift` | `-uitest-go-to-day <key>` launch arg; planned search-prompt accessibility fix — not applied (see Task 6's Outcome note: the finding did not reproduce). |
 | `ios/ChqCalendarShared/Domain/OpenDayTarget.swift` | The intent's whole decision — day key + reachability — as a pure, testable type. |
 | `ios/ChqCalendar/Intents/EventIntents.swift` | Add `OpenDayIntent` beside `OpenEventIntent`. |
 | `ios/ChqCalendar/Intents/ChqShortcuts.swift` | Register the 8th `AppShortcut`. |
@@ -1042,12 +1046,22 @@ git commit -m "feat(ios): add a Show a Day intent that opens the list on a spoke
 
 ---
 
-### Task 6: The two clipped-text accessibility fixes
+### Task 6: The `Filters` pill accessibility fix (search-prompt finding did not reproduce)
 
 Both were found by phase 3b's on-device `performAccessibilityAudit()` and both
-are **pre-existing**, untouched by 3b's diff. Both fixes are gated on
+are **pre-existing**, untouched by 3b's diff. The fix below is gated on
 `dynamicTypeSize.isAccessibilitySize` so nothing at default text size moves a
 pixel — which is what makes PR A's screenshot opt-out honest.
+
+**Outcome:** Step 1's repro confirmed the `Filters` pill truncation, which
+Step 2 fixed as written. It did **not** confirm the `Search events` placeholder
+clip — across five configurations at maximum accessibility text size the
+placeholder never clipped — so Step 3 below was not implemented. Steps 3–4 are
+left in place as the repro/fix recipe to run again if the finding ever does
+reproduce (a different device class, a longer locale string, a future prompt
+change), but as of this phase `CalendarView` still uses the unconditional
+`prompt: "Search events"` at both `.searchable` sites, and there is no
+`searchPrompt` computed property or `dynamicTypeSize` read in that file.
 
 **Files:**
 - Modify: `ios/ChqCalendar/Features/Calendar/EventListView.swift:801-836` (`filterPillBar`)
@@ -1070,10 +1084,13 @@ open -a Simulator
 xcrun simctl io booted screenshot /tmp/claude-501/-Users-bernard-src-chq-chq-calendar/*/scratchpad/a11y-before.png
 ```
 
-Confirm with your own eyes: the bottom `Filters` pill truncates to `…`, and the
-`Search events` placeholder clips. Do not implement a fix for a finding you have
-not seen — the audit's contrast findings on this same screen were mostly false
-(see the phase 3b write-up), and these two were verified real by a human render.
+Confirm with your own eyes: the bottom `Filters` pill truncates to `…`. Check
+whether the `Search events` placeholder clips too — the audit's contrast
+findings on this same screen were mostly false (see the phase 3b write-up), so
+verify both by human render rather than trusting the audit output. Do not
+implement a fix for a finding you have not seen reproduce. (Recorded outcome:
+the pill truncated on every configuration tried; the placeholder did not clip
+on any of five — see this task's Outcome note above.)
 
 - [ ] **Step 2: Fix the pill bar**
 
@@ -1127,7 +1144,9 @@ and wrap the bar's `HStack` so it can scroll at accessibility sizes only:
 Move the two `.padding` modifiers to the outer `Group` as shown — leaving them
 on the inner `HStack` would inset the scroll content instead of the bar.
 
-- [ ] **Step 3: Fix the search prompt**
+- [ ] **Step 3: Fix the search prompt (not run — see Outcome note above; the
+  finding did not reproduce, so this step was skipped and `CalendarView` is
+  unchanged)**
 
 In `CalendarView.swift`, add:
 
@@ -1158,10 +1177,12 @@ Relaunch at the largest accessibility size and capture again:
 xcrun simctl io booted screenshot /tmp/claude-501/-Users-bernard-src-chq-chq-calendar/*/scratchpad/a11y-after.png
 ```
 
-Confirm the `Filters` label reads in full (scrolling the row if needed) and the
-placeholder is not clipped. Then set the text size back to **default** and
-confirm the bar looks exactly as it did before this task — the `Spacer` still
-pushes the pills left, no scroll indicator, "Search events" restored.
+Confirm the `Filters` label reads in full (scrolling the row if needed). The
+placeholder step is moot — Step 3 was not run — but confirm it still reads
+"Search events" unclipped in whatever configuration you test, since that
+remains the unconditional prompt. Then set the text size back to **default**
+and confirm the bar looks exactly as it did before this task — the `Spacer`
+still pushes the pills left, no scroll indicator.
 
 - [ ] **Step 5: Run the whole suite**
 
@@ -1172,16 +1193,18 @@ cd ios && xcodebuild test \
   -parallel-testing-enabled NO CODE_SIGNING_ALLOWED=NO
 ```
 
-Expected: PASS. Any UI test that queries the search field by its placeholder
-string will need updating — it runs at default text size, so `searchPrompt` is
-still `"Search events"` there, but check.
+Expected: PASS. (Since Step 3 was not run, there is no `searchPrompt` and no
+UI test needs updating for it — this note applies only if a future pass
+implements Step 3.)
 
 - [ ] **Step 6: Commit**
 
+Only `EventListView.swift` changed — `CalendarView.swift` is untouched because
+Step 3 did not run:
+
 ```bash
-git add ios/ChqCalendar/Features/Calendar/EventListView.swift \
-  ios/ChqCalendar/Features/Calendar/CalendarView.swift
-git commit -m "fix(ios): keep the Filters pill and search prompt whole at accessibility text sizes"
+git add ios/ChqCalendar/Features/Calendar/EventListView.swift
+git commit -m "fix(ios): keep the Filters pill whole at accessibility text sizes"
 ```
 
 - [ ] **Step 7: Open PR A**
@@ -1199,11 +1222,14 @@ your way there. The link is consumed by `EventListView.selectDay` — literally
 the function a chip tap calls — so voice and touch land in identical state:
 same window expansion, same pinned selection, same queued scroll.
 
-Also fixes the two clipped-text findings from phase 3b's on-device
-accessibility audit (the `Filters` pill truncating to `…` and the `Search
-events` placeholder clipping at the largest accessibility text size). Both are
-pre-existing and both fixes are gated on `dynamicTypeSize.isAccessibilitySize`,
-so nothing at default text size changes.
+Also fixes one of the two clipped-text findings from phase 3b's on-device
+accessibility audit: the `Filters` pill truncating to `…` at the largest
+accessibility text size. It is pre-existing and the fix is gated on
+`dynamicTypeSize.isAccessibilitySize`, so nothing at default text size
+changes. The audit's other finding — the `Search events` placeholder clipping
+— did not reproduce across five configurations during this phase's repro
+pass, so no fix was written; `CalendarView` still uses the unconditional
+`prompt: "Search events"`.
 
 [skip-screenshots: every visible change is gated on accessibility text sizes or
 lives on the About sheet, neither of which any shot in ios/Scripts/screenshot-plan.json
@@ -1489,7 +1515,7 @@ ASK FOR A DAY
 • Siri and the day rail land in exactly the same place
 
 ACCESSIBILITY
-• The Filters button and the search field no longer clip their labels at the largest text sizes
+• The Filters button no longer clips its label at the largest text sizes
 ```
 
 Do not claim anything you have not seen running. If the on-device pass in
@@ -1526,8 +1552,9 @@ xcrun simctl boot 'iPhone 17' && open -a Simulator
 - Reach the end of the list → it grows.
 - Run "Show me tomorrow in Chautauqua" from the Shortcuts app → the app opens on
   tomorrow. (Siri proper needs a device; the Shortcuts app runs the same intent.)
-- Set the largest accessibility text size → `Filters` and the search placeholder
-  read in full.
+- Set the largest accessibility text size → `Filters` reads in full (the search
+  placeholder was never fixed — Task 6 found it did not reproduce — so nothing
+  to check there).
 
 Anything that does not behave as written is a bug or a wrong bullet — decide
 which, and fix that one, before continuing.

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -153,6 +153,12 @@ final class AppModel {
     ///   `snapshot` changes until the target event is found (or the snapshot
     ///   is loaded, no refresh that could still surface the event is in
     ///   flight, and it's confirmed unknown).
+    /// - `.day` likewise stays pending, for `EventListView` (task 12,
+    ///   phase 4), via `resolvePendingDayDeepLinkIfPossible()` below: the
+    ///   day key needs no lookup, but navigating to it does need a snapshot
+    ///   (`goToDay` bounds against it), so the link waits exactly as long.
+    ///   `EventListView` hosts those triggers on its `body`, not on the list
+    ///   it may not be rendering — see its own comment there.
     var pendingDeepLink: DeepLink?
 
     /// The venue a consumed `chqcal://map/<venue>` deep link asked to focus

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1623,6 +1623,30 @@ final class AppModel {
     /// value in every real launch) keeps this path fully inert.
     var uiTestPendingScrollDelay: TimeInterval = 0
 
+    /// How many of the next `proxy.scrollTo` calls `EventListView.issueScroll`
+    /// should swallow instead of performing, set by `CalendarView` from
+    /// `-uitest-drop-scrolls <n>` and decremented once per swallowed call.
+    ///
+    /// Makes reachable, deterministically and on any machine, a state that
+    /// otherwise depends on winning a layout race: a `scrollTo` that is
+    /// issued and does nothing, because the section it names was not part of
+    /// the scroll view's resolved content yet (see
+    /// `PendingDayScroll.hasLanded`). Forcing that race directly did not work
+    /// — 24 CPU spinners on a 12-core host and a cold-booted simulator both
+    /// still landed the scroll — so the hook models the *observable
+    /// consequence* instead: the scroll goes nowhere. Before the retry chain,
+    /// one dropped call was fatal, since nothing fired again; with it, the
+    /// pending target survives and the next attempt lands it.
+    ///
+    /// Note this is not the #250 CI failure itself — that one never issued a
+    /// scroll at all (see `EventListView.resolvePendingScroll`'s abandon
+    /// guard, and `testADayDeepLinkLandsOnThatDay`, which falsifies it
+    /// directly). This covers the neighbouring assumption in the same
+    /// function.
+    ///
+    /// `0` (the default, and every real launch) keeps this fully inert.
+    var uiTestScrollsToDrop = 0
+
     /// The first `(day, week)` pairing — in `days` display order — whose
     /// badge actually has a theme. The deterministic target for
     /// `-uitest-show-week-theme`: not every week has one (a partial sidecar

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -648,6 +648,26 @@ final class AppModel {
         return nil
     }
 
+    /// Resolves a pending `.day(key:)` deep link, clearing `pendingDeepLink`
+    /// and returning the key once a snapshot exists to navigate within.
+    ///
+    /// Unlike the `.event` resolver above there is no "is it present?"
+    /// question to retry: a day key needs no lookup, and `goToDay` is the
+    /// authority on whether the day is reachable. So this clears the link as
+    /// soon as the list has data, whether or not the caller's subsequent
+    /// `goToDay` accepts it — a day outside `navigableBounds` is refused, not
+    /// retried, and holding the link would make it fire again on the next
+    /// snapshot refresh.
+    ///
+    /// Waiting for `snapshot` is what makes a cold launch work: before it
+    /// lands there are no day sections mounted for `PendingDayScroll` to find.
+    func resolvePendingDayDeepLinkIfPossible() -> String? {
+        guard case .day(let key) = pendingDeepLink else { return nil }
+        guard snapshot != nil else { return nil }
+        pendingDeepLink = nil
+        return key
+    }
+
     func toggleFavorite(_ id: String) {
         if favorites.contains(id) {
             favorites.remove(id)

--- a/ios/ChqCalendar/Features/About/AboutInfo.swift
+++ b/ios/ChqCalendar/Features/About/AboutInfo.swift
@@ -63,6 +63,7 @@ enum AboutInfo {
         SiriPhrase(id: "speaking", phrase: "Who is speaking tomorrow in Chautauqua?"),
         SiriPhrase(id: "theme", phrase: "What's the theme this week in Chautauqua?"),
         SiriPhrase(id: "myday", phrase: "What am I doing tomorrow in Chautauqua?"),
+        SiriPhrase(id: "show-day", phrase: "Show me tomorrow in Chautauqua?"),
     ]
 
     /// Formats the marketing version and build number for display.

--- a/ios/ChqCalendar/Features/About/AboutInfo.swift
+++ b/ios/ChqCalendar/Features/About/AboutInfo.swift
@@ -63,7 +63,7 @@ enum AboutInfo {
         SiriPhrase(id: "speaking", phrase: "Who is speaking tomorrow in Chautauqua?"),
         SiriPhrase(id: "theme", phrase: "What's the theme this week in Chautauqua?"),
         SiriPhrase(id: "myday", phrase: "What am I doing tomorrow in Chautauqua?"),
-        SiriPhrase(id: "show-day", phrase: "Show me tomorrow in Chautauqua?"),
+        SiriPhrase(id: "show-day", phrase: "Show me tomorrow in Chautauqua."),
     ]
 
     /// Formats the marketing version and build number for display.

--- a/ios/ChqCalendar/Features/Calendar/CalendarView.swift
+++ b/ios/ChqCalendar/Features/Calendar/CalendarView.swift
@@ -267,6 +267,22 @@ struct CalendarView: View {
             }
         }
 
+        // `-uitest-go-to-day <yyyy-MM-dd>` lands the Events list on a named
+        // day by feeding `model.pendingDeepLink` — the same channel
+        // `OpenDayIntent` writes through `PendingIntentLink`. Going through
+        // the link rather than calling `model.goToDay` directly is the point:
+        // the screenshot and the UI test then cover the real pipeline, not a
+        // shortcut around it. A non-canonical key is ignored (the link is
+        // never constructed), leaving the launch behaving as if the flag were
+        // absent.
+        if let flagIndex = arguments.firstIndex(of: "-uitest-go-to-day"),
+           arguments.index(after: flagIndex) < arguments.endIndex {
+            let key = arguments[arguments.index(after: flagIndex)]
+            if ChqTime.isCanonicalDayKey(key) {
+                model.pendingDeepLink = .day(key: key)
+            }
+        }
+
         // `-uitest-search <term>` reads the argument that follows it and
         // commits it straight to `model.filter.searchText`. `searchDraft` is
         // set too so the visible search field shows the term, but the

--- a/ios/ChqCalendar/Features/Calendar/CalendarView.swift
+++ b/ios/ChqCalendar/Features/Calendar/CalendarView.swift
@@ -232,6 +232,14 @@ struct CalendarView: View {
             model.uiTestPendingScrollDelay = 3
         }
 
+        // `-uitest-drop-scrolls <n>` — see `AppModel.uiTestScrollsToDrop` for
+        // why a UI test needs to be able to make a `scrollTo` do nothing.
+        if let flagIndex = arguments.firstIndex(of: "-uitest-drop-scrolls"),
+           arguments.index(after: flagIndex) < arguments.endIndex,
+           let count = Int(arguments[arguments.index(after: flagIndex)]), count > 0 {
+            model.uiTestScrollsToDrop = count
+        }
+
         if arguments.contains("-uitest-show-about") {
             model.uiTestShowAbout = true
         }

--- a/ios/ChqCalendar/Features/Calendar/CalendarView.swift
+++ b/ios/ChqCalendar/Features/Calendar/CalendarView.swift
@@ -107,7 +107,10 @@ struct CalendarView: View {
     /// guard against clearing a link a still-running refresh might yet
     /// satisfy); this just pushes the resolved event onto the right
     /// navigation surface. Does nothing for `.myDay`/`.map` — `RootTabView`
-    /// consumes those at the tab level before this view ever sees them.
+    /// consumes those at the tab level before this view ever sees them — and
+    /// nothing for `.day`, the other link the tab switch deliberately leaves
+    /// pending: `EventListView` consumes that one on its own `body`, through
+    /// `resolvePendingDayDeepLinkIfPossible`.
     private func consumePendingDeepLinkIfPossible() {
         guard let event = model.resolvePendingEventDeepLinkIfPossible() else { return }
         route(to: event)

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -22,6 +22,8 @@ struct EventListView: View {
     @Bindable var model: AppModel
     var selection: Binding<Event?>?
 
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
     @State private var isAboutPresented = false
 
     /// Which pill's sheet is up, if any.
@@ -831,7 +833,28 @@ struct EventListView: View {
     /// pills moved out of the toolbar system entirely into a safe-area
     /// inset, which the tab bar's own safe-area contribution stacks
     /// *above* rather than under (screenshot-verified in task 16).
+    ///
+    /// At accessibility text sizes the two pills no longer fit side by side —
+    /// the date pill is `fixedSize` (abbreviating the date is worse than
+    /// scrolling for it), so `Filters` was the one that truncated to `…`.
+    /// Scrolling the row keeps both labels whole. Gated on
+    /// `isAccessibilitySize` so the default layout — where both fit with room
+    /// to spare — keeps its `Spacer` and stays pixel-identical.
     private var filterPillBar: some View {
+        Group {
+            if dynamicTypeSize.isAccessibilitySize {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    pillRow
+                }
+            } else {
+                pillRow
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 4)
+    }
+
+    private var pillRow: some View {
         HStack(spacing: 10) {
             pillButton {
                 KeyboardDismisser.dismiss()
@@ -858,14 +881,13 @@ struct EventListView: View {
                     Image(systemName: "line.3.horizontal.decrease")
                     Text(filterCount > 0 ? "Filters (\(filterCount))" : "Filters")
                         .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
                 }
             }
             .accessibilityLabel(filtersAccessibilityLabel)
 
             Spacer(minLength: 0)
         }
-        .padding(.horizontal, 16)
-        .padding(.bottom, 4)
     }
 
     /// One pill: a plain button whose chrome matches the platform — Liquid

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -146,6 +146,46 @@ struct EventListView: View {
     @State private var pendingScrollDeadline: Date?
     #endif
 
+    /// How long after `selectDay` arms a target we keep re-issuing its
+    /// `scrollTo` until the day is actually on screen — see
+    /// `PendingDayScroll.hasLanded` for why issuing one is not landing one.
+    ///
+    /// Generous on purpose. It costs nothing when the scroll lands on the
+    /// first attempt (the common case: the confirmation reads `visibleDays`,
+    /// sees the target, and clears immediately). It is a ceiling on how long
+    /// an unlandable target stays armed, not a latency anyone waits out, and
+    /// picking a tight number here would be guessing at exactly the timing
+    /// that is not understood well enough to guess at.
+    private static let scrollRetryWindow: TimeInterval = 5
+
+    /// Gap between those re-issues. Short enough that a reader never sees the
+    /// list sitting still after asking for a day; long enough that each
+    /// attempt gets a layout pass to actually use.
+    private static let scrollRetryInterval: TimeInterval = 0.1
+
+    /// The wall-clock moment `pendingScroll` stops being re-issued and is
+    /// dropped whether or not its day ever appeared. Stamped by `selectDay`,
+    /// cleared alongside `pendingScroll`.
+    ///
+    /// A deadline rather than an attempt counter for the same reason
+    /// `pendingScrollDeadline` is one: `list(days:)` wires several
+    /// independent triggers onto `landPendingScroll`, more than one can fire
+    /// from a single commit, and two concurrent retry chains sharing a
+    /// counter would burn the budget at twice the rate. Sharing a wall-clock
+    /// deadline, they simply stop at the same moment.
+    @State private var scrollRetryDeadline: Date?
+
+    /// Bumped by a scheduled re-check so `list(days:)` re-runs
+    /// `landPendingScroll` — see its `.onChange(of: scrollRetryTick)`.
+    ///
+    /// The retry goes through view state rather than re-entering
+    /// `landPendingScroll` from the dispatched closure directly so that each
+    /// attempt reads the `days` array of the *current* render. A closure
+    /// capturing `days` would re-scroll against a snapshot that may since
+    /// have shrunk (a filter change) or grown, which is the class of bug
+    /// `PendingDayScroll.Key` exists to catch, not to reintroduce.
+    @State private var scrollRetryTick = 0
+
     /// The earliest visible day section — the day whose header is at (or
     /// just above) the top of the viewport. `min()` on day-key strings works
     /// because `DayGroup.id` sorts lexicographically the same as
@@ -419,6 +459,7 @@ struct EventListView: View {
             key: PendingDayScroll.key(for: model.filter, year: model.selectedYear))
         pendingScroll = target
         pinnedSelection = target
+        scrollRetryDeadline = Date().addingTimeInterval(Self.scrollRetryWindow)
         #if DEBUG
         // `model.uiTestPendingScrollDelay` is still consumed once, here —
         // reset to `0` so only this one arm is delayed, not every tap after
@@ -462,6 +503,9 @@ struct EventListView: View {
     /// the window away from the target without ever covering it, which
     /// `DayRailNavigation.shouldAbandonScroll` alone cannot see.
     ///
+    /// Landing is *confirmed*, not assumed: see `PendingDayScroll.hasLanded`
+    /// and `resolvePendingScroll`'s abandon guard below.
+    ///
     /// **Deliberately unanimated.** A smooth scroll does not re-target
     /// mid-flight: on the web the equivalent animation ran ~2s while the
     /// document grew 1020px beneath it, and the tap landed ~1058px short of
@@ -499,19 +543,89 @@ struct EventListView: View {
 
         let currentKey = PendingDayScroll.key(for: model.filter, year: model.selectedYear)
         if PendingDayScroll.isStale(pending, currentKey: currentKey) {
-            pendingScroll = nil
+            clearPendingScroll()
             return
         }
 
         if days.contains(where: { $0.id == pending.day }) {
-            proxy.scrollTo(pending.day, anchor: .top)
-            pendingScroll = nil
+            issueScroll(proxy, to: pending.day)
+        } else if !visibleDays.isEmpty,
+                  DayRailNavigation.shouldAbandonScroll(
+                    target: pending.day, window: model.currentWindow) {
+            // `!visibleDays.isEmpty` is the fix for #250, and it is load-
+            // bearing. `shouldAbandonScroll` reads `model.currentWindow` —
+            // live state — while `days` is whatever array the enclosing
+            // render captured. On a cold launch consuming a day deep link
+            // those two disagree exactly once, and fatally: `content` builds
+            // `list(days:)` the moment `snapshot` lands, then `body`'s
+            // `.onChange(of: model.pendingDeepLink)` runs `selectDay` in that
+            // same update, so `goToDay` has already grown the window by the
+            // time the freshly-mounted list's `.onAppear` fires — carrying
+            // the *pre-growth* `days`. The rule then reads "the window covers
+            // this day and it has no section", concludes it is an ordinary
+            // empty day, and drops the target. The two `.onChange` triggers
+            // arrive with correct data about two milliseconds later and are
+            // swallowed by `landPendingScroll`'s `pendingScroll != nil`
+            // guard, because there is no longer anything pending. Measured
+            // on an iPhone 17 Pro / iOS 26.1 simulator: 5 failures in 18
+            // runs, every one of them logging that single stale-`days` call
+            // and nothing after it; 12 for 12 with this guard, with 9 of
+            // those runs still hitting the stale call.
+            //
+            // An empty `visibleDays` means the list has not rendered a single
+            // day header yet, which is true only of that first-mount call —
+            // and is precisely when `days` cannot be trusted to correspond to
+            // the current window. Any settled render (every chip tap, which
+            // is what this rule was written for) has headers on screen and
+            // still abandons immediately.
+            clearPendingScroll()
             return
         }
 
-        if DayRailNavigation.shouldAbandonScroll(target: pending.day, window: model.currentWindow) {
-            pendingScroll = nil
+        // Whether or not the day was mountable in `days`, the target is only
+        // done once it is actually on screen — issuing a scroll is not
+        // landing one, and `days` here may not even be the array this
+        // render's `List` is showing. `PendingDayScroll.hasLanded` decides;
+        // until it says yes, the target stays armed and
+        // `scheduleScrollRetry` brings us back with whatever `days` the next
+        // render has.
+        if PendingDayScroll.hasLanded(
+            day: pending.day,
+            visibleDays: visibleDays,
+            retryDeadline: scrollRetryDeadline,
+            now: Date()) {
+            clearPendingScroll()
+        } else {
+            scheduleScrollRetry()
         }
+    }
+
+    /// The one place `pendingScroll` is dropped, so its retry deadline can
+    /// never outlive it and re-arm a chain for a target that is gone.
+    private func clearPendingScroll() {
+        pendingScroll = nil
+        scrollRetryDeadline = nil
+    }
+
+    /// Ask `list(days:)` to run `landPendingScroll` again shortly, with the
+    /// `days` of whatever render is current by then — see `scrollRetryTick`.
+    private func scheduleScrollRetry() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollRetryInterval) { [self] in
+            scrollRetryTick &+= 1
+        }
+    }
+
+    /// `proxy.scrollTo`, with the `-uitest-drop-scrolls` hook in front of it.
+    private func issueScroll(_ proxy: ScrollViewProxy, to day: String) {
+        #if DEBUG
+        if model.uiTestScrollsToDrop > 0 {
+            // Simulate the scroll `List` drops when the target's section is
+            // not resolvable yet — see `AppModel.uiTestScrollsToDrop`.
+            model.uiTestScrollsToDrop -= 1
+            return
+        }
+        #endif
+        proxy.scrollTo(day, anchor: .top)
     }
 
     @ViewBuilder
@@ -642,6 +756,22 @@ struct EventListView: View {
             // `pendingScroll != nil` guard makes that second call a no-op,
             // so this cannot re-arm itself in a loop.
             .onChange(of: pendingScroll) { _, _ in
+                landPendingScroll(proxy, days: days)
+            }
+            // The third trigger. The two above each fire at most once per
+            // arm and `.onAppear` fires exactly once, so between them a
+            // target gets a single `scrollTo` — which `List` can silently
+            // drop when the section it names has not been resolved yet, and
+            // which nothing would then re-issue. `resolvePendingScroll` bumps
+            // `scrollRetryTick` whenever `PendingDayScroll.hasLanded` says
+            // the day still is not on screen, landing back here with this
+            // render's `days` to try again.
+            //
+            // Not the fix for #250 — that is the abandon guard in
+            // `resolvePendingScroll` — but the same function's other
+            // unchecked assumption, and `testADayDeepLinkSurvivesADroppedScroll`
+            // pins it.
+            .onChange(of: scrollRetryTick) { _, _ in
                 landPendingScroll(proxy, days: days)
             }
             .onAppear {

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -191,6 +191,41 @@ struct EventListView: View {
                     filterPillBar
                 }
             }
+            // The link can arrive before this view exists (a cold launch from
+            // Siri), at the moment the tab switch mounts it, or later while it
+            // is already on screen — and in every case it can only be acted on
+            // once `snapshot` lands. Hence three triggers, all funnelling into
+            // one idempotent resolver: `resolvePendingDayDeepLinkIfPossible`
+            // returns the key exactly once, so extra calls cost a nil check.
+            // `snapshot?.fetchedAt` rather than `phase` for the same reason
+            // `resolvePendingEventDeepLinkIfPossible`'s callers use it: a warm
+            // launch sets `phase = .ready` immediately and never changes it
+            // again when the background refresh replaces the snapshot.
+            //
+            // **On `body`, deliberately — not inside `list(days:)`.** `content`
+            // only builds the list when `model.dayGroups` is non-empty, so
+            // triggers hosted there are unmounted in exactly the states a
+            // pending link most needs resolving: a persisted favourites-only
+            // filter with nothing upcoming, or any filter matching nothing,
+            // renders `noMatchesView` instead. Siri would say "Opening
+            // tomorrow.", nothing would happen, and the link would stay
+            // pending — then fire minutes later, teleporting the reader, the
+            // moment they cleared the filter and the list mounted. `body` is
+            // always mounted, which is also where the `.event` resolver has
+            // always lived (`CalendarView`). Nothing here needs the list:
+            // `selectDay` takes no `ScrollViewProxy` (it arms `pendingScroll`,
+            // which `list(days:)` resolves whenever it does mount), and
+            // `resolvePendingDayDeepLinkIfPossible` already gates on
+            // `snapshot != nil`.
+            .onChange(of: model.pendingDeepLink) { _, _ in
+                consumePendingDayLinkIfPossible()
+            }
+            .onChange(of: model.snapshot?.fetchedAt) { _, _ in
+                consumePendingDayLinkIfPossible()
+            }
+            .onAppear {
+                consumePendingDayLinkIfPossible()
+            }
             .sheet(isPresented: $isAboutPresented) {
                 AboutView(model: model)
             }
@@ -401,10 +436,21 @@ struct EventListView: View {
     /// `consumesLink: false`).
     ///
     /// Routes through `selectDay` — the exact function a rail chip tap calls —
-    /// so a Siri "show me tomorrow" and a finger on tomorrow's chip leave the
-    /// app in identical state: same window expansion, same pinned selection,
-    /// same queued scroll. `selectDay` already refuses an unreachable day, so
-    /// nothing extra is needed for a link naming a day outside the season.
+    /// so for any day the rail also offers, a Siri "show me tomorrow" and a
+    /// finger on tomorrow's chip leave the app in identical state: same window
+    /// expansion, same pinned selection, same queued scroll. `selectDay`
+    /// already refuses an unreachable day, so nothing extra is needed for a
+    /// link naming a day outside the season.
+    ///
+    /// Voice reaches strictly *more* days than touch, and that is intended.
+    /// `OpenDayTarget` bounds against the whole unfiltered year, so a day
+    /// holding nothing under the reader's active filter is still a legal
+    /// target — while the rail disables that day's chip, so a finger cannot
+    /// choose it. This is the same asymmetry `AppModel.goToDay` already
+    /// documents and `goToDayAcceptsAnEmptyDayEvenThoughTheRailDisablesItsChip`
+    /// pins: a day the reader *names* is a destination even when empty. It is
+    /// also not closable — an App Intent runs out of process against the
+    /// shared cache and cannot see the live filter at all.
     private func consumePendingDayLinkIfPossible() {
         guard let dayKey = model.resolvePendingDayDeepLinkIfPossible() else { return }
         selectDay(dayKey)
@@ -600,25 +646,6 @@ struct EventListView: View {
             }
             .onAppear {
                 landPendingScroll(proxy, days: days)
-            }
-            // The link can arrive before this view exists (a cold launch from
-            // Siri), at the moment the tab switch mounts it, or later while it
-            // is already on screen — and in every case it can only be acted on
-            // once `snapshot` lands. Hence three triggers, all funnelling into
-            // one idempotent resolver: `resolvePendingDayDeepLinkIfPossible`
-            // returns the key exactly once, so extra calls cost a nil check.
-            // `snapshot?.fetchedAt` rather than `phase` for the same reason
-            // `resolvePendingEventDeepLinkIfPossible`'s callers use it: a warm
-            // launch sets `phase = .ready` immediately and never changes it
-            // again when the background refresh replaces the snapshot.
-            .onChange(of: model.pendingDeepLink) { _, _ in
-                consumePendingDayLinkIfPossible()
-            }
-            .onChange(of: model.snapshot?.fetchedAt) { _, _ in
-                consumePendingDayLinkIfPossible()
-            }
-            .onAppear {
-                consumePendingDayLinkIfPossible()
             }
         }
     }
@@ -837,9 +864,22 @@ struct EventListView: View {
     /// At accessibility text sizes the two pills no longer fit side by side —
     /// the date pill is `fixedSize` (abbreviating the date is worse than
     /// scrolling for it), so `Filters` was the one that truncated to `…`.
-    /// Scrolling the row keeps both labels whole. Gated on
-    /// `isAccessibilitySize` so the default layout — where both fit with room
-    /// to spare — keeps its `Spacer` and stays pixel-identical.
+    /// Scrolling the row keeps both labels whole.
+    ///
+    /// **Both halves of that fix are gated on `isAccessibilitySize`, and the
+    /// two gates must stay in step**: this `ScrollView`, and `Filters`' own
+    /// `fixedSize` in `pillRow`. `fixedSize` without the `ScrollView` to
+    /// rescue it is worse than the truncation it replaces — the row overflows
+    /// with neither truncation nor scrolling, and the Filters capsule is
+    /// clipped at the screen edge. That band is real and reachable:
+    /// `.xxLarge`/`.xxxLarge` are large text but not *accessibility* text, so
+    /// `isAccessibilitySize` is `false` there, and a long date label
+    /// (`DateFilterLabel`'s "Weeks 1, 3, 5") on a 375pt-wide iPhone overflows
+    /// the row. Those sizes therefore keep the pre-existing behaviour —
+    /// `Filters` truncates to `…` and stays fully on screen — rather than
+    /// getting the scrolling row. Below them both pills fit with room to
+    /// spare, so the default layout keeps its `Spacer` and is pixel-identical
+    /// either way.
     private var filterPillBar: some View {
         Group {
             if dynamicTypeSize.isAccessibilitySize {
@@ -881,7 +921,15 @@ struct EventListView: View {
                     Image(systemName: "line.3.horizontal.decrease")
                     Text(filterCount > 0 ? "Filters (\(filterCount))" : "Filters")
                         .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
+                        // Only where `filterPillBar`'s `ScrollView` is there
+                        // to scroll to it — see that property's comment for
+                        // why an ungated `fixedSize` clips this capsule off
+                        // the screen edge at `.xxLarge`/`.xxxLarge`. Both
+                        // arguments `false` is a no-op, so the non-
+                        // accessibility bands keep truncating to `…` exactly
+                        // as they always have.
+                        .fixedSize(
+                            horizontal: dynamicTypeSize.isAccessibilitySize, vertical: false)
                 }
             }
             .accessibilityLabel(filtersAccessibilityLabel)

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -394,6 +394,20 @@ struct EventListView: View {
         #endif
     }
 
+    /// Completes a `chqcal://day/<key>` deep link the tab route deliberately
+    /// left pending (`DeepLinkTabRoute.resolve(.day)` sets
+    /// `consumesLink: false`).
+    ///
+    /// Routes through `selectDay` — the exact function a rail chip tap calls —
+    /// so a Siri "show me tomorrow" and a finger on tomorrow's chip leave the
+    /// app in identical state: same window expansion, same pinned selection,
+    /// same queued scroll. `selectDay` already refuses an unreachable day, so
+    /// nothing extra is needed for a link naming a day outside the season.
+    private func consumePendingDayLinkIfPossible() {
+        guard let dayKey = model.resolvePendingDayDeepLinkIfPossible() else { return }
+        selectDay(dayKey)
+    }
+
     /// Land a pending target if its day has mounted; give up if it never
     /// will, or if the reader has since left the scope/filters it was
     /// tapped under (`PendingDayScroll.isStale`) — a scope change can move
@@ -584,6 +598,25 @@ struct EventListView: View {
             }
             .onAppear {
                 landPendingScroll(proxy, days: days)
+            }
+            // The link can arrive before this view exists (a cold launch from
+            // Siri), at the moment the tab switch mounts it, or later while it
+            // is already on screen — and in every case it can only be acted on
+            // once `snapshot` lands. Hence three triggers, all funnelling into
+            // one idempotent resolver: `resolvePendingDayDeepLinkIfPossible`
+            // returns the key exactly once, so extra calls cost a nil check.
+            // `snapshot?.fetchedAt` rather than `phase` for the same reason
+            // `resolvePendingEventDeepLinkIfPossible`'s callers use it: a warm
+            // launch sets `phase = .ready` immediately and never changes it
+            // again when the background refresh replaces the snapshot.
+            .onChange(of: model.pendingDeepLink) { _, _ in
+                consumePendingDayLinkIfPossible()
+            }
+            .onChange(of: model.snapshot?.fetchedAt) { _, _ in
+                consumePendingDayLinkIfPossible()
+            }
+            .onAppear {
+                consumePendingDayLinkIfPossible()
             }
         }
     }

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -1013,18 +1013,29 @@ struct EventListView: View {
     private var filterPillBar: some View {
         Group {
             if dynamicTypeSize.isAccessibilitySize {
+                // No trailing `Spacer` here: inside a horizontal `ScrollView`
+                // the scroll axis offers effectively unbounded width, so an
+                // unconditional `Spacer(minLength: 0)` claims a large ideal
+                // width and produces a big blank scrollable tail past the
+                // two pills — harder to use at exactly the text sizes this
+                // branch exists to fix.
                 ScrollView(.horizontal, showsIndicators: false) {
-                    pillRow
+                    pillRow(includeTrailingSpacer: false)
                 }
             } else {
-                pillRow
+                pillRow(includeTrailingSpacer: true)
             }
         }
         .padding(.horizontal, 16)
         .padding(.bottom, 4)
     }
 
-    private var pillRow: some View {
+    /// `includeTrailingSpacer` is `false` only inside `filterPillBar`'s
+    /// `ScrollView` branch — see that property's comment. Everywhere else
+    /// the trailing `Spacer` is what pushes the pills left and fills the
+    /// row, so it stays `true` there and the non-scrolling layout is
+    /// unchanged.
+    private func pillRow(includeTrailingSpacer: Bool) -> some View {
         HStack(spacing: 10) {
             pillButton {
                 KeyboardDismisser.dismiss()
@@ -1064,7 +1075,9 @@ struct EventListView: View {
             }
             .accessibilityLabel(filtersAccessibilityLabel)
 
-            Spacer(minLength: 0)
+            if includeTrailingSpacer {
+                Spacer(minLength: 0)
+            }
         }
     }
 

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -218,6 +218,32 @@ struct EventListView: View {
     /// `PendingDayScroll.Key` exists to catch, not to reintroduce.
     @State private var scrollRetryTick = 0
 
+    /// Guards `scheduleScrollRetry` so at most one retry timer is ever in
+    /// flight at once.
+    ///
+    /// `resolvePendingScroll` runs once per triggering `.onChange`, and
+    /// `list(days:)` wires several independent triggers onto
+    /// `landPendingScroll` — more than one can fire from a single SwiftUI
+    /// commit (see `scrollRetryDeadline`'s doc). Before this guard, each of
+    /// those calls that failed to land its target scheduled its own
+    /// `asyncAfter`, so a single commit could leave N concurrent timers
+    /// running `scrollRetryInterval` apart from each other rather than from a
+    /// shared start — a burst of `scrollTo` attempts and view updates instead
+    /// of the one retry per interval this was designed for.
+    ///
+    /// Keyed on "a timer is outstanding", not on which target it is for, so
+    /// it cannot suppress a genuine retry: the scheduled closure always fires
+    /// and always re-checks live `pendingScroll` state before deciding
+    /// whether to bump `scrollRetryTick`, exactly as before this guard
+    /// existed. If the target changes (or lands, or goes stale) while a timer
+    /// is outstanding, a caller that would have scheduled a second timer for
+    /// the new state instead no-ops — the one outstanding timer still fires
+    /// and still re-enters `landPendingScroll` against whatever is pending by
+    /// then, so the retry is deduplicated, never dropped. Cleared
+    /// unconditionally inside the closure — the only place it goes back to
+    /// `false` — so a stale `true` can never wedge every later retry.
+    @State private var scrollRetryScheduled = false
+
     /// The earliest visible day section — the day whose header is at (or
     /// just above) the top of the viewport. `min()` on day-key strings works
     /// because `DayGroup.id` sorts lexicographically the same as
@@ -679,8 +705,16 @@ struct EventListView: View {
     /// "something is pending", not "the same thing is still pending", so an
     /// in-flight retry for a still-armed (even if different) target keeps
     /// working exactly as before.
+    ///
+    /// Also guarded by `scrollRetryScheduled` so only one such timer is ever
+    /// outstanding — see that property's doc for why a second, concurrent
+    /// caller no-ops here rather than stacking another timer, and why that
+    /// cannot drop a retry that is still genuinely owed.
     private func scheduleScrollRetry() {
+        guard !scrollRetryScheduled else { return }
+        scrollRetryScheduled = true
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollRetryInterval) { [self] in
+            scrollRetryScheduled = false
             guard pendingScroll != nil else { return }
             scrollRetryTick &+= 1
         }

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -146,9 +146,20 @@ struct EventListView: View {
     @State private var pendingScrollDeadline: Date?
     #endif
 
-    /// How long after `selectDay` arms a target we keep re-issuing its
-    /// `scrollTo` until the day is actually on screen — see
-    /// `PendingDayScroll.hasLanded` for why issuing one is not landing one.
+    /// How long after `resolvePendingScroll`'s first actual attempt at a
+    /// target we keep re-issuing its `scrollTo` until the day is actually on
+    /// screen — see `PendingDayScroll.hasLanded` for why issuing one is not
+    /// landing one.
+    ///
+    /// Measured from the first *attempt*, not from `selectDay` arming the
+    /// target — `list(days:)`, where every attempt happens, is not mounted
+    /// when `model.dayGroups` is empty (a favourites-only filter with
+    /// nothing upcoming, say). A deadline stamped at arm time would burn down
+    /// in real time while the list is unmounted and nothing can even try;
+    /// when the reader later clears the filter and the list mounts, the
+    /// window could already be spent, and the first attempt would read as
+    /// "already expired" and give up without ever issuing a `scrollTo`. See
+    /// `resolvePendingScroll` for where this is stamped.
     ///
     /// Generous on purpose. It costs nothing when the scroll lands on the
     /// first attempt (the common case: the confirmation reads `visibleDays`,
@@ -164,8 +175,29 @@ struct EventListView: View {
     private static let scrollRetryInterval: TimeInterval = 0.1
 
     /// The wall-clock moment `pendingScroll` stops being re-issued and is
-    /// dropped whether or not its day ever appeared. Stamped by `selectDay`,
-    /// cleared alongside `pendingScroll`.
+    /// dropped whether or not its day ever appeared.
+    ///
+    /// Stamped lazily by `resolvePendingScroll`, on its first actual
+    /// resolution attempt for the current target — **not** by `selectDay` at
+    /// arm time. `selectDay` only resets this to `nil`. The two used to be
+    /// the same moment, and that was itself a bug fixed on this branch
+    /// (`resolvePendingScroll`'s `!visibleDays.isEmpty` guard, for #250): a
+    /// deep link consumed while `list(days:)` is unmounted (a
+    /// favourites-only filter with nothing upcoming, showing
+    /// `noMatchesView`) has no `resolvePendingScroll` call to stamp anything
+    /// — arming at `selectDay` would burn the whole window in real time
+    /// before a single attempt could run, and the eventual first attempt,
+    /// after the reader clears the filter, would find the deadline already
+    /// passed and give up immediately.
+    ///
+    /// `nil` here means "no attempt has happened yet for the armed target",
+    /// which is also the meaning while nothing is pending at all —
+    /// `clearPendingScroll` resets both together. It is never read as "give
+    /// up" by `PendingDayScroll.hasLanded`: `resolvePendingScroll` always
+    /// stamps a concrete deadline before that call, so `hasLanded`'s own
+    /// `nil` branch (its pre-existing "do not retry" default) is dead in
+    /// this path and stays only as the conservative fallback if that ever
+    /// stops being true.
     ///
     /// A deadline rather than an attempt counter for the same reason
     /// `pendingScrollDeadline` is one: `list(days:)` wires several
@@ -459,7 +491,13 @@ struct EventListView: View {
             key: PendingDayScroll.key(for: model.filter, year: model.selectedYear))
         pendingScroll = target
         pinnedSelection = target
-        scrollRetryDeadline = Date().addingTimeInterval(Self.scrollRetryWindow)
+        // Reset, not stamped: a fresh arm must not inherit whatever deadline
+        // (spent or otherwise) belonged to a previous target, and stamping
+        // one here would measure the retry window from a moment
+        // `resolvePendingScroll` may not get to run at for a while — see
+        // `scrollRetryDeadline`'s doc. It gets its real value lazily, on the
+        // first actual resolution attempt.
+        scrollRetryDeadline = nil
         #if DEBUG
         // `model.uiTestPendingScrollDelay` is still consumed once, here —
         // reset to `0` so only this one arm is delayed, not every tap after
@@ -541,6 +579,27 @@ struct EventListView: View {
     private func resolvePendingScroll(_ proxy: ScrollViewProxy, days: [DayGroup]) {
         guard let pending = pendingScroll else { return }
 
+        // The retry window starts here, on the first real attempt at this
+        // target — not back when `selectDay` armed it. `selectDay` only
+        // resets `scrollRetryDeadline` to `nil`; a `nil` reaching this point
+        // means no attempt has happened yet for `pending`; see
+        // `scrollRetryDeadline`'s doc for why arm time was the wrong moment.
+        // Every call to `resolvePendingScroll` after this one for the same
+        // target finds a non-nil deadline and leaves it alone.
+        //
+        // Kept in a local as well as in `@State` because the `hasLanded`
+        // call at the bottom of this function has to read *this* attempt's
+        // deadline with certainty. `hasLanded` reads `nil` as "done, do not
+        // retry"; if the write below were not yet visible to a read later in
+        // the same function, the very first attempt would abandon its own
+        // target — precisely the failure this stamping order exists to fix.
+        // A local removes the question rather than resolving it, and
+        // `PendingDayScroll.retryDeadline`'s non-optional return means the
+        // value handed to `hasLanded` cannot be `nil` by construction.
+        let retryDeadline = PendingDayScroll.retryDeadline(
+            existing: scrollRetryDeadline, now: Date(), window: Self.scrollRetryWindow)
+        scrollRetryDeadline = retryDeadline
+
         let currentKey = PendingDayScroll.key(for: model.filter, year: model.selectedYear)
         if PendingDayScroll.isStale(pending, currentKey: currentKey) {
             clearPendingScroll()
@@ -592,7 +651,7 @@ struct EventListView: View {
         if PendingDayScroll.hasLanded(
             day: pending.day,
             visibleDays: visibleDays,
-            retryDeadline: scrollRetryDeadline,
+            retryDeadline: retryDeadline,
             now: Date()) {
             clearPendingScroll()
         } else {

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -609,8 +609,20 @@ struct EventListView: View {
 
     /// Ask `list(days:)` to run `landPendingScroll` again shortly, with the
     /// `days` of whatever render is current by then — see `scrollRetryTick`.
+    ///
+    /// Guarded by the same `pendingScroll != nil` check `landPendingScroll`
+    /// itself opens with: by the time this closure runs, the target that
+    /// justified the retry may already be gone — landed via an earlier
+    /// retry, abandoned as stale, or cleared by a fresh tap elsewhere — and
+    /// bumping the tick for nothing still forces a view update that
+    /// re-enters `landPendingScroll` only to no-op. A tap that lands a new
+    /// `pendingScroll` before this fires is still honored: the guard reads
+    /// "something is pending", not "the same thing is still pending", so an
+    /// in-flight retry for a still-armed (even if different) target keeps
+    /// working exactly as before.
     private func scheduleScrollRetry() {
         DispatchQueue.main.asyncAfter(deadline: .now() + Self.scrollRetryInterval) { [self] in
+            guard pendingScroll != nil else { return }
             scrollRetryTick &+= 1
         }
     }

--- a/ios/ChqCalendar/Features/Calendar/PendingDayScroll.swift
+++ b/ios/ChqCalendar/Features/Calendar/PendingDayScroll.swift
@@ -64,4 +64,32 @@ nonisolated enum PendingDayScroll {
     static func isStale(_ target: Target, currentKey: Key) -> Bool {
         target.key != currentKey
     }
+
+    /// Whether a `scrollTo` that has *just been issued* for `day` may be
+    /// treated as done, or has to be issued again.
+    ///
+    /// Issuing a scroll is not the same as landing one. `ScrollViewProxy`
+    /// resolves an id against the scroll view's already-resolved content, and
+    /// the caller's `days` is whatever array its enclosing render captured —
+    /// on a cold launch consuming a `chqcal://day/…` link, neither is
+    /// reliably the current truth at the instant the link is consumed. Rather
+    /// than reason about which, `EventListView.resolvePendingScroll` confirms
+    /// the outcome: `visibleDays` — the set it already maintains from section
+    /// header `onAppear`/`onDisappear` — containing the target is direct
+    /// evidence the day is on screen. Until it does, the scroll is still owed
+    /// and gets re-issued against the next render's `days`.
+    ///
+    /// `retryDeadline` bounds that. A target that can never become visible —
+    /// an empty day with no section, or a list that unmounts — stops being
+    /// re-issued rather than retrying forever, which is the hazard the
+    /// staleness check above exists to prevent in the first place. `nil` (no
+    /// deadline stamped) means "do not retry", the behavior before this
+    /// existed.
+    static func hasLanded(
+        day: String, visibleDays: Set<String>, retryDeadline: Date?, now: Date
+    ) -> Bool {
+        if visibleDays.contains(day) { return true }
+        guard let retryDeadline else { return true }
+        return now >= retryDeadline
+    }
 }

--- a/ios/ChqCalendar/Features/Calendar/PendingDayScroll.swift
+++ b/ios/ChqCalendar/Features/Calendar/PendingDayScroll.swift
@@ -85,11 +85,37 @@ nonisolated enum PendingDayScroll {
     /// staleness check above exists to prevent in the first place. `nil` (no
     /// deadline stamped) means "do not retry", the behavior before this
     /// existed.
+    ///
+    /// `EventListView.resolvePendingScroll` — the only caller — takes its
+    /// deadline from `retryDeadline(existing:now:window:)` below, whose
+    /// return type is non-optional, so in practice this function never sees
+    /// `nil` while a target is genuinely still being retried. The `nil`
+    /// branch is a conservative fallback for a caller that has not stamped
+    /// yet, not a state the live path visits.
     static func hasLanded(
         day: String, visibleDays: Set<String>, retryDeadline: Date?, now: Date
     ) -> Bool {
         if visibleDays.contains(day) { return true }
         guard let retryDeadline else { return true }
         return now >= retryDeadline
+    }
+
+    /// The retry deadline governing an attempt happening at `now`: whatever
+    /// was already stamped for this target, or a fresh `window` if this is
+    /// its first attempt.
+    ///
+    /// **Non-optional by return type, on purpose.** `hasLanded` above reads a
+    /// `nil` deadline as "done, do not retry", so a target arriving at its
+    /// first attempt with nothing stamped would be abandoned before a single
+    /// `scrollTo` could land. Routing every attempt through here makes "an
+    /// attempt always has a deadline" a property of the type rather than of
+    /// the caller remembering to stamp in the right order.
+    ///
+    /// **`existing` wins, on purpose.** The window is measured from the first
+    /// attempt and then stops moving. Re-stamping on every attempt would push
+    /// the deadline out by one interval each time and the target would retry
+    /// forever — the unbounded wait the deadline exists to prevent.
+    static func retryDeadline(existing: Date?, now: Date, window: TimeInterval) -> Date {
+        existing ?? now.addingTimeInterval(window)
     }
 }

--- a/ios/ChqCalendar/Features/Root/RootTabView.swift
+++ b/ios/ChqCalendar/Features/Root/RootTabView.swift
@@ -26,7 +26,8 @@ nonisolated struct DeepLinkTabRoute: Equatable, Sendable {
     let tab: AppTab
 
     /// Whether selecting `tab` fully consumes the link (clears
-    /// `pendingDeepLink`). `false` only for `.event` — see above.
+    /// `pendingDeepLink`). `false` for `.event` and `.day` — both need the
+    /// Events tab's own content before the navigation is complete.
     let consumesLink: Bool
 
     /// For a consumed `.map` link, the venue focus to hand `AppModel`

--- a/ios/ChqCalendar/Features/Root/RootTabView.swift
+++ b/ios/ChqCalendar/Features/Root/RootTabView.swift
@@ -43,6 +43,8 @@ nonisolated struct DeepLinkTabRoute: Equatable, Sendable {
             return DeepLinkTabRoute(tab: .myDay, consumesLink: true, mapFocusVenue: nil)
         case .map(let venue):
             return DeepLinkTabRoute(tab: .map, consumesLink: true, mapFocusVenue: venue)
+        case .day:
+            return DeepLinkTabRoute(tab: .events, consumesLink: false, mapFocusVenue: nil)
         }
     }
 }

--- a/ios/ChqCalendar/Features/Root/RootTabView.swift
+++ b/ios/ChqCalendar/Features/Root/RootTabView.swift
@@ -14,9 +14,12 @@ nonisolated enum AppTab: Hashable, Sendable {
 /// split out of `RootTabView` so it's testable without a SwiftUI scene.
 ///
 /// Two-phase consumption contract (see `AppModel.pendingDeepLink`):
-/// - `.event` is **not** consumed by the tab switch — `CalendarView` owns
-///   resolving it against the snapshot, which may not have loaded yet, so
-///   the link must stay pending after `RootTabView` selects the Events tab.
+/// - `.event` and `.day` are **not** consumed by the tab switch — the Events
+///   tab's own views own resolving them against the snapshot, which may not
+///   have loaded yet, so the link must stay pending after `RootTabView`
+///   selects that tab. `CalendarView` resolves `.event` (an id has to be
+///   looked up); `EventListView` resolves `.day` through the same `selectDay`
+///   a rail chip tap calls.
 /// - `.myDay` and `.map` **are** consumed by the tab switch itself: the tab
 ///   selection is the whole navigation. A `.map` link's optional venue
 ///   outlives the link as `AppModel.mapFocusVenue`, which `GroundsMapView`
@@ -141,7 +144,8 @@ struct RootTabView: View {
     /// Applies `DeepLinkTabRoute` to whatever is pending: switches tabs for
     /// every link kind, consumes `.myDay`/`.map` (handing a `.map` venue off
     /// to `model.mapFocusVenue` for task 18's `GroundsMapView`), and leaves
-    /// `.event` pending for `CalendarView`'s snapshot-aware resolution.
+    /// `.event` and `.day` pending for the Events tab's own snapshot-aware
+    /// resolution (`CalendarView` and `EventListView` respectively).
     private func routePendingLinkIfNeeded() {
         guard let link = model.pendingDeepLink else { return }
         let route = DeepLinkTabRoute.resolve(link)

--- a/ios/ChqCalendar/Intents/ChqShortcuts.swift
+++ b/ios/ChqCalendar/Intents/ChqShortcuts.swift
@@ -79,6 +79,12 @@ nonisolated struct ChqShortcuts: AppShortcutsProvider {
             shortTitle: "Open Event",
             systemImageName: "arrow.up.right.circle"
         )
+        // The first phrase in each array below is the one SiriTipView and
+        // the Shortcuts gallery display verbatim (phraseTemplates[0]) —
+        // `\(.applicationName)` resolves there, but a parameter slot like
+        // `\(\.$week)` does not, so it must lead with a plain phrase. The
+        // parameterized variants stay in the list (just not first) because
+        // they're what makes the slots fillable by voice.
         AppShortcut(
             intent: OpenDayIntent(),
             phrases: [
@@ -94,12 +100,6 @@ nonisolated struct ChqShortcuts: AppShortcutsProvider {
             shortTitle: "Show a Day",
             systemImageName: "calendar.day.timeline.left"
         )
-        // The first phrase in each array below is the one SiriTipView and
-        // the Shortcuts gallery display verbatim (phraseTemplates[0]) —
-        // `\(.applicationName)` resolves there, but a parameter slot like
-        // `\(\.$week)` does not, so it must lead with a plain phrase. The
-        // parameterized variants stay in the list (just not first) because
-        // they're what makes the slots fillable by voice.
         AppShortcut(
             intent: WeekThemeIntent(),
             phrases: [

--- a/ios/ChqCalendar/Intents/ChqShortcuts.swift
+++ b/ios/ChqCalendar/Intents/ChqShortcuts.swift
@@ -1,10 +1,10 @@
 import AppIntents
 
 /// Registers the app's #193 Siri/Shortcuts surface — this is what makes
-/// the seven shortcuts (listed in the Shortcuts app gallery under CHQ
+/// the eight shortcuts (listed in the Shortcuts app gallery under CHQ
 /// Calendar by their `AppIntent.title`: "What's Next", "Today at
 /// Chautauqua", "Open Event", "Weekly Theme", "My Schedule", "Who's
-/// Speaking", "Show Time") show up without the user configuring anything,
+/// Speaking", "Show Time", "Show a Day") show up without the user configuring anything,
 /// and lets Siri run them by voice. "What's Next" alone carries 27
 /// phrases across four families — plain, kind-parameterized,
 /// timeframe-parameterized, and venue-parameterized — so a user can ask
@@ -78,6 +78,21 @@ nonisolated struct ChqShortcuts: AppShortcutsProvider {
             ],
             shortTitle: "Open Event",
             systemImageName: "arrow.up.right.circle"
+        )
+        AppShortcut(
+            intent: OpenDayIntent(),
+            phrases: [
+                "Show me a day in \(.applicationName)",
+                "Show me a day at \(.applicationName)",
+                "Show me \(\.$timeframe) in \(.applicationName)",
+                "Show me \(\.$timeframe) at \(.applicationName)",
+                "Open \(\.$timeframe) in \(.applicationName)",
+                "Open \(\.$timeframe) at \(.applicationName)",
+                "Take me to \(\.$timeframe) in \(.applicationName)",
+                "Take me to \(\.$timeframe) at \(.applicationName)"
+            ],
+            shortTitle: "Show a Day",
+            systemImageName: "calendar.day.timeline.left"
         )
         // The first phrase in each array below is the one SiriTipView and
         // the Shortcuts gallery display verbatim (phraseTemplates[0]) —

--- a/ios/ChqCalendar/Intents/EventIntents.swift
+++ b/ios/ChqCalendar/Intents/EventIntents.swift
@@ -37,6 +37,14 @@ nonisolated enum PendingIntentLink {
         guard let url = URL(string: raw) else { return nil }
         return DeepLink.parse(url)
     }
+
+    /// Removes whatever is stored under `defaultsKey` without parsing it —
+    /// for callers (like a refused `OpenDayIntent`) that need to guarantee
+    /// nothing is left pending but have no link of their own to hand back.
+    /// Harmless when nothing is pending.
+    static func clear(from defaults: UserDefaults) {
+        defaults.removeObject(forKey: defaultsKey)
+    }
 }
 
 /// "Open Event" — the Shortcuts/Siri equivalent of tapping a
@@ -95,8 +103,10 @@ struct OpenDayIntent: AppIntent {
     }
 
     /// The half of `perform()` that has an effect: writes the day link for a
-    /// `.navigate` target, writes nothing for a `.refuse`, and returns the
-    /// line to speak either way.
+    /// `.navigate` target, clears any pending link for a `.refuse` (so a
+    /// stale link from an earlier, not-yet-consumed run can't outlive the
+    /// refusal that just told the user it wouldn't navigate), and returns
+    /// the line to speak either way.
     ///
     /// Split out for the same reason `OpenDayTarget` is: what remains in
     /// `perform()` needs the AppIntents runtime *and* a populated shared
@@ -108,6 +118,13 @@ struct OpenDayIntent: AppIntent {
     ) -> String {
         switch target {
         case .refuse(let dialog):
+            // A previous run may have written a pending link that hasn't
+            // been consumed yet — the app already foreground-active is the
+            // documented case where consumption is delayed. Without this,
+            // a refused run leaves that stale link in place and the next
+            // `.active` transition navigates anyway, contradicting the
+            // dialog the user just heard.
+            PendingIntentLink.clear(from: defaults)
             return dialog
         case .navigate(let dayKey):
             PendingIntentLink.write(.day(key: dayKey), to: defaults)

--- a/ios/ChqCalendar/Intents/EventIntents.swift
+++ b/ios/ChqCalendar/Intents/EventIntents.swift
@@ -80,14 +80,15 @@ struct OpenDayIntent: AppIntent {
         let now = Date()
         let events = await IntentDataSource.events(now: now)
         let year = await IntentDataSource.defaultYear()
+        let resolvedTimeframe = timeframe ?? .today
 
         switch OpenDayTarget.resolve(
-            timeframe: timeframe, now: now, year: year, events: events) {
+            timeframe: resolvedTimeframe, now: now, year: year, events: events) {
         case .refuse(let dialog):
             return .result(dialog: "\(dialog)")
         case .navigate(let dayKey):
             PendingIntentLink.write(.day(key: dayKey), to: AppGroup.userDefaults())
-            return .result(dialog: "\((timeframe ?? .today).spokenLabel.capitalized).")
+            return .result(dialog: "Opening \(resolvedTimeframe.spokenLabel).")
         }
     }
 }

--- a/ios/ChqCalendar/Intents/EventIntents.swift
+++ b/ios/ChqCalendar/Intents/EventIntents.swift
@@ -57,6 +57,41 @@ struct OpenEventIntent: AppIntent {
     }
 }
 
+/// "Show a Day" — the Siri/Shortcuts equivalent of tapping a day chip on the
+/// rail. Closes the inconsistency #226 recorded: `IntentTimeframe` has shipped
+/// `tomorrow` and `nextWeek` as spoken targets since #193, so a user could
+/// *ask* Siri for tomorrow but, until phase 3b's rail, could not *tap* their
+/// way there. Routing this through the same `chqcal://day/<key>` link the rail
+/// resolves means voice and touch land in identical state.
+///
+/// `openAppWhenRun` brings the app forward; `perform()` hands the day off via
+/// `PendingIntentLink` rather than touching `AppModel` (see that type's doc
+/// comment — an intent can run with the app not launched at all).
+///
+/// Every decision lives in `OpenDayTarget`; this is the delivery shell.
+struct OpenDayIntent: AppIntent {
+    static let title: LocalizedStringResource = "Show a Day"
+    static let openAppWhenRun = true
+
+    @Parameter(title: "When")
+    var timeframe: IntentTimeframe?
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let now = Date()
+        let events = await IntentDataSource.events(now: now)
+        let year = await IntentDataSource.defaultYear()
+
+        switch OpenDayTarget.resolve(
+            timeframe: timeframe, now: now, year: year, events: events) {
+        case .refuse(let dialog):
+            return .result(dialog: "\(dialog)")
+        case .navigate(let dayKey):
+            PendingIntentLink.write(.day(key: dayKey), to: AppGroup.userDefaults())
+            return .result(dialog: "\((timeframe ?? .today).spokenLabel.capitalized).")
+        }
+    }
+}
+
 /// "What's Next" — the #193 workhorse: upcoming events optionally
 /// narrowed by kind of event, timeframe, or venue (each narrowable by
 /// voice through its own phrase family — one parameter per phrase is a

--- a/ios/ChqCalendar/Intents/EventIntents.swift
+++ b/ios/ChqCalendar/Intents/EventIntents.swift
@@ -76,19 +76,42 @@ struct OpenDayIntent: AppIntent {
     @Parameter(title: "When")
     var timeframe: IntentTimeframe?
 
+    /// An unspoken "show me a day" means today. Resolved once, here, so the
+    /// day navigated to and the day the dialog names cannot disagree —
+    /// `OpenDayTarget.resolve` takes the already-resolved value (see its own
+    /// doc comment for why it holds no second copy of this default).
+    var resolvedTimeframe: IntentTimeframe { timeframe ?? .today }
+
     func perform() async throws -> some IntentResult & ProvidesDialog {
         let now = Date()
         let events = await IntentDataSource.events(now: now)
         let year = await IntentDataSource.defaultYear()
-        let resolvedTimeframe = timeframe ?? .today
+        let timeframe = resolvedTimeframe
 
-        switch OpenDayTarget.resolve(
-            timeframe: resolvedTimeframe, now: now, year: year, events: events) {
+        let target = OpenDayTarget.resolve(
+            timeframe: timeframe, now: now, year: year, events: events)
+        return .result(
+            dialog: "\(Self.deliver(target, timeframe: timeframe, to: AppGroup.userDefaults()))")
+    }
+
+    /// The half of `perform()` that has an effect: writes the day link for a
+    /// `.navigate` target, writes nothing for a `.refuse`, and returns the
+    /// line to speak either way.
+    ///
+    /// Split out for the same reason `OpenDayTarget` is: what remains in
+    /// `perform()` needs the AppIntents runtime *and* a populated shared
+    /// on-disk cache to reach either branch, so the one step the whole
+    /// feature hangs on — a navigable day actually reaching
+    /// `PendingIntentLink` — would otherwise have no coverage at all.
+    static func deliver(
+        _ target: OpenDayTarget, timeframe: IntentTimeframe, to defaults: UserDefaults
+    ) -> String {
+        switch target {
         case .refuse(let dialog):
-            return .result(dialog: "\(dialog)")
+            return dialog
         case .navigate(let dayKey):
-            PendingIntentLink.write(.day(key: dayKey), to: AppGroup.userDefaults())
-            return .result(dialog: "Opening \(resolvedTimeframe.spokenLabel).")
+            PendingIntentLink.write(.day(key: dayKey), to: defaults)
+            return "Opening \(timeframe.spokenLabel)."
         }
     }
 }

--- a/ios/ChqCalendarShared/Domain/DeepLink.swift
+++ b/ios/ChqCalendarShared/Domain/DeepLink.swift
@@ -13,10 +13,14 @@ import Foundation
 /// - `chqcal://my-day` — the (not-yet-built, task 16) My Day tab.
 /// - `chqcal://map` / `chqcal://map/<venue>` — the (not-yet-built) map tab,
 ///   optionally centered on a venue.
+/// - `chqcal://day/<yyyy-MM-dd>` — open the Events tab on that day, growing
+///   the window if the day lies past an edge. The key must be canonical
+///   (`ChqTime.isCanonicalDayKey`); see `dayWithANonCanonicalKeyIsRejected`.
 nonisolated enum DeepLink: Equatable, Sendable {
     case event(id: String)
     case myDay
     case map(venue: String?)
+    case day(key: String)
 
     private static let scheme = "chqcal"
 
@@ -46,6 +50,9 @@ nonisolated enum DeepLink: Equatable, Sendable {
             return .myDay
         case "map":
             return .map(venue: pathComponents.first)
+        case "day":
+            guard let key = pathComponents.first, ChqTime.isCanonicalDayKey(key) else { return nil }
+            return .day(key: key)
         default:
             return nil
         }
@@ -70,6 +77,9 @@ nonisolated enum DeepLink: Equatable, Sendable {
             if let venue {
                 components.path = "/\(venue)"
             }
+        case .day(let key):
+            components.host = "day"
+            components.path = "/\(key)"
         }
 
         // Every case above builds `components` from an ASCII scheme/host and

--- a/ios/ChqCalendarShared/Domain/DeepLink.swift
+++ b/ios/ChqCalendarShared/Domain/DeepLink.swift
@@ -14,10 +14,9 @@ import Foundation
 /// - `chqcal://map` / `chqcal://map/<venue>` — the (not-yet-built) map tab,
 ///   optionally centered on a venue.
 /// - `chqcal://day/<yyyy-MM-dd>` — open the Events tab on that day, growing
-///   the window if the day lies past an edge. The key must be canonical
-///   (`ChqTime.isCanonicalDayKey`); see `dayWithANonCanonicalKeyIsRejected`.
-///   Routes to the Events tab; the scroll-to-day itself is (not-yet-built)
-///   pending list-side wiring.
+///   the window if the day lies past an edge and scrolling the list to it.
+///   The key must be canonical (`ChqTime.isCanonicalDayKey`); see
+///   `dayWithANonCanonicalKeyIsRejected`.
 nonisolated enum DeepLink: Equatable, Sendable {
     case event(id: String)
     case myDay

--- a/ios/ChqCalendarShared/Domain/DeepLink.swift
+++ b/ios/ChqCalendarShared/Domain/DeepLink.swift
@@ -16,6 +16,8 @@ import Foundation
 /// - `chqcal://day/<yyyy-MM-dd>` — open the Events tab on that day, growing
 ///   the window if the day lies past an edge. The key must be canonical
 ///   (`ChqTime.isCanonicalDayKey`); see `dayWithANonCanonicalKeyIsRejected`.
+///   Routes to the Events tab; the scroll-to-day itself is (not-yet-built)
+///   pending list-side wiring.
 nonisolated enum DeepLink: Equatable, Sendable {
     case event(id: String)
     case myDay

--- a/ios/ChqCalendarShared/Domain/IntentDialogText.swift
+++ b/ios/ChqCalendarShared/Domain/IntentDialogText.swift
@@ -57,6 +57,14 @@ nonisolated enum IntentDialogText {
 
     static func noTheme() -> String { "No theme is listed for that week." }
 
+    /// Spoken when a requested day exists on the calendar but lies outside
+    /// everything navigation can reach — e.g. "show me tomorrow" asked on the
+    /// season's last day. Distinct from `offSeason`, which explains that the
+    /// *season* is not running; this explains that the *day* is not in it.
+    static func unreachableDay(year: Int) -> String {
+        "That day is outside the \(year) season."
+    }
+
     static func offSeason(_ status: SeasonStatus, year: Int) -> String? {
         switch status {
         case .inSeason: return nil

--- a/ios/ChqCalendarShared/Domain/IntentTimeframe.swift
+++ b/ios/ChqCalendarShared/Domain/IntentTimeframe.swift
@@ -77,6 +77,22 @@ nonisolated enum IntentTimeframe: String, CaseIterable, Sendable {
             return DateInterval(start: w.start, end: w.end)
         }
     }
+
+    /// The single NY day this timeframe should open the Events tab on — the
+    /// first day of `interval`, in `ChqTime.dayKey` form.
+    ///
+    /// A timeframe names a *window*; navigation needs a *day*. Taking the
+    /// window's first day is what makes "what's happening this week" and
+    /// "show me this week" agree about where the reader lands, and the day
+    /// rail carries them onward from there.
+    ///
+    /// Always returns a canonical key, including for the degenerate windows
+    /// `interval` produces off-season and for week 9's "next week" — whether
+    /// that day is *reachable* is `ViewWindow.navigableBounds`' question, and
+    /// `OpenDayIntent` asks it.
+    func targetDayKey(now: Date, year: Int) -> String {
+        ChqTime.dayKey(for: interval(now: now, year: year).start)
+    }
 }
 
 /// Where `now` falls relative to `year`'s season — drives the off-season

--- a/ios/ChqCalendarShared/Domain/OpenDayTarget.swift
+++ b/ios/ChqCalendarShared/Domain/OpenDayTarget.swift
@@ -21,12 +21,18 @@ nonisolated enum OpenDayTarget: Equatable, Sendable {
     case navigate(dayKey: String)
     case refuse(dialog: String)
 
+    /// `timeframe` is non-optional on purpose. `OpenDayIntent`'s parameter is
+    /// optional (an unspoken "show me a day" is legal), but the intent
+    /// resolves that `nil` to `.today` once, up front, and speaks the same
+    /// resolved value back in its dialog — so a `?? .today` here would be a
+    /// second, unreachable copy of the same default, free to drift from the
+    /// one the user is actually told about.
     static func resolve(
-        timeframe: IntentTimeframe?, now: Date, year: Int, events: [Event]
+        timeframe: IntentTimeframe, now: Date, year: Int, events: [Event]
     ) -> OpenDayTarget {
         guard !events.isEmpty else { return .refuse(dialog: IntentDialogText.coldCache()) }
 
-        let key = (timeframe ?? .today).targetDayKey(now: now, year: year)
+        let key = timeframe.targetDayKey(now: now, year: year)
         let bounds = ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
         guard bounds.contains(key) else {
             let status = SeasonStatus.make(now: now, year: year)

--- a/ios/ChqCalendarShared/Domain/OpenDayTarget.swift
+++ b/ios/ChqCalendarShared/Domain/OpenDayTarget.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// `OpenDayIntent`'s decision, separated from the AppIntents runtime that
+/// delivers it — the same split `IntentDataSource.selectMatching` uses, and for
+/// the same reason: the rule is what can be wrong, and a rule in a `perform()`
+/// body can only be tested by booting Shortcuts.
+///
+/// The reachability check lives here rather than in the app because an intent
+/// that cannot navigate should *say so*. `AppModel.goToDay` already refuses an
+/// out-of-bounds day, but it refuses silently — the user would watch the app
+/// open and do nothing. Both sides ask
+/// `ViewWindow.navigableBounds(year:events:starredDays: [])`, so the two
+/// answers cannot drift.
+nonisolated enum OpenDayTarget: Equatable, Sendable {
+    case navigate(dayKey: String)
+    case refuse(dialog: String)
+
+    static func resolve(
+        timeframe: IntentTimeframe?, now: Date, year: Int, events: [Event]
+    ) -> OpenDayTarget {
+        guard !events.isEmpty else { return .refuse(dialog: IntentDialogText.coldCache()) }
+
+        let key = (timeframe ?? .today).targetDayKey(now: now, year: year)
+        let bounds = ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
+        guard bounds.contains(key) else {
+            let status = SeasonStatus.make(now: now, year: year)
+            return .refuse(
+                dialog: IntentDialogText.offSeason(status, year: year)
+                    ?? IntentDialogText.unreachableDay(year: year))
+        }
+        return .navigate(dayKey: key)
+    }
+}

--- a/ios/ChqCalendarShared/Domain/OpenDayTarget.swift
+++ b/ios/ChqCalendarShared/Domain/OpenDayTarget.swift
@@ -10,7 +10,13 @@ import Foundation
 /// out-of-bounds day, but it refuses silently — the user would watch the app
 /// open and do nothing. Both sides ask
 /// `ViewWindow.navigableBounds(year:events:starredDays: [])`, so the two
-/// answers cannot drift.
+/// agree *within a year* — but only within one: this intent resolves `year`
+/// from `IntentDataSource.defaultYear()`, while `AppModel.goToDay` bounds
+/// against `AppModel.selectedYear`. A reader parked on an archived year who
+/// asks Siri for "tomorrow" gets a dialog resolved against the current
+/// season, not the year on screen — a known gap, not a guarantee this type
+/// closes. Fixing that is a design change (year-switching) outside this
+/// intent's scope.
 nonisolated enum OpenDayTarget: Equatable, Sendable {
     case navigate(dayKey: String)
     case refuse(dialog: String)

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1512,6 +1512,47 @@ struct AppModelTests {
         #expect(model.filter.windowStartDayKey == nil)
     }
 
+    // MARK: - Pending day deep link
+
+    @Test func pendingDayLinkResolvesOnceASnapshotExists() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.pendingDeepLink = .day(key: "2026-08-06")
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == "2026-08-06")
+        #expect(model.pendingDeepLink == nil)
+    }
+
+    /// Idempotent: a second call must not re-deliver a link already acted on,
+    /// or every `.onChange` trigger in `EventListView` would re-scroll a reader
+    /// who has since moved.
+    @Test func pendingDayLinkIsDeliveredExactlyOnce() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.pendingDeepLink = .day(key: "2026-08-06")
+
+        _ = model.resolvePendingDayDeepLinkIfPossible()
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == nil)
+    }
+
+    /// Before the snapshot lands there are no day sections to scroll to, so
+    /// holding the link is what makes a cold launch work.
+    @Test func pendingDayLinkIsHeldUntilTheSnapshotArrives() throws {
+        let model = try makeInSeasonModel(defaults: makeDefaults())
+        model.snapshot = nil
+        model.pendingDeepLink = .day(key: "2026-08-06")
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == nil)
+        #expect(model.pendingDeepLink == .day(key: "2026-08-06"))
+    }
+
+    @Test func pendingEventLinkIsNotResolvedAsADay() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.pendingDeepLink = .event(id: "seed0")
+
+        #expect(model.resolvePendingDayDeepLinkIfPossible() == nil)
+        #expect(model.pendingDeepLink == .event(id: "seed0"))
+    }
+
     // MARK: - ⟳ Now
     //
     // There is no `AppModel.resetToNow()` any more (finding 2 of the phase

--- a/ios/ChqCalendarTests/ChqShortcutsTests.swift
+++ b/ios/ChqCalendarTests/ChqShortcutsTests.swift
@@ -124,7 +124,7 @@ struct ChqShortcutsTests {
         #expect(
             Set(checkedIntents) == [
                 "NextEventsIntent", "TodayEventsIntent", "OpenEventIntent",
-                "WeekThemeIntent", "MyScheduleIntent", "WhoIsSpeakingIntent",
+                "OpenDayIntent", "WeekThemeIntent", "MyScheduleIntent", "WhoIsSpeakingIntent",
                 "ShowTimeIntent",
             ],
             "Unexpected set of intents found in ChqShortcuts.swift: \(checkedIntents)"

--- a/ios/ChqCalendarTests/DeepLinkTabRouteTests.swift
+++ b/ios/ChqCalendarTests/DeepLinkTabRouteTests.swift
@@ -51,4 +51,15 @@ struct DeepLinkTabRouteTests {
         #expect(route.tab == .map)
         #expect(route.mapFocusVenue == "Sports Club, Waterfront")
     }
+
+    /// `.day` behaves like `.event`, not like `.myDay`: selecting the Events
+    /// tab is not the navigation, so the link must survive the tab switch for
+    /// `EventListView` to consume once a snapshot exists.
+    @Test func dayLinkRoutesToEventsWithoutConsumingTheLink() {
+        let route = DeepLinkTabRoute.resolve(.day(key: "2026-07-29"))
+
+        #expect(route.tab == .events)
+        #expect(route.consumesLink == false)
+        #expect(route.mapFocusVenue == nil)
+    }
 }

--- a/ios/ChqCalendarTests/DeepLinkTests.swift
+++ b/ios/ChqCalendarTests/DeepLinkTests.swift
@@ -30,6 +30,31 @@ struct DeepLinkTests {
         #expect(DeepLink.parse(link.url) == link)
     }
 
+    @Test func dayRoundTrips() {
+        let link = DeepLink.day(key: "2026-07-29")
+        #expect(DeepLink.parse(link.url) == link)
+    }
+
+    @Test func dayURLHasExpectedShape() {
+        #expect(DeepLink.day(key: "2026-07-29").url.absoluteString == "chqcal://day/2026-07-29")
+    }
+
+    /// `ChqTime.parse` is more permissive than its format string suggests —
+    /// `"2026-7-9"` reads as July 9th and `"26-07-09"` reads as year 26 — and
+    /// neither is a key `EventFilter`'s raw string comparisons will ever
+    /// match. A link carrying one must be rejected at the door rather than
+    /// silently resolving to a day the list cannot show.
+    @Test func dayWithANonCanonicalKeyIsRejected() {
+        #expect(DeepLink.parse(URL(string: "chqcal://day/2026-7-9")!) == nil)
+        #expect(DeepLink.parse(URL(string: "chqcal://day/26-07-09")!) == nil)
+        #expect(DeepLink.parse(URL(string: "chqcal://day/tomorrow")!) == nil)
+    }
+
+    @Test func dayWithNoKeyIsRejected() {
+        #expect(DeepLink.parse(URL(string: "chqcal://day")!) == nil)
+        #expect(DeepLink.parse(URL(string: "chqcal://day/")!) == nil)
+    }
+
     // MARK: - URL shape
 
     @Test func eventURLHasExpectedShape() {

--- a/ios/ChqCalendarTests/IntentSelectionTests.swift
+++ b/ios/ChqCalendarTests/IntentSelectionTests.swift
@@ -224,12 +224,19 @@ struct IntentSelectionTests {
         #expect(dialog == "Opening tomorrow.")
     }
 
-    /// A refusal must leave *nothing* pending. `openAppWhenRun` brings the
-    /// app forward either way, so a link written on a refused run would
-    /// navigate on a launch whose own dialog just said it could not — the
-    /// silent teleport the refusal exists to prevent.
-    @Test func deliveringARefusalWritesNothingAndSpeaksItsDialog() {
+    /// A refusal must leave *nothing* pending, even when a previous run
+    /// already wrote a link that hasn't been consumed yet — the app already
+    /// foreground-active is the documented case where consumption is
+    /// delayed. `openAppWhenRun` brings the app forward either way, so a
+    /// stale link left in place on a refused run would navigate on the next
+    /// `.active` transition, contradicting the dialog the user just heard.
+    /// Seeding via a prior `.navigate` delivery (rather than writing the key
+    /// directly) proves the refusal *clears* an existing pending link, not
+    /// merely that it declines to write a new one.
+    @Test func deliveringARefusalClearsAPriorPendingLinkAndSpeaksItsDialog() {
         let defaults = makeDefaults()
+        _ = OpenDayIntent.deliver(
+            .navigate(dayKey: "2026-07-28"), timeframe: .tomorrow, to: defaults)
 
         let dialog = OpenDayIntent.deliver(
             .refuse(dialog: IntentDialogText.coldCache()), timeframe: .today, to: defaults)

--- a/ios/ChqCalendarTests/IntentSelectionTests.swift
+++ b/ios/ChqCalendarTests/IntentSelectionTests.swift
@@ -205,4 +205,48 @@ struct IntentSelectionTests {
         // forever), matching `DeepLink.parse`'s "ignore it" convention.
         #expect(defaults.string(forKey: PendingIntentLink.defaultsKey) == nil)
     }
+
+    // MARK: - OpenDayIntent handoff
+
+    /// The step the whole "show me a day" feature hangs on: a navigable
+    /// target writes the `.day` link the next launch consumes, and the dialog
+    /// names the timeframe the user actually spoke. `OpenDayTargetTests`
+    /// covers the decision; nothing covered the effect, which is what
+    /// `OpenDayIntent.deliver` exists to make reachable without the
+    /// AppIntents runtime.
+    @Test func deliveringANavigableDayWritesTheDayLink() {
+        let defaults = makeDefaults()
+
+        let dialog = OpenDayIntent.deliver(
+            .navigate(dayKey: "2026-07-28"), timeframe: .tomorrow, to: defaults)
+
+        #expect(PendingIntentLink.consume(from: defaults) == .day(key: "2026-07-28"))
+        #expect(dialog == "Opening tomorrow.")
+    }
+
+    /// A refusal must leave *nothing* pending. `openAppWhenRun` brings the
+    /// app forward either way, so a link written on a refused run would
+    /// navigate on a launch whose own dialog just said it could not — the
+    /// silent teleport the refusal exists to prevent.
+    @Test func deliveringARefusalWritesNothingAndSpeaksItsDialog() {
+        let defaults = makeDefaults()
+
+        let dialog = OpenDayIntent.deliver(
+            .refuse(dialog: IntentDialogText.coldCache()), timeframe: .today, to: defaults)
+
+        #expect(PendingIntentLink.consume(from: defaults) == nil)
+        #expect(dialog == IntentDialogText.coldCache())
+    }
+
+    /// "Show me a day" with no timeframe spoken is legal, and means today.
+    /// Asserted on the intent because that is the *only* place the default
+    /// lives: `OpenDayTarget.resolve` takes a non-optional timeframe
+    /// precisely so a second, drifting copy of it cannot exist.
+    @Test func anUnspokenTimeframeMeansToday() {
+        var intent = OpenDayIntent()
+        #expect(intent.resolvedTimeframe == .today)
+
+        intent.timeframe = .nextWeek
+        #expect(intent.resolvedTimeframe == .nextWeek)
+    }
 }

--- a/ios/ChqCalendarTests/IntentTimeframeTests.swift
+++ b/ios/ChqCalendarTests/IntentTimeframeTests.swift
@@ -131,10 +131,15 @@ struct IntentTimeframeTests {
     }
 
     /// Week 9's "next week" is past the season: `interval` returns a
-    /// zero-length window at the season's end. A day key still comes out — it
-    /// is `OpenDayIntent`'s bounds check, not this function, that refuses it.
-    /// Pinned so a later "return nil when empty" refactor has to argue with a
-    /// test rather than silently change where the refusal lives.
+    /// zero-length window at the season's end. A day key still comes out —
+    /// and it lands exactly on `weeks[8].end`'s day, which is the season's
+    /// last day and therefore inside `ViewWindow.navigableBounds`, so
+    /// `OpenDayIntent` navigates there rather than refusing (pinned in
+    /// `OpenDayTargetTests.weekNineNextWeekNavigatesToTheSeasonsLastDay`).
+    /// Landing on the last day is more useful than a refusal for a day that
+    /// genuinely is reachable. Pinned here so a later "return nil when
+    /// empty" refactor has to argue with a test rather than silently change
+    /// what key comes out.
     @Test func targetDayKeyForNextWeekInWeekNineStillProducesAKey() throws {
         let weeks = SeasonCalendar.weeks(forYear: 2026)
         let inWeekNine = weeks[8].start.addingTimeInterval(3600)

--- a/ios/ChqCalendarTests/IntentTimeframeTests.swift
+++ b/ios/ChqCalendarTests/IntentTimeframeTests.swift
@@ -96,4 +96,52 @@ struct IntentTimeframeTests {
         #expect(SeasonStatus.make(now: during, year: year) == .inSeason)
         #expect(SeasonStatus.make(now: after, year: year) == .postSeason)
     }
+
+    // MARK: - targetDayKey
+
+    /// The day a spoken timeframe should *land on* is the first day of the
+    /// window it means — not the whole window. "This week" opens on today, not
+    /// on Saturday: the reader asked what is happening, and the rail is right
+    /// there for the rest of the week.
+    @Test func targetDayKeyIsTheFirstDayOfTheInterval() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+
+        #expect(IntentTimeframe.today.targetDayKey(now: now, year: 2026) == "2026-07-27")
+        #expect(IntentTimeframe.tonight.targetDayKey(now: now, year: 2026) == "2026-07-27")
+        #expect(IntentTimeframe.tomorrow.targetDayKey(now: now, year: 2026) == "2026-07-28")
+        #expect(IntentTimeframe.thisWeek.targetDayKey(now: now, year: 2026) == "2026-07-27")
+    }
+
+    /// `tonight` is 5pm-anchored, so asking at 9pm must still mean today —
+    /// `interval` clamps its start to `now`, and the day key of either is the
+    /// same day. Pinned because a naive "5pm tomorrow" rewrite would pass the
+    /// morning case above and break this one.
+    @Test func targetDayKeyForTonightAskedLateIsStillToday() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 21:30:00"))
+
+        #expect(IntentTimeframe.tonight.targetDayKey(now: now, year: 2026) == "2026-07-27")
+    }
+
+    @Test func targetDayKeyForAnExplicitWeekIsThatWeeksFirstDay() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+        let week3 = SeasonCalendar.weeks(forYear: 2026)[2]
+
+        #expect(IntentTimeframe.week3.targetDayKey(now: now, year: 2026)
+                == ChqTime.dayKey(for: week3.start))
+    }
+
+    /// Week 9's "next week" is past the season: `interval` returns a
+    /// zero-length window at the season's end. A day key still comes out — it
+    /// is `OpenDayIntent`'s bounds check, not this function, that refuses it.
+    /// Pinned so a later "return nil when empty" refactor has to argue with a
+    /// test rather than silently change where the refusal lives.
+    @Test func targetDayKeyForNextWeekInWeekNineStillProducesAKey() throws {
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let inWeekNine = weeks[8].start.addingTimeInterval(3600)
+
+        let key = IntentTimeframe.nextWeek.targetDayKey(now: inWeekNine, year: 2026)
+
+        #expect(ChqTime.isCanonicalDayKey(key))
+        #expect(key == ChqTime.dayKey(for: weeks[8].end))
+    }
 }

--- a/ios/ChqCalendarTests/IntentTimeframeTests.swift
+++ b/ios/ChqCalendarTests/IntentTimeframeTests.swift
@@ -141,7 +141,6 @@ struct IntentTimeframeTests {
 
         let key = IntentTimeframe.nextWeek.targetDayKey(now: inWeekNine, year: 2026)
 
-        #expect(ChqTime.isCanonicalDayKey(key))
         #expect(key == ChqTime.dayKey(for: weeks[8].end))
     }
 }

--- a/ios/ChqCalendarTests/OpenDayTargetTests.swift
+++ b/ios/ChqCalendarTests/OpenDayTargetTests.swift
@@ -29,7 +29,13 @@ struct OpenDayTargetTests {
     /// The case the refusal exists for: asked on the season's last day,
     /// "tomorrow" names a real calendar day that navigation cannot reach.
     /// Opening the app and silently doing nothing is the behaviour this
-    /// prevents.
+    /// prevents. `now` (9am Saturday) is still before the season's actual
+    /// end instant (noon Saturday), so `SeasonStatus.make` reports
+    /// `.inSeason` and `IntentDialogText.offSeason` returns `nil` — that's
+    /// what makes this the one path in the whole suite that reaches
+    /// `IntentDialogText.unreachableDay`, so the exact string is asserted
+    /// rather than just non-emptiness: a `??` fallback to any other
+    /// non-empty string would otherwise go unnoticed.
     @Test func theDayAfterTheSeasonEndsIsRefusedWithADialog() throws {
         let bounds = ViewWindow.navigableBounds(year: 2026, events: [], starredDays: [])
         let lastDay = try #require(ChqTime.parse("\(bounds.upperBound) 09:00:00"))
@@ -38,11 +44,7 @@ struct OpenDayTargetTests {
         let target = OpenDayTarget.resolve(
             timeframe: .tomorrow, now: lastDay, year: 2026, events: events)
 
-        guard case .refuse(let dialog) = target else {
-            Issue.record("expected a refusal, got \(target)")
-            return
-        }
-        #expect(!dialog.isEmpty)
+        #expect(target == .refuse(dialog: IntentDialogText.unreachableDay(year: 2026)))
     }
 
     /// Out of season entirely, the refusal should explain *that* rather than
@@ -63,10 +65,11 @@ struct OpenDayTargetTests {
         #expect(target == .refuse(dialog: expected))
     }
 
-    /// A day the reader starred outside the season widens
-    /// `navigableBounds` — so reachability is a question about *this* user's
-    /// data, not about the calendar. Pinned because a "clamp to the season"
-    /// rewrite would pass every other test here.
+    /// A day carrying an event outside the season widens `navigableBounds`
+    /// — so reachability is a question about *this* user's data (an event
+    /// landing there; `starredDays` is passed empty), not about the
+    /// calendar. Pinned because a "clamp to the season" rewrite would pass
+    /// every other test here.
     @Test func aDayReachableOnlyBecauseAnEventLivesThereIsAccepted() throws {
         let bounds = ViewWindow.navigableBounds(year: 2026, events: [], starredDays: [])
         let dayAfter = try #require(
@@ -93,5 +96,40 @@ struct OpenDayTargetTests {
             timeframe: .today, now: now, year: 2026, events: [])
 
         #expect(target == .refuse(dialog: IntentDialogText.coldCache()))
+    }
+
+    /// `IntentDataSource.events(now:)` returns the whole unfiltered year
+    /// snapshot, so an empty list means "no snapshot has loaded yet," not
+    /// "no events today" — that's true regardless of what `now` is. Pins
+    /// cold-cache as winning over the season question even when `now` is
+    /// itself off-season: a rewrite to "empty && in-season -> coldCache,
+    /// else offSeason" would pass every other test in this file but fail
+    /// this one, since it would report the off-season dialog here instead.
+    @Test func offSeasonWithEmptyEventsIsStillAColdCacheRefusal() throws {
+        let now = try #require(ChqTime.parse("2026-02-01 09:00:00"))
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .today, now: now, year: 2026, events: [])
+
+        #expect(target == .refuse(dialog: IntentDialogText.coldCache()))
+    }
+
+    /// Week 9's "next week" resolves to a day key equal to the season's
+    /// last day (`IntentTimeframeTests
+    /// .targetDayKeyForNextWeekInWeekNineStillProducesAKey` pins the key
+    /// itself) — and that day is inside `navigableBounds`, so `OpenDayTarget`
+    /// navigates there rather than refusing. Landing on the last day is more
+    /// useful than a refusal for a day that genuinely is reachable; this
+    /// pins the half of that picture `OpenDayTarget` owns; `IntentTimeframe`
+    /// only produces the key.
+    @Test func weekNineNextWeekNavigatesToTheSeasonsLastDay() throws {
+        let weeks = SeasonCalendar.weeks(forYear: 2026)
+        let inWeekNine = weeks[8].start.addingTimeInterval(3600)
+        let events = [makeEvent(id: "a", start: weeks[8].start)]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .nextWeek, now: inWeekNine, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: ChqTime.dayKey(for: weeks[8].end)))
     }
 }

--- a/ios/ChqCalendarTests/OpenDayTargetTests.swift
+++ b/ios/ChqCalendarTests/OpenDayTargetTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+/// `OpenDayIntent`'s whole decision, minus the AppIntents runtime.
+struct OpenDayTargetTests {
+    @Test func aDayInsideTheSeasonIsNavigatedTo() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-28 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .tomorrow, now: now, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: "2026-07-28"))
+    }
+
+    /// No timeframe spoken ("show me a day") means today — the same default
+    /// every other timeframe-carrying intent uses.
+    @Test func noTimeframeMeansToday() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-27 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: nil, now: now, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: "2026-07-27"))
+    }
+
+    /// The case the refusal exists for: asked on the season's last day,
+    /// "tomorrow" names a real calendar day that navigation cannot reach.
+    /// Opening the app and silently doing nothing is the behaviour this
+    /// prevents.
+    @Test func theDayAfterTheSeasonEndsIsRefusedWithADialog() throws {
+        let bounds = ViewWindow.navigableBounds(year: 2026, events: [], starredDays: [])
+        let lastDay = try #require(ChqTime.parse("\(bounds.upperBound) 09:00:00"))
+        let events = [makeEvent(id: "a", start: lastDay)]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .tomorrow, now: lastDay, year: 2026, events: events)
+
+        guard case .refuse(let dialog) = target else {
+            Issue.record("expected a refusal, got \(target)")
+            return
+        }
+        #expect(!dialog.isEmpty)
+    }
+
+    /// Out of season entirely, the refusal should explain *that* rather than
+    /// talk about a day — `IntentDialogText.offSeason` is the established
+    /// vocabulary and must win over the generic line. A fixture event inside
+    /// the season keeps the event list non-empty so resolution reaches the
+    /// bounds check instead of short-circuiting on the cold-cache branch —
+    /// with `events: []` this hits `IntentDialogText.coldCache()` first.
+    @Test func offSeasonRefusalUsesTheOffSeasonDialog() throws {
+        let now = try #require(ChqTime.parse("2026-02-01 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-27 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .today, now: now, year: 2026, events: events)
+
+        let expected = try #require(
+            IntentDialogText.offSeason(SeasonStatus.make(now: now, year: 2026), year: 2026))
+        #expect(target == .refuse(dialog: expected))
+    }
+
+    /// A day the reader starred outside the season widens
+    /// `navigableBounds` — so reachability is a question about *this* user's
+    /// data, not about the calendar. Pinned because a "clamp to the season"
+    /// rewrite would pass every other test here.
+    @Test func aDayReachableOnlyBecauseAnEventLivesThereIsAccepted() throws {
+        let bounds = ViewWindow.navigableBounds(year: 2026, events: [], starredDays: [])
+        let dayAfter = try #require(
+            ChqTime.day(bounds.upperBound, offsetBy: 1))
+        let asked = try #require(ChqTime.parse("\(bounds.upperBound) 09:00:00"))
+        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("\(dayAfter) 10:00:00")))]
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .tomorrow, now: asked, year: 2026, events: events)
+
+        #expect(target == .navigate(dayKey: dayAfter))
+    }
+
+    /// An empty event list is a cold cache, full stop — it wins over the
+    /// bounds question even when `now` is in season, because there is
+    /// nothing to check bounds against. Tightened from an earlier `||`
+    /// between the cold-cache and off-season dialogs: with the real
+    /// implementation the empty-events guard runs first, so exactly one of
+    /// those two outcomes is possible here, not "one of two things."
+    @Test func aColdCacheIsRefusedWithTheColdCacheDialog() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
+
+        let target = OpenDayTarget.resolve(
+            timeframe: .today, now: now, year: 2026, events: [])
+
+        #expect(target == .refuse(dialog: IntentDialogText.coldCache()))
+    }
+}

--- a/ios/ChqCalendarTests/OpenDayTargetTests.swift
+++ b/ios/ChqCalendarTests/OpenDayTargetTests.swift
@@ -14,14 +14,23 @@ struct OpenDayTargetTests {
         #expect(target == .navigate(dayKey: "2026-07-28"))
     }
 
-    /// No timeframe spoken ("show me a day") means today — the same default
-    /// every other timeframe-carrying intent uses.
-    @Test func noTimeframeMeansToday() throws {
-        let now = try #require(ChqTime.parse("2026-07-27 09:00:00"))
-        let events = [makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-27 10:00:00")))]
+    /// `.today` is `now`'s own day, not the next day carrying an event: the
+    /// rail's chips are days, and a reader asking for today wants today even
+    /// once its last event has started. (Where the *unspoken* timeframe gets
+    /// turned into `.today` is `OpenDayIntent.resolvedTimeframe` — asserted in
+    /// `IntentSelectionTests.anUnspokenTimeframeMeansToday`, since `resolve`
+    /// deliberately holds no second copy of that default.) `now` is 21:00,
+    /// after the fixture event has begun, so a "next upcoming event" reading
+    /// would have to answer 2026-07-28 and fail here.
+    @Test func todayIsNowsOwnDayEvenAfterItsEventsHaveStarted() throws {
+        let now = try #require(ChqTime.parse("2026-07-27 21:00:00"))
+        let events = [
+            makeEvent(id: "a", start: try #require(ChqTime.parse("2026-07-27 10:00:00"))),
+            makeEvent(id: "b", start: try #require(ChqTime.parse("2026-07-28 10:00:00"))),
+        ]
 
         let target = OpenDayTarget.resolve(
-            timeframe: nil, now: now, year: 2026, events: events)
+            timeframe: .today, now: now, year: 2026, events: events)
 
         #expect(target == .navigate(dayKey: "2026-07-27"))
     }

--- a/ios/ChqCalendarTests/PendingDayScrollTests.swift
+++ b/ios/ChqCalendarTests/PendingDayScrollTests.swift
@@ -167,12 +167,55 @@ struct PendingDayScrollTests {
 
     /// No deadline stamped means no retry — the behavior before this
     /// existed, kept as the safe fallback for any path that arms a target
-    /// without going through `selectDay`.
+    /// without going through `resolvePendingScroll`. The live path cannot
+    /// reach it: `retryDeadline(existing:now:window:)` below returns a
+    /// non-optional, and every attempt goes through it.
     @Test func noRetryDeadlineMeansASingleAttempt() {
         #expect(PendingDayScroll.hasLanded(
             day: "2026-08-21",
             visibleDays: [],
             retryDeadline: nil,
             now: Date()))
+    }
+
+    // MARK: retryDeadline — the window starts at the first attempt
+
+    /// A target reaching its first resolution attempt with nothing stamped
+    /// gets its full window measured from *that* moment.
+    ///
+    /// This is the fix: the deadline used to be stamped by `selectDay` at arm
+    /// time, but every attempt happens inside `EventListView.list(days:)`,
+    /// which is not mounted while `dayGroups` is empty. A deep link consumed
+    /// against an unmounted list burned its whole window in real time before
+    /// one attempt could run — and the first attempt after the list finally
+    /// mounted found the deadline already spent and gave up without issuing
+    /// a single `scrollTo`.
+    @Test func theFirstAttemptStampsAFreshWindow() {
+        let now = Date()
+        let deadline = PendingDayScroll.retryDeadline(existing: nil, now: now, window: 5)
+        #expect(deadline == now.addingTimeInterval(5))
+        // The point of the fix, stated as the caller sees it: this deadline
+        // has not already expired, however long the target sat armed.
+        #expect(!PendingDayScroll.hasLanded(
+            day: "2026-08-21", visibleDays: [], retryDeadline: deadline, now: now))
+    }
+
+    /// Later attempts keep the first attempt's deadline rather than pushing
+    /// it out. Re-stamping each time would slide the window forward by an
+    /// interval per retry and the target would retry forever — the unbounded
+    /// wait the deadline exists to prevent.
+    @Test func aLaterAttemptDoesNotSlideTheWindowForward() {
+        let first = Date()
+        let stamped = PendingDayScroll.retryDeadline(existing: nil, now: first, window: 5)
+        let later = first.addingTimeInterval(4.9)
+        #expect(
+            PendingDayScroll.retryDeadline(existing: stamped, now: later, window: 5) == stamped)
+        // And the window really does close, rather than being renewed.
+        #expect(PendingDayScroll.hasLanded(
+            day: "2026-08-21",
+            visibleDays: [],
+            retryDeadline: PendingDayScroll.retryDeadline(
+                existing: stamped, now: first.addingTimeInterval(5.1), window: 5),
+            now: first.addingTimeInterval(5.1)))
     }
 }

--- a/ios/ChqCalendarTests/PendingDayScrollTests.swift
+++ b/ios/ChqCalendarTests/PendingDayScrollTests.swift
@@ -125,4 +125,54 @@ struct PendingDayScrollTests {
             for: selection(dateScope: .day, selectedDayKey: "2026-07-05"), year: 2026)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
+
+    // MARK: hasLanded — issuing a scroll is not landing one
+
+    /// The confirmation that fixes #250. The target's header is on screen
+    /// (`visibleDays` is maintained from section-header `onAppear`), so the
+    /// scroll did what it was asked and the pending target is done.
+    @Test func aVisibleTargetHasLanded() {
+        #expect(PendingDayScroll.hasLanded(
+            day: "2026-08-21",
+            visibleDays: ["2026-08-20", "2026-08-21"],
+            retryDeadline: Date().addingTimeInterval(5),
+            now: Date()))
+    }
+
+    /// The CI failure, in one assertion: the day is nowhere on screen after
+    /// the `scrollTo`, so the scroll was dropped and is still owed. Before
+    /// this check existed the caller cleared `pendingScroll` here anyway and
+    /// no trigger ever fired again.
+    @Test func aTargetThatIsNotOnScreenHasNotLanded() {
+        let now = Date()
+        #expect(!PendingDayScroll.hasLanded(
+            day: "2026-08-21",
+            visibleDays: ["2026-07-01", "2026-07-03", "2026-07-04"],
+            retryDeadline: now.addingTimeInterval(5),
+            now: now))
+    }
+
+    /// Retrying is bounded: a target whose day can never become visible —
+    /// the list unmounted, or it vanished for a reason neither staleness nor
+    /// `shouldAbandonScroll` catches — stops being re-issued once its window
+    /// closes, rather than re-scrolling forever.
+    @Test func aTargetPastItsRetryDeadlineIsGivenUpOn() {
+        let now = Date()
+        #expect(PendingDayScroll.hasLanded(
+            day: "2026-08-21",
+            visibleDays: ["2026-07-01"],
+            retryDeadline: now.addingTimeInterval(-0.001),
+            now: now))
+    }
+
+    /// No deadline stamped means no retry — the behavior before this
+    /// existed, kept as the safe fallback for any path that arms a target
+    /// without going through `selectDay`.
+    @Test func noRetryDeadlineMeansASingleAttempt() {
+        #expect(PendingDayScroll.hasLanded(
+            day: "2026-08-21",
+            visibleDays: [],
+            retryDeadline: nil,
+            now: Date()))
+    }
 }

--- a/ios/ChqCalendarUITests/DayRailUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailUITests.swift
@@ -551,9 +551,21 @@ final class DayRailUITests: XCTestCase {
         // 2026-08-21 is a Friday; the fixture titles every day header through
         // ChqTime.dayTitle ("EEEE, MMMM d", en_US_POSIX, no year), same as
         // testADistantChipTapLandsOnThatDay above.
+        //
+        // 40s, not this file's usual 20, because this test has no warm-up.
+        // testADistantChipTapLandsOnThatDay targets the same 51-day-out day
+        // and makes the same assertions, but spends ~10 revealByScrolling
+        // swipes bringing the chip into view before it ever taps — seconds
+        // of wall clock during which cold start finishes on a real device,
+        // and only after that does its own 10s header wait begin. This test
+        // fires the deep link at launch, so its wait has to cover cold-start
+        // fixture load, first render, the window growth, and the list
+        // rebuild all at once — on the 3-core CI runner (see ios.yml) that
+        // raced past a 20s budget once already. Don't tidy this back down
+        // to match the sibling without re-adding an equivalent warm-up.
         let header = app.staticTexts["Friday, August 21"]
         XCTAssertTrue(
-            header.waitForExistence(timeout: 20),
+            header.waitForExistence(timeout: 40),
             "The linked day never mounted — the deep link never reached selectDay, or the window did not grow")
         XCTAssertTrue(
             header.isHittable,

--- a/ios/ChqCalendarUITests/DayRailUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailUITests.swift
@@ -552,21 +552,66 @@ final class DayRailUITests: XCTestCase {
         // ChqTime.dayTitle ("EEEE, MMMM d", en_US_POSIX, no year), same as
         // testADistantChipTapLandsOnThatDay above.
         //
-        // 40s, not this file's usual 20, because this test has no warm-up.
-        // testADistantChipTapLandsOnThatDay targets the same 51-day-out day
-        // and makes the same assertions, but spends ~10 revealByScrolling
-        // swipes bringing the chip into view before it ever taps — seconds
-        // of wall clock during which cold start finishes on a real device,
-        // and only after that does its own 10s header wait begin. This test
-        // fires the deep link at launch, so its wait has to cover cold-start
-        // fixture load, first render, the window growth, and the list
-        // rebuild all at once — on the 3-core CI runner (see ios.yml) that
-        // raced past a 20s budget once already. Don't tidy this back down
-        // to match the sibling without re-adding an equivalent warm-up.
+        // Back to this file's usual 10s. This wait was briefly 40s on the
+        // theory that the CI failure was cold start racing a budget. It was
+        // not, and it was not CI-only either: on an unmodified build this
+        // test failed 3 runs in 8 on an iPhone 17 Pro / iOS 26.1 simulator,
+        // in 15s each — a coin flip, not a slow machine. The defect was
+        // `EventListView.resolvePendingScroll` abandoning the pending target
+        // on the one call whose `days` predates `goToDay`'s window growth;
+        // see its abandon guard. **This test is that fix's falsifier** —
+        // remove the guard and it goes back to failing about half the time,
+        // so do not weaken these assertions or stretch this budget to make a
+        // red run go away.
         let header = app.staticTexts["Friday, August 21"]
         XCTAssertTrue(
-            header.waitForExistence(timeout: 40),
+            header.waitForExistence(timeout: 10),
             "The linked day never mounted — the deep link never reached selectDay, or the window did not grow")
+        XCTAssertTrue(
+            header.isHittable,
+            "The day mounted but the list never scrolled to it")
+        XCTAssertTrue(
+            app.buttons["day-chip-2026-08-21"].isSelected,
+            "The linked day is not the rail's pinned selection")
+    }
+
+    /// The same link, with its first three `scrollTo` calls thrown away.
+    ///
+    /// The companion to the fix for #250, covering its *second* half. The
+    /// root cause there was `resolvePendingScroll` abandoning the target on a
+    /// stale `days` array (see its abandon guard); that is falsified by
+    /// `testADayDeepLinkLandsOnThatDay` above, which fails roughly one run in
+    /// three without the guard. What that test cannot reach is the other
+    /// assumption in the same function: that a `scrollTo`, once issued, has
+    /// landed. It may not have — `ScrollViewProxy` resolves an id against
+    /// already-resolved content — and before this branch, clearing
+    /// `pendingScroll` right after the call spent the only attempt anyone
+    /// would ever make.
+    ///
+    /// That race cannot be won on demand: CPU-saturating the host with 24
+    /// spinners and re-running this file's siblings never reproduced it. So
+    /// `-uitest-drop-scrolls 3` models the observable consequence instead —
+    /// the scroll is issued and goes nowhere — deterministically, on any
+    /// machine. Three, not one, so passing takes a genuine retry *chain*
+    /// rather than one spare trigger firing by luck.
+    ///
+    /// Falsified by reverting `resolvePendingScroll` to clear `pendingScroll`
+    /// unconditionally after `issueScroll`: this test then fails on the
+    /// header wait, in the same shape CI failed.
+    func testADayDeepLinkSurvivesADroppedScroll() {
+        let app = launchFixtureApp(
+            now: "2026-07-01 10:00:00",
+            extraArgs: [
+                "-uitest-go-to-day", "2026-08-21",
+                "-uitest-drop-scrolls", "3",
+            ])
+        let rail = app.scrollViews["day-rail"]
+        XCTAssertTrue(rail.waitForExistence(timeout: 20))
+
+        let header = app.staticTexts["Friday, August 21"]
+        XCTAssertTrue(
+            header.waitForExistence(timeout: 10),
+            "A dropped scroll was never retried — the pending target was cleared as though it had landed")
         XCTAssertTrue(
             header.isHittable,
             "The day mounted but the list never scrolled to it")

--- a/ios/ChqCalendarUITests/DayRailUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailUITests.swift
@@ -562,4 +562,45 @@ final class DayRailUITests: XCTestCase {
             app.buttons["day-chip-2026-08-21"].isSelected,
             "The linked day is not the rail's pinned selection")
     }
+
+    /// The same link, arriving when there is **no list to host it**.
+    ///
+    /// `content` only builds `list(days:)` when `model.dayGroups` is
+    /// non-empty, so a filter matching nothing (here a search term no fixture
+    /// event carries; a persisted favourites-only filter with nothing
+    /// upcoming is the shape a real reader hits) renders `noMatchesView`
+    /// instead. While the `.day` triggers lived inside `list(days:)`, that
+    /// state left the link pending forever: Siri said "Opening tomorrow.",
+    /// nothing happened, and the link fired later — teleporting the reader —
+    /// the moment they cleared the filter and the list mounted.
+    ///
+    /// The rail is the observable: it is a `safeAreaInset` on `body`, so it
+    /// is drawn even with no day groups, and it pins whatever `selectDay`
+    /// chose. An empty day's chip is a plain view rather than a `Button`
+    /// (`DayChip.isDisabled`), hence the identifier-only query — see
+    /// `DayRailAccessibilityUITests.railElementPredicate` for the same
+    /// reason.
+    func testADayDeepLinkIsConsumedEvenWithNoDayGroupsOnScreen() {
+        let app = launchFixtureApp(
+            now: "2026-07-01 10:00:00",
+            extraArgs: [
+                "-uitest-search", "zzzznofixtureeventsaysthis",
+                "-uitest-go-to-day", "2026-08-21",
+            ])
+
+        // The precondition this test exists for: the list is not mounted.
+        XCTAssertTrue(
+            app.staticTexts["No matching events"].waitForExistence(timeout: 20),
+            "The search term matched something — the list is mounted and this proves nothing")
+
+        let chip = app.descendants(matching: .any)
+            .matching(identifier: "day-chip-2026-08-21").firstMatch
+        XCTAssertTrue(
+            chip.waitForExistence(timeout: 20),
+            "The rail never scrolled to the linked day — the link was not consumed")
+        XCTAssertTrue(
+            chip.isSelected,
+            "The linked day is not the rail's pinned selection: the link is still pending, "
+                + "waiting to fire whenever the reader next clears their filter")
+    }
 }

--- a/ios/ChqCalendarUITests/DayRailUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailUITests.swift
@@ -529,4 +529,37 @@ final class DayRailUITests: XCTestCase {
         // The rail may not exist at all off-season; either way, no Now button.
         XCTAssertFalse(app.buttons["day-rail-now"].waitForExistence(timeout: 10))
     }
+
+    /// A `chqcal://day/<key>` link — the shape `OpenDayIntent` writes — lands
+    /// the list on that day and pins the rail's highlight there, exactly as a
+    /// chip tap does. Driven through the launch argument, which feeds
+    /// `model.pendingDeepLink` rather than calling `goToDay` directly, so this
+    /// covers the whole pipeline a Siri run takes.
+    ///
+    /// The target is fifty-one days beyond `now`, outside the launch window —
+    /// the same target `testADistantChipTapLandsOnThatDay` uses, and for the
+    /// same reason: nothing here can pass by accident. The window has to grow,
+    /// the day has to mount, the list has to scroll, and the rail has to adopt
+    /// the pin. None of that is something a launch does on its own.
+    func testADayDeepLinkLandsOnThatDay() {
+        let app = launchFixtureApp(
+            now: "2026-07-01 10:00:00",
+            extraArgs: ["-uitest-go-to-day", "2026-08-21"])
+        let rail = app.scrollViews["day-rail"]
+        XCTAssertTrue(rail.waitForExistence(timeout: 20))
+
+        // 2026-08-21 is a Friday; the fixture titles every day header through
+        // ChqTime.dayTitle ("EEEE, MMMM d", en_US_POSIX, no year), same as
+        // testADistantChipTapLandsOnThatDay above.
+        let header = app.staticTexts["Friday, August 21"]
+        XCTAssertTrue(
+            header.waitForExistence(timeout: 20),
+            "The linked day never mounted — the deep link never reached selectDay, or the window did not grow")
+        XCTAssertTrue(
+            header.isHittable,
+            "The day mounted but the list never scrolled to it")
+        XCTAssertTrue(
+            app.buttons["day-chip-2026-08-21"].isSelected,
+            "The linked day is not the rail's pinned selection")
+    }
 }


### PR DESCRIPTION
Phase 4, part 1 of the cross-platform date-navigation initiative
(`docs/superpowers/specs/2026-08-15-cross-platform-date-navigation-design.md:631`).
Plan: `docs/superpowers/plans/2026-08-20-date-navigation-phase-4-ios-consolidation.md`.

## What this does

A new `chqcal://day/<yyyy-MM-dd>` deep link and an `OpenDayIntent` route Siri
through the same `AppModel.goToDay` a rail chip tap uses, closing the
inconsistency #226 recorded: `IntentTimeframe` has shipped `tomorrow` and
`nextWeek` as spoken targets since #193, so you could *ask* Siri for tomorrow
but, until phase 3b's rail, could not *tap* your way there.

The link is consumed by `EventListView.selectDay` — literally the function a
chip tap calls — so voice and touch land in the same state by construction:
same window expansion, same pinned selection, same queued scroll.

The intent's decision lives in a pure `OpenDayTarget.resolve`, split out of
`perform()` on purpose. An assertion written against `ViewWindow.navigableBounds`
directly would pass even with the intent's guard deleted; testing the extracted
type means the guard is falsifiable, and the test suite proves it by breaking it.

Refusals are **spoken**. `openAppWhenRun` is static, so the app comes forward
either way — an unreachable day that opened the app and silently did nothing is
exactly the outcome this design exists to avoid.

## Also here

The `Filters` pill no longer truncates to `…` at accessibility text sizes
(pre-existing, found by phase 3b's on-device audit). Gated on
`dynamicTypeSize.isAccessibilitySize`, so nothing at other sizes moves.

**The second finding from that audit — the `Search events` placeholder
clipping — did not reproduce** in five configurations at the true maximum
accessibility size (iPhone 17 focused/unfocused, iPad focused/unfocused,
iPhone 13 mini). No speculative fix was written for it. Only iOS 26.0/26.1
runtimes were available, so an older-renderer-specific repro is not ruled out.

## Known gaps, deliberately not fixed here

- The intent resolves the year from `IntentDataSource.defaultYear()` while
  `AppModel.goToDay` uses `selectedYear`, so a reader parked on an **archived
  year** hears a dialog and sees nothing happen. Documented honestly in
  `OpenDayTarget`; automatic year-switching is a design change this branch does
  not make.
- Week 9's "next week" navigates to the season's last day rather than being
  refused. That day is genuinely reachable and landing there beats refusing;
  the behaviour is pinned by a test.
- `"Open <timeframe> in …"` shares its verb with `OpenEventIntent`'s
  `"Open <event> in …"`. Siri disambiguation is not decidable in CI — it goes
  on the pre-submission on-device checklist.

## Testing

876 unit tests across 64 suites, plus 20 UI tests, 0 failures (iPhone 17,
iOS 26.1, serial). Every guard on the branch was proven by breaking it and
watching the test fail, then restoring — including the one that matters most
here, `phrases[0]` carrying no parameter slot, which shipped `${timeframe}` to
real users on 4 of 7 actions in #193.

[skip-screenshots: the only visible change outside accessibility text sizes is
one example phrase on the About sheet, and no shot in ios/Scripts/screenshot-plan.json
covers that screen; phase 4 part 2 regenerates the manifest for the 1.1.3 submission]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P6kpm9Fv7eNtxs1X1SBVV