### PR TITLE
ci(ios): split the iOS job into a fast unit leg and a UI leg

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -38,11 +38,16 @@ jobs:
     # would silently drift apart.
     #
     # Why split at all: the ~21 XCUITests each boot the app and account for
-    # most of a ~20-minute combined run, while the ~880 unit tests finish in a
-    # small fraction of it. Combined, a one-line Swift mistake took ~20
-    # minutes to surface. Split, the unit leg reports in a few minutes and the
-    # UI leg keeps running — so the common failure is seen fast without
-    # weakening the gate.
+    # most of a ~20-minute combined run: measured on this runner, the UI leg
+    # executes 18 tests in 999s while the unit leg's 852 tests across 63
+    # suites execute in under four seconds. Combined, a one-line Swift mistake
+    # took ~20 minutes to surface. Split, the first run measured 6m31s for the
+    # unit leg against 20m59s for the UI leg — so the common failure is seen
+    # ~3x sooner without weakening the gate.
+    #
+    # Note what the split does NOT save: both legs still do a full build, so
+    # the unit leg's wall clock is almost entirely compilation, not its four
+    # seconds of tests.
     #
     # BOTH legs still gate a merge. The UI suite is not advisory and must not
     # be moved to a nightly: it is what caught the real scroll defect in #250,

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -30,14 +30,52 @@ concurrency:
 
 jobs:
   test-ios:
-    name: Build and test (iOS)
+    # Two legs of one matrix, not two hand-written jobs: every setup step
+    # below is identical for both, and GitHub Actions has no YAML anchors to
+    # share them with (see the `paths:` note above). A matrix is the only way
+    # to express "same setup, different `-only-testing:`" without maintaining
+    # two copies of the Xcode-selection and simulator-resolution steps that
+    # would silently drift apart.
+    #
+    # Why split at all: the ~21 XCUITests each boot the app and account for
+    # most of a ~20-minute combined run, while the ~880 unit tests finish in a
+    # small fraction of it. Combined, a one-line Swift mistake took ~20
+    # minutes to surface. Split, the unit leg reports in a few minutes and the
+    # UI leg keeps running — so the common failure is seen fast without
+    # weakening the gate.
+    #
+    # BOTH legs still gate a merge. The UI suite is not advisory and must not
+    # be moved to a nightly: it is what caught the real scroll defect in #250,
+    # where a Siri-opened day grew the window and moved the rail's highlight
+    # but never scrolled the list. No unit test saw that, and it reached a PR.
+    #
+    # `fail-fast: false` because the two legs answer different questions. A UI
+    # failure must not cancel the unit leg (or the reverse) — the whole point
+    # is to learn both answers in one run.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - suite: unit
+            label: unit tests
+            target: ChqCalendarTests
+            timeout: 30
+          - suite: ui
+            label: UI tests
+            target: ChqCalendarUITests
+            timeout: 60
+
+    name: Build and test (iOS, ${{ matrix.label }})
     runs-on: macos-15
     # Mirrors build-and-test.yml's dedupe: for same-repo PRs the `push` event
     # already covers the branch, so the `pull_request` run would be a
     # duplicate. Fork PRs get no `push` event on this repo, so they are the
     # one case that must run on `pull_request`.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == true
-    timeout-minutes: 60
+    # Per-leg: the UI leg boots the app once per test and needs the old 60;
+    # the unit leg has no reason to sit anywhere near that long, and a tighter
+    # ceiling turns a hang into a fast red instead of a 60-minute one.
+    timeout-minutes: ${{ matrix.timeout }}
 
     steps:
       - uses: actions/checkout@v7
@@ -78,6 +116,9 @@ jobs:
         # image releases. Resolving a concrete UDID at runtime — newest
         # available iOS >= the project's 18.0 deployment target, on an iPhone —
         # means this job does not break when the image's simulator set moves.
+        #
+        # Both legs need this: unit tests run on a simulator too, not just the
+        # XCUITests.
         run: |
           set -euo pipefail
           resolved=$(xcrun simctl list devices available --json | python3 -c '
@@ -113,7 +154,7 @@ jobs:
           echo "SIMULATOR_UDID=$udid" >> "$GITHUB_ENV"
           echo "Using $name (iOS $os) — $udid"
 
-      - name: Build and test
+      - name: Build and test (${{ matrix.label }})
         env:
           # Interleaves xcodebuild's stdout/stderr in real time so a failure
           # appears next to the work that caused it in the job log.
@@ -124,13 +165,14 @@ jobs:
         # the condition this flag creates. Its own doc comment names the flag.
         # Dropping it turns a green tree red.
         #
-        # One step covers all three source trees: the ChqCalendar scheme
+        # Both legs compile all three source trees: the ChqCalendar scheme
         # builds the ChqCalendarWidgets target too (it is embedded in the app),
-        # so a compile error anywhere in ChqCalendarWidgets/ fails this job.
+        # so a compile error anywhere in ChqCalendarWidgets/ fails either leg.
         # Verified empirically by planting a type error in
         # ChqCalendarWidgets/WidgetViews.swift and watching `xcodebuild build
         # -scheme ChqCalendar` fail on it — a separate widgets build step
-        # would be redundant.
+        # would be redundant. `-only-testing:` narrows which tests RUN, not
+        # what gets BUILT, so the unit leg is still a full compile gate.
         #
         # -parallel-testing-enabled NO is load-bearing on this runner, and was
         # arrived at by measurement, not preference. A GitHub-hosted macos-15
@@ -146,8 +188,8 @@ jobs:
         # `waitUntil` (ChqCalendarTests/TestSupport.swift). On 3 cores the
         # cooperative pool is oversubscribed, the awaited state does not
         # settle inside that helper's 5s deadline, and it records an issue.
-        # Locally the entire 716-test suite finishes in under a second, so
-        # the pressure never materializes and the headroom is invisible.
+        # Locally the entire suite finishes in seconds, so the pressure never
+        # materializes and the headroom is invisible.
         #
         # Serial is also simply faster here than the contended parallel run
         # (47.7s vs 101.7s of test time), so this costs nothing. Note it
@@ -155,13 +197,12 @@ jobs:
         # tracked separately; see the follow-up issue referenced in the PR.
         # Do not drop this flag without re-measuring on a 3-core runner.
         #
-        # ChqCalendarUITests (added in phase 3b) runs in this same invocation.
-        # UI tests are slow — each one boots the app — so the timeout above is
-        # 60 rather than 45. They are also the reason
-        # -parallel-testing-enabled NO matters twice over: two XCUITest
-        # classes running concurrently on a 3-core runner contend for the
-        # single booted simulator, which fails as "Application is not
-        # running" rather than as anything resembling the real cause.
+        # The flag matters on the UI leg for a second, unrelated reason: two
+        # XCUITest classes running concurrently on a 3-core runner contend for
+        # the single booted simulator, which fails as "Application is not
+        # running" rather than as anything resembling the real cause. Splitting
+        # the legs across runners does not change that — each leg still has one
+        # simulator — so the flag stays on both.
         run: |
           set -euo pipefail
           cd ios
@@ -169,17 +210,28 @@ jobs:
             -project ChqCalendar.xcodeproj \
             -scheme ChqCalendar \
             -destination "id=$SIMULATOR_UDID" \
+            -only-testing:${{ matrix.target }} \
             -resultBundlePath "$RUNNER_TEMP/ChqCalendar.xcresult" \
             -parallel-testing-enabled NO \
             CODE_SIGNING_ALLOWED=NO
 
       - name: Upload test results
         # Only on failure: the .xcresult bundle is large and uninteresting
-        # when everything passed, but it is the only way to see which of the
-        # 716 tests failed and why without re-running locally.
+        # when everything passed, but it is the only way to see which tests
+        # failed and why without re-running locally. For a UI failure it also
+        # carries the accessibility hierarchy and a screen recording from the
+        # moment of failure — which is how #250's scroll defect was actually
+        # diagnosed, after a plausible-sounding theory had already wasted a
+        # full CI cycle. Pull it before theorising:
+        #   gh run download <run-id> -n xcresult-ui -D <dir> -R <owner>/<repo>
+        #   xcrun xcresulttool export attachments \
+        #     --test-id '<Suite>/<test>()' --path <dir> --output-path <dir>/att
+        #
+        # The artifact name is per-leg because both legs upload, and
+        # upload-artifact rejects two artifacts sharing a name in one run.
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: xcresult
+          name: xcresult-${{ matrix.suite }}
           path: ${{ runner.temp }}/ChqCalendar.xcresult
           retention-days: 7

--- a/ios/README.md
+++ b/ios/README.md
@@ -70,7 +70,9 @@ xcodebuild build \
   CODE_SIGNING_ALLOWED=NO
 
 # Unit tests only — what you want while iterating.
-# ~880 tests, no app launches, finishes in a couple of minutes.
+# 852 tests across 63 suites, a few seconds of test time once built.
+# It still boots a simulator and launches the test host — what it skips is
+# XCUITest's app boot per test, which is where the minutes actually go.
 xcodebuild test \
   -project ChqCalendar.xcodeproj -scheme ChqCalendar \
   -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
@@ -85,7 +87,7 @@ xcodebuild test \
 ```
 
 **The plain `xcodebuild test` runs the UI tests too.** Since phase 3b added
-`ChqCalendarUITests` to this scheme, the ~21 XCUITests each boot the app and
+`ChqCalendarUITests` to this scheme, the XCUITests each boot the app and
 account for most of the runtime — so reach for `-only-testing:ChqCalendarTests`
 while iterating and keep the full run for the commit. `-only-testing:` narrows
 which tests *run*, not what gets *built*, so the unit-only command is still a

--- a/ios/README.md
+++ b/ios/README.md
@@ -69,16 +69,38 @@ xcodebuild build \
   -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
   CODE_SIGNING_ALLOWED=NO
 
-# Full test suite (unit tests, no UI tests)
+# Unit tests only — what you want while iterating.
+# ~880 tests, no app launches, finishes in a couple of minutes.
+xcodebuild test \
+  -project ChqCalendar.xcodeproj -scheme ChqCalendar \
+  -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
+  -only-testing:ChqCalendarTests \
+  CODE_SIGNING_ALLOWED=NO
+
+# Everything, including ChqCalendarUITests. Run this once before you commit.
 xcodebuild test \
   -project ChqCalendar.xcodeproj -scheme ChqCalendar \
   -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.1' \
   CODE_SIGNING_ALLOWED=NO
 ```
 
+**The plain `xcodebuild test` runs the UI tests too.** Since phase 3b added
+`ChqCalendarUITests` to this scheme, the ~21 XCUITests each boot the app and
+account for most of the runtime — so reach for `-only-testing:ChqCalendarTests`
+while iterating and keep the full run for the commit. `-only-testing:` narrows
+which tests *run*, not what gets *built*, so the unit-only command is still a
+full compile gate over all three targets. `.github/workflows/ios.yml` splits
+along the same line, into a fast unit leg and a slower UI leg that both gate a
+merge.
+
 Swap the `-destination` name/OS for whatever simulators are installed
 locally (`xcrun simctl list devices available`). `CODE_SIGNING_ALLOWED=NO`
 avoids needing a signing identity for simulator builds.
+
+To wait on a background `xcodebuild` from a script, poll with
+`until ! pgrep -x xcodebuild >/dev/null; do sleep 15; done`. Do **not** use
+`pgrep -f "xcodebuild test …"` — the polling shell's own command line contains
+that string, so it matches itself and the loop never exits.
 
 ### Targets
 


### PR DESCRIPTION
**Both legs still gate a merge.** This changes how fast a failure surfaces, not how much is tested.

## Why

The ~21 XCUITests each boot the app and account for most of a ~20-minute combined run. The unit tests are **852 tests across 63 suites that execute in under four seconds**. Combined, a one-line Swift mistake took ~20 minutes to surface — that happened repeatedly on #250.

Split, the unit leg reports as soon as its build finishes and the UI leg keeps running in parallel, so the common failure is seen much sooner.

**Honest about the size of the win:** the saving is UI *test execution* (21 app boots), not compilation. Both legs still do a full build, so the unit leg will be dominated by compile time in CI rather than by its 4 seconds of tests. Expect first signal in roughly half the previous time, not in seconds.

## Why a matrix, not two jobs

The Xcode-selection and simulator-resolution steps are identical for both legs, and GitHub Actions has no YAML anchors to share them with — the file already carries a comment saying exactly that about its duplicated `paths:` lists. Two hand-written jobs would be ~60 duplicated lines that drift apart.

`fail-fast: false`, because the legs answer different questions: a UI failure must not cancel the unit leg, or the split buys nothing.

## What is deliberately unchanged

- **The UI suite is not moved to a nightly.** It is what caught the scroll defect in #250 — a Siri-opened day grew the window and moved the rail's highlight but never scrolled the list. No unit test saw that, and it reached a PR.
- `-parallel-testing-enabled NO` stays on **both** legs. It matters on the unit leg for the documented 3-core contention, and independently on the UI leg because concurrent XCUITest classes fight over the single booted simulator and fail as "Application is not running". Splitting across runners doesn't change that — each leg still has one simulator.
- `CODE_SIGNING_ALLOWED=NO` on both, for the reason its own comment gives.

## Verification

Ran the partition locally: `-only-testing:ChqCalendarTests` executes **852 tests, starts zero UI test cases**, and still compiles the UI test target and `ChqCalendarWidgets`. `-only-testing:` narrows what *runs*, not what *builds*, so the fast leg remains a full compile gate over all three targets.

This PR touches `.github/workflows/ios.yml`, which is in the workflow's own `paths:` trigger — so this PR's own CI run is the real test of the split.

**No merge gate is affected:** the repo's ruleset has no required-status-check rule, so the new job names (`Build and test (iOS, unit tests)` / `(iOS, UI tests)`) replace the old one without needing a settings change on your side.

## Also here

`ios/README.md` claimed the plain `xcodebuild test` runs "no UI tests". That stopped being true when phase 3b added `ChqCalendarUITests` to the scheme. It now documents both recipes, and the `pgrep -x xcodebuild` form for waiting on a background run — `pgrep -f "xcodebuild test …"` matches the polling shell's own command line and never exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011P6kpm9Fv7eNtxs1X1SBVV