### PR TITLE
test(ios): make the day-rail accessibility gate able to fail (#261)

### DIFF
--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -473,21 +473,14 @@ struct EventListView: View {
         Button {
             selectDay(todayKey)
         } label: {
-            Label("Now", systemImage: "arrow.clockwise")
-                .labelStyle(.iconOnly)
-                .font(.subheadline.weight(.semibold))
-                // `.primary`, not the default accent tint (accessibility
-                // follow-up to #245): the accent colour against the opaque
-                // `dayRailControlBackground` measures under 4.5:1, caught
-                // by an on-device audit.
-                .foregroundStyle(.primary)
-                // Minimum, not fixed (accessibility follow-up to #245): a
-                // fixed frame clipped the symbol at large Dynamic Type
-                // sizes. 44pt still meets the HIG tap-target minimum; at
-                // the default text size this renders at exactly 44x62,
-                // matching `DayChip`.
-                .frame(minWidth: 44, minHeight: 62)
-                .background(Color.dayRailControlBackground, in: RoundedRectangle(cornerRadius: 12))
+            // Tint, frame and background all live in
+            // `DayRailEndControlLabel`, shared with My Day's expand controls
+            // — see its doc comment for why each of them is load-bearing and
+            // why a second copy here was a drift risk.
+            DayRailEndControlLabel {
+                Label("Now", systemImage: "arrow.clockwise")
+                    .labelStyle(.iconOnly)
+            }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(stepLabel(for: todayKey, nav: nav))

--- a/ios/ChqCalendar/Features/MyDay/MyDayView.swift
+++ b/ios/ChqCalendar/Features/MyDay/MyDayView.swift
@@ -453,7 +453,12 @@ struct MyDayView: View {
 ///
 /// The visible chip stays narrow — the count lives in the accessibility
 /// label, not on screen.
-private struct MyDayExpandControl: View {
+/// Internal rather than `private` so `DayRailDynamicTypeTests` can name it:
+/// #261 found the rail's accessibility audit is structurally blind to this
+/// control (an icon-only button presents no text for a Dynamic Type audit to
+/// measure), so the guard on its frame growing had to move to a measured unit
+/// test — and a test cannot host a `private` view.
+struct MyDayExpandControl: View {
     enum Direction { case earlier, later }
 
     let direction: Direction
@@ -463,28 +468,15 @@ private struct MyDayExpandControl: View {
 
     var body: some View {
         Button(action: action) {
-            Image(systemName: symbol)
-                .font(.subheadline.weight(.semibold))
-                // `.primary`, not the default accent tint (accessibility
-                // follow-up to #245): the accent colour against the opaque
-                // `dayRailControlBackground` measures under 4.5:1, caught
-                // by an on-device audit.
-                .foregroundStyle(.primary)
-                // Width's minimum is 44pt to meet the HIG minimum tap
-                // target. The horizontal axis is the mis-tap-prone one
-                // here — this chip sits at the end of a
-                // horizontally-scrolling strip flanked by 8pt spacing and
-                // other chips, and is tapped side-to-side, not
-                // top-to-bottom. Height's minimum stays 62 to match
-                // `DayChip`. The neighbouring chips (`minWidth: 58`)
-                // already clear 44pt. Both are minimums, not fixed sizes
-                // (accessibility follow-up to #245): a fixed frame clipped
-                // the chevron at large Dynamic Type sizes, caught by an
-                // on-device audit. At the default text size the icon is
-                // far smaller than either minimum, so nothing changes
-                // there.
-                .frame(minWidth: 44, minHeight: 62)
-                .background(Color.dayRailControlBackground, in: RoundedRectangle(cornerRadius: 12))
+            // Tint, frame and background all live in
+            // `DayRailEndControlLabel`, shared with the Events tab's `⟳ Now`
+            // — see its doc comment for why each of them is load-bearing and
+            // why a second copy here was a drift risk. At the default text
+            // size the chevron is far smaller than either minimum, so the
+            // frame only starts doing work at large Dynamic Type sizes.
+            DayRailEndControlLabel {
+                Image(systemName: symbol)
+            }
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)

--- a/ios/ChqCalendar/Features/Shared/DayRailView.swift
+++ b/ios/ChqCalendar/Features/Shared/DayRailView.swift
@@ -743,10 +743,15 @@ enum DayRailEndControl {
 }
 
 struct DayRailEndControlLabel<Icon: View>: View {
-    @ViewBuilder let icon: Icon
+    /// A builder closure rather than a stored `Icon`, matching
+    /// `DayRailView`'s own `leading`/`trailing` above. Both forms compile and
+    /// both support the trailing-closure call sites — the memberwise
+    /// initializer carries the `@ViewBuilder` either way — so this is the
+    /// file's convention, not a correctness fix.
+    @ViewBuilder let icon: () -> Icon
 
     var body: some View {
-        icon
+        icon()
             // `.primary`, not the default accent tint (accessibility
             // follow-up to #245): the accent colour against the opaque
             // `dayRailControlBackground` measures under 4.5:1, caught by an

--- a/ios/ChqCalendar/Features/Shared/DayRailView.swift
+++ b/ios/ChqCalendar/Features/Shared/DayRailView.swift
@@ -707,6 +707,71 @@ private struct WeekBandSegmentView: View {
     }
 }
 
+/// The chrome the rail's two fixed end controls share: `⟳ Now` on the Events
+/// tab (`EventListView.nowButton`) and My Day's earlier/later expand controls
+/// (`MyDayExpandControl`). Only the icon differs between them — one is a
+/// `Label(…).labelStyle(.iconOnly)`, the other a bare `Image(systemName:)` —
+/// so the icon stays at the call site and everything wrapped around it lives
+/// here once.
+///
+/// **Why one type rather than the two identical modifier stacks this
+/// replaces.** Both call sites carried the same decisions, each with its own
+/// copy of the same comment explaining it, and every one of them is an
+/// accessibility fix that was paid for on-device (follow-ups to #245): the
+/// `.primary` tint, because the default accent against
+/// `dayRailControlBackground` measures under 4.5:1; and the *minimum* frame,
+/// because a fixed one clipped the glyph at large Dynamic Type sizes. That is
+/// exactly the drift risk `RailMetrics` already exists to prevent for the
+/// gutter — two copies of a number agree only until one of them is tuned.
+///
+/// **It is also what makes those decisions testable.**
+/// `DayRailDynamicTypeTests` measures this view against the glyph it has to
+/// hold, which is the guard that was missing: #261 showed the rail's
+/// `performAccessibilityAudit` could not see a fixed frame here at all,
+/// because an icon-only control presents no text for a Dynamic Type audit to
+/// measure. A test cannot name `MyDayExpandControl`'s or `nowButton`'s label
+/// without this type — one was `private`, the other a method body — and
+/// re-declaring the same modifier stack inside the test would gate a copy
+/// nothing renders.
+enum DayRailEndControl {
+    /// The glyph's text style. Named here rather than written inline below so
+    /// `DayRailDynamicTypeTests` can measure the icon on its own against the
+    /// chrome that has to hold it, using the *same* value the chrome renders
+    /// with — the reason `WeekBandRun.unreachableFillOpacity` is a named
+    /// constant too: a copy of it in the test would gate a font nothing draws.
+    static let iconFont: Font = .subheadline.weight(.semibold)
+}
+
+struct DayRailEndControlLabel<Icon: View>: View {
+    @ViewBuilder let icon: Icon
+
+    var body: some View {
+        icon
+            // `.primary`, not the default accent tint (accessibility
+            // follow-up to #245): the accent colour against the opaque
+            // `dayRailControlBackground` measures under 4.5:1, caught by an
+            // on-device audit.
+            .font(DayRailEndControl.iconFont)
+            .foregroundStyle(.primary)
+            // Minimums, never fixed sizes (accessibility follow-up to #245):
+            // a fixed frame clipped the glyph at large Dynamic Type sizes.
+            // 44pt is the HIG tap-target minimum — and the horizontal axis is
+            // the mis-tap-prone one for a control at the end of a
+            // horizontally-scrolling strip, tapped side-to-side rather than
+            // top-to-bottom. 62pt matches `DayChip`'s height at the default
+            // text size, where these render at exactly 44x62; the
+            // neighbouring chips (`minWidth: 58`) already clear 44pt.
+            //
+            // Both minimums are load-bearing at large sizes and neither is
+            // slack: at `.accessibility5` the `arrow.clockwise` glyph measures
+            // ≈52.3x61.7, so it has outgrown the width minimum outright and
+            // clears the height one by about a third of a point.
+            // `DayRailDynamicTypeTests` measures exactly that.
+            .frame(minWidth: 44, minHeight: 62)
+            .background(Color.dayRailControlBackground, in: RoundedRectangle(cornerRadius: 12))
+    }
+}
+
 /// One selectable day chip in `MyDayView`'s strip (#192).
 ///
 /// All labelling lives in `MyDayChipContent` so it can be tested without a

--- a/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
+++ b/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
@@ -19,6 +19,14 @@ private nonisolated let endControlSymbols = ["arrow.clockwise", "chevron.left", 
 /// `DayChipContrastTests` made for contrast, for the same reason, and against
 /// the same wall.
 ///
+/// The shared precedent is the *strategy* — when the audit is structurally
+/// blind to a property, gate that property exactly, against the real thing —
+/// not the technique. `DayChipContrastTests` needs no view host at all: a
+/// contrast ratio is computable from two asset-catalog colours. A layout
+/// question is not, so this file hosts and measures. Don't come here looking
+/// for a literal pattern to copy from that file; the thing they share is the
+/// reasoning.
+///
 /// **Why the audit could not do this job.** `DayRailAccessibilityUITests` ran
 /// `.dynamicType` over the rail and, on every attempt of every run, reported
 /// only issues whose element carried an empty `identifier` — all of which its

--- a/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
+++ b/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
@@ -103,14 +103,37 @@ struct DayRailDynamicTypeTests {
             action: {})
     }
 
+    /// Each control's icon built the way *its own call site* builds it:
+    /// `EventListView.nowButton` passes a
+    /// `Label("Now", systemImage:).labelStyle(.iconOnly)`, while
+    /// `MyDayExpandControl` passes a bare `Image(systemName:)`.
+    ///
+    /// An earlier version measured every symbol through `Image`, on the
+    /// unstated assumption that `.labelStyle(.iconOnly)` sizes identically to
+    /// a bare `Image`. It does today — both measure 52.33pt wide at
+    /// `.accessibility5` — but that is an Apple implementation detail this
+    /// file has no business resting on, and it would silently stop covering
+    /// the real Now button if it ever changed. Building each icon the way
+    /// production builds it costs one branch and removes the assumption.
+    @ViewBuilder
+    private func productionIcon(_ symbol: String) -> some View {
+        if symbol == Self.nowSymbol {
+            Label("Now", systemImage: symbol).labelStyle(.iconOnly)
+        } else {
+            Image(systemName: symbol)
+        }
+    }
+
+    private static let nowSymbol = "arrow.clockwise"
+
     private func endControl(_ symbol: String) -> some View {
-        DayRailEndControlLabel { Image(systemName: symbol) }
+        DayRailEndControlLabel { productionIcon(symbol) }
     }
 
     /// The bare glyph the chrome has to hold, drawn in the chrome's own font
     /// (`DayRailEndControl.iconFont`, not a copy of it).
     private func endControlGlyph(_ symbol: String) -> some View {
-        Image(systemName: symbol).font(DayRailEndControl.iconFont)
+        productionIcon(symbol).font(DayRailEndControl.iconFont)
     }
 
     // MARK: - The chip grows with Dynamic Type
@@ -297,6 +320,39 @@ struct DayRailDynamicTypeTests {
         #expect(
             chrome.width < glyph.width,
             "a fixed 44pt width must clip the Now glyph at accessibility5 (glyph \(glyph.width) vs frame \(chrome.width)), or this self-check proves nothing")
+    }
+
+    /// The chrome tests above measure `DayRailEndControlLabel` directly. This
+    /// measures the real `MyDayExpandControl` — the actual call-site view,
+    /// in all four of its states — so the chain from production view to
+    /// chrome is checked rather than assumed. (`EventListView.nowButton` has
+    /// no equivalent here: it is a private method needing a `NavMatching` to
+    /// build its accessibility label, so its icon construction is mirrored by
+    /// `productionIcon(_:)` instead.)
+    ///
+    /// 44x62 is asserted as a floor at every size rather than an equality,
+    /// because the frame is a minimum: if a future chevron outgrew it, growing
+    /// is the correct behaviour and this must not call it a regression.
+    @Test func theRealMyDayExpandControlMeetsTheChromesContract() {
+        for direction in [MyDayExpandControl.Direction.earlier, .later] {
+            for isExpanded in [false, true] {
+                let control = MyDayExpandControl(
+                    direction: direction, isExpanded: isExpanded, hiddenCount: 3, action: {})
+                let state = "\(direction)/expanded=\(isExpanded)"
+
+                let atDefault = measure(control, at: .large)
+                #expect(
+                    atDefault.width == 44 && atDefault.height == 62,
+                    "\(state) should render at 44x62 by default, measured \(atDefault)")
+
+                for size in DynamicTypeSize.allCases {
+                    let measured = measure(control, at: size)
+                    #expect(
+                        measured.width >= 44 && measured.height >= 62,
+                        "\(state) fell below the 44x62 minimum at \(size): \(measured)")
+                }
+            }
+        }
     }
 
     /// The default-size rendering `DayRailEndControlLabel`'s comment states as

--- a/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
+++ b/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
@@ -307,19 +307,28 @@ struct DayRailDynamicTypeTests {
     }
 
     /// Falsification, and the one that matters most here: this is defect #2
-    /// from #261 — `day-rail-now`'s `.frame(minWidth: 44, minHeight: 62)` made
-    /// fixed, the exact defect the code comment says an on-device audit once
-    /// caught, and which the automated audit was proven to pass. Pinned to
-    /// 44×62, the chrome is narrower than the `arrow.clockwise` glyph at
-    /// `.accessibility5`, and the check above fails.
+    /// from #261 — `day-rail-now`'s `.frame(minWidth: 44, minHeight: 62)`
+    /// made fixed, the exact defect the code comment says an on-device audit
+    /// once caught, and which the automated audit was proven to pass.
+    ///
+    /// Pins the real chrome view rather than a bare glyph in a frame: the
+    /// point is that the *control* stops being able to hold its content, so
+    /// the constraint belongs on the control. Constrained to a fixed 44x62,
+    /// `DayRailEndControlLabel` is narrower at `.accessibility5` than the
+    /// glyph it is wrapping, which is precisely what
+    /// `theEndControlChromeAlwaysHoldsItsGlyph` checks for.
+    ///
+    /// This is a stand-in for the defect, applied from outside. The defect
+    /// itself was also injected directly into `DayRailEndControlLabel`'s own
+    /// `.frame` and confirmed to fail that test — see the PR for #261.
     @Test func aFixedEndControlFrameClipsTheGlyphAndIsCaught() {
-        let pinned = endControlGlyph("arrow.clockwise").frame(width: 44, height: 62)
-        let chrome = measure(pinned, at: .accessibility5)
-        let glyph = measure(endControlGlyph("arrow.clockwise"), at: .accessibility5)
+        let pinnedChrome = measure(
+            endControl(Self.nowSymbol).frame(width: 44, height: 62), at: .accessibility5)
+        let glyph = measure(endControlGlyph(Self.nowSymbol), at: .accessibility5)
 
         #expect(
-            chrome.width < glyph.width,
-            "a fixed 44pt width must clip the Now glyph at accessibility5 (glyph \(glyph.width) vs frame \(chrome.width)), or this self-check proves nothing")
+            pinnedChrome.width < glyph.width,
+            "a fixed 44pt width must clip the Now glyph at accessibility5 (glyph \(glyph.width) vs frame \(pinnedChrome.width)), or this self-check proves nothing")
     }
 
     /// The chrome tests above measure `DayRailEndControlLabel` directly. This

--- a/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
+++ b/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
@@ -1,0 +1,305 @@
+import SwiftUI
+import Testing
+import UIKit
+@testable import ChqCalendar
+
+/// Pins the day rail's Dynamic Type behaviour by *measuring the real views*
+/// instead of by `performAccessibilityAudit` (#261) — the same move
+/// `DayChipContrastTests` made for contrast, for the same reason, and against
+/// the same wall.
+///
+/// **Why the audit could not do this job.** `DayRailAccessibilityUITests` ran
+/// `.dynamicType` over the rail and, on every attempt of every run, reported
+/// only issues whose element carried an empty `identifier` — all of which its
+/// own filter then dropped as unattributable. Three defects injected into app
+/// code (a chip narrowed until its text truncated, `day-rail-now`'s minimum
+/// frame made fixed, its font made non-scaling) all passed. The reason is
+/// structural, and it covers the whole rail rather than just the chips:
+///
+/// - A **chip**'s three `Text` runs sit inside a `Button` (`DayChip.body` —
+///   the alternative, a hidden visual layer under a `Color.clear` tap target,
+///   was tried and reverted because it broke tap delivery after a drag), which
+///   collapses them into one accessibility node. The audit cannot attribute a
+///   finding to an individual run.
+/// - A **week-band segment** collapses the same way, via
+///   `WeekBandSegmentView`'s `.accessibilityElement()`.
+/// - The **end controls** present *no text at all*: both are icon-only
+///   (`Label(…).labelStyle(.iconOnly)` on the Events tab,
+///   `Image(systemName:)` on My Day). A Dynamic Type audit measures text, so
+///   there is nothing on either control for it to look at.
+///
+/// That last point is what the audit's own doc comment used to get wrong: it
+/// justified keeping `.dynamicType` by saying the check still covered "the end
+/// controls, whose single-`Text` buttons don't collapse multiple runs." There
+/// are no `Text`s on those buttons. `.dynamicType` therefore had no addressable
+/// text anywhere on the rail, which is why it could not fail.
+///
+/// **What replaces it.** A hosted measurement has none of that ambiguity: a
+/// `UIHostingController` renders the actual view at an actual
+/// `dynamicTypeSize` and reports the size it actually takes. Every assertion
+/// below is a property the app's own comments already claim, and none of them
+/// was verified anywhere until now.
+///
+/// **What this does NOT gate, stated plainly** so the file is not read as
+/// wider coverage than it is: the text style chosen for an individual `Text`
+/// *inside* the chip. SwiftUI's `Font` is opaque — it cannot be inspected —
+/// and `chipVisual`/`countLine` are private, so there is no seam at which to
+/// measure one line on its own. A change from `.font(.subheadline)` to
+/// `.font(.system(size: 15))` on the middle line would shrink the chip's
+/// growth without stopping it, and nothing here would fail. The chip's
+/// *container* behaviour — that it grows, and that it widens to hold longer
+/// text rather than clipping it — is what is gated, and that is where every
+/// defect this rail has actually shipped has lived (see `DayChip.body` and
+/// `DayRailEndControlLabel`'s comments, all of them frame or fill decisions).
+/// Both end controls are the same chrome around a different glyph since they
+/// were unified into `DayRailEndControlLabel`, so measuring that chrome with
+/// each real symbol covers `EventListView.nowButton` and both directions of
+/// `MyDayExpandControl`.
+///
+/// `nonisolated`, at file scope rather than on the test type:
+/// `@Test(arguments:)` evaluates its argument list outside the actor, so
+/// neither a `@MainActor` type nor this module's default main-actor isolation
+/// can hold it.
+private nonisolated let endControlSymbols = ["arrow.clockwise", "chevron.left", "chevron.right"]
+
+@MainActor
+struct DayRailDynamicTypeTests {
+
+    // MARK: - Measurement
+
+    /// The size the view actually takes when rendered at `size`, from a real
+    /// hosting controller — not a computation over the fonts the view is
+    /// *believed* to use. That distinction is the whole point: the audit's
+    /// failure here was that it inspected a description of the view, and this
+    /// measures the view.
+    private func measure(_ view: some View, at size: DynamicTypeSize) -> CGSize {
+        let host = UIHostingController(rootView: view.dynamicTypeSize(size))
+        return host.sizeThatFits(
+            in: CGSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude))
+    }
+
+    /// A chip with real content, built through `MyDayChipContent`'s own
+    /// initializer so the lines measured are the lines the rail renders.
+    private func chip(dateLine: String = "Jul 15", count: Int = 3) -> DayChip {
+        DayChip(
+            dayKey: "2026-07-15",
+            content: MyDayChipContent(
+                topLine: "Wed",
+                dateLine: dateLine,
+                count: count,
+                symbol: nil,
+                isToday: false,
+                accessibilityLabel: "Wednesday, July 15, \(count) events"),
+            isSelected: false,
+            isDisabled: false,
+            action: {})
+    }
+
+    private func endControl(_ symbol: String) -> some View {
+        DayRailEndControlLabel { Image(systemName: symbol) }
+    }
+
+    /// The bare glyph the chrome has to hold, drawn in the chrome's own font
+    /// (`DayRailEndControl.iconFont`, not a copy of it).
+    private func endControlGlyph(_ symbol: String) -> some View {
+        Image(systemName: symbol).font(DayRailEndControl.iconFont)
+    }
+
+    // MARK: - The chip grows with Dynamic Type
+
+    /// The chip must be strictly larger at the largest text size than at the
+    /// smallest, in both axes.
+    ///
+    /// End-to-end rather than step-by-step for width, because width genuinely
+    /// does not move for most of the ladder: `.frame(minWidth: 58)` plus 10pt
+    /// of horizontal padding pins it at 78pt all the way to `.accessibility1`,
+    /// and only past there does the text outgrow the minimum. A per-step
+    /// "strictly wider" assertion would be false on today's correct code.
+    @Test func theChipIsLargerAtTheLargestTextSizeThanTheSmallest() {
+        let smallest = measure(chip(), at: .xSmall)
+        let largest = measure(chip(), at: .accessibility5)
+
+        #expect(
+            largest.width > smallest.width,
+            "chip width did not grow: \(smallest.width) → \(largest.width)")
+        #expect(
+            largest.height > smallest.height,
+            "chip height did not grow: \(smallest.height) → \(largest.height)")
+    }
+
+    /// …and it must never *shrink* on the way there. A frame that grows and
+    /// then caps out mid-ladder still passes the end-to-end check above if the
+    /// cap sits above the smallest size; this is what notices it.
+    @Test func theChipNeverShrinksAsTheTextSizeRises() {
+        var previous = measure(chip(), at: DynamicTypeSize.allCases[0])
+        for size in DynamicTypeSize.allCases.dropFirst() {
+            let current = measure(chip(), at: size)
+            #expect(
+                current.width >= previous.width,
+                "chip width shrank at \(size): \(previous.width) → \(current.width)")
+            #expect(
+                current.height >= previous.height,
+                "chip height shrank at \(size): \(previous.height) → \(current.height)")
+            previous = current
+        }
+    }
+
+    /// Falsification: the check above must actually catch a fixed frame, which
+    /// is the defect shape every one of this rail's real Dynamic Type bugs has
+    /// had. Constraining the *real* chip from outside reproduces it exactly —
+    /// and this is the injection #261 proved the accessibility audit passes.
+    @Test func aFixedFrameStopsTheChipGrowingAndIsCaught() {
+        let pinned = chip().frame(width: 78, height: 66)
+        let smallest = measure(pinned, at: .xSmall)
+        let largest = measure(pinned, at: .accessibility5)
+
+        #expect(
+            largest.width == smallest.width && largest.height == smallest.height,
+            "a fixed frame must not grow, or this self-check proves nothing")
+    }
+
+    // MARK: - The chip holds its text rather than clipping it
+
+    /// A longer date line must make the chip wider — at *every* text size.
+    ///
+    /// This is the clipping guard, and it needs no access to `chipVisual`'s
+    /// internals: a chip that widens to fit its content is a chip that is not
+    /// truncating it. A fixed width collapses the two measurements onto each
+    /// other, which is what the falsification below relies on.
+    @Test func theChipWidensToHoldALongerDateLineAtEveryTextSize() {
+        for size in DynamicTypeSize.allCases {
+            let short = measure(chip(dateLine: "Jul 1"), at: size)
+            let long = measure(chip(dateLine: "September 30"), at: size)
+            #expect(
+                long.width > short.width,
+                "chip did not widen for longer text at \(size): \(short.width) vs \(long.width)")
+        }
+    }
+
+    /// Falsification for the check above, using the same fixed-width defect
+    /// that made `.textClipped` fire in the UI audit (#261's probe) — proving
+    /// this measurement sees it too, without needing a simulator app launch.
+    @Test func aFixedWidthHidesLongerTextAndIsCaught() {
+        let short = measure(chip(dateLine: "Jul 1").frame(width: 32), at: .large)
+        let long = measure(chip(dateLine: "September 30").frame(width: 32), at: .large)
+
+        #expect(
+            long.width == short.width,
+            "a fixed-width chip must not widen for longer text, or this self-check proves nothing")
+    }
+
+    // MARK: - The empty count line keeps pace with a populated one
+
+    /// `DayChip.countLine` reserves the empty case's height with a
+    /// `@ScaledMetric(relativeTo: .caption2)`, and its doc comment claims that
+    /// keeps an empty chip the same height as a populated one "at every text
+    /// size, not just the default." Nothing verified that claim until now, and
+    /// it is exactly the kind a plain `14` would silently break: the two
+    /// heights would still match at the default size and drift apart only for
+    /// the readers who need the scaling.
+    ///
+    /// A band rather than equality, because the two are never exactly equal:
+    /// the empty line reserves a whole scaled line box while a populated one is
+    /// sized by its glyphs, so an empty chip runs consistently taller. The gap
+    /// is not uniform across the ladder either — it is about 1% for the
+    /// non-accessibility sizes up to `.large`, jumps to a peak of 5.0% at
+    /// `.xLarge`, then falls back toward 2% through `.accessibility5` as the
+    /// chip's total height grows faster than the gap does. 8% clears that peak
+    /// with room to spare; `theBandIsNarrowerThanTheDefectItGuardsAgainst`
+    /// below is what keeps it from being merely permissive.
+    private static let countLineHeightBand = 0.08
+
+    @Test func anEmptyChipTracksAPopulatedOnesHeightAtEveryTextSize() {
+        for size in DynamicTypeSize.allCases {
+            let empty = measure(chip(count: 0), at: size).height
+            let populated = measure(chip(count: 3), at: size).height
+            #expect(
+                abs(empty - populated) / populated < Self.countLineHeightBand,
+                "empty and populated chip heights diverged at \(size): \(empty) vs \(populated)")
+        }
+    }
+
+    /// Falsification: the band must be narrower than the divergence the real
+    /// defect produces, or it proves nothing.
+    ///
+    /// The defect is specific — `countLineHeight` written as a plain `14`
+    /// instead of `@ScaledMetric(relativeTo: .caption2)` — so rather than
+    /// standing in a proxy mismatch, this reconstructs it. `@ScaledMetric` is
+    /// `UIFontMetrics.scaledValue(for:)` under the environment's content size
+    /// category, so subtracting the scaled reservation the empty chip really
+    /// used and adding back the unscaled 14 gives the height that chip would
+    /// have had with the defect in place. That height must fall outside the
+    /// band at the largest text size, where it matters most.
+    @Test func theBandIsNarrowerThanTheDefectItGuardsAgainst() {
+        let traits = UITraitCollection(preferredContentSizeCategory: .accessibilityExtraExtraExtraLarge)
+        let scaledReservation = UIFontMetrics(forTextStyle: .caption2)
+            .scaledValue(for: 14, compatibleWith: traits)
+
+        let empty = measure(chip(count: 0), at: .accessibility5).height
+        let populated = measure(chip(count: 3), at: .accessibility5).height
+        let withDefect = empty - scaledReservation + 14
+
+        #expect(
+            scaledReservation > 14,
+            "caption2 must scale at accessibility5, or this reconstruction is not the defect")
+        #expect(
+            abs(withDefect - populated) / populated >= Self.countLineHeightBand,
+            "an unscaled 14pt reservation must fall outside the band (would be \(withDefect) against \(populated)), or the band proves nothing")
+    }
+
+    // MARK: - The end controls never clip their glyph
+
+    /// The property `DayRailEndControlLabel`'s comment actually claims — "a
+    /// fixed frame clipped the glyph at large Dynamic Type sizes" — is that the
+    /// chrome is always at least as big as the glyph inside it. Not that it
+    /// *grows*: it does not. The 62pt height minimum is never exceeded by any
+    /// of these symbols, and the 44pt width minimum is only exceeded by
+    /// `arrow.clockwise`, at `.accessibility4` and above. A growth assertion
+    /// would be false on correct code; this one is the real invariant.
+    ///
+    /// It is also live rather than vacuous: at `.accessibility5` the
+    /// `arrow.clockwise` glyph measures ≈52.3×61.7 inside a 44×62 minimum — it
+    /// has already outgrown the width minimum outright, and clears the height
+    /// minimum by about a third of a point.
+    @Test(arguments: endControlSymbols)
+    func theEndControlChromeAlwaysHoldsItsGlyph(symbol: String) {
+        for size in DynamicTypeSize.allCases {
+            let chrome = measure(endControl(symbol), at: size)
+            let glyph = measure(endControlGlyph(symbol), at: size)
+            #expect(
+                chrome.width >= glyph.width,
+                "\(symbol) chrome is narrower than its glyph at \(size): \(chrome.width) < \(glyph.width)")
+            #expect(
+                chrome.height >= glyph.height,
+                "\(symbol) chrome is shorter than its glyph at \(size): \(chrome.height) < \(glyph.height)")
+        }
+    }
+
+    /// Falsification, and the one that matters most here: this is defect #2
+    /// from #261 — `day-rail-now`'s `.frame(minWidth: 44, minHeight: 62)` made
+    /// fixed, the exact defect the code comment says an on-device audit once
+    /// caught, and which the automated audit was proven to pass. Pinned to
+    /// 44×62, the chrome is narrower than the `arrow.clockwise` glyph at
+    /// `.accessibility5`, and the check above fails.
+    @Test func aFixedEndControlFrameClipsTheGlyphAndIsCaught() {
+        let pinned = endControlGlyph("arrow.clockwise").frame(width: 44, height: 62)
+        let chrome = measure(pinned, at: .accessibility5)
+        let glyph = measure(endControlGlyph("arrow.clockwise"), at: .accessibility5)
+
+        #expect(
+            chrome.width < glyph.width,
+            "a fixed 44pt width must clip the Now glyph at accessibility5 (glyph \(glyph.width) vs frame \(chrome.width)), or this self-check proves nothing")
+    }
+
+    /// The default-size rendering `DayRailEndControlLabel`'s comment states as
+    /// fact — "at the default text size these render at exactly 44x62" — and
+    /// which nothing checked. It is load-bearing for layout: 62pt is chosen to
+    /// match `DayChip`'s own height so the strip's ends line up with its chips.
+    @Test(arguments: endControlSymbols)
+    func theEndControlIsFortyFourBySixtyTwoAtTheDefaultTextSize(symbol: String) {
+        let size = measure(endControl(symbol), at: .large)
+
+        #expect(size.width == 44, "expected 44pt wide at the default text size, measured \(size.width)")
+        #expect(size.height == 62, "expected 62pt tall at the default text size, measured \(size.height)")
+    }
+}

--- a/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
+++ b/ios/ChqCalendarTests/DayRailDynamicTypeTests.swift
@@ -3,6 +3,17 @@ import Testing
 import UIKit
 @testable import ChqCalendar
 
+/// Both end controls are the same chrome around a different glyph since they
+/// were unified into `DayRailEndControlLabel`, so measuring that chrome with
+/// each real symbol covers `EventListView.nowButton` and both directions of
+/// `MyDayExpandControl`.
+///
+/// `nonisolated`, at file scope rather than on the test type:
+/// `@Test(arguments:)` evaluates its argument list outside the actor, so
+/// neither a `@MainActor` type nor this module's default main-actor isolation
+/// can hold it.
+private nonisolated let endControlSymbols = ["arrow.clockwise", "chevron.left", "chevron.right"]
+
 /// Pins the day rail's Dynamic Type behaviour by *measuring the real views*
 /// instead of by `performAccessibilityAudit` (#261) — the same move
 /// `DayChipContrastTests` made for contrast, for the same reason, and against
@@ -12,7 +23,7 @@ import UIKit
 /// `.dynamicType` over the rail and, on every attempt of every run, reported
 /// only issues whose element carried an empty `identifier` — all of which its
 /// own filter then dropped as unattributable. Three defects injected into app
-/// code (a chip narrowed until its text truncated, `day-rail-now`'s minimum
+/// code (a chip narrowed to a fixed width, `day-rail-now`'s minimum
 /// frame made fixed, its font made non-scaling) all passed. The reason is
 /// structural, and it covers the whole rail rather than just the chips:
 ///
@@ -51,17 +62,6 @@ import UIKit
 /// text rather than clipping it — is what is gated, and that is where every
 /// defect this rail has actually shipped has lived (see `DayChip.body` and
 /// `DayRailEndControlLabel`'s comments, all of them frame or fill decisions).
-/// Both end controls are the same chrome around a different glyph since they
-/// were unified into `DayRailEndControlLabel`, so measuring that chrome with
-/// each real symbol covers `EventListView.nowButton` and both directions of
-/// `MyDayExpandControl`.
-///
-/// `nonisolated`, at file scope rather than on the test type:
-/// `@Test(arguments:)` evaluates its argument list outside the actor, so
-/// neither a `@MainActor` type nor this module's default main-actor isolation
-/// can hold it.
-private nonisolated let endControlSymbols = ["arrow.clockwise", "chevron.left", "chevron.right"]
-
 @MainActor
 struct DayRailDynamicTypeTests {
 

--- a/ios/ChqCalendarUITests/DayRailAccessibilityUITests.swift
+++ b/ios/ChqCalendarUITests/DayRailAccessibilityUITests.swift
@@ -10,8 +10,12 @@ import XCTest
 /// and two non-empty ones (`Mon`, `Thu`) failed contrast outright, the
 /// selected chip's white-on-accent text and `⟳ Now` "nearly passed", and
 /// the count line's blank-placeholder text partially failed Dynamic Type.
-/// This file exists to pin that regression shut — with one exception, see
-/// `auditTypes` below: contrast itself is no longer gated here.
+/// This file exists to pin that regression shut — but only `.textClipped` is
+/// still gated here. Contrast and Dynamic Type are both structurally
+/// unreportable on this rail and are gated by exact unit tests instead
+/// (`DayChipContrastTests`, `WeekBandContrastTests`,
+/// `DayRailDynamicTypeTests`); see `auditTypes` below for what that means and
+/// how each was verified.
 ///
 /// **Why filtering, not a scoped audit call.** `performAccessibilityAudit`
 /// is declared only on `XCUIApplication` (see `XCUIAutomation.framework`'s
@@ -30,8 +34,9 @@ import XCTest
 /// on `rail.frame` let the pre-existing, out-of-scope `Search events`
 /// clipped-text finding leak in as a rail issue. Matching on the offending
 /// element's own `identifier` instead was tried and rejected before that:
-/// the contrast/Dynamic Type audits report per-text-run `SwiftUI.
-/// AccessibilityNode`s that carry no identifier of their own (only the
+/// the audits report per-text-run `SwiftUI.AccessibilityNode`s — clipping
+/// included, which is the one type still run here — that carry no identifier
+/// of their own (only the
 /// enclosing `Button` — or, for a disabled chip, the enclosing plain view,
 /// see below — does, via `DayChip`'s `.accessibilityIdentifier`), so
 /// identifier matching silently dropped every genuine chip-text issue —
@@ -54,57 +59,37 @@ import XCTest
 /// no `.disabled()` left to do that now). Matching by identifier against
 /// every node in the hierarchy, whatever its type, closes that gap.
 ///
-/// **Why a nil `issue.element` still counts as a rail issue, and why a
-/// non-nil-but-anonymous one sometimes doesn't.** `DayChip` wraps its
-/// visual content (`chipVisual`) directly in a `Button` (no hidden layer
-/// underneath — see `DayChip.body`'s own comment for why that was tried and
-/// reverted). Two different things can happen to an issue found on one of
-/// `chipVisual`'s individual `Text` runs once it sits inside that `Button`,
-/// and they are not the same failure mode:
+/// **Why a nil `issue.element` still counts as a rail issue.** `DayChip`
+/// wraps its visual content (`chipVisual`) directly in a `Button` (no hidden
+/// layer underneath — see `DayChip.body`'s own comment for why that was tried
+/// and reverted). A truly hidden node (`DayChip.countLine`'s empty-count
+/// placeholder, `.accessibilityHidden(true)`) is invisible to the audit's
+/// element *resolution* even though its *rendering* is still inspected — an
+/// issue found there arrives with `issue.element == nil`: no frame, no label,
+/// no identifier, nothing to intersect with `railBounds`. An earlier version
+/// of this test required a non-nil element inside `railBounds` and so
+/// silently dropped every one of these, which is exactly what let a
+/// falsification (restoring the pre-fix `.thinMaterial`/`.secondary` styling)
+/// stay green. Nil-element issues are counted for that reason.
 ///
-/// - A truly hidden node (`DayChip.countLine`'s empty-count placeholder,
-///   `.accessibilityHidden(true)`) is invisible to the audit's element
-///   *resolution* even though its *rendering* is still inspected — an issue
-///   found there arrives with `issue.element == nil`: no frame, no label,
-///   no identifier, nothing to intersect with `railBounds`. This is what an
-///   earlier version of this test got wrong by requiring a non-nil element
-///   inside `railBounds` — it silently dropped every one of these, which is
-///   exactly what let a falsification (restoring the pre-fix
-///   `.thinMaterial`/`.secondary` styling) stay green, and exactly what the
-///   count-line placeholder's own real, pre-fix Dynamic Type failure would
-///   have been dropped as too. Nil-element issues are still counted below
-///   for that reason.
-/// - A `Text` run that's merely *visible but unnamed* — not hidden, just
-///   lacking its own accessibility identifier because only the enclosing
-///   `Button` carries one (`DayChip`'s `.accessibilityIdentifier`) — comes
-///   back with a real, non-nil `XCUIElement`: a genuine frame inside
-///   `railBounds`, just an empty `identifier`. An A/B check confirmed this
-///   is where the Events rail's populated count digits land: ordinary
-///   `Text("\(content.count)").font(.caption2)`, unchanged code, audited
-///   clean with `.contrast` in play under the pre-collapse `DayChip`
-///   (hidden `chipVisual` plus a separate `Color.clear`-labelled `Button`,
-///   this file's own history above), and started reporting "Dynamic Type
-///   font sizes are partially unsupported" — non-nil element, real frame,
-///   `identifier == ""` — the moment the chip went back to wrapping
-///   `chipVisual` directly in a `Button`. Nothing about `countLine`'s code
-///   changed between the two runs, only whether its text sat inside a
-///   collapsing `Button`. That's the same underlying limitation that makes
-///   contrast unusable here (see `auditTypes` below), just surfacing
-///   through the non-nil branch instead of the nil one, so `railIssues`
-///   drops a bounds-matched `.dynamicType` issue whose element has an empty
-///   `identifier` rather than treating every bounds-matched issue as
-///   equally trustworthy.
+/// On the two screens this file audits (Events, My Day), the count-line
+/// placeholder is the only `.accessibilityHidden(true)` content left on
+/// screen — `FacetAllList` and `OffSeasonLandingView`'s hidden elements live
+/// on other screens entirely, and `WeekRangeStrip`'s hidden
+/// `currentWeekMarker` renders only inside the filter sheet — so treating a
+/// nil-element issue as rail-scoped on these two screens is sound, not just
+/// convenient.
 ///
-/// `.textClipped` keeps counting every issue in both branches, on the
-/// current evidence: nothing in this file's history or the A/B check above
-/// shows it hitting either wall, and dropping it pre-emptively would reopen
-/// the exact false-negative gap this file exists to prevent. On the two
-/// screens this file audits (Events, My Day), the count-line placeholder is
-/// the only `.accessibilityHidden(true)` content left on screen —
-/// `FacetAllList` and `OffSeasonLandingView`'s hidden elements live on
-/// other screens entirely, and `WeekRangeStrip`'s hidden `currentWeekMarker`
-/// renders only inside the filter sheet — so treating a nil-element issue
-/// as rail-scoped on these two screens is sound, not just convenient.
+/// **An anonymous, non-nil element is counted too, and that is load-bearing
+/// for the one audit type left here.** A `Text` run that is merely *visible
+/// but unnamed* — not hidden, just lacking its own identifier because only
+/// the enclosing `Button` carries one — comes back with a real
+/// `XCUIElement`: a genuine frame inside `railBounds`, an empty
+/// `identifier`. Every clipping finding on this rail is of that shape.
+/// Verified directly (#261): narrowing a chip to a fixed 32pt with
+/// `.lineLimit(1)` made the Events audit report five `Text clipped` issues,
+/// all with `id=`, and fail the test. A filter that dropped anonymous
+/// elements would drop all five.
 ///
 /// `issueHandler` returns `true` for every issue unconditionally so the
 /// audit call itself never throws partway through; the assertions below run
@@ -118,35 +103,48 @@ final class DayRailAccessibilityUITests: XCTestCase {
         continueAfterFailure = false
     }
 
-    /// Deliberately excludes `.contrast`. `DayChip` wraps its label
-    /// directly in a `Button` (see `DayChip.body`'s comment — the
-    /// alternative, a hidden visual layer under a separate `Color.clear`
-    /// tap target, was tried and reverted because it broke tap delivery
-    /// after a drag), and `performAccessibilityAudit` cannot sample an
-    /// individual `Text` run once a `Button` has collapsed it into one
-    /// accessibility node with everything else in the label. Run with
-    /// `.contrast` included, it reports failures against chip text whose
-    /// real, on-screen pixels measure roughly 18.8:1 (light, unselected)
-    /// and 17.0:1 (dark, unselected) — false positives produced by the
-    /// audit's own blind spot here, not a real regression (see the type's
-    /// doc comment, "Why a nil `issue.element`…", for the mechanism).
-    /// `DayChipContrastTests` gates contrast instead, by computing the WCAG
-    /// ratio directly between the two colours this rail actually renders
-    /// (`DayChipBackground`, `DayChipSelected`) and their real foregrounds
-    /// — exact, where this audit is structurally blind. Dynamic Type
-    /// *does* hit the identical wall on individual chip text (confirmed by
-    /// A/B testing the count digits against the pre-collapse `DayChip` —
-    /// see the type's doc comment for the exact check), so `railIssues`
-    /// drops a `.dynamicType` finding whenever its element is an anonymous
-    /// (empty-identifier) descendant rather than excluding the whole audit
-    /// type: that keeps this file gating Dynamic Type on everything else on
-    /// the rail (the end controls, whose single-`Text` buttons don't
-    /// collapse multiple runs, so a real finding there still has the
-    /// button's own identifier) while conceding, explicitly, that it can no
-    /// longer see inside a chip's own label. Text clipping has not shown
-    /// the same failure on any evidence gathered so far, so it stays fully
-    /// included.
-    private let auditTypes: XCUIAccessibilityAuditType = [.dynamicType, .textClipped]
+    /// `.textClipped` alone. Both other audit types are gated by exact unit
+    /// tests instead, because both are structurally unreportable on this rail
+    /// — the audit cannot see them, rather than seeing them and finding
+    /// nothing.
+    ///
+    /// **`.contrast`** was removed first. `performAccessibilityAudit` cannot
+    /// sample an individual `Text` run once a container has collapsed it into
+    /// one accessibility node with the rest of the label, which `DayChip`'s
+    /// `Button` and `WeekBandSegmentView`'s `.accessibilityElement()` both do.
+    /// Run with `.contrast` included, it reports failures against chip text
+    /// whose real, on-screen pixels measure roughly 18.8:1 (light, unselected)
+    /// and 17.0:1 (dark, unselected) — false positives produced by the audit's
+    /// own blind spot, not a regression. `DayChipContrastTests` and
+    /// `WeekBandContrastTests` compute the WCAG ratio between the actual
+    /// colours instead, which is exact where this is blind.
+    ///
+    /// **`.dynamicType`** followed it, for a reason that turned out to be
+    /// wider than the chips (#261). A previous version of this comment kept it
+    /// on the grounds that it still covered "the end controls, whose
+    /// single-`Text` buttons don't collapse multiple runs." Those buttons have
+    /// no `Text` at all: both end controls are icon-only —
+    /// `Label(…).labelStyle(.iconOnly)` on the Events tab,
+    /// `Image(systemName:)` on My Day — and a Dynamic Type audit measures
+    /// text. With the chips and the week band collapsing, and the end controls
+    /// presenting nothing to measure, `.dynamicType` had no addressable text
+    /// anywhere on the rail. It reported 8 anonymous issues on every attempt
+    /// of every run, all of which the filter here dropped, so the in-scope
+    /// count was 0 unconditionally and three defects injected into app code
+    /// all passed. `DayRailDynamicTypeTests` measures the real views in a
+    /// hosting controller instead, and catches all three.
+    ///
+    /// **`.textClipped` stays because it demonstrably works.** It is the one
+    /// type whose findings survive the collapse: they arrive anonymous, and
+    /// `railIssues` counts anonymous findings. Falsified directly rather than
+    /// assumed — see the type's doc comment for the injection and its five
+    /// reported issues.
+    ///
+    /// Note the earlier attempt that made this look toothless: narrowing the
+    /// chip *without* `.lineLimit(1)` makes SwiftUI **wrap** the text rather
+    /// than truncate it, so nothing is clipped and the audit is right to stay
+    /// silent. A clipping falsification has to actually clip.
+    private let auditTypes: XCUIAccessibilityAuditType = [.textClipped]
 
     /// Every element identifier the rail itself mounts, on either screen.
     /// A chip (`day-chip-*`) is a `Button` when tappable, but `DayChip`'s
@@ -227,12 +225,10 @@ final class DayRailAccessibilityUITests: XCTestCase {
 
     /// Runs the audit across the whole app, keeping only issues that belong
     /// to the rail: either the offending element's frame lies inside
-    /// `railBounds(in:)` (excluding an anonymous, empty-identifier
-    /// `.dynamicType` element — see the type's doc comment for why that
-    /// specific combination is a false positive, not a real finding), or
-    /// the issue has no resolvable element at all — see the type's doc
-    /// comment for why a nil element is still treated as a rail issue on
-    /// these two screens.
+    /// `railBounds(in:)`, or the issue has no resolvable element at all —
+    /// see the type's doc comment for why a nil element is still treated as
+    /// a rail issue on these two screens, and why an anonymous one is kept
+    /// rather than filtered out.
     ///
     /// Samples `attempts` times, re-settling between each, and requires a
     /// *majority* of samples to find something before reporting it.
@@ -270,38 +266,61 @@ final class DayRailAccessibilityUITests: XCTestCase {
     /// still available for the failure message. `AuditSampleTally` holds the
     /// arithmetic, and `AuditSampleTallyTests` proves over every possible
     /// sample sequence that the early exit returns what the full run would.
+    /// **A timed-out audit is retried, never recorded.** The audit itself can
+    /// fail with `com.apple.xcode.xctest.accessibilityAudit` code -56, "Audit
+    /// failed to complete in time" — which happened on `main` right after
+    /// #260 on a runner where *every* test was slow, including pure in-memory
+    /// ones (a 511-iteration arithmetic loop went from 0.5s to 8.9s). That is
+    /// infrastructure, not a verdict, and it must not be either kind of
+    /// answer: failing the test on it makes a red build out of a slow runner,
+    /// and recording it as a clean sample would let a degraded run vote for
+    /// "found nothing."
+    ///
+    /// It cannot simply consume the attempt either, because `AuditSampleTally`
+    /// takes its majority over the number of samples the caller *intends*.
+    /// With five intended attempts, three timeouts and two samples that both
+    /// found real issues, `nonEmpty * 2 > attempts` is `4 > 5` — silent, on
+    /// two independent confirmations of a genuine defect. So a timeout is
+    /// retried instead: the tally always receives its full `attempts` samples
+    /// and its contract is untouched. Only when timeouts exceed `attempts` —
+    /// a runner too degraded to audit at all — does this give up, and it does
+    /// so as a skip rather than a failure.
     @MainActor
     private func railIssues(in app: XCUIApplication, attempts: Int = 5) throws -> [XCUIAccessibilityAuditIssue] {
         var samples: [[XCUIAccessibilityAuditIssue]] = []
         var tally = AuditSampleTally(attempts: attempts)
-        for attempt in 0..<attempts {
-            if attempt > 0 { settleRailAnimation() }
+        var timeouts = 0
+        var isFirstTry = true
+        while tally.taken < attempts {
+            if !isFirstTry { settleRailAnimation() }
+            isFirstTry = false
             let bounds = try railBounds(in: app)
             var found: [XCUIAccessibilityAuditIssue] = []
-            try app.performAccessibilityAudit(for: auditTypes) { issue in
-                if let element = issue.element {
-                    let isAnonymousDynamicTypeIssue = issue.auditType == .dynamicType && element.identifier.isEmpty
-                    if bounds.contains(element.frame) && !isAnonymousDynamicTypeIssue {
-                        // The identifier check excludes exactly the false
-                        // positive the type's doc comment ("Why a nil
-                        // `issue.element`…") walks through: a real,
-                        // bounds-matched frame with no identifier of its
-                        // own is a chip's individual `Text` run, collapsed
-                        // into the enclosing `Button`'s single accessibility
-                        // node, and the audit cannot verify Dynamic Type
-                        // support for that specific run. A finding on one
-                        // of the rail's own identified buttons (non-empty
-                        // `identifier`) is unaffected and still counted.
+            do {
+                try app.performAccessibilityAudit(for: auditTypes) { issue in
+                    if let element = issue.element {
+                        if bounds.contains(element.frame) { found.append(issue) }
+                    } else {
                         found.append(issue)
                     }
-                } else {
-                    found.append(issue)
+                    // Always "handled": the raw audit call must never throw
+                    // for a *finding* — the test's own assertions below are
+                    // what report failure, with a message naming exactly
+                    // which issues matched the rail. The `catch` below is
+                    // therefore only ever an audit-machinery error, never a
+                    // finding.
+                    return true
                 }
-                // Always "handled": the raw audit call must never throw
-                // here — the test's own assertions below are what report
-                // failure, with a message naming exactly which issues
-                // matched the rail.
-                return true
+            } catch {
+                guard Self.isAuditTimeout(error) else { throw error }
+                timeouts += 1
+                guard timeouts <= attempts else {
+                    throw XCTSkip(
+                        "The accessibility audit timed out \(timeouts) times "
+                            + "(\(Self.auditTimeoutDomain) code \(Self.auditTimeoutCode)). "
+                            + "This is a degraded runner, not a finding — see railIssues' doc comment.")
+                }
+                continue
             }
             samples.append(found)
             tally.record(foundIssues: !found.isEmpty)
@@ -309,7 +328,7 @@ final class DayRailAccessibilityUITests: XCTestCase {
         }
         // Reachable only when `attempts == 0` (the loop never runs, so nothing
         // is ever tallied). For every `attempts >= 1` this is an invariant, not
-        // live logic: falling out of the loop means the final iteration found
+        // live logic: leaving the loop means the final sample found
         // `isSettledEmpty == false` with no samples remaining, which — with
         // `remaining == 0` — is exactly `foundMajority`. Kept rather than
         // dropped so the degenerate case still returns `[]` instead of reading
@@ -318,6 +337,16 @@ final class DayRailAccessibilityUITests: XCTestCase {
         // Report the richest sample so a failure message is as complete as
         // possible.
         return samples.filter { !$0.isEmpty }.max(by: { $0.count < $1.count }) ?? []
+    }
+
+    private static let auditTimeoutDomain = "com.apple.xcode.xctest.accessibilityAudit"
+    /// `XCTestErrorCode.timeoutWhileWaiting`, which the audit reports when it
+    /// cannot finish rather than when it finds something.
+    private static let auditTimeoutCode = -56
+
+    private static func isAuditTimeout(_ error: any Error) -> Bool {
+        let error = error as NSError
+        return error.domain == auditTimeoutDomain && error.code == auditTimeoutCode
     }
 
     /// `DayRailView.scroll(_:to:)` runs a 0.2s `withAnimation(.easeInOut)`
@@ -343,7 +372,7 @@ final class DayRailAccessibilityUITests: XCTestCase {
         }.joined(separator: "\n")
     }
 
-    func testEventsDayRailPassesDynamicTypeAndClippingAudit() throws {
+    func testEventsDayRailPassesTextClippingAudit() throws {
         let app = launchFixtureApp()
         let rail = app.scrollViews["day-rail"]
         XCTAssertTrue(rail.waitForExistence(timeout: 20))
@@ -422,7 +451,7 @@ final class DayRailAccessibilityUITests: XCTestCase {
         }
     }
 
-    func testMyDayRailPassesDynamicTypeAndClippingAudit() throws {
+    func testMyDayRailPassesTextClippingAudit() throws {
         let app = launchFixtureApp(extraArgs: [
             "-uitest-seed-favorites", "2026-07-15-0,2026-07-15-1,2026-07-15-2",
             "-uitest-tab", "my-day",


### PR DESCRIPTION
Closes #261.

## What #261 found, and what it turned out to be

`DayRailAccessibilityUITests` ran `.dynamicType` over the day rail and could not fail: every issue it found arrived with an empty `identifier` and was dropped by its own deliberate exclusion, so the in-scope count was 0 on every attempt of every run.

The issue attributed that to the chips, whose `Text` runs collapse into the enclosing `Button`'s single accessibility node. **The cause is wider — it covers the whole rail:**

- a chip's three runs collapse inside its `Button` (`DayChip.body`);
- a week-band segment collapses the same way, via `WeekBandSegmentView`'s `.accessibilityElement()`;
- the end controls present **no text at all** — both are icon-only (`Label(…).labelStyle(.iconOnly)` on Events, `Image(systemName:)` on My Day), and a Dynamic Type audit measures text.

That last point is what the audit's own doc comment got wrong. It justified keeping `.dynamicType` on the grounds that the check still covered *"the end controls, whose single-`Text` buttons don't collapse multiple runs."* Those buttons have no `Text`. `.dynamicType` had no addressable text anywhere on the rail, which is why it could not report.

## Option 4, answered: `.textClipped` works

The issue could not get `.textClipped` to fire and left open whether it had teeth. It does — the earlier probe just wasn't clipping anything.

`.frame(width: 24)` with no `lineLimit` makes SwiftUI **wrap** the text, not truncate it. Adding `.lineLimit(1)` makes the Events audit report five `Text clipped` issues and fail:

```
[Text clipped] label=Jul 16 id= frame=(290.0, 224.33, 32.0, 18.0)
```

All five arrive anonymous, so counting anonymous findings is load-bearing for this type. So the audit stays, narrowed to `[.textClipped]` — the one type that can actually report here.

## What replaces the Dynamic Type gate

`DayRailDynamicTypeTests` measures the real views in a `UIHostingController` across the full Dynamic Type ladder — option 1, the `DayChipContrastTests` precedent, exact where the audit is structurally blind. It gates four properties the app's own comments assert and nothing verified:

- the chip grows in both axes, and never shrinks on the way;
- the chip widens to hold a longer date line at every text size (the clipping guard);
- an empty chip's height tracks a populated one's at every text size — `countLine`'s `@ScaledMetric` claim;
- the end-control chrome always holds its glyph, and renders at exactly 44×62 at the default text size.

Note what the last one is **not**: a growth assertion. Measurement shows the chevron controls stay 44×62 at every size through `.accessibility5`, and `arrow.clockwise` only widens at `.accessibility4`+ — *"it grows"* would be false on correct code. The real invariant is that the chrome is never smaller than the glyph, and it is live rather than vacuous: at `.accessibility5` that glyph measures ≈52.3×61.7 inside a 44×62 minimum.

## Proven by breaking the code

Every guard was falsified against the real defect shape, using #261's own injections:

| Injected defect | Old audit | New tests |
|---|---|---|
| Chip `.frame(minWidth: 58)` → `.frame(width: 24)` | passed | **caught** (14 issues) |
| `day-rail-now` frame made fixed | passed | **caught** — `chrome.width 44.0 >= glyph.width 52.33` at AX5 |
| `countLineHeight` loses `@ScaledMetric` | passed | **caught** by the count-line band |
| `dateLine` font made non-scaling | passed | passes — **the documented gap** |
| Chip fixed width **+ `.lineLimit(1)`** | — | **caught** by the narrowed audit (5 issues) |

The last row was re-run against the rewritten sampling loop, not just the original.

**The gap is stated plainly in the file** rather than papered over: this does not gate the text style chosen for an individual `Text` inside the chip. SwiftUI's `Font` is opaque and `chipVisual`/`countLine` are private, so there is no seam to measure one line at. Container behaviour is what is gated — and that is where every Dynamic Type defect this rail has actually shipped has lived.

## The `-56` timeout

Treated as infrastructure, per the issue's second comment. A timed-out sample is **retried, not consumed** — consuming it would be a false negative, because `AuditSampleTally` takes its majority over the number of samples the caller *intends*: five intended attempts, three timeouts, and two samples that both found real issues gives `nonEmpty * 2 > attempts` = `4 > 5`, silent on two independent confirmations of a genuine defect. Retrying keeps the tally's exhaustively-tested contract untouched. Only when timeouts exceed `attempts` does it give up, as a skip rather than a failure.

## Supporting refactor

To make the end controls testable, their two identical modifier stacks are unified into `DayRailEndControlLabel`, and `MyDayExpandControl` drops `private`. Both call sites carried the same accessibility fixes with duplicate comments — the drift risk `RailMetrics` already exists to prevent for the gutter — and a test cannot name a `private` view or a method body. No pixel changes: the modifier stack is identical in content and order, and the new test pins the 44×62 default rendering.

## Verification

- Unit suite: **943 tests, 71 suites, green** (3.0s) — the new suite is 10 tests in 0.72s, in the fast leg
- UI suite: **32 tests, 0 failures** (800s)
- Narrowed audit: Events 26.5s, My Day 16.1s, week band 72.2s

[skip-screenshots: pure refactor, no visual change — the end-control chrome was extracted with an identical modifier stack, and DayRailDynamicTypeTests pins its 44x62 default rendering]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012JyRPDdmTQ37qSNAgdqtVs