### PR TITLE
feat(web): tapping the event name opens its details, with an "Open on chq.org" link inside

### DIFF
--- a/frontend/src/__tests__/components/calendar/EventCard.articleLinks.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventCard.articleLinks.test.tsx
@@ -42,12 +42,12 @@ describe('EventCard article links', () => {
     expect(screen.queryByText('In the Chautauquan Daily')).toBeNull();
   });
 
-  it('collapsed card shows the hint glyph inside the Show more control, not the titled links', () => {
+  it('collapsed card shows the hint glyph on the title line, not the titled links', () => {
     renderCard({ articleLinks: LINKS });
-    // The glyph now sits inside the "Show more" disclosure control, signalling
-    // that expanding reveals the articles (not up in the time/location line).
-    const showMore = screen.getByRole('button', { name: /Show more/ });
-    expect(within(showMore).getByTitle('Chautauquan Daily coverage')).toBeTruthy();
+    // The glyph sits inside the title control — the event name is what expands
+    // the card — signalling that opening it reveals the articles.
+    const title = screen.getByRole('button', { name: /Interfaith Lecture/ });
+    expect(within(title).getByTitle('Chautauquan Daily coverage')).toBeTruthy();
     expect(screen.queryByText('In the Chautauquan Daily')).toBeNull();
   });
 
@@ -62,12 +62,12 @@ describe('EventCard article links', () => {
     expect(screen.getByText('(preview 7/13)')).toBeTruthy();
   });
 
-  it('event with article links but no description still gets the disclosure widget', () => {
+  it('event with article links but no description still gets an expandable title', () => {
     renderCard({
       event: { ...baseEvent, description: undefined, categories: undefined },
       articleLinks: LINKS,
     });
-    expect(screen.getByText(/Show more/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Interfaith Lecture/ })).toBeTruthy();
   });
 });
 

--- a/frontend/src/__tests__/components/calendar/EventCard.programLinks.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventCard.programLinks.test.tsx
@@ -50,18 +50,18 @@ describe('EventCard program links', () => {
     expect(link.rel).toContain('noreferrer');
   });
 
-  it('collapsed card shows the 📖 badge inside the Show more control', () => {
+  it('collapsed card shows the 📖 badge inside the title control', () => {
     renderCard({ programLinks: PROGRAM_LINKS });
-    const showMore = screen.getByRole('button', { name: /Show more/ });
-    expect(within(showMore).getByTitle('Digital program')).toBeTruthy();
+    const title = screen.getByRole('button', { name: /Interfaith Lecture/ });
+    expect(within(title).getByTitle('Digital program')).toBeTruthy();
   });
 
-  it('event with no description, categories, or articleLinks but WITH programLinks still gets the disclosure widget', () => {
+  it('event with no description, categories, or articleLinks but WITH programLinks still gets an expandable title', () => {
     renderCard({
       event: { ...baseEvent, description: undefined, categories: undefined },
       programLinks: PROGRAM_LINKS,
     });
-    expect(screen.getByText(/Show more/)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Interfaith Lecture/ })).toBeTruthy();
   });
 
   it('expanded card with both programLinks and articleLinks renders "Digital Program" before "In the Chautauquan Daily" in document order', () => {

--- a/frontend/src/__tests__/components/calendar/EventCard.publisherSource.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventCard.publisherSource.test.tsx
@@ -59,24 +59,32 @@ describe('EventCard publisher attribution and status', () => {
     expect(screen.queryByText(/Rescheduled/i)).toBeNull();
   });
 
-  it('suppresses the title link when status=cancelled even if url is set', () => {
+  it('never makes the title a link, even when url is set', () => {
+    render(<EventCard event={baseEvent({ url: 'https://example.com/event' })} {...noopProps} />);
+    expect(screen.queryByRole('link', { name: /Test/ })).toBeNull();
+    expect(screen.getByRole('button', { name: /Test/ })).toBeInTheDocument();
+  });
+
+  it('keeps the panel and its link available when status=cancelled and url is set', () => {
     render(
       <EventCard
         event={baseEvent({ url: 'https://example.com/event', status: 'cancelled' })}
         {...noopProps}
+        isExpanded={true}
       />,
     );
-    const link = screen.queryByRole('link', { name: /Test/ });
-    expect(link).toBeNull();
+    expect(screen.getByRole('button', { name: /Test/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open event page/ })).toBeInTheDocument();
   });
 
-  it('keeps the title link when status=rescheduled and url is set', () => {
+  it('keeps the panel and its link available when status=rescheduled and url is set', () => {
     render(
       <EventCard
         event={baseEvent({ url: 'https://example.com/event', status: 'rescheduled' })}
         {...noopProps}
+        isExpanded={true}
       />,
     );
-    expect(screen.getByRole('link', { name: /Test/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Open event page/ })).toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/components/calendar/EventCard.titleDetails.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventCard.titleDetails.test.tsx
@@ -340,3 +340,54 @@ describe('EventCard expanded panel body', () => {
     expect(firstParagraph.compareDocumentPosition(chip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 });
+
+/**
+ * Two defects Copilot caught on PR #264, both introduced by #244 itself.
+ */
+describe('EventCard panel layout regressions (#264 review)', () => {
+  /** The chips live in the panel's only `flex flex-wrap` container. */
+  const chipContainers = (panel: HTMLElement) => panel.querySelectorAll('div.flex.flex-wrap');
+
+  it('renders no empty category container when the panel has only a url', () => {
+    // Before #244 a url alone never opened a panel, so an always-rendered
+    // category div cost nothing. Now it does: this panel holds the link only,
+    // and an empty `mb-2` container above it is a visible gap.
+    renderCard({ event: { ...bareEvent, url: 'https://www.chq.org/event/x' }, isExpanded: true });
+    const panel = document.getElementById(titleButton(/Bare Event/).getAttribute('aria-controls')!)!;
+    expect(chipContainers(panel)).toHaveLength(0);
+  });
+
+  it('renders no empty category container when the event has only Week N categories', () => {
+    renderCard({
+      event: { ...bareEvent, url: 'https://www.chq.org/event/x', categories: [{ name: 'Week 5' }] },
+      isExpanded: true,
+    });
+    const panel = document.getElementById(titleButton(/Bare Event/).getAttribute('aria-controls')!)!;
+    expect(chipContainers(panel)).toHaveLength(0);
+  });
+
+  it('still renders the container when there is at least one non-week category', () => {
+    renderCard({ event: { ...baseEvent, categories: [{ name: 'Lecture' }] }, isExpanded: true });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    expect(chipContainers(panel)).toHaveLength(1);
+    expect(within(panel).getByRole('button', { name: 'Lecture' })).toBeTruthy();
+  });
+
+  it('does not turn a cancelled title blue on hover', () => {
+    // The <h4> greys and strikes through a cancelled event; a blue hover on the
+    // button inside it overrides that treatment on the way past.
+    renderCard({
+      event: { ...baseEvent, url: 'https://www.chq.org/event/x', status: 'cancelled' },
+    });
+    const control = titleButton();
+    expect(control.className).not.toMatch(/hover:text-blue/);
+    // The cancelled treatment itself is untouched, and still lives on the <h4>.
+    expect(control.closest('h4')!.className).toMatch(/line-through/);
+    expect(control.closest('h4')!.className).toMatch(/text-gray-500/);
+  });
+
+  it('keeps the blue hover on a title that is not cancelled', () => {
+    renderCard({ event: { ...baseEvent, url: 'https://www.chq.org/event/x' } });
+    expect(titleButton().className).toMatch(/hover:text-blue-700/);
+  });
+});

--- a/frontend/src/__tests__/components/calendar/EventCard.titleDetails.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventCard.titleDetails.test.tsx
@@ -1,0 +1,342 @@
+/// <reference types="vitest/globals" />
+import { render, screen, within, fireEvent, cleanup } from '@testing-library/preact';
+import { EventCard, isChqOrgUrl } from '@/components/calendar/EventCard';
+import type { Event } from '@/lib/types';
+import type { ArticleLink } from '@/hooks/useArticleLinks';
+import type { ProgramLink } from '@/hooks/useProgramLinks';
+
+const baseEvent: Event = {
+  id: 'e1',
+  title: 'Interfaith Lecture',
+  description: 'A talk about peace.',
+  startDate: '2026-07-15T14:00:00',
+  endDate: '2026-07-15T15:00:00',
+  location: 'Hall of Philosophy',
+};
+
+/** An event with a title and a time and nothing else worth expanding. */
+const bareEvent: Event = {
+  id: 'bare',
+  title: 'Bare Event',
+  startDate: '2026-07-15T14:00:00',
+  endDate: '2026-07-15T15:00:00',
+};
+
+const PROGRAM_LINKS: ProgramLink[] = [
+  { title: 'Best for Baby: Digital Program', url: 'https://audienceaccess.co/best-for-baby/' },
+];
+
+const ARTICLE_LINKS: ArticleLink[] = [
+  { title: 'Syeed to speak today', url: 'https://chqdaily.com/preview/', kind: 'preview', pubDate: '2026-07-13' },
+];
+
+function renderCard(overrides: Partial<Parameters<typeof EventCard>[0]> = {}) {
+  return render(
+    <EventCard
+      event={baseEvent}
+      index={0}
+      isExpanded={false}
+      onToggleDescription={vi.fn()}
+      onToggleTag={vi.fn()}
+      isTagSelected={() => false}
+      isFavorite={false}
+      onToggleFavorite={vi.fn()}
+      onDownloadICS={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+/** The disclosure control that the event name became. */
+function titleButton(name: RegExp | string = /Interfaith Lecture/) {
+  return screen.getByRole('button', { name });
+}
+
+describe('isChqOrgUrl', () => {
+  it('accepts the bare apex host', () => {
+    expect(isChqOrgUrl('https://chq.org')).toBe(true);
+  });
+
+  it('accepts a www URL with a path', () => {
+    expect(isChqOrgUrl('https://www.chq.org/x')).toBe(true);
+  });
+
+  it('accepts any subdomain', () => {
+    expect(isChqOrgUrl('https://tickets.chq.org/')).toBe(true);
+  });
+
+  it('rejects a host that merely ends in the same letters', () => {
+    expect(isChqOrgUrl('https://notchq.org')).toBe(false);
+  });
+
+  it('rejects a look-alike host that only has chq.org as a prefix', () => {
+    expect(isChqOrgUrl('https://chq.org.evil.com')).toBe(false);
+  });
+
+  it('rejects a malformed URL rather than throwing', () => {
+    expect(isChqOrgUrl('garbage')).toBe(false);
+  });
+});
+
+describe('EventCard title as the disclosure control', () => {
+  it('clicking the event name toggles that event id', () => {
+    const onToggleDescription = vi.fn();
+    renderCard({ onToggleDescription });
+    fireEvent.click(titleButton());
+    expect(onToggleDescription).toHaveBeenCalledWith('e1');
+  });
+
+  it('the event name is a real <button>, so Enter and Space work without key handlers', () => {
+    renderCard();
+    const control = titleButton();
+    expect(control.tagName).toBe('BUTTON');
+    expect(control.getAttribute('type')).toBe('button');
+  });
+
+  it('the event name is not a link to event.url any more', () => {
+    renderCard({ event: { ...baseEvent, url: 'https://www.chq.org/event/x' } });
+    expect(screen.queryByRole('link', { name: /Interfaith Lecture/ })).toBeNull();
+  });
+
+  it('aria-expanded follows isExpanded and aria-controls names the rendered panel', () => {
+    const { rerender } = renderCard();
+    expect(titleButton().getAttribute('aria-expanded')).toBe('false');
+    // Collapsed: the panel is unmounted, not merely hidden.
+    const panelId = titleButton().getAttribute('aria-controls')!;
+    expect(panelId).toBeTruthy();
+    expect(document.getElementById(panelId)).toBeNull();
+
+    rerender(
+      <EventCard
+        event={baseEvent}
+        index={0}
+        isExpanded={true}
+        onToggleDescription={vi.fn()}
+        onToggleTag={vi.fn()}
+        isTagSelected={() => false}
+        isFavorite={false}
+        onToggleFavorite={vi.fn()}
+        onDownloadICS={vi.fn()}
+      />,
+    );
+    expect(titleButton().getAttribute('aria-expanded')).toBe('true');
+    expect(document.getElementById(panelId)).not.toBeNull();
+  });
+
+  it('there is no separate Show more / Show less control any more', () => {
+    renderCard({ programLinks: PROGRAM_LINKS });
+    expect(screen.queryByText(/Show more/)).toBeNull();
+    cleanup();
+    renderCard({ isExpanded: true });
+    expect(screen.queryByText(/Show less/)).toBeNull();
+  });
+
+  it('the chevron is decorative and flips with the expanded state', () => {
+    const { rerender } = renderCard();
+    expect(within(titleButton()).getByText('▸').getAttribute('aria-hidden')).toBe('true');
+    rerender(
+      <EventCard
+        event={baseEvent}
+        index={0}
+        isExpanded={true}
+        onToggleDescription={vi.fn()}
+        onToggleTag={vi.fn()}
+        isTagSelected={() => false}
+        isFavorite={false}
+        onToggleFavorite={vi.fn()}
+        onDownloadICS={vi.fn()}
+      />,
+    );
+    expect(within(titleButton()).getByText('▾')).toBeTruthy();
+  });
+});
+
+describe('EventCard title with nothing to expand', () => {
+  it('renders the name as plain text, not a button, when the event has no expandable content', () => {
+    renderCard({ event: bareEvent });
+    expect(screen.queryByRole('button', { name: /Bare Event/ })).toBeNull();
+    expect(screen.getByText('Bare Event')).toBeTruthy();
+  });
+
+  it('renders no chevron when the event has no expandable content', () => {
+    renderCard({ event: bareEvent });
+    expect(screen.queryByText('▸')).toBeNull();
+    expect(screen.queryByText('▾')).toBeNull();
+  });
+
+  it('a url alone makes the name expandable', () => {
+    renderCard({ event: { ...bareEvent, url: 'https://www.chq.org/event/x' } });
+    expect(screen.getByRole('button', { name: /Bare Event/ })).toBeTruthy();
+  });
+
+  it('non-week categories alone make the name expandable, but Week N alone does not', () => {
+    const weekOnly = { ...bareEvent, categories: [{ name: 'Week 5' }] };
+    renderCard({ event: weekOnly });
+    expect(screen.queryByRole('button', { name: /Bare Event/ })).toBeNull();
+
+    cleanup();
+    renderCard({ event: { ...bareEvent, categories: [{ name: 'Week 5' }, { name: 'Lecture' }] } });
+    expect(screen.getByRole('button', { name: /Bare Event/ })).toBeTruthy();
+  });
+});
+
+describe('EventCard "Open on chq.org" link inside the panel', () => {
+  it('labels a chq.org URL "Open on chq.org"', () => {
+    renderCard({ event: { ...baseEvent, url: 'https://www.chq.org/event/x' }, isExpanded: true });
+    const link = screen.getByRole('link', { name: /Open on chq\.org/ }) as HTMLAnchorElement;
+    expect(link.href).toBe('https://www.chq.org/event/x');
+    expect(link.target).toBe('_blank');
+    expect(link.rel).toContain('noopener');
+    expect(link.rel).toContain('noreferrer');
+  });
+
+  it('labels a publisher URL "Open event page"', () => {
+    renderCard({
+      event: {
+        ...baseEvent,
+        url: 'https://example-publisher.org/events/42',
+        sourcePublisherId: 'p1',
+        sourcePublisherName: 'Example Publisher',
+      },
+      isExpanded: true,
+    });
+    expect(screen.getByRole('link', { name: /Open event page/ })).toBeTruthy();
+    expect(screen.queryByRole('link', { name: /Open on chq\.org/ })).toBeNull();
+  });
+
+  it('renders no such link when the event has no url', () => {
+    renderCard({ isExpanded: true });
+    expect(screen.queryByRole('link', { name: /Open on chq\.org/ })).toBeNull();
+    expect(screen.queryByRole('link', { name: /Open event page/ })).toBeNull();
+  });
+
+  it('renders the link only when expanded', () => {
+    renderCard({ event: { ...baseEvent, url: 'https://www.chq.org/event/x' } });
+    expect(screen.queryByRole('link', { name: /Open on chq\.org/ })).toBeNull();
+  });
+
+  it('a cancelled event keeps the panel openable and keeps the chq.org link', () => {
+    renderCard({
+      event: { ...baseEvent, url: 'https://www.chq.org/event/x', status: 'cancelled' },
+      isExpanded: true,
+    });
+    expect(screen.getByRole('button', { name: /Interfaith Lecture/ })).toBeTruthy();
+    expect(screen.getByRole('link', { name: /Open on chq\.org/ })).toBeTruthy();
+  });
+
+  it('places the link last, after the Chautauquan Daily section', () => {
+    renderCard({
+      event: { ...baseEvent, url: 'https://www.chq.org/event/x' },
+      programLinks: PROGRAM_LINKS,
+      articleLinks: ARTICLE_LINKS,
+      isExpanded: true,
+    });
+    const daily = screen.getByText('In the Chautauquan Daily');
+    const link = screen.getByRole('link', { name: /Open on chq\.org/ });
+    expect(daily.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});
+
+describe('EventCard hint glyphs on the title line', () => {
+  it('renders 📖 and 📰 inside the title control, not as separate focusable controls', () => {
+    renderCard({ programLinks: PROGRAM_LINKS, articleLinks: ARTICLE_LINKS });
+    const control = titleButton();
+    const program = within(control).getByTitle('Digital program');
+    const daily = within(control).getByTitle('Chautauquan Daily coverage');
+    expect(program.tagName).toBe('SPAN');
+    expect(daily.tagName).toBe('SPAN');
+    expect(program.getAttribute('tabindex')).toBeNull();
+    expect(daily.getAttribute('tabindex')).toBeNull();
+    // Exactly one focusable control carries the title.
+    expect(screen.queryAllByRole('button', { name: /Interfaith Lecture/ })).toHaveLength(1);
+  });
+
+  it('keeps the glyphs on the title line when expanded', () => {
+    renderCard({ programLinks: PROGRAM_LINKS, articleLinks: ARTICLE_LINKS, isExpanded: true });
+    const control = titleButton();
+    expect(within(control).getByTitle('Digital program')).toBeTruthy();
+    expect(within(control).getByTitle('Chautauquan Daily coverage')).toBeTruthy();
+  });
+});
+
+/**
+ * The panel body — description paragraphs and category chips — is the largest
+ * mechanical part of #244: ~40 lines lifted out of the old collapsed/expanded
+ * ternary into the new panel. Nothing else in this file looks at it, so
+ * deleting either block wholesale would otherwise leave the suite green.
+ */
+describe('EventCard expanded panel body', () => {
+  const CATEGORIED: Event = {
+    ...baseEvent,
+    description: 'First paragraph.\nSecond paragraph.',
+    categories: [
+      { name: 'Week 5' },
+      { name: 'Lecture' },
+      { name: 'Chautauqua Institution Program' },
+    ],
+  };
+
+  it('renders the description text inside the open panel', () => {
+    renderCard({ isExpanded: true });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    expect(within(panel).getByText('A talk about peace.')).toBeTruthy();
+  });
+
+  it('splits the description on newlines into separate paragraphs', () => {
+    renderCard({ event: CATEGORIED, isExpanded: true });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    const paragraphs = Array.from(panel.querySelectorAll('p')).map(p => p.textContent);
+    expect(paragraphs).toEqual(['First paragraph.', 'Second paragraph.']);
+  });
+
+  it('renders no description text when the event has none', () => {
+    renderCard({
+      event: { ...bareEvent, url: 'https://www.chq.org/event/x' },
+      isExpanded: true,
+    });
+    const panel = document.getElementById(titleButton(/Bare Event/).getAttribute('aria-controls')!)!;
+    expect(panel.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('renders a category chip for each non-week category, under its display name', () => {
+    renderCard({ event: CATEGORIED, isExpanded: true });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    expect(within(panel).getByRole('button', { name: 'Lecture' })).toBeTruthy();
+    // "Chautauqua Institution Program" is shortened by getCategoryDisplayName.
+    expect(within(panel).getByRole('button', { name: 'CHQ Program' })).toBeTruthy();
+  });
+
+  it('does not render a chip for a Week N category', () => {
+    renderCard({ event: CATEGORIED, isExpanded: true });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    expect(within(panel).queryByRole('button', { name: 'Week 5' })).toBeNull();
+  });
+
+  it('clicking a category chip calls onToggleTag with the raw category name', () => {
+    const onToggleTag = vi.fn();
+    renderCard({ event: CATEGORIED, isExpanded: true, onToggleTag });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    fireEvent.click(within(panel).getByRole('button', { name: 'CHQ Program' }));
+    // The raw name, not the shortened label — it is what the filter matches on.
+    expect(onToggleTag).toHaveBeenCalledWith('Chautauqua Institution Program');
+  });
+
+  it('marks a selected category chip and leaves the others unselected', () => {
+    renderCard({
+      event: CATEGORIED,
+      isExpanded: true,
+      isTagSelected: (tag: string) => tag === 'Lecture',
+    });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    expect(within(panel).getByRole('button', { name: 'Lecture' }).className).toMatch(/bg-blue-600/);
+    expect(within(panel).getByRole('button', { name: 'CHQ Program' }).className).not.toMatch(/bg-blue-600/);
+  });
+
+  it('renders description before categories in document order', () => {
+    renderCard({ event: CATEGORIED, isExpanded: true });
+    const panel = document.getElementById(titleButton().getAttribute('aria-controls')!)!;
+    const firstParagraph = within(panel).getByText('First paragraph.');
+    const chip = within(panel).getByRole('button', { name: 'Lecture' });
+    expect(firstParagraph.compareDocumentPosition(chip) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+});

--- a/frontend/src/components/calendar/EventCard.tsx
+++ b/frontend/src/components/calendar/EventCard.tsx
@@ -17,6 +17,22 @@ export function formatArticleMeta(kind: ArticleLink['kind'], pubDate: string): s
   return `(${kind} ${m}/${d})`;
 }
 
+/**
+ * Whether `url` points at chq.org or one of its subdomains, which is what
+ * decides between the "Open on chq.org" and "Open event page" labels.
+ * Publisher-feed events carry the publisher's own URL, so the label is derived
+ * from the host rather than from `sourcePublisherId` — that stays right even
+ * when a publisher links back to chq.org. A malformed URL is not chq.org.
+ */
+export function isChqOrgUrl(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'chq.org' || host.endsWith('.chq.org');
+  } catch {
+    return false;
+  }
+}
+
 interface EventCardProps {
   event: Event;
   index: number;
@@ -42,6 +58,30 @@ export function EventCard({ event, index, isExpanded, onToggleDescription, onTog
       onDownloadICS(event);
     }
   };
+
+  const detailCategories = event.categories?.filter(cat => !cat.name.startsWith('Week ')) ?? [];
+  const hasProgramLinks = Boolean(programLinks && programLinks.length > 0);
+  const hasArticleLinks = Boolean(articleLinks && articleLinks.length > 0);
+  /**
+   * The event name is the disclosure control only when there is something
+   * behind it. An event with nothing but a title and a time should not offer a
+   * control that opens an empty box.
+   */
+  const hasDetails = Boolean(
+    event.description ||
+    detailCategories.length > 0 ||
+    hasProgramLinks ||
+    hasArticleLinks ||
+    event.url,
+  );
+  const detailPanelId = `event-details-${event.id}`;
+
+  const hintGlyphs = (
+    <>
+      {hasProgramLinks && <span className="ml-1" title="Digital program">📖</span>}
+      {hasArticleLinks && <span className="ml-1" title="Chautauquan Daily coverage">📰</span>}
+    </>
+  );
 
   return (
     <div data-event-id={event.id} className={`event-card py-2 sm:py-3 ${index > 0 ? 'border-t border-gray-200 dark:border-gray-700' : ''} hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors`}>
@@ -92,15 +132,20 @@ export function EventCard({ event, index, isExpanded, onToggleDescription, onTog
                 : 'text-gray-900 dark:text-white'
             }`}
           >
-            {event.url && event.status !== 'cancelled' ? (
-              <a
-                href={event.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
+            {hasDetails ? (
+              <button
+                type="button"
+                onClick={() => onToggleDescription(event.id)}
+                aria-expanded={isExpanded}
+                aria-controls={detailPanelId}
+                className="text-left w-full hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
               >
-                {event.title} 🔗
-              </a>
+                {event.title}
+                {hintGlyphs}
+                <span className="ml-1 text-xs align-middle text-gray-400 dark:text-gray-500" aria-hidden="true">
+                  {isExpanded ? '▾' : '▸'}
+                </span>
+              </button>
             ) : (
               event.title
             )}
@@ -129,111 +174,100 @@ export function EventCard({ event, index, isExpanded, onToggleDescription, onTog
             </div>
           )}
 
-          {/* Description with disclosure widget */}
-          {(event.description ||
-            (event.categories && event.categories.filter(cat => !cat.name.startsWith('Week ')).length > 0) ||
-            (articleLinks && articleLinks.length > 0) ||
-            (programLinks && programLinks.length > 0)) && (
-            <div className="mb-2">
-              {isExpanded ? (
-                <div>
-                  <button
-                    onClick={() => onToggleDescription(event.id)}
-                    className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs font-medium flex items-center gap-1"
-                  >
-                    <span className="text-xs">▼</span> Show less
-                  </button>
-
-                  {event.description && (
-                    <div className="text-gray-600 dark:text-gray-300 text-sm mb-2">
-                      {event.description
-                        .split(/\r?\n/)
-                        .map(line => line.trim())
-                        .filter(line => line.length > 0)
-                        .map((paragraph, index) => (
-                          <p key={index} className={index > 0 ? 'mt-2' : ''}>
-                            {paragraph}
-                          </p>
-                        ))}
-                    </div>
-                  )}
-
-                  <div className="mb-2 flex flex-wrap gap-1">
-                    {event.categories?.filter(cat => !cat.name.startsWith('Week ')).map((category, catIndex) => (
-                      <button
-                        key={`${event.id}-category-${catIndex}`}
-                        onClick={() => onToggleTag(category.name)}
-                        className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
-                          isTagSelected(category.name)
-                            ? 'bg-blue-600 text-white'
-                            : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
-                        }`}
-                      >
-                        {getCategoryDisplayName(category.name)}
-                      </button>
+          {/* Detail panel, opened by the event name above. Left unmounted when
+              collapsed rather than hidden — the list renders ~1,470 events. */}
+          {hasDetails && isExpanded && (
+            <div id={detailPanelId} className="mb-2">
+              {event.description && (
+                <div className="text-gray-600 dark:text-gray-300 text-sm mb-2">
+                  {event.description
+                    .split(/\r?\n/)
+                    .map(line => line.trim())
+                    .filter(line => line.length > 0)
+                    .map((paragraph, index) => (
+                      <p key={index} className={index > 0 ? 'mt-2' : ''}>
+                        {paragraph}
+                      </p>
                     ))}
-                  </div>
-
-                  {programLinks && programLinks.length > 0 && (
-                    <div className="mb-2">
-                      <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">
-                        Digital Program
-                      </div>
-                      <ul className="space-y-0.5">
-                        {programLinks.map((link) => (
-                          <li key={link.url} className="text-sm">
-                            <a
-                              href={link.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
-                            >
-                              📖 {link.title}
-                            </a>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-
-                  {articleLinks && articleLinks.length > 0 && (
-                    <div className="mb-2">
-                      <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">
-                        In the Chautauquan Daily
-                      </div>
-                      <ul className="space-y-0.5">
-                        {articleLinks.map((link) => (
-                          <li key={link.url} className="text-sm">
-                            <a
-                              href={link.url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                              className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
-                            >
-                              📰 {link.title}
-                            </a>
-                            <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
-                              {formatArticleMeta(link.kind, link.pubDate)}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
                 </div>
-              ) : (
-                <button
-                  onClick={() => onToggleDescription(event.id)}
-                  className="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-xs font-medium flex items-center gap-1"
-                >
-                  {programLinks && programLinks.length > 0 && (
-                    <span title="Digital program">📖</span>
-                  )}
-                  {articleLinks && articleLinks.length > 0 && (
-                    <span title="Chautauquan Daily coverage">📰</span>
-                  )}
-                  <span className="text-xs">▶</span> Show more
-                </button>
+              )}
+
+              <div className="mb-2 flex flex-wrap gap-1">
+                {detailCategories.map((category, catIndex) => (
+                  <button
+                    key={`${event.id}-category-${catIndex}`}
+                    onClick={() => onToggleTag(category.name)}
+                    className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
+                      isTagSelected(category.name)
+                        ? 'bg-blue-600 text-white'
+                        : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+                    }`}
+                  >
+                    {getCategoryDisplayName(category.name)}
+                  </button>
+                ))}
+              </div>
+
+              {programLinks && programLinks.length > 0 && (
+                <div className="mb-2">
+                  <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">
+                    Digital Program
+                  </div>
+                  <ul className="space-y-0.5">
+                    {programLinks.map((link) => (
+                      <li key={link.url} className="text-sm">
+                        <a
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
+                        >
+                          📖 {link.title}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
+              {articleLinks && articleLinks.length > 0 && (
+                <div className="mb-2">
+                  <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">
+                    In the Chautauquan Daily
+                  </div>
+                  <ul className="space-y-0.5">
+                    {articleLinks.map((link) => (
+                      <li key={link.url} className="text-sm">
+                        <a
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:underline"
+                        >
+                          📰 {link.title}
+                        </a>
+                        <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
+                          {formatArticleMeta(link.kind, link.pubDate)}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {/* Kept for cancelled events too: chq.org is where a
+                  cancellation is confirmed. */}
+              {event.url && (
+                <div className="mb-1">
+                  <a
+                    href={event.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 px-3 py-1.5 rounded-md border border-blue-600 dark:border-blue-400 text-blue-600 dark:text-blue-400 text-sm font-medium hover:bg-blue-50 dark:hover:bg-blue-900/30 transition-colors"
+                  >
+                    {isChqOrgUrl(event.url) ? 'Open on chq.org' : 'Open event page'}
+                    <span aria-hidden="true">↗</span>
+                  </a>
+                </div>
               )}
             </div>
           )}

--- a/frontend/src/components/calendar/EventCard.tsx
+++ b/frontend/src/components/calendar/EventCard.tsx
@@ -138,7 +138,11 @@ export function EventCard({ event, index, isExpanded, onToggleDescription, onTog
                 onClick={() => onToggleDescription(event.id)}
                 aria-expanded={isExpanded}
                 aria-controls={detailPanelId}
-                className="text-left w-full hover:text-blue-700 dark:hover:text-blue-300 transition-colors"
+                className={`text-left w-full transition-colors ${
+                  event.status === 'cancelled'
+                    ? ''
+                    : 'hover:text-blue-700 dark:hover:text-blue-300'
+                }`}
               >
                 {event.title}
                 {hintGlyphs}
@@ -192,21 +196,23 @@ export function EventCard({ event, index, isExpanded, onToggleDescription, onTog
                 </div>
               )}
 
-              <div className="mb-2 flex flex-wrap gap-1">
-                {detailCategories.map((category, catIndex) => (
-                  <button
-                    key={`${event.id}-category-${catIndex}`}
-                    onClick={() => onToggleTag(category.name)}
-                    className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
-                      isTagSelected(category.name)
-                        ? 'bg-blue-600 text-white'
-                        : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
-                    }`}
-                  >
-                    {getCategoryDisplayName(category.name)}
-                  </button>
-                ))}
-              </div>
+              {detailCategories.length > 0 && (
+                <div className="mb-2 flex flex-wrap gap-1">
+                  {detailCategories.map((category, catIndex) => (
+                    <button
+                      key={`${event.id}-category-${catIndex}`}
+                      onClick={() => onToggleTag(category.name)}
+                      className={`px-1 py-0.5 sm:px-2 sm:py-1 rounded-full text-xs transition-colors cursor-pointer hover:opacity-80 ${
+                        isTagSelected(category.name)
+                          ? 'bg-blue-600 text-white'
+                          : 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-200 hover:bg-gray-200 dark:hover:bg-gray-600'
+                      }`}
+                    >
+                      {getCategoryDisplayName(category.name)}
+                    </button>
+                  ))}
+                </div>
+              )}
 
               {programLinks && programLinks.length > 0 && (
                 <div className="mb-2">


### PR DESCRIPTION
Closes #244.

## What changed

The event **title is now the disclosure control**: a `<button>` inside the existing `<h4>`, toggling the same `expandedDescriptions` state the "Show more" link used to. The separate "Show more"/"Show less" row is gone (each card with details is one line shorter), the 📖/📰 hint glyphs move onto the title line, and a chevron (`▸`/`▾`, `aria-hidden`) marks expandability. Titles of events with nothing expandable render as plain text with no chevron.

The **chq.org link moves into the expanded panel**: a button-styled link at the bottom, labelled **"Open on chq.org"** when the URL's host is `chq.org` or a subdomain and **"Open event page"** otherwise (publisher-feed events point at the publisher's own page). Cancelled events keep the panel openable and keep the link — the chq.org page is where a cancellation is confirmed.

Everything else follows the issue's spec verbatim: `aria-expanded`/`aria-controls` wired, panel unmounted while collapsed, panel content in iOS's order (description → category chips → 📖 links → 📰 links → open link), no state-shape change, no localStorage migration, no iOS changes.

## Tests

- New `EventCard.titleDetails.test.tsx` (32 tests): title-as-button behaviour, host-label logic (`isChqOrgUrl` incl. `chq.org.evil.com` → false), plain-text-title gate, `aria-expanded`, cancelled-event panel, and the full panel body (description paragraphs, category chips render + `onToggleTag` with the raw name, selected-chip styling).
- Retargeted the 📖/📰 glyph tests and the cancelled-title test in the existing suites.
- TDD (RED → GREEN) and 8 falsification injections — each new guard was proven by breaking the code it guards and watching it fail.
- `npm run build` green: 1,133 tests, coverage 82.93% (floor 74.3).
- Verified in a real browser against the dev server: toggling, keyboard Enter, panel unmount, new-tab link to www.chq.org.

## Notes for review

- All 1,687 live events currently carry a `www.chq.org` URL, so the plain-text-title and "Open event page" paths are unit-tested but unreachable with today's data.
- The known cost (from the issue): reaching chq.org is now two taps, and ⌘-click/middle-click on the title no longer applies — the issue's stated fallback (a small 🔗 icon-button in the meta row) is deliberately not in this first cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adwf2e24aT5Nr3BiATm9xe