### PR TITLE
perf(ios-tests): cut the day-rail accessibility audits' cost (#259)

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -37,13 +37,20 @@ jobs:
     # two copies of the Xcode-selection and simulator-resolution steps that
     # would silently drift apart.
     #
-    # Why split at all: the ~21 XCUITests each boot the app and account for
-    # most of a ~20-minute combined run: measured on this runner, the UI leg
-    # executes 18 tests in 999s while the unit leg's 852 tests across 63
-    # suites execute in under four seconds. Combined, a one-line Swift mistake
-    # took ~20 minutes to surface. Split, the first run measured 6m31s for the
-    # unit leg against 20m59s for the UI leg — so the common failure is seen
-    # ~3x sooner without weakening the gate.
+    # Why split at all: the XCUITests dominate a combined run. Measured on
+    # this runner, the UI leg executed 18 tests in 999s while the unit leg's
+    # 852 tests across 63 suites executed in under four seconds. Combined, a
+    # one-line Swift mistake took ~20 minutes to surface. Split, the first run
+    # measured 6m31s for the unit leg against 20m59s for the UI leg — so the
+    # common failure is seen ~3x sooner without weakening the gate.
+    #
+    # What that cost is NOT, despite an earlier version of this comment
+    # saying so (#259): the per-test app launches. Launching is cheap —
+    # LaunchFixtureUITests does nothing else and takes ~6.7s, the median test
+    # is ~18s, and all 25 launches together are ~9% of test time. Rewriting
+    # tests to share a launch would trade real interaction coverage for
+    # almost nothing. Measure before optimising here; the cost has twice now
+    # turned out to sit somewhere other than where it looked.
     #
     # Note what the split does NOT save: both legs still do a full build, so
     # the unit leg's wall clock is almost entirely compilation, not its four

--- a/ios/ChqCalendarUITests/AuditSampleTally.swift
+++ b/ios/ChqCalendarUITests/AuditSampleTally.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+/// The majority rule `DayRailAccessibilityUITests.railIssues(in:attempts:)`
+/// applies across its repeated accessibility-audit samples, lifted out of the
+/// sampling loop so it can be proved exhaustively without launching an app.
+///
+/// **Why this exists as a separate type.** The rule itself is three lines of
+/// arithmetic, but it decides whether a merge-gating audit reports or stays
+/// silent, and the early exit below changes how many samples get taken. Both
+/// are worth proving rather than eyeballing, and neither can be proved from
+/// inside an XCUITest: reaching `railIssues` at all costs an app launch and
+/// several whole-app audits, so an exhaustive check of every sample sequence
+/// would be the single most expensive test in the repo. As a plain value type
+/// the same check runs over every sequence in microseconds — see
+/// `AuditSampleTallyTests`.
+///
+/// **Why the early exit is safe.** `isSettledEmpty` fires only when no
+/// remaining sample could lift `nonEmpty` to a majority — that is, only when
+/// the run's verdict is already `[]`. An empty verdict carries no diagnostic
+/// content (`railIssues`' "report the richest sample" logic exists to make a
+/// *failure* message complete, and there is no failure message here), so
+/// stopping early loses nothing at all: same verdict, same reported issues,
+/// fewer audits. The converse case is deliberately *not* short-circuited —
+/// once a majority is already reached, sampling continues to the end so the
+/// richest sample is still available for the failure message.
+///
+/// On the green path this is the whole point: with `attempts == 5`, three
+/// empty samples settle the verdict, so a passing audit runs three whole-app
+/// audits instead of five.
+struct AuditSampleTally {
+    /// The total number of samples the caller intends to take.
+    let attempts: Int
+
+    /// How many samples have been recorded so far.
+    private(set) var taken = 0
+
+    /// How many of those samples found at least one in-scope issue.
+    private(set) var nonEmpty = 0
+
+    init(attempts: Int) {
+        self.attempts = attempts
+    }
+
+    mutating func record(foundIssues: Bool) {
+        taken += 1
+        if foundIssues { nonEmpty += 1 }
+    }
+
+    /// True once even a clean sweep of the remaining samples could not reach
+    /// a majority — so the verdict is already `[]` and further sampling
+    /// cannot change it.
+    var isSettledEmpty: Bool {
+        (nonEmpty + (attempts - taken)) * 2 <= attempts
+    }
+
+    /// Whether a strict majority of samples found something. Mirrors the
+    /// original `nonEmptySamples.count * 2 > attempts` guard exactly; a tie
+    /// (2 of 4) is not a majority and does not report.
+    var foundMajority: Bool {
+        nonEmpty * 2 > attempts
+    }
+}

--- a/ios/ChqCalendarUITests/AuditSampleTallyTests.swift
+++ b/ios/ChqCalendarUITests/AuditSampleTallyTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+
+/// Proves `AuditSampleTally`'s early exit changes only the *cost* of
+/// `DayRailAccessibilityUITests.railIssues(in:attempts:)`, never its verdict.
+///
+/// This class launches no app. It is in `ChqCalendarUITests` because the type
+/// it proves is UI-test infrastructure and belongs next to its only caller;
+/// costing nothing to run, it does not meaningfully add to the UI leg it
+/// exists to shorten.
+///
+/// The central test is exhaustive rather than exemplary: an off-by-one in a
+/// majority rule is exactly the kind of defect a handful of hand-picked cases
+/// walks past, and the whole state space here is small enough to enumerate.
+final class AuditSampleTallyTests: XCTestCase {
+    /// The pre-early-exit implementation, verbatim in behaviour: take every
+    /// sample, then require a strict majority of them to be non-empty. This
+    /// is the oracle the early-exit version must match.
+    private func referenceReportsIssues(_ samplesFoundIssues: [Bool]) -> Bool {
+        let nonEmpty = samplesFoundIssues.filter { $0 }.count
+        return nonEmpty * 2 > samplesFoundIssues.count
+    }
+
+    /// Replays a sample sequence through `AuditSampleTally` the way
+    /// `railIssues` does, stopping as soon as the verdict is settled empty.
+    /// Returns the verdict and how many samples were actually consumed.
+    private func earlyExit(_ samplesFoundIssues: [Bool]) -> (reportsIssues: Bool, taken: Int) {
+        var tally = AuditSampleTally(attempts: samplesFoundIssues.count)
+        for found in samplesFoundIssues {
+            tally.record(foundIssues: found)
+            if tally.isSettledEmpty { return (false, tally.taken) }
+        }
+        return (tally.foundMajority, tally.taken)
+    }
+
+    /// Every possible sequence of sample outcomes, for every plausible
+    /// `attempts`, must produce the identical verdict with and without the
+    /// early exit. This is the claim the change rests on — that it is a
+    /// pure cost reduction — and enumerating 1..8 attempts covers 510
+    /// sequences in well under a second.
+    func testEarlyExitNeverChangesTheVerdictForAnySampleSequence() {
+        for attempts in 1...8 {
+            for bits in 0..<(1 << attempts) {
+                let samples = (0..<attempts).map { bits & (1 << $0) != 0 }
+                let expected = referenceReportsIssues(samples)
+                let actual = earlyExit(samples)
+                XCTAssertEqual(
+                    actual.reportsIssues, expected,
+                    "verdict diverged for \(samples)")
+                XCTAssertLessThanOrEqual(
+                    actual.taken, attempts,
+                    "early exit consumed more samples than it was given for \(samples)")
+            }
+        }
+    }
+
+    /// The saving this change exists to buy, pinned to a number: on the green
+    /// path — every sample clean, which is every passing CI run — a 5-attempt
+    /// audit performs three audits, not five.
+    func testAnAllCleanRunStopsAfterThreeOfFiveSamples() {
+        let result = earlyExit([false, false, false, false, false])
+        XCTAssertFalse(result.reportsIssues)
+        XCTAssertEqual(result.taken, 3)
+    }
+
+    /// The guard that keeps the saving from becoming a false negative: two
+    /// clean samples are *not* enough to conclude, because samples 3, 4 and 5
+    /// could still form a majority.
+    func testTwoCleanSamplesDoNotSettleTheVerdict() {
+        var tally = AuditSampleTally(attempts: 5)
+        tally.record(foundIssues: false)
+        tally.record(foundIssues: false)
+        XCTAssertFalse(
+            tally.isSettledEmpty,
+            "settling after two of five would drop a regression found on the last three samples")
+    }
+
+    /// A real regression — the falsification runs in
+    /// `DayRailAccessibilityUITests`' doc comment reproduced across every
+    /// attempt — must still be reported, and must consume every sample so the
+    /// richest one is available for the failure message.
+    func testAConsistentRegressionIsReportedAndUsesEverySample() {
+        let result = earlyExit([true, true, true, true, true])
+        XCTAssertTrue(result.reportsIssues)
+        XCTAssertEqual(
+            result.taken, 5,
+            "a reporting run must not short-circuit; railIssues picks the richest sample for its message")
+    }
+
+    /// The mistimed-sample case the resampling was added to absorb: a single
+    /// spurious finding among clean samples stays unreported.
+    func testOneSpuriousSampleAmongCleanOnesIsAbsorbed() {
+        XCTAssertFalse(earlyExit([true, false, false, false, false]).reportsIssues)
+        XCTAssertFalse(earlyExit([false, false, true, false, false]).reportsIssues)
+    }
+
+    /// A majority is strict: with an even `attempts`, a tie does not report.
+    /// Pinned because `>` versus `>=` here is the difference between absorbing
+    /// a mistimed sample and failing the build on one.
+    func testATieIsNotAMajority() {
+        XCTAssertFalse(earlyExit([true, true, false, false]).reportsIssues)
+        XCTAssertTrue(earlyExit([true, true, true, false]).reportsIssues)
+    }
+}

--- a/ios/ChqCalendarUITests/AuditSampleTallyTests.swift
+++ b/ios/ChqCalendarUITests/AuditSampleTallyTests.swift
@@ -35,10 +35,12 @@ final class AuditSampleTallyTests: XCTestCase {
     /// Every possible sequence of sample outcomes, for every plausible
     /// `attempts`, must produce the identical verdict with and without the
     /// early exit. This is the claim the change rests on — that it is a
-    /// pure cost reduction — and enumerating 1..8 attempts covers 510
-    /// sequences in well under a second.
+    /// pure cost reduction — and enumerating 0...8 attempts covers 511
+    /// sequences in well under a second. Zero is included because it is the
+    /// one case the loop cannot reach by early exit; see
+    /// `testZeroAttemptsReportsNothing`.
     func testEarlyExitNeverChangesTheVerdictForAnySampleSequence() {
-        for attempts in 1...8 {
+        for attempts in 0...8 {
             for bits in 0..<(1 << attempts) {
                 let samples = (0..<attempts).map { bits & (1 << $0) != 0 }
                 let expected = referenceReportsIssues(samples)
@@ -91,6 +93,18 @@ final class AuditSampleTallyTests: XCTestCase {
     func testOneSpuriousSampleAmongCleanOnesIsAbsorbed() {
         XCTAssertFalse(earlyExit([true, false, false, false, false]).reportsIssues)
         XCTAssertFalse(earlyExit([false, false, true, false, false]).reportsIssues)
+    }
+
+    /// The degenerate case, pinned because it is the one path on which
+    /// `railIssues`' closing `guard tally.foundMajority` is still live logic
+    /// rather than an invariant: with no attempts the loop never runs, nothing
+    /// is tallied, and an empty tally must read as "nothing found" rather than
+    /// as a majority of zero samples.
+    func testZeroAttemptsReportsNothing() {
+        let result = earlyExit([])
+        XCTAssertFalse(result.reportsIssues)
+        XCTAssertEqual(result.taken, 0)
+        XCTAssertFalse(AuditSampleTally(attempts: 0).foundMajority)
     }
 
     /// A majority is strict: with an even `attempts`, a tie does not report.

--- a/ios/ChqCalendarUITests/DayRailAccessibilityUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailAccessibilityUITests.swift
@@ -205,14 +205,17 @@ final class DayRailAccessibilityUITests: XCTestCase {
     /// same hierarchy, same frames — because the query form was resolving
     /// against this very tree, once per element, instead of once.
     ///
-    /// A failure to snapshot returns `.null`, which `CGRect.contains` answers
-    /// `false` for. That cannot silently pass a broken audit: every
-    /// bounds-matched issue would be dropped, but nil-element issues are
-    /// still counted (see the type's doc comment), and the audit's own throw
-    /// would surface first in practice.
+    /// A snapshot failure throws rather than degrading to `.null`. `.null`
+    /// answers `false` to `CGRect.contains` for every element, so swallowing
+    /// the error would drop every bounds-matched issue and let the audit pass
+    /// having checked nothing — the precise "green test that checks nothing"
+    /// shape this file exists to prevent. `snapshot()` and
+    /// `performAccessibilityAudit` are independent calls, so an earlier draft's
+    /// reasoning that "the audit's own throw would surface first" did not hold:
+    /// nothing guarantees the audit fails just because the snapshot did.
     @MainActor
-    private func railBounds(in app: XCUIApplication) -> CGRect {
-        guard let root = try? app.snapshot() else { return .null }
+    private func railBounds(in app: XCUIApplication) throws -> CGRect {
+        let root = try app.snapshot()
         var box = CGRect.null
         var pending = [root]
         while let node = pending.popLast() {
@@ -273,7 +276,7 @@ final class DayRailAccessibilityUITests: XCTestCase {
         var tally = AuditSampleTally(attempts: attempts)
         for attempt in 0..<attempts {
             if attempt > 0 { settleRailAnimation() }
-            let bounds = railBounds(in: app)
+            let bounds = try railBounds(in: app)
             var found: [XCUIAccessibilityAuditIssue] = []
             try app.performAccessibilityAudit(for: auditTypes) { issue in
                 if let element = issue.element {
@@ -304,6 +307,13 @@ final class DayRailAccessibilityUITests: XCTestCase {
             tally.record(foundIssues: !found.isEmpty)
             if tally.isSettledEmpty { return [] }
         }
+        // Reachable only when `attempts == 0` (the loop never runs, so nothing
+        // is ever tallied). For every `attempts >= 1` this is an invariant, not
+        // live logic: falling out of the loop means the final iteration found
+        // `isSettledEmpty == false` with no samples remaining, which — with
+        // `remaining == 0` — is exactly `foundMajority`. Kept rather than
+        // dropped so the degenerate case still returns `[]` instead of reading
+        // a majority off an empty tally.
         guard tally.foundMajority else { return [] }
         // Report the richest sample so a failure message is as complete as
         // possible.

--- a/ios/ChqCalendarUITests/DayRailAccessibilityUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailAccessibilityUITests.swift
@@ -43,16 +43,16 @@ import XCTest
 /// fully inside their element's frame — while excluding the search field,
 /// which sits well outside it.
 ///
-/// **Why `descendants(matching: .any)`, not `app.buttons`.** A chip is a
-/// `Button` when tappable, but `DayChip`'s `isDisabled` branch (an empty day
-/// on the Events rail, `disablesEmptyDays: true`) mounts the identical
-/// `day-chip-*` identifier on a plain, non-button view instead — see
-/// `DayChip.body`. A `railBounds(in:)` built from `app.buttons` alone
-/// silently excludes every disabled chip from the audit's scope, which is
-/// exactly backwards: an empty chip is where the original, real defect
-/// lived (`.disabled()` dimming text to ~3.7:1, see `DayChip.body`'s own
-/// comment on why there is no `.disabled()` left to do that now). Matching
-/// by identifier against every element type closes that gap.
+/// **Why every element type, not `app.buttons`.** A chip is a `Button` when
+/// tappable, but `DayChip`'s `isDisabled` branch (an empty day on the Events
+/// rail, `disablesEmptyDays: true`) mounts the identical `day-chip-*`
+/// identifier on a plain, non-button view instead — see `DayChip.body`. A
+/// `railBounds(in:)` built from `app.buttons` alone silently excludes every
+/// disabled chip from the audit's scope, which is exactly backwards: an
+/// empty chip is where the original, real defect lived (`.disabled()`
+/// dimming text to ~3.7:1, see `DayChip.body`'s own comment on why there is
+/// no `.disabled()` left to do that now). Matching by identifier against
+/// every node in the hierarchy, whatever its type, closes that gap.
 ///
 /// **Why a nil `issue.element` still counts as a rail issue, and why a
 /// non-nil-but-anonymous one sometimes doesn't.** `DayChip` wraps its
@@ -167,22 +167,59 @@ final class DayRailAccessibilityUITests: XCTestCase {
     /// segment is exposed at all (`WeekBandSegmentView`), so this
     /// matches the nine `WEEK n` segments, whose frames sit at the band
     /// row's own y and together span it.
-    private let railElementPredicate = NSPredicate(
-        format: """
-            identifier BEGINSWITH 'day-chip-' OR identifier BEGINSWITH 'day-rail-expand-' \
-            OR identifier BEGINSWITH 'day-band-' \
-            OR identifier IN {'day-rail-now'}
-            """)
+    ///
+    /// A plain function rather than the `NSPredicate` this used to be:
+    /// `railBounds(in:)` now walks an `XCUIElementSnapshot` tree (see its
+    /// doc comment for why), whose nodes are not the KVC-compliant objects
+    /// an `NSPredicate` needs. The match itself is unchanged, prefix for
+    /// prefix.
+    private func isRailElement(_ identifier: String) -> Bool {
+        identifier.hasPrefix("day-chip-")
+            || identifier.hasPrefix("day-rail-expand-")
+            || identifier.hasPrefix("day-band-")
+            || identifier == "day-rail-now"
+    }
 
     /// The union of every rail element's own frame — see the type's doc
     /// comment for why this, and not `rail.frame` or an issue's own element
-    /// identifier, is what scopes the audit. `descendants(matching: .any)`,
-    /// not `app.buttons`, so a disabled (non-button) empty chip is included
-    /// — see `railElementPredicate`.
+    /// identifier, is what scopes the audit. Every node type is considered,
+    /// not just buttons, so a disabled (non-button) empty chip is included —
+    /// see `isRailElement(_:)`.
+    ///
+    /// **Why one snapshot, and not `descendants(matching:).matching(_:)`.**
+    /// This was the single most expensive thing in the iOS UI suite (#259).
+    /// The query form returns live `XCUIElement`s, and *each* `.frame` access
+    /// re-resolves its element against the app — a fresh whole-hierarchy
+    /// traversal per element, visible in the test log as a run of `Find the
+    /// Any (Element at index n)` lines. The Events rail mounts its chips
+    /// eagerly across the whole navigable span, so that was 99 elements and
+    /// therefore 99 sequential traversals. Measured on an iPhone 17 Pro
+    /// simulator, one `railBounds` call cost **30.4s**, against **10.3s** for
+    /// the `performAccessibilityAudit` it exists to scope: three quarters of
+    /// the work was spent deciding where to look, on a screen deliberately
+    /// held still.
+    ///
+    /// `snapshot()` takes the entire hierarchy in one round trip and returns
+    /// plain values whose `frame` is already resolved, so walking it is
+    /// local work. The set of matched frames is identical — same identifiers,
+    /// same hierarchy, same frames — because the query form was resolving
+    /// against this very tree, once per element, instead of once.
+    ///
+    /// A failure to snapshot returns `.null`, which `CGRect.contains` answers
+    /// `false` for. That cannot silently pass a broken audit: every
+    /// bounds-matched issue would be dropped, but nil-element issues are
+    /// still counted (see the type's doc comment), and the audit's own throw
+    /// would surface first in practice.
     @MainActor
     private func railBounds(in app: XCUIApplication) -> CGRect {
-        app.descendants(matching: .any).matching(railElementPredicate).allElementsBoundByIndex
-            .reduce(CGRect.null) { $0.union($1.frame) }
+        guard let root = try? app.snapshot() else { return .null }
+        var box = CGRect.null
+        var pending = [root]
+        while let node = pending.popLast() {
+            if isRailElement(node.identifier) { box = box.union(node.frame) }
+            pending.append(contentsOf: node.children)
+        }
+        return box
     }
 
     /// Runs the audit across the whole app, keeping only issues that belong
@@ -216,9 +253,24 @@ final class DayRailAccessibilityUITests: XCTestCase {
     /// across every attempt in every run observed, so a real regression
     /// still clears a majority easily — only a one-off mistimed sample
     /// gets absorbed.
+    ///
+    /// **Sampling stops as soon as the verdict is settled empty.** Once
+    /// enough samples have come back clean that the remaining ones could not
+    /// form a majority even if every one of them found something, the result
+    /// is already `[]` and further audits cannot change it — so the loop
+    /// returns. With the default five attempts that means a clean screen
+    /// costs three audits, not five. This is a pure cost cut, not a weaker
+    /// check: it can only fire on a verdict of `[]`, which carries no
+    /// diagnostic content, and the majority threshold itself is untouched.
+    /// The reporting case is deliberately *not* short-circuited — a run that
+    /// has already reached a majority keeps sampling so the richest sample is
+    /// still available for the failure message. `AuditSampleTally` holds the
+    /// arithmetic, and `AuditSampleTallyTests` proves over every possible
+    /// sample sequence that the early exit returns what the full run would.
     @MainActor
     private func railIssues(in app: XCUIApplication, attempts: Int = 5) throws -> [XCUIAccessibilityAuditIssue] {
         var samples: [[XCUIAccessibilityAuditIssue]] = []
+        var tally = AuditSampleTally(attempts: attempts)
         for attempt in 0..<attempts {
             if attempt > 0 { settleRailAnimation() }
             let bounds = railBounds(in: app)
@@ -249,12 +301,13 @@ final class DayRailAccessibilityUITests: XCTestCase {
                 return true
             }
             samples.append(found)
+            tally.record(foundIssues: !found.isEmpty)
+            if tally.isSettledEmpty { return [] }
         }
-        let nonEmptySamples = samples.filter { !$0.isEmpty }
-        guard nonEmptySamples.count * 2 > attempts else { return [] }
+        guard tally.foundMajority else { return [] }
         // Report the richest sample so a failure message is as complete as
         // possible.
-        return nonEmptySamples.max(by: { $0.count < $1.count }) ?? []
+        return samples.filter { !$0.isEmpty }.max(by: { $0.count < $1.count }) ?? []
     }
 
     /// `DayRailView.scroll(_:to:)` runs a 0.2s `withAnimation(.easeInOut)`


### PR DESCRIPTION
Closes part of #259.

The iOS UI leg is the dominant wall-clock cost of any iOS PR. Before proposing anything I measured where the time actually goes, and **two of the issue's four premises turned out to be wrong**.

## Where the time goes

Per-test timings from the UI job log on `4078de2` (run `32593698578`). The 41-min job is ~5 min build and **30.0 min of test execution**:

| Class | Tests | Time | Share |
|---|---|---|---|
| `DayRailAccessibilityUITests` | 3 | **17.3 min** | **57.7%** |
| `DayRailUITests` | 18 | 11.7 min | 39.1% |
| `SearchToolbarUITests` | 3 | 0.8 min | 2.8% |
| `LaunchFixtureUITests` | 1 | 0.1 min | 0.4% |

`testWeekBandPassesAuditAtBothEndsOfTheRamp` alone was 9.9 min.

The suite had also **doubled in one PR**. Against `483c4c03`, before #256's week band: `testEventsDayRail…` 228s → 386s, and the suite as a whole ~15 min → 30 min.

## The cause

Instrumenting `railIssues` on an iPhone 17 Pro simulator:

```
SPIKE attempt=0 elements=99 query=0.38s frames=30.43s audit=10.29s total=41.09s
```

`railBounds` was **30.4s of a 41s attempt (74%)**; the audit it exists to scope was 10.3s. `allElementsBoundByIndex` returns live elements whose every `.frame` access **re-resolves against the app** — one whole-hierarchy traversal per element, visible in the log as a run of `Find the Any (Element at index n)`. The Events rail mounts 99 chips eagerly across the season.

It also scales with screen complexity, which is why nine `day-band-*` elements cost 158s: My Day's 24 elements resolve at 0.04s each, the Events screen's 99 at 0.31s each.

## What changed

**1. One snapshot instead of 99 traversals.** `app.snapshot()` returns the whole hierarchy in one round trip with frames already resolved.

**2. Early exit when the verdict is settled empty.** Once three of five samples are clean, no remaining sample can form a majority, so the result is already `[]`. The reporting path is deliberately *not* short-circuited, so a failure still reports its richest sample.

## Evidence

**The bounds are provably identical** — an A/B on all three audited screens returned bit-identical rects from identical element counts:

```
events   old={{-1360,176},{5481.67,82}} (99 els, 29.56s)  new=same (99 els, 0.58s)
myday    old={{-440,222},{1884,66.33}}  (24 els,  0.97s)  new=same (24 els, 0.10s)
weekband old={{0,176},{5497.67,82}}     (99 els, 30.31s)  new=same (99 els, 0.59s)
```

**The early exit is proved exhaustively.** `AuditSampleTallyTests` checks every sample sequence for 1..8 attempts against the pre-change rule. The six tests add **0.4s** and launch no app.

**Detection is unchanged**, checked three ways: identical bounds rects, identical verdicts for every sample sequence, and an injected defect that the *pre-change* implementation passes exactly as this one does.

## Result

Local, before → after: Events audit **214.6s → 39.5s**, My Day 30.6s → 17.2s. The audit class falls from dominating the suite to **18.0%** of it. Full UI suite green (31 tests); unit suite green (933 tests, 70 suites).

## Deliberately not done

- **Option 2 (double runs)** — measured, already fine: every `pull_request` run shows `skipped` at 0.0m.
- **Option 3 (narrow `paths:`)** — buys ~one skipped run in 31. Docs-only pushes are already skipped (`7b8d13b4` got no push run).
- **Option 4 (share app launches)** — premise falsified. `LaunchFixtureUITests` does nothing but launch and takes 6.7s; the median test is ~18s; all 25 launches are ~9% of test time. `ios.yml`'s comment saying otherwise is corrected here.
- **Option 1 (larger runner)** — left alone on purpose: this repo is **public**, so standard runners bill at **zero** and a larger one would convert a free workflow into a paid one. Worth revisiting only if the remaining time still hurts.

## Separate finding, filed not fixed

While falsifying, I found `testEventsDayRailPassesDynamicTypeAndClippingAudit` reports **8 `.dynamicType` issues on every run, all with empty identifiers**, every one dropped by the deliberate `isAnonymousDynamicTypeIssue` exclusion — so it currently cannot fail on that audit type. This is pre-existing (the pre-change implementation behaves identically) and out of scope here; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qst18DTowysjSbxodgFGzV