### PR TITLE
fix: week filters include the full boundary Saturdays (#257)

### DIFF
--- a/frontend/src/__tests__/lib/utils/dateHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/dateHelpers.test.ts
@@ -1,4 +1,5 @@
-import { getAdaptiveEndDate, getChautauquaSeasonWeeks, isInChautauquaWeek } from '@/lib/utils/dateHelpers';
+import { getAdaptiveEndDate, getChautauquaSeasonWeeks, weekNumbersForCalendarDate } from '@/lib/utils/dateHelpers';
+import { parseEventDate } from '@/lib/utils/chqTime';
 import type { Event } from '@/lib/types';
 
 function makeEvent(dateStr: string, id?: string): Event {
@@ -134,11 +135,29 @@ describe('season weeks in Institution time', () => {
     }
   });
 
-  it('places an event by its Institution instant', () => {
+  it('places a boundary Saturday in both adjacent weeks, whole (#257)', () => {
     const weeks = getChautauquaSeasonWeeks(2026);
-    // 11:00 on the Saturday is still the previous week; 13:00 is the next.
-    expect(isInChautauquaWeek('2026-07-04 11:00:00', 1, weeks)).toBe(true);
-    expect(isInChautauquaWeek('2026-07-04 13:00:00', 1, weeks)).toBe(false);
-    expect(isInChautauquaWeek('2026-07-04 13:00:00', 2, weeks)).toBe(true);
+    // Jul 4 is the week 1/2 boundary. The noon bounds still decide which
+    // weeks the DAY intersects, but the whole day belongs to both of them —
+    // 11:00 and 13:00 answer identically. This replaced `isInChautauquaWeek`,
+    // which split the Saturday at noon (11:00 → week 1 only, 13:00 → week 2
+    // only) and so handed back half a day when you filtered to a week.
+    expect(weekNumbersForCalendarDate(parseEventDate('2026-07-04 11:00:00'), weeks)).toEqual([1, 2]);
+    expect(weekNumbersForCalendarDate(parseEventDate('2026-07-04 13:00:00'), weeks)).toEqual([1, 2]);
+  });
+
+  it('places a mid-week day in exactly one week', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    expect(weekNumbersForCalendarDate(parseEventDate('2026-07-01 11:00:00'), weeks)).toEqual([1]);
+  });
+
+  it('places the season edges in the first and last weeks', () => {
+    const weeks = getChautauquaSeasonWeeks(2026);
+    // The opening Saturday morning precedes `weeks[0].start` and the closing
+    // Saturday afternoon follows `weeks[8].end`, but both days are labelled
+    // Week 1 and Week 9 by the calendar, and now filter that way too.
+    expect(weekNumbersForCalendarDate(parseEventDate('2026-06-27 10:00:00'), weeks)).toEqual([1]);
+    expect(weekNumbersForCalendarDate(parseEventDate('2026-08-29 15:00:00'), weeks)).toEqual([9]);
+    expect(weekNumbersForCalendarDate(parseEventDate('2026-06-26 10:00:00'), weeks)).toEqual([]);
   });
 });

--- a/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
@@ -8,7 +8,12 @@
 // all.
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { filterEvents, type FilterOptions } from '@/lib/utils/filterHelpers';
-import { getChautauquaSeasonWeeks, getCurrentWeekNumber } from '@/lib/utils/dateHelpers';
+import {
+  getChautauquaSeasonWeeks,
+  getCurrentWeekNumber,
+  weekNumbersForCalendarDate,
+} from '@/lib/utils/dateHelpers';
+import { parseEventDate } from '@/lib/utils/chqTime';
 import { navigableBounds, viewWindow } from '@/lib/utils/dayWindow';
 import type { Event } from '@/lib/types';
 
@@ -286,6 +291,55 @@ describe('filterEvents week stage — day-granular boundary Saturdays (#257)', (
     ];
     const result = filterEvents(events, baseOptions({ dateFilter: 'all', selectedWeeks: [5, 6] }));
     expect(result.map((e) => e.id)).toEqual(['fri-wk5', 'sat-boundary', 'sun-wk6']);
+  });
+
+  // The filter derives each selected week's day-granular instant range once
+  // (`calendarDaySpanOfWeek`) instead of deriving every event's week numbers
+  // (`weekNumbersForCalendarDate`), for ~7 fewer Intl round-trips per event.
+  // That is only sound while the two agree EXACTLY, so walk the whole season
+  // — every hour of every day from a week before it opens to a week after it
+  // closes — and require the filter to return precisely the events the
+  // badge's own rule says belong to each week. Any drift between the fast
+  // path and the display rule reintroduces #257's two-models bug.
+  it('agrees with weekNumbersForCalendarDate for every hour of the season', () => {
+    const probes: Event[] = [];
+    const cursor = new Date(2026, 5, 20, 0, 0);
+    const stop = new Date(2026, 8, 5, 0, 0);
+    while (cursor < stop) {
+      probes.push(makeEvent(`p-${cursor.getTime()}`, new Date(cursor)));
+      cursor.setHours(cursor.getHours() + 1);
+    }
+    expect(probes.length).toBeGreaterThan(1800);
+
+    for (let week = 1; week <= 9; week++) {
+      const expected = probes
+        .filter((e) =>
+          weekNumbersForCalendarDate(parseEventDate(e.startDate), seasonWeeks).includes(week)
+        )
+        .map((e) => e.id);
+      const actual = filterEvents(
+        probes,
+        baseOptions({ dateFilter: 'all', selectedWeeks: [week] })
+      ).map((e) => e.id);
+
+      expect(actual, `week ${week}`).toEqual(expected);
+      // Eight calendar days of 24 hourly probes — a week is 7 days but
+      // touches 8, which is the whole point of #257.
+      expect(expected.length, `week ${week} span`).toBe(8 * 24);
+    }
+  });
+
+  it('ignores a selected week number the season does not have', () => {
+    // The pre-#257 predicate indexed `seasonWeeks[n - 1]` unguarded and threw
+    // on `undefined.start`. Nothing in the UI can select week 12, but a
+    // corrupt localStorage payload reaches this code directly.
+    const events = [makeEvent('midweek', new Date(2026, 6, 29, 10, 0))];
+    expect(
+      filterEvents(events, baseOptions({ dateFilter: 'all', selectedWeeks: [12] })).map((e) => e.id)
+    ).toEqual([]);
+    expect(
+      filterEvents(events, baseOptions({ dateFilter: 'all', selectedWeeks: [5, 12] })).map((e) => e.id)
+    ).toEqual(['midweek']);
   });
 
   it('matches no week for an out-of-season event', () => {

--- a/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
+++ b/frontend/src/__tests__/lib/utils/filterHelpers.test.ts
@@ -229,3 +229,71 @@ describe('filterEvents date stage — post-refactor deltas', () => {
     expect(result.map((e) => e.id)).toEqual(['good']);
   });
 });
+
+// #257: the week filter is day-granular, matching the `Wk 5/6` badge the day
+// headers already render. A boundary Saturday belongs to BOTH adjacent weeks
+// in full — the noon split that used to hand back half of it is gone. Weeks
+// are therefore no longer a partition: they overlap by one calendar day.
+describe('filterEvents week stage — day-granular boundary Saturdays (#257)', () => {
+  // Anchor the fixtures to the real 2026 bounds rather than trusting the
+  // dates below: week 5 runs Sat Jul 25 noon → Sat Aug 1 noon, week 6 Aug 1
+  // noon → Aug 8 noon, so Aug 1 is the week 5/6 boundary Saturday.
+  it('has the 2026 season bounds these fixtures assume', () => {
+    expect(seasonWeeks[4].start).toEqual(new Date(2026, 6, 25, 12, 0));
+    expect(seasonWeeks[5].start).toEqual(new Date(2026, 7, 1, 12, 0));
+    expect(seasonWeeks[0].start).toEqual(new Date(2026, 5, 27, 12, 0));
+    expect(seasonWeeks[8].end).toEqual(new Date(2026, 7, 29, 12, 0));
+  });
+
+  const weekOf = (id: string, at: Date, week: number) =>
+    filterEvents([makeEvent(id, at)], baseOptions({ dateFilter: 'all', selectedWeeks: [week] }))
+      .map((e) => e.id);
+
+  it('puts a boundary Saturday morning in both adjacent weeks', () => {
+    const morning = new Date(2026, 7, 1, 10, 0);
+    expect(weekOf('sat-am', morning, 5)).toEqual(['sat-am']);
+    expect(weekOf('sat-am', morning, 6)).toEqual(['sat-am']);
+  });
+
+  it('puts a boundary Saturday afternoon in both adjacent weeks', () => {
+    const afternoon = new Date(2026, 7, 1, 15, 0);
+    expect(weekOf('sat-pm', afternoon, 5)).toEqual(['sat-pm']);
+    expect(weekOf('sat-pm', afternoon, 6)).toEqual(['sat-pm']);
+  });
+
+  it("matches week 1 for the opening Saturday's morning", () => {
+    // Before noon on Jun 27 sits before `weeks[0].start`, so the old noon
+    // predicate put it in no week at all — on a day the app labels Week 1.
+    expect(weekOf('opening-am', new Date(2026, 5, 27, 10, 0), 1)).toEqual(['opening-am']);
+  });
+
+  it("matches week 9 for the closing Saturday's afternoon", () => {
+    expect(weekOf('closing-pm', new Date(2026, 7, 29, 15, 0), 9)).toEqual(['closing-pm']);
+  });
+
+  it('still puts a mid-week event in exactly one week', () => {
+    const wednesday = new Date(2026, 6, 29, 10, 0);
+    expect(weekOf('midweek', wednesday, 5)).toEqual(['midweek']);
+    expect(weekOf('midweek', wednesday, 4)).toEqual([]);
+    expect(weekOf('midweek', wednesday, 6)).toEqual([]);
+  });
+
+  it('returns the union once, not twice, when both adjacent weeks are picked', () => {
+    const events = [
+      makeEvent('fri-wk5', new Date(2026, 6, 31, 10, 0)),
+      makeEvent('sat-boundary', new Date(2026, 7, 1, 10, 0)),
+      makeEvent('sun-wk6', new Date(2026, 7, 2, 10, 0)),
+    ];
+    const result = filterEvents(events, baseOptions({ dateFilter: 'all', selectedWeeks: [5, 6] }));
+    expect(result.map((e) => e.id)).toEqual(['fri-wk5', 'sat-boundary', 'sun-wk6']);
+  });
+
+  it('matches no week for an out-of-season event', () => {
+    const september = new Date(2026, 8, 15, 10, 0);
+    expect(weekOf('off-season', september, 9)).toEqual([]);
+    expect(
+      filterEvents([makeEvent('off-season', september)],
+        baseOptions({ dateFilter: 'all', selectedWeeks: [1, 2, 3, 4, 5, 6, 7, 8, 9] }))
+    ).toEqual([]);
+  });
+});

--- a/frontend/src/components/filters/DateFilter.tsx
+++ b/frontend/src/components/filters/DateFilter.tsx
@@ -52,10 +52,11 @@ function DateFilterButton({ label, title, isActive, onClick, ariaLabel }: {
  * mean nothing; the last two are absolute and are always offered, so an
  * archived season is never left without a scope control.
  *
- * There is deliberately no "This Week" button. `isThisWeek` and
- * `isInChautauquaWeek` compute identical bounds, so tapping the current week
- * on the strip has always been the same operation — iOS reached this
- * conclusion first and keeps `.thisWeek` out of `visibleScopes`. The
+ * There is deliberately no "This Week" button. Tapping the current week on
+ * the strip has always been the same operation — iOS reached this conclusion
+ * first and keeps `.thisWeek` out of `visibleScopes`. (Since #257 the week
+ * chip is the slightly wider of the two: `'this-week'` still runs noon to
+ * noon, while a week selection takes in both boundary Saturdays whole.) The
  * `'this-week'` value stays in the `DateFilter` union so a value persisted in
  * localStorage keeps working and renders as the current week highlighted on
  * the strip.

--- a/frontend/src/lib/utils/dateHelpers.ts
+++ b/frontend/src/lib/utils/dateHelpers.ts
@@ -77,6 +77,38 @@ export function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]
   return numbers;
 }
 
+/**
+ * The half-open instant range `[start, end)` covering every Institution
+ * calendar day that `week` touches — `weekNumbersForCalendarDate`'s rule,
+ * inverted so a caller can test many event instants against one range
+ * instead of deriving a day for each of them.
+ *
+ * A week runs noon Saturday to noon Saturday, so it touches eight calendar
+ * days: it is widened backwards to the opening Saturday's midnight and
+ * forwards to the midnight ending the closing Saturday. An event instant
+ * falls in this range exactly when `weekNumbersForCalendarDate` would list
+ * this week's number for it — day boundaries are where both rules cut, so
+ * the equivalence is exact rather than approximate (pinned by a test that
+ * walks the whole season hour by hour).
+ *
+ * Exists for the week filter's inner loop. `weekNumbersForCalendarDate`
+ * costs ~7 `Intl.formatToParts` round-trips per call (one `chqParts` plus
+ * two `chqDateAt`, each of which is three more), and `filterEvents` runs
+ * over the full ~1,470-event corpus twice per filter change — so paying that
+ * per event more than tripled the stage's cost. This is paid once per
+ * selected week per filter call instead: at most 9 times, not 1,470.
+ */
+export function calendarDaySpanOfWeek(week: SeasonWeek): { start: Date; end: Date } {
+  const s = chqParts(week.start);
+  const e = chqParts(week.end);
+  return {
+    start: chqDateAt(s.year, s.month, s.day, 0, 0, 0, 0),
+    // `chqDateAt` normalises an out-of-range day, so month/year rollover and
+    // a DST day of 23 or 25 hours both need no special case here.
+    end: chqDateAt(e.year, e.month, e.day + 1, 0, 0, 0, 0),
+  };
+}
+
 export function isWeekInPast(weekNumber: number, seasonWeeks: SeasonWeek[]): boolean {
   const week = seasonWeeks[weekNumber - 1];
   const now = new Date();

--- a/frontend/src/lib/utils/dateHelpers.ts
+++ b/frontend/src/lib/utils/dateHelpers.ts
@@ -47,10 +47,34 @@ function formatWeekEdge(d: Date): string {
   return weekEdgeFormatter.format(d);
 }
 
-export function isInChautauquaWeek(dateString: string, weekNumber: number, seasonWeeks: SeasonWeek[]): boolean {
-  const eventDate = parseEventDate(dateString);
-  const week = seasonWeeks[weekNumber - 1];
-  return eventDate >= week.start && eventDate < week.end;
+/**
+ * The season week numbers that span any portion of the Institution calendar
+ * date `date` falls on — 1 or 2 entries, empty off-season.
+ *
+ * Day-granular on purpose. `seasonWeeks` are bounded noon-to-noon (the gate
+ * program's turnover), so a Saturday on an in-season boundary intersects both
+ * the outgoing and the incoming week and returns two numbers (e.g. `[1, 2]`).
+ * This is the single model of "which week is this day in" for both the day
+ * header's `Wk 5/6` badge and the week filter (#257): filtering to week 5
+ * hands back the whole boundary Saturday, not the half of it before noon.
+ *
+ * Weeks therefore overlap by one calendar day and are not a partition. For
+ * "which week is it right now" — a question that needs one answer — use
+ * `getCurrentWeekNumber`, which stays noon-based.
+ */
+export function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]): number[] {
+  const { year, month, day } = chqParts(date);
+  const dayStart = chqDateAt(year, month, day, 0, 0, 0, 0);
+  // Half-open against the next Institution midnight, so a DST day of 23 or
+  // 25 hours needs no special case.
+  const dayEnd = chqDateAt(year, month, day + 1, 0, 0, 0, 0);
+  const numbers: number[] = [];
+  for (const w of seasonWeeks) {
+    if (w.start < dayEnd && w.end > dayStart) {
+      numbers.push(w.number);
+    }
+  }
+  return numbers;
 }
 
 export function isWeekInPast(weekNumber: number, seasonWeeks: SeasonWeek[]): boolean {

--- a/frontend/src/lib/utils/eventHelpers.ts
+++ b/frontend/src/lib/utils/eventHelpers.ts
@@ -1,6 +1,7 @@
 import type { Event, SeasonWeek } from '@/lib/types';
 import { dayKeyOf } from '@/lib/utils/dayWindow';
-import { chqDateAt, chqParts, formatChqDayLabel, parseEventDate } from '@/lib/utils/chqTime';
+import { formatChqDayLabel, parseEventDate } from '@/lib/utils/chqTime';
+import { weekNumbersForCalendarDate } from '@/lib/utils/dateHelpers';
 
 // Lookup table for common HTML entities found in event data
 const HTML_ENTITY_MAP: Record<string, string> = {
@@ -91,21 +92,6 @@ export interface DayGroup {
   /** Season week numbers that span any portion of this calendar date (1-2 entries). */
   weekNumbers: number[];
   events: Event[];
-}
-
-function weekNumbersForCalendarDate(date: Date, seasonWeeks: SeasonWeek[]): number[] {
-  const { year, month, day } = chqParts(date);
-  const dayStart = chqDateAt(year, month, day, 0, 0, 0, 0);
-  // Half-open against the next Institution midnight, so a DST day of 23 or
-  // 25 hours needs no special case.
-  const dayEnd = chqDateAt(year, month, day + 1, 0, 0, 0, 0);
-  const numbers: number[] = [];
-  for (const w of seasonWeeks) {
-    if (w.start < dayEnd && w.end > dayStart) {
-      numbers.push(w.number);
-    }
-  }
-  return numbers;
 }
 
 export function groupEventsByDay(events: Event[], seasonWeeks: SeasonWeek[]): DayGroup[] {

--- a/frontend/src/lib/utils/filterHelpers.ts
+++ b/frontend/src/lib/utils/filterHelpers.ts
@@ -32,34 +32,46 @@ export function filterEvents(events: Event[], options: FilterOptions): Event[] {
     filtered = searchEvents(filtered, options.searchTerm);
   }
 
-  // The date stage. One half-open range check for every scope — the four
+  // The date and week stages, as one pass over the events.
+  //
+  // They are two independent, ANDed predicates and read as two stages, but
+  // both need the event's start instant and `parseEventDate` is the most
+  // expensive thing either of them does — a regex plus, for the feed's naive
+  // wall-time strings, ~3 `Intl.formatToParts` round-trips. Run separately
+  // they parsed the same event twice whenever both were active, over a
+  // ~1,470-event corpus that `page.tsx` filters twice per filter change.
+  // Merging them is worth the small loss in readability; nothing else in the
+  // pipeline needs the parsed date, so this is the only place it happens.
+  //
+  // The date half: one half-open range check for every scope — the four
   // scope-specific predicates this replaced (isToday, isThisWeek, the
   // inline 'next' arithmetic, and 'all' doing nothing) all reduce to this
   // once the scope has been turned into a window.
-  const dateWindow = options.viewWindow;
-  filtered = filtered.filter((event) => windowContains(dateWindow, parseEventDate(event.startDate)));
-
-  // Week filter (independent of date filter). Day-granular, matching the
-  // day header's `Wk 5/6` badge: a boundary Saturday belongs to both adjacent
-  // weeks in full, so filtering to week 5 no longer hands back only the half
-  // of that Saturday before noon (#257).
   //
-  // Each selected week is turned into its day-granular instant range ONCE,
-  // here, and every event is then a pair of numeric comparisons. Deriving the
+  // The week half: day-granular, matching the day header's `Wk 5/6` badge —
+  // a boundary Saturday belongs to both adjacent weeks in full, so filtering
+  // to week 5 no longer hands back only the half of that Saturday before noon
+  // (#257). Each selected week becomes its day-granular instant range once,
+  // below, leaving a pair of numeric comparisons per event; deriving the
   // event's week numbers per event instead would be the same answer at ~7
-  // extra `Intl.formatToParts` round-trips each, over a corpus this runs
-  // twice per filter change. `parseEventDate` likewise runs once per event,
-  // not once per selected week as the pre-#257 predicate did.
-  if (options.selectedWeeks.length > 0) {
-    const spans = options.selectedWeeks
-      .map(n => options.seasonWeeks[n - 1])
-      .filter((w): w is SeasonWeek => w !== undefined)
-      .map(calendarDaySpanOfWeek);
-    filtered = filtered.filter(event => {
-      const at = parseEventDate(event.startDate);
-      return spans.some(s => at >= s.start && at < s.end);
-    });
-  }
+  // extra `Intl.formatToParts` round-trips each.
+  const dateWindow = options.viewWindow;
+  // `null` (rather than an empty array) means "no week narrowing at all". An
+  // *empty* array is a real, different answer: it is what a selection of week
+  // numbers the season does not have reduces to, and it must match nothing.
+  const weekSpans = options.selectedWeeks.length > 0
+    ? options.selectedWeeks
+        .map(n => options.seasonWeeks[n - 1])
+        .filter((w): w is SeasonWeek => w !== undefined)
+        .map(calendarDaySpanOfWeek)
+    : null;
+
+  filtered = filtered.filter((event) => {
+    const at = parseEventDate(event.startDate);
+    if (!windowContains(dateWindow, at)) return false;
+    if (weekSpans === null) return true;
+    return weekSpans.some(s => at >= s.start && at < s.end);
+  });
 
   // Location filter - case insensitive
   if (options.selectedLocationsLowerSet.size > 0) {

--- a/frontend/src/lib/utils/filterHelpers.ts
+++ b/frontend/src/lib/utils/filterHelpers.ts
@@ -1,6 +1,6 @@
 import type { Event, SeasonWeek } from '@/lib/types';
 import { parseEventDate } from '@/lib/utils/chqTime';
-import { isInChautauquaWeek } from './dateHelpers';
+import { weekNumbersForCalendarDate } from './dateHelpers';
 import { windowContains, type ViewWindow } from './dayWindow';
 import { searchEvents } from './searchHelpers';
 
@@ -39,11 +39,17 @@ export function filterEvents(events: Event[], options: FilterOptions): Event[] {
   const dateWindow = options.viewWindow;
   filtered = filtered.filter((event) => windowContains(dateWindow, parseEventDate(event.startDate)));
 
-  // Week filter (independent of date filter)
+  // Week filter (independent of date filter). Day-granular, matching the
+  // day header's `Wk 5/6` badge: a boundary Saturday belongs to both adjacent
+  // weeks in full, so filtering to week 5 no longer hands back only the half
+  // of that Saturday before noon (#257). `parseEventDate` is expensive, so it
+  // runs once per event here, not once per selected week.
   if (options.selectedWeeks.length > 0) {
-    filtered = filtered.filter(event =>
-      options.selectedWeeks.some(weekNum => isInChautauquaWeek(event.startDate, weekNum, options.seasonWeeks))
-    );
+    const selected = new Set(options.selectedWeeks);
+    filtered = filtered.filter(event => {
+      const numbers = weekNumbersForCalendarDate(parseEventDate(event.startDate), options.seasonWeeks);
+      return numbers.some(n => selected.has(n));
+    });
   }
 
   // Location filter - case insensitive

--- a/frontend/src/lib/utils/filterHelpers.ts
+++ b/frontend/src/lib/utils/filterHelpers.ts
@@ -1,6 +1,6 @@
 import type { Event, SeasonWeek } from '@/lib/types';
 import { parseEventDate } from '@/lib/utils/chqTime';
-import { weekNumbersForCalendarDate } from './dateHelpers';
+import { calendarDaySpanOfWeek } from './dateHelpers';
 import { windowContains, type ViewWindow } from './dayWindow';
 import { searchEvents } from './searchHelpers';
 
@@ -42,13 +42,22 @@ export function filterEvents(events: Event[], options: FilterOptions): Event[] {
   // Week filter (independent of date filter). Day-granular, matching the
   // day header's `Wk 5/6` badge: a boundary Saturday belongs to both adjacent
   // weeks in full, so filtering to week 5 no longer hands back only the half
-  // of that Saturday before noon (#257). `parseEventDate` is expensive, so it
-  // runs once per event here, not once per selected week.
+  // of that Saturday before noon (#257).
+  //
+  // Each selected week is turned into its day-granular instant range ONCE,
+  // here, and every event is then a pair of numeric comparisons. Deriving the
+  // event's week numbers per event instead would be the same answer at ~7
+  // extra `Intl.formatToParts` round-trips each, over a corpus this runs
+  // twice per filter change. `parseEventDate` likewise runs once per event,
+  // not once per selected week as the pre-#257 predicate did.
   if (options.selectedWeeks.length > 0) {
-    const selected = new Set(options.selectedWeeks);
+    const spans = options.selectedWeeks
+      .map(n => options.seasonWeeks[n - 1])
+      .filter((w): w is SeasonWeek => w !== undefined)
+      .map(calendarDaySpanOfWeek);
     filtered = filtered.filter(event => {
-      const numbers = weekNumbersForCalendarDate(parseEventDate(event.startDate), options.seasonWeeks);
-      return numbers.some(n => selected.has(n));
+      const at = parseEventDate(event.startDate);
+      return spans.some(s => at >= s.start && at < s.end);
     });
   }
 

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -90,11 +90,15 @@ nonisolated enum EventFilter {
         // is NOT in that list: it already reads the day-granular
         // `weekNumbers(spanningDayOf:in:)`, same as this stage now does.
         // The `in:` overload reuses the `weeks` built once above rather than
-        // rebuilding all 9 structs per event.
+        // rebuilding all 9 structs per event. The intersection is spelled as
+        // `contains(where:)` over the 1-2 returned numbers rather than
+        // `Set(...).isDisjoint(with:)`, which would allocate a `Set` per event
+        // to hold at most two elements; `sel.selectedWeeks` is already a
+        // `Set<Int>`, so each membership test is a hashed lookup either way.
         if !sel.selectedWeeks.isEmpty {
             result = result.filter { event in
-                !Set(SeasonCalendar.weekNumbers(spanningDayOf: event.start, in: weeks))
-                    .isDisjoint(with: sel.selectedWeeks)
+                SeasonCalendar.weekNumbers(spanningDayOf: event.start, in: weeks)
+                    .contains(where: sel.selectedWeeks.contains)
             }
         }
 

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -86,7 +86,9 @@ nonisolated enum EventFilter {
         // noon (#257). Weeks therefore overlap by one calendar day and are not
         // a partition. `SeasonWeek.contains` — the noon split — is still the
         // right question for "which week is it *now*" (`currentWeekNumber(at:)`,
-        // `WeekStripState`, `ViewWindow`, `WeekBands`), which needs one answer.
+        // `WeekStripState`, `ViewWindow`), which needs one answer. `WeekBands`
+        // is NOT in that list: it already reads the day-granular
+        // `weekNumbers(spanningDayOf:in:)`, same as this stage now does.
         // The `in:` overload reuses the `weeks` built once above rather than
         // rebuilding all 9 structs per event.
         if !sel.selectedWeeks.isEmpty {

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -79,9 +79,21 @@ nonisolated enum EventFilter {
         else { return [] }
         result = result.filter { window.contains($0.start) }
 
+        // The weeks stage is day-granular, matching the `Wk 5/6` badge the day
+        // headers render from the same helper: a Saturday on an in-season week
+        // boundary belongs to BOTH adjacent weeks in full, so filtering to
+        // week 5 no longer hands back only the half of that Saturday before
+        // noon (#257). Weeks therefore overlap by one calendar day and are not
+        // a partition. `SeasonWeek.contains` — the noon split — is still the
+        // right question for "which week is it *now*" (`currentWeekNumber(at:)`,
+        // `WeekStripState`, `ViewWindow`, `WeekBands`), which needs one answer.
+        // The `in:` overload reuses the `weeks` built once above rather than
+        // rebuilding all 9 structs per event.
         if !sel.selectedWeeks.isEmpty {
-            let selected = weeks.filter { sel.selectedWeeks.contains($0.number) }
-            result = result.filter { event in selected.contains { $0.contains(event.start) } }
+            result = result.filter { event in
+                !Set(SeasonCalendar.weekNumbers(spanningDayOf: event.start, in: weeks))
+                    .isDisjoint(with: sel.selectedWeeks)
+            }
         }
 
         // Lowercased once per call rather than per event — mirrors the web's

--- a/ios/ChqCalendarShared/Domain/FilterChipState.swift
+++ b/ios/ChqCalendarShared/Domain/FilterChipState.swift
@@ -46,9 +46,14 @@ nonisolated enum FilterChipState {
         switch scope {
         case .thisWeek:
             if effective == .thisWeek { return true }
-            // Selecting *only* the current week is the same range as
-            // "This Week"; selecting it alongside others is not. That
-            // equivalence is itself a current-year concept — off-year there
+            // Selecting *only* the current week is what a reader means by
+            // "This Week"; selecting it alongside others is not. The two are
+            // no longer quite the same RANGE, though: since #257 a week
+            // selection takes both of its boundary Saturdays whole, while
+            // `.thisWeek` stays noon-bounded (`ViewWindow.base`). The chip
+            // still lights, because it names the reader's intent rather than
+            // asserting the windows are byte-identical. That correspondence
+            // is itself a current-year concept — off-year there
             // is no "current week" for the browsed season to match against
             // — so it is additionally gated on `isCurrentYear`, matching the
             // unconditional `false` the old `guard isCurrentYear else` block

--- a/ios/ChqCalendarTests/EventFilterTests.swift
+++ b/ios/ChqCalendarTests/EventFilterTests.swift
@@ -180,7 +180,7 @@ struct EventFilterTests {
 
     // MARK: - apply: weeks filter
 
-    @Test func weeksFilterMatchesEventBySeasonWeekContainingStart() throws {
+    @Test func weeksFilterMatchesEventBySeasonWeekSpanningItsDay() throws {
         let event = makeEvent(id: "e1", start: try #require(ChqTime.parse("2026-07-08 12:00:00"))) // week 2
 
         let selMatching = FilterSelection(dateScope: .all, selectedWeeks: [2])
@@ -190,14 +190,93 @@ struct EventFilterTests {
         #expect(EventFilter.apply(selNonMatching, to: [event], favorites: [], now: Date(), year: 2026, isCurrentYear: true).isEmpty)
     }
 
-    @Test func noonBoundaryEventBelongsToIncomingWeekNotOutgoingWeek() throws {
-        let event = makeEvent(id: "boundary", start: try #require(ChqTime.parse("2026-07-04 12:00:00")))
+    // #257: the weeks stage is day-granular, matching the `Wk 5/6` badge the
+    // day headers already render via `SeasonCalendar.weekNumbers(spanningDayOf:)`.
+    // A boundary Saturday belongs to BOTH adjacent weeks in full — the noon
+    // split that used to hand back half of it is gone, so weeks overlap by one
+    // calendar day and are no longer a partition. `SeasonCalendar.weeks` keeps
+    // its noon bounds (the gate program's turnover) and `currentWeekNumber(at:)`
+    // stays single-valued; only which events a SELECTION returns changed.
 
-        let selWeek1 = FilterSelection(dateScope: .all, selectedWeeks: [1])
-        let selWeek2 = FilterSelection(dateScope: .all, selectedWeeks: [2])
+    /// Reference instant for the weeks-stage cases: mid-season, so no case
+    /// below depends on the wall clock.
+    private static func midSeasonNow() throws -> Date {
+        try #require(ChqTime.parse("2026-07-15 15:00:00"))
+    }
 
-        #expect(EventFilter.apply(selWeek1, to: [event], favorites: [], now: Date(), year: 2026, isCurrentYear: true).isEmpty)
-        #expect(EventFilter.apply(selWeek2, to: [event], favorites: [], now: Date(), year: 2026, isCurrentYear: true).count == 1)
+    private func weeksMatching(_ event: Event, _ week: Int, now: Date) -> Bool {
+        !EventFilter.apply(
+            FilterSelection(dateScope: .all, selectedWeeks: [week]),
+            to: [event], favorites: [], now: now, year: 2026, isCurrentYear: true
+        ).isEmpty
+    }
+
+    @Test func boundarySaturdayMorningBelongsToBothAdjacentWeeks() throws {
+        // Aug 1 2026 is the week 5/6 boundary Saturday.
+        let now = try Self.midSeasonNow()
+        let event = makeEvent(id: "sat-am", start: try #require(ChqTime.parse("2026-08-01 10:00:00")))
+
+        #expect(weeksMatching(event, 5, now: now))
+        #expect(weeksMatching(event, 6, now: now))
+    }
+
+    @Test func boundarySaturdayAfternoonBelongsToBothAdjacentWeeks() throws {
+        let now = try Self.midSeasonNow()
+        let event = makeEvent(id: "sat-pm", start: try #require(ChqTime.parse("2026-08-01 15:00:00")))
+
+        #expect(weeksMatching(event, 5, now: now))
+        #expect(weeksMatching(event, 6, now: now))
+    }
+
+    @Test func openingSaturdayMorningBelongsToWeekOne() throws {
+        // Before noon on Jun 27 sits ahead of `weeks[0].start`, so the old
+        // noon predicate put it in no week at all — on a day the app labels
+        // Week 1.
+        let now = try Self.midSeasonNow()
+        let event = makeEvent(id: "opening-am", start: try #require(ChqTime.parse("2026-06-27 10:00:00")))
+
+        #expect(weeksMatching(event, 1, now: now))
+    }
+
+    @Test func closingSaturdayAfternoonBelongsToWeekNine() throws {
+        let now = try Self.midSeasonNow()
+        let event = makeEvent(id: "closing-pm", start: try #require(ChqTime.parse("2026-08-29 15:00:00")))
+
+        #expect(weeksMatching(event, 9, now: now))
+    }
+
+    @Test func midWeekEventStillBelongsToExactlyOneWeek() throws {
+        let now = try Self.midSeasonNow()
+        let event = makeEvent(id: "midweek", start: try #require(ChqTime.parse("2026-07-29 10:00:00")))
+
+        #expect(weeksMatching(event, 5, now: now))
+        #expect(!weeksMatching(event, 4, now: now))
+        #expect(!weeksMatching(event, 6, now: now))
+    }
+
+    @Test func twoAdjacentWeeksReturnTheUnionOnceNotTwice() throws {
+        let now = try Self.midSeasonNow()
+        let events = [
+            makeEvent(id: "fri-wk5", start: try #require(ChqTime.parse("2026-07-31 10:00:00"))),
+            makeEvent(id: "sat-boundary", start: try #require(ChqTime.parse("2026-08-01 10:00:00"))),
+            makeEvent(id: "sun-wk6", start: try #require(ChqTime.parse("2026-08-02 10:00:00"))),
+        ]
+        let result = EventFilter.apply(
+            FilterSelection(dateScope: .all, selectedWeeks: [5, 6]),
+            to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
+
+        #expect(result.map(\.id) == ["fri-wk5", "sat-boundary", "sun-wk6"])
+    }
+
+    @Test func outOfSeasonEventMatchesNoWeek() throws {
+        let now = try Self.midSeasonNow()
+        let event = makeEvent(id: "off-season", start: try #require(ChqTime.parse("2026-09-15 10:00:00")))
+
+        let result = EventFilter.apply(
+            FilterSelection(dateScope: .all, selectedWeeks: Set(1...9)),
+            to: [event], favorites: [], now: now, year: 2026, isCurrentYear: true)
+
+        #expect(result.isEmpty)
     }
 
     // MARK: - season scope

--- a/ios/ChqCalendarTests/ViewWindowTests.swift
+++ b/ios/ChqCalendarTests/ViewWindowTests.swift
@@ -416,9 +416,10 @@ struct EventFilterWindowTests {
         // `inWeek2` sits a full day past the week 1/2 boundary rather than an
         // hour past it: since #257 the weeks stage is day-granular, so an
         // event on the boundary Saturday itself belongs to weeks 1 AND 2 and
-        // would be kept by `selectedWeeks: [1]` — which would make this test
-        // pass for the wrong reason (nothing about window expansion) or fail
-        // for one. The `w2` event has to be on a day only week 2 spans.
+        // would be kept by `selectedWeeks: [1]`. That would make this test
+        // pass or fail for reasons having nothing to do with window
+        // expansion, which is the only thing it exists to check. The `w2`
+        // event has to be on a day only week 2 spans.
         let weeks = SeasonCalendar.weeks(forYear: 2026)
         let now = weeks[0].start.addingTimeInterval(3600)
         let inWeek1 = makeEvent(id: "w1", start: now.addingTimeInterval(600))

--- a/ios/ChqCalendarTests/ViewWindowTests.swift
+++ b/ios/ChqCalendarTests/ViewWindowTests.swift
@@ -412,13 +412,21 @@ struct EventFilterWindowTests {
 
     @Test func windowExpansionStillRespectsTheWeeksStage() throws {
         // The weeks stage is separate and ANDed. Phase 1 does not change that.
+        //
+        // `inWeek2` sits a full day past the week 1/2 boundary rather than an
+        // hour past it: since #257 the weeks stage is day-granular, so an
+        // event on the boundary Saturday itself belongs to weeks 1 AND 2 and
+        // would be kept by `selectedWeeks: [1]` — which would make this test
+        // pass for the wrong reason (nothing about window expansion) or fail
+        // for one. The `w2` event has to be on a day only week 2 spans.
         let weeks = SeasonCalendar.weeks(forYear: 2026)
         let now = weeks[0].start.addingTimeInterval(3600)
         let inWeek1 = makeEvent(id: "w1", start: now.addingTimeInterval(600))
-        let inWeek2 = makeEvent(id: "w2", start: weeks[1].start.addingTimeInterval(3600))
+        let dayAfterBoundary = weeks[1].start.addingTimeInterval(86400 + 3600)
+        let inWeek2 = makeEvent(id: "w2", start: dayAfterBoundary)
 
         var sel = FilterSelection(dateScope: .today, selectedWeeks: [1])
-        sel.windowEndDayKey = ChqTime.dayKey(for: weeks[1].start.addingTimeInterval(3600))
+        sel.windowEndDayKey = ChqTime.dayKey(for: dayAfterBoundary)
         let result = EventFilter.apply(
             sel, to: [inWeek1, inWeek2], favorites: [], now: now, year: 2026, isCurrentYear: true)
         #expect(result.map(\.id) == ["w1"])


### PR DESCRIPTION
Closes #257.

[skip-screenshots: week-filter predicate only; no shot in screenshot-plan.json selects a week]

## What changed

Both platforms carried two models of "which week is this day in": the day-header badge (`Wk 5/6`) already used the day-granular model, while the week *filter* still split boundary Saturdays at noon — so the app would label a day weeks 5 **and** 6, then hand back half of it when filtering to week 5. The filter now uses the day-granular helper each platform already shipped:

- **iOS** — `EventFilter.apply`'s week stage matches an event when `SeasonCalendar.weekNumbers(spanningDayOf:in:)` intersects the selection.
- **web** — `filterEvents`' week stage precomputes each selected week's calendar-day span once per call (`calendarDaySpanOfWeek`) and compares the event's already-parsed instant — same semantics, and the per-event cost stays at the one `parseEventDate` the stage always paid (measured: 3.00 Intl round-trips/event, flat in week count; the naive per-event helper call would have been 10).
- Web `isInChautauquaWeek` is deleted (the filter was its only caller); `weekNumbersForCalendarDate` moved to `dateHelpers.ts` beside the other week predicates, body unchanged.

Deliberately unchanged, per the issue: `SeasonCalendar.weeks`' noon bounds (gate-program turnover; `GatePassPolicy` reads them), `SeasonWeek.contains`, and `currentWeekNumber(at:)` (Siri needs one answer). Comments that claimed a week selection equals "This Week" are corrected on both platforms — `.thisWeek` (unreachable from the UI on either platform) keeps its noon window.

## Consequences

Weeks now overlap by one day, so selected weeks are no longer a partition (nothing counts events per week, checked). Week 1 gains the opening Saturday's morning and week 9 the closing Saturday's afternoon — those events sat on days the app already labels Week 1/Week 9.

## Tests

- Same 7 boundary cases asserted on both platforms against identical 2026 instants (boundary Saturday matches both adjacent weeks; opening morning → week 1; closing afternoon → week 9; mid-week unchanged; union without duplicates).
- Web adds an every-hour-of-the-season equivalence walk (1,848 probes) comparing the shipped filter path against the badge helper — it alone catches a one-day over-widening (proven by injection).
- TDD (RED → GREEN on both platforms) and predicate-revert falsifications on both platforms.
- iOS full unit suite green (959 tests / 71 suites); web `npm run build` green (1,112 tests, coverage 82.78% vs 74.3 floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adwf2e24aT5Nr3BiATm9xe