### PR TITLE
fix(ios): three small fixes — #235 env-dependent test, #252 hook conflict, #234 scope re-tap reset

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -171,11 +171,16 @@ jobs:
           # Interleaves xcodebuild's stdout/stderr in real time so a failure
           # appears next to the work that caused it in the job log.
           NSUnbufferedIO: YES
-        # CODE_SIGNING_ALLOWED=NO is required, not cosmetic. Without it,
-        # AppGroupTests.containerURLIsNilInTheUnitTestHost fails on a signed
-        # run: it asserts there is NO App Group entitlement, which is exactly
-        # the condition this flag creates. Its own doc comment names the flag.
-        # Dropping it turns a green tree red.
+        # CODE_SIGNING_ALLOWED=NO is required, not cosmetic: these runners
+        # have no signing identity and no provisioning profile, so a build
+        # that tries to sign fails outright. Simulator builds do not need
+        # signing, and this is how you say so.
+        #
+        # It used to be justified here by a test that asserted the App Group
+        # container was absent under an unsigned run. #235 deleted that test
+        # — the container's presence is a property of the simulator, not of
+        # this flag — so the signing-identity reason above is now the whole
+        # reason. Keep the flag; it was never the test's to justify.
         #
         # Both legs compile all three source trees: the ChqCalendar scheme
         # builds the ChqCalendarWidgets target too (it is embedded in the app),

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1714,6 +1714,11 @@ final class AppModel {
     /// app as idle and hands control back to the test immediately after the
     /// tap, giving it a real window to act in. `0` (the default, and the
     /// value in every real launch) keeps this path fully inert.
+    ///
+    /// Mutually exclusive with `uiTestScrollsToDrop` below: a delay shorter
+    /// than the drop-retry window is swallowed by it, so the pair produces a
+    /// failure unrelated to whatever the test is probing (#252).
+    /// `UITestScrollHooks.parse` rejects a launch that passes both flags.
     var uiTestPendingScrollDelay: TimeInterval = 0
 
     /// How many of the next `proxy.scrollTo` calls `EventListView.issueScroll`
@@ -1738,6 +1743,10 @@ final class AppModel {
     /// function.
     ///
     /// `0` (the default, and every real launch) keeps this fully inert.
+    ///
+    /// Mutually exclusive with `uiTestPendingScrollDelay` above — the
+    /// retry chain and a deferred `resolvePendingScroll` interfere (#252) —
+    /// and `UITestScrollHooks.parse` rejects a launch that passes both flags.
     var uiTestScrollsToDrop = 0
 
     /// The first `(day, week)` pairing — in `days` display order — whose

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1079,16 +1079,48 @@ final class AppModel {
     /// the week strip are two ways of expressing one date range, never two
     /// ranges to intersect.
     ///
-    /// Re-tapping the active scope is a no-op. The web toggles back to
-    /// "all" here, but it has no All button; iOS does, so the scope row
-    /// behaves as a radio group instead.
+    /// Re-tapping the active scope *resets* it: any scope-local date state
+    /// — a window widened by "Show next day", a window grown by day-rail
+    /// navigation, a browsed day — is cleared, leaving exactly what a fresh
+    /// selection of that scope would give. Only a re-tap with nothing left
+    /// to clear is a no-op. The web toggles back to "all" here, but it has
+    /// no All button; iOS does, so the scope row behaves as a radio group
+    /// instead.
+    ///
+    /// The rail is the *likeliest* source of that state since #258, not an
+    /// afterthought: `goToDay` writes `windowStartDayKey` and
+    /// `windowEndDayKey`, and every rail chip tap reaches it through
+    /// `EventListView.selectDay` — including the rail's own `⟳ Now`. So the
+    /// common path into this reset is navigate the rail → open Filters →
+    /// re-tap the active chip, and the accumulated expansion collapses.
+    /// `expandWindowEnd` ("Show next day") is only the other writer.
+    ///
+    /// The guard therefore tests "nothing would change", not "same scope"
+    /// (#234). Its purpose is unchanged — not writing `filter`, and so not
+    /// firing its `didSet` or a `persistFilter`, when genuinely nothing
+    /// changes — but the old one-liner made the early return the single path
+    /// into this method that skipped `clearScopeLocalDateState()`, so
+    /// "Show next day" ×2 → Now kept the widened window.
+    ///
+    /// This is the *only* "put me back" gesture in the app, which is why it
+    /// has to actually reset. The rail's `⟳ Now` is not a second one: #258
+    /// deleted `AppModel.resetToNow()` precisely so that control could be
+    /// pure navigation — the spec has it "not touch scope, weeks,
+    /// categories, or search," and `AppModelTests.nowLeavesAnyAccumulated`
+    /// `ExpansionInPlace` pins that it leaves a widened window alone. The
+    /// two controls share a name, not a job (#258 finding 2).
     ///
     /// Also drops the two pieces of state that only mean something under a
     /// scope the user is leaving, via `clearScopeLocalDateState()` — see
     /// that method for why both belong to the scope rather than to the
     /// selection as a whole (#156, #197).
     func selectScope(_ scope: DateScope) {
-        guard filter.dateScope != scope || !filter.selectedWeeks.isEmpty else { return }
+        let unchanged = filter.dateScope == scope
+            && filter.selectedWeeks.isEmpty
+            && filter.windowStartDayKey == nil
+            && filter.windowEndDayKey == nil
+            && filter.selectedDayKey == nil
+        guard !unchanged else { return }
         filter.dateScope = scope
         filter.selectedWeeks = []
         clearScopeLocalDateState()

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1106,9 +1106,10 @@ final class AppModel {
     /// has to actually reset. The rail's `⟳ Now` is not a second one: #258
     /// deleted `AppModel.resetToNow()` precisely so that control could be
     /// pure navigation — the spec has it "not touch scope, weeks,
-    /// categories, or search," and `AppModelTests.nowLeavesAnyAccumulated`
-    /// `ExpansionInPlace` pins that it leaves a widened window alone. The
-    /// two controls share a name, not a job (#258 finding 2).
+    /// categories, or search," and
+    /// `AppModelTests.nowLeavesAnyAccumulatedExpansionInPlace` pins that it
+    /// leaves a widened window alone. The two controls share a name, not a
+    /// job (#258 finding 2).
     ///
     /// Also drops the two pieces of state that only mean something under a
     /// scope the user is leaving, via `clearScopeLocalDateState()` — see

--- a/ios/ChqCalendar/Features/Calendar/CalendarView.swift
+++ b/ios/ChqCalendar/Features/Calendar/CalendarView.swift
@@ -66,6 +66,26 @@ struct CalendarView: View {
             if committed != searchDraft { searchDraft = committed }
         }
         .task {
+            #if DEBUG
+            // Validated *before* `model.start()`, deliberately. #252 asks for
+            // an incompatible pair of scroll hooks to be rejected "at
+            // launch", and `start()` is not instant — on a cold install it
+            // reaches the network for `availableYears()` — so validating
+            // after it would put an arbitrary wait, and a loading spinner, in
+            // front of a launch that is already known-bad. Parsing is pure
+            // and reads only `ProcessInfo`, so it has nothing to wait for.
+            //
+            // Only the *check* moves. The parsed values are applied in
+            // `applyUITestHooks` below, after the model settles, exactly
+            // where they were — so a launch with valid flags (or none) is
+            // unaffected in both what happens and when.
+            let scrollHooks: (delay: TimeInterval, dropCount: Int)
+            do {
+                scrollHooks = try UITestScrollHooks.parse(ProcessInfo.processInfo.arguments)
+            } catch {
+                preconditionFailure(String(describing: error))
+            }
+            #endif
             await model.start()
             // Covers the case where a deep link arrived (setting
             // `pendingDeepLink`) before this `.task` ran, and `start()`
@@ -75,7 +95,7 @@ struct CalendarView: View {
             // changes if a cached snapshot loads directly into `.ready`.
             consumePendingDeepLinkIfPossible()
             #if DEBUG
-            await applyUITestHooks()
+            await applyUITestHooks(scrollHooks: scrollHooks)
             #endif
         }
         // Scene-level concerns — `.onOpenURL`, Spotlight's
@@ -215,7 +235,7 @@ struct CalendarView: View {
     /// identical launches of the same build, back to back, differed only in
     /// whether this raced. The retry below forces one more full refresh
     /// before giving up, which is enough to clear it in practice.
-    private func applyUITestHooks() async {
+    private func applyUITestHooks(scrollHooks: (delay: TimeInterval, dropCount: Int)) async {
         let arguments = ProcessInfo.processInfo.arguments
 
         // Any `-uitest-*` launch is a screenshot/automation context, so a
@@ -244,19 +264,12 @@ struct CalendarView: View {
 
         // The two scroll hooks — `-uitest-delay-pending-scroll` (see
         // `AppModel.uiTestPendingScrollDelay`) and `-uitest-drop-scrolls <n>`
-        // (see `AppModel.uiTestScrollsToDrop`) — parse together because they
-        // are mutually exclusive: `UITestScrollHooks.parse` throws when a
-        // launch passes both (#252). Crashing here, by name, is deliberate.
-        // This is a DEBUG-only launch path reached solely from an automated
-        // run, and the alternative — arming one hook and silently dropping
-        // the other — is exactly the confusing, twenty-minutes-later red the
-        // issue was filed about. Either flag alone behaves as before.
-        let scrollHooks: (delay: TimeInterval, dropCount: Int)
-        do {
-            scrollHooks = try UITestScrollHooks.parse(arguments)
-        } catch {
-            preconditionFailure(String(describing: error))
-        }
+        // (see `AppModel.uiTestScrollsToDrop`) — arrive already parsed and
+        // already validated: they are mutually exclusive, and the `.task`
+        // above rejected the pair before `model.start()` was even awaited
+        // (#252). Only the application is left to do here, at the same point
+        // in the launch as every other hook below.
+        //
         // Assigned only when non-inert: `AppModel` is `@Observable`, whose
         // generated setter fires a mutation for *every* write, equal value or
         // not, so writing a 0 over the default 0 would be a real (if small)

--- a/ios/ChqCalendar/Features/Calendar/CalendarView.swift
+++ b/ios/ChqCalendar/Features/Calendar/CalendarView.swift
@@ -242,20 +242,30 @@ struct CalendarView: View {
             model.uiTestShowWeekTheme = true
         }
 
-        // `-uitest-delay-pending-scroll` — see `AppModel.uiTestPendingScrollDelay`
-        // for why a UI test needs this to exercise the day rail's pending-
-        // scroll staleness check at all. 3 seconds is comfortably longer
-        // than opening the date sheet and tapping a scope chip takes.
-        if arguments.contains("-uitest-delay-pending-scroll") {
-            model.uiTestPendingScrollDelay = 3
+        // The two scroll hooks — `-uitest-delay-pending-scroll` (see
+        // `AppModel.uiTestPendingScrollDelay`) and `-uitest-drop-scrolls <n>`
+        // (see `AppModel.uiTestScrollsToDrop`) — parse together because they
+        // are mutually exclusive: `UITestScrollHooks.parse` throws when a
+        // launch passes both (#252). Crashing here, by name, is deliberate.
+        // This is a DEBUG-only launch path reached solely from an automated
+        // run, and the alternative — arming one hook and silently dropping
+        // the other — is exactly the confusing, twenty-minutes-later red the
+        // issue was filed about. Either flag alone behaves as before.
+        let scrollHooks: (delay: TimeInterval, dropCount: Int)
+        do {
+            scrollHooks = try UITestScrollHooks.parse(arguments)
+        } catch {
+            preconditionFailure(String(describing: error))
         }
-
-        // `-uitest-drop-scrolls <n>` — see `AppModel.uiTestScrollsToDrop` for
-        // why a UI test needs to be able to make a `scrollTo` do nothing.
-        if let flagIndex = arguments.firstIndex(of: "-uitest-drop-scrolls"),
-           arguments.index(after: flagIndex) < arguments.endIndex,
-           let count = Int(arguments[arguments.index(after: flagIndex)]), count > 0 {
-            model.uiTestScrollsToDrop = count
+        // Assigned only when non-inert: `AppModel` is `@Observable`, whose
+        // generated setter fires a mutation for *every* write, equal value or
+        // not, so writing a 0 over the default 0 would be a real (if small)
+        // behaviour change on every non-scroll UI-test launch.
+        if scrollHooks.delay > 0 {
+            model.uiTestPendingScrollDelay = scrollHooks.delay
+        }
+        if scrollHooks.dropCount > 0 {
+            model.uiTestScrollsToDrop = scrollHooks.dropCount
         }
 
         if arguments.contains("-uitest-show-about") {

--- a/ios/ChqCalendar/Features/Calendar/UITestScrollHooks.swift
+++ b/ios/ChqCalendar/Features/Calendar/UITestScrollHooks.swift
@@ -19,7 +19,11 @@ import Foundation
 ///
 /// Pure and `nonisolated` so the rejection is unit-testable without booting
 /// the app: `CalendarView` is the only caller and turns a thrown
-/// `HookConflict` into an immediate `preconditionFailure`.
+/// `HookConflict` into a `preconditionFailure`. It calls this at the very
+/// top of its `.task`, *before* `await model.start()` — "at launch" in #252
+/// means before the app can spend a cold install's network round-trip on a
+/// run that is already known-bad. Applying the values stays where it was,
+/// in `applyUITestHooks`, after the model settles.
 ///
 /// Compiles out of Release builds along with its only call site.
 nonisolated enum UITestScrollHooks {

--- a/ios/ChqCalendar/Features/Calendar/UITestScrollHooks.swift
+++ b/ios/ChqCalendar/Features/Calendar/UITestScrollHooks.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+#if DEBUG
+/// Launch-argument parsing for the two DEBUG-only scroll hooks
+/// `CalendarView.applyUITestHooks` arms — `-uitest-delay-pending-scroll`
+/// (`AppModel.uiTestPendingScrollDelay`) and `-uitest-drop-scrolls <n>`
+/// (`AppModel.uiTestScrollsToDrop`).
+///
+/// Extracted from `CalendarView` for one reason (#252): the two hooks do
+/// **not** compose, and until now a launch that passed both produced a
+/// plausible-looking red that pointed at the code under test rather than at
+/// the harness. A deferred `resolvePendingScroll` and the drop-retry chain
+/// interfere — a 2 s delay sits well inside the 5 s retry window, so the
+/// resulting failure is never about the deadline such a test was written to
+/// probe. Bisecting that cost real time during #250. The fix is not to make
+/// them compose (that would mean redesigning DEBUG harness code nobody needs
+/// composed) but to reject the pair at launch, by name, before either hook
+/// is armed.
+///
+/// Pure and `nonisolated` so the rejection is unit-testable without booting
+/// the app: `CalendarView` is the only caller and turns a thrown
+/// `HookConflict` into an immediate `preconditionFailure`.
+///
+/// Compiles out of Release builds along with its only call site.
+nonisolated enum UITestScrollHooks {
+    /// Defers the *next* pending scroll's resolution by this many seconds.
+    static let delayFlag = "-uitest-delay-pending-scroll"
+
+    /// Swallows the next `n` `proxy.scrollTo` calls. Takes a value.
+    static let dropFlag = "-uitest-drop-scrolls"
+
+    /// Seconds `-uitest-delay-pending-scroll` arms, comfortably longer than
+    /// opening the date sheet and tapping a scope chip takes.
+    static let delaySeconds: TimeInterval = 3
+
+    /// Thrown when a launch passes both hooks. Its description is the whole
+    /// point of #252 — the failure has to name the incompatibility rather
+    /// than look like a bug in the code under test.
+    struct HookConflict: Error, CustomStringConvertible {
+        var description: String {
+            """
+            \(UITestScrollHooks.delayFlag) and \(UITestScrollHooks.dropFlag) \
+            cannot be used together: the deferred pending-scroll resolution and \
+            the drop-retry chain interfere, so the combination fails for reasons \
+            unrelated to whatever the test is probing (a delay shorter than the \
+            retry window is swallowed by it). See issue #252. Pass one hook or \
+            the other, not both.
+            """
+        }
+    }
+
+    /// The hook values a launch with these `arguments` should arm.
+    ///
+    /// - Returns: `delay` in seconds (`0` when the flag is absent, and in
+    ///   every real launch) and `dropCount` (`0` when the flag is absent, has
+    ///   no value, or its value does not parse as a positive `Int` — an
+    ///   inert hook, matching the `count > 0` guard this was extracted from).
+    /// - Throws: `HookConflict` when *both* flags are present, regardless of
+    ///   order and regardless of whether the drop count would itself have
+    ///   been inert. It is the pair that is rejected, so a launch can never
+    ///   half-arm one hook while quietly discarding the other.
+    static func parse(_ arguments: [String]) throws -> (delay: TimeInterval, dropCount: Int) {
+        let hasDelay = arguments.contains(delayFlag)
+        let hasDrop = arguments.contains(dropFlag)
+        guard !(hasDelay && hasDrop) else { throw HookConflict() }
+
+        var dropCount = 0
+        if let flagIndex = arguments.firstIndex(of: dropFlag),
+           arguments.index(after: flagIndex) < arguments.endIndex,
+           let count = Int(arguments[arguments.index(after: flagIndex)]), count > 0 {
+            dropCount = count
+        }
+
+        return (delay: hasDelay ? delaySeconds : 0, dropCount: dropCount)
+    }
+}
+#endif

--- a/ios/ChqCalendarShared/Data/AppGroup.swift
+++ b/ios/ChqCalendarShared/Data/AppGroup.swift
@@ -56,12 +56,15 @@ nonisolated enum AppGroup {
     /// Broken out as a pure function of two `Bool`s — rather than reading
     /// `isAppProcess`/`containerURL()` live inline at each call site — so
     /// both branches of the gate are directly testable even though neither
-    /// live value can be flipped from within the unit-test host: it has no
-    /// real App Group entitlement, so `containerURL()` is always `nil`
-    /// there (see `AppGroupTests.containerURLIsNilInTheUnitTestHost`), and
-    /// `isAppProcess` itself is always `true` there (see `isAppProcess`'s
-    /// own doc comment on why `Bundle.main` can't distinguish a test run
-    /// from a real app launch).
+    /// live value can be *flipped* from within the unit-test host:
+    /// `isAppProcess` is always `true` there (see `isAppProcess`'s own doc
+    /// comment on why `Bundle.main` can't distinguish a test run from a
+    /// real app launch), and `containerURL()` is whatever the host
+    /// environment makes it — `nil` on a simulator that has never had the
+    /// App Group container provisioned, non-`nil` on one that has. Neither
+    /// is a property of this code, so neither is asserted by a test; the
+    /// decision matrix is pinned against the pure function instead, by
+    /// `AppGroupTests.shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer`.
     static func shouldRunAppOnlyMigration(isAppProcess: Bool, hasGroupContainer: Bool) -> Bool {
         isAppProcess && hasGroupContainer
     }

--- a/ios/ChqCalendarShared/Data/AppGroup.swift
+++ b/ios/ChqCalendarShared/Data/AppGroup.swift
@@ -4,11 +4,19 @@ import Foundation
 /// which lets the main app and a future widget extension read the same
 /// disk cache and `UserDefaults` state.
 ///
-/// Every function here degrades gracefully when the App Group entitlement
-/// is absent — unit-test hosts and un-entitled builds fall back to the
-/// pre-App-Group legacy paths (`Library/Caches/chq-data` and
-/// `UserDefaults.standard`), so nothing here changes behavior for a build
-/// that hasn't picked up the entitlement yet.
+/// Every function here degrades gracefully when the App Group container is
+/// unavailable — un-entitled builds fall back to the pre-App-Group legacy
+/// paths (`Library/Caches/chq-data` and `UserDefaults.standard`), so
+/// nothing here changes behavior for a build that hasn't picked up the
+/// entitlement yet.
+///
+/// A unit-test host is **not** reliably in that category, despite the
+/// obvious guess (#235). The test bundle is hosted inside `ChqCalendar.app`
+/// and inherits its entitlement, so `containerURL()` returns a real URL on
+/// any simulator where the group container has been provisioned, and `nil`
+/// only on one where it never has. Which of the two a given machine is, is
+/// an environment fact: branch on the value, and never treat "running in
+/// tests" as a synonym for "no group container".
 nonisolated enum AppGroup {
     static let identifier = "group.org.chqcal.app"
 
@@ -61,17 +69,27 @@ nonisolated enum AppGroup {
     /// comment on why `Bundle.main` can't distinguish a test run from a
     /// real app launch), and `containerURL()` is whatever the host
     /// environment makes it — `nil` on a simulator that has never had the
-    /// App Group container provisioned, non-`nil` on one that has. Neither
-    /// is a property of this code, so neither is asserted by a test; the
-    /// decision matrix is pinned against the pure function instead, by
+    /// App Group container provisioned, non-`nil` on one that has.
+    ///
+    /// That container value is an environment fact rather than a property of
+    /// this code, so no test asserts it (#235 deleted the one that did).
+    /// `isAppProcess` is the opposite case — it is fixed for this target,
+    /// and `AppGroupTests.isAppProcessIsTrueInsideTheAppHostedUnitTestTarget`
+    /// pins it. The decision matrix itself is pinned against this pure
+    /// function, by
     /// `AppGroupTests.shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer`.
     static func shouldRunAppOnlyMigration(isAppProcess: Bool, hasGroupContainer: Bool) -> Bool {
         isAppProcess && hasGroupContainer
     }
 
-    /// The shared container for the App Group, or `nil` if the running
+    /// The shared container for the App Group, or `nil` when the running
     /// process lacks the `com.apple.security.application-groups`
-    /// entitlement (unit-test hosts, un-entitled builds).
+    /// entitlement (un-entitled builds) or the container has never been
+    /// provisioned on this device/simulator.
+    ///
+    /// A unit-test host is not automatically a `nil` case — see this type's
+    /// own doc comment: it inherits the app host's entitlement, so this
+    /// answers per-simulator rather than per-configuration (#235).
     static func containerURL() -> URL? {
         FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: identifier)
     }

--- a/ios/ChqCalendarShared/Data/AppGroup.swift
+++ b/ios/ChqCalendarShared/Data/AppGroup.swift
@@ -57,9 +57,9 @@ nonisolated enum AppGroup {
     /// The gate behind both app-only migration triggers
     /// (`UserStateStore.didMigrateDefaults`, `DiskCache.didMigrate`): a
     /// migration should only actually run when the process is the app
-    /// (not the widget extension) *and* the App Group entitlement is
-    /// present (a real device/simulator build, not an un-entitled unit-test
-    /// host).
+    /// (not the widget extension) *and* the App Group container is actually
+    /// available to it — i.e. `containerURL()` is non-`nil`. There is
+    /// nothing to migrate *into* otherwise.
     ///
     /// Broken out as a pure function of two `Bool`s — rather than reading
     /// `isAppProcess`/`containerURL()` live inline at each call site — so

--- a/ios/ChqCalendarTests/AppGroupTests.swift
+++ b/ios/ChqCalendarTests/AppGroupTests.swift
@@ -187,16 +187,6 @@ struct AppGroupTests {
         #expect(AppGroup.isAppProcess)
     }
 
-    /// `AppGroup.containerURL()` is `nil` in the unit test host — there is
-    /// no real App Group entitlement applied to an unsigned
-    /// (`CODE_SIGNING_ALLOWED=NO`) test run — regardless of `isAppProcess`.
-    /// Pins the assumption `UserStateStoreTests`'/`DiskCacheTests`' own
-    /// `triggerMigrationIfNeeded` tests rely on: neither `isAppProcess`
-    /// branch can reach the real migration call from this target.
-    @Test func containerURLIsNilInTheUnitTestHost() {
-        #expect(AppGroup.containerURL() == nil)
-    }
-
     @Test func shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer() {
         #expect(AppGroup.shouldRunAppOnlyMigration(isAppProcess: true, hasGroupContainer: true))
         #expect(!AppGroup.shouldRunAppOnlyMigration(isAppProcess: true, hasGroupContainer: false))

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1120,11 +1120,115 @@ struct AppModelTests {
         #expect(model.filter.windowEndDayKey == nil)
     }
 
-    @Test func reselectingTheActiveScopeIsANoOp() throws {
+    /// #234: the early return was the one path into `selectScope` that
+    /// skipped `clearScopeLocalDateState()`, so "Show next day" ×2 → Now
+    /// left the window two days wider than a fresh `.next` selection —
+    /// re-tapping the scope you are already on means "reset it".
+    ///
+    /// Note this does *not* make the scope chip agree with the rail's
+    /// `⟳ Now`: `nowLeavesAnyAccumulatedExpansionInPlace` below pins the
+    /// opposite for that control, deliberately (#258 deleted
+    /// `AppModel.resetToNow()` to make `⟳ Now` pure navigation). They share
+    /// a name, not a job — the chip resets its scope, the rail control
+    /// travels without touching the filter.
+    ///
+    /// `windowStartDayKey` still has no writer of its own, so it is set
+    /// directly here for the same reason `selectScopeResetsWindowExpansion`
+    /// does it: to pin that both window fields are cleared, not only the one
+    /// the UI happens to exercise.
+    @Test func reTappingTheActiveScopeClearsItsWidenedWindow() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        #expect(model.filter.dateScope == .next)
+        model.expandWindowEnd()
+        // The next day with events in the fixture, per expandWindowEnd's step
+        // rule — not a hardcoded calendar step. The point is that the re-tap
+        // throws it away, regardless of which day it landed on.
+        #expect(model.filter.windowEndDayKey == "2026-08-06")
+        model.filter.windowStartDayKey = "2026-08-01"
+
+        model.selectScope(.next)
+
+        #expect(model.filter.dateScope == .next)
+        #expect(model.filter.windowStartDayKey == nil)
+        #expect(model.filter.windowEndDayKey == nil)
+    }
+
+    /// The same reset, driven by the writer that actually produces most of
+    /// this state in the field. `expandWindowEnd` (the test above) is the
+    /// "Show next day" button; since #258 the day rail is the busier source
+    /// — every chip tap goes `EventListView.selectDay` → `AppModel.goToDay`,
+    /// which writes `windowStartDayKey`/`windowEndDayKey` directly. So the
+    /// realistic path into #234 is: navigate the rail, open Filters, re-tap
+    /// the chip you are already on.
+    ///
+    /// Both edges are grown here, each by a `goToDay` in its own direction,
+    /// and each is asserted before the re-tap — a `goToDay` that silently
+    /// refused its target would otherwise let this pass while pinning
+    /// nothing.
+    @Test func reTappingTheActiveScopeClearsAWindowGrownByTheDayRail() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        #expect(model.filter.dateScope == .next)
+
+        // Before the fixture's "now" (2026-08-03 12:00), so the start edge
+        // has to grow to reach it — 08-03 itself is already inside a fresh
+        // `.next` window and `goToDay` would correctly write nothing.
+        #expect(model.goToDay("2026-08-01"))
+        #expect(model.filter.windowStartDayKey == "2026-08-01")
+        #expect(model.goToDay("2026-08-09"))
+        #expect(model.filter.windowEndDayKey == "2026-08-09")
+
+        model.selectScope(.next)
+
+        #expect(model.filter.dateScope == .next)
+        #expect(model.filter.windowStartDayKey == nil)
+        #expect(model.filter.windowEndDayKey == nil)
+    }
+
+    /// Re-tapping `.day` clears `selectedDayKey`, leaving `.day` with no day.
+    /// That is deliberate, not an oversight, on two counts.
+    ///
+    /// First it is a *total* state, not a broken one: the #192 exemption trio
+    /// all route through `EffectiveScope.resolve`, which downgrades `.day`
+    /// with a `nil` key to `.all` (`ViewWindow` does the same via
+    /// `dayWindow(forDayScope:)`), so the list, the date label and the chip
+    /// state agree on "All Year" — a reset, which is what a re-tap now means.
+    ///
+    /// Second it is unreachable from the UI anyway. `selectScope`'s only
+    /// caller is `FilterSheet`'s chip row, whose `visibleScopes` is
+    /// `[.next, .today, .season, .all]` on the current year and `[.all]`
+    /// otherwise; `.day` is never offered (see `DateScope.day`: "Derived, not
+    /// pickable"), and neither is `.thisWeek`, which the week strip owns.
+    /// `.day` arrives only from `browseDay`, which sets the scope and the day
+    /// in one assignment and is therefore never a re-tap.
+    @Test func reTappingDayScopeClearsItsBrowsedDayAndFallsBackToAll() throws {
         let model = try makeInSeasonModel(defaults: makeDefaults())
+        model.browseDay("2026-08-09")
+        #expect(model.filter.dateScope == .day)
+
+        model.selectScope(.day)
+
+        #expect(model.filter.selectedDayKey == nil)
+        #expect(EffectiveScope.resolve(model.filter, isCurrentYear: true) == .all)
+    }
+
+    /// The guard's *original* purpose survives: when there is genuinely
+    /// nothing to clear, `filter` is never written, so its `didSet` never
+    /// fires and no save happens. Asserting only `dateScope == .today` would
+    /// have passed just as well with the guard deleted outright — the erased
+    /// payload below is what makes this able to fail.
+    @Test func reselectingTheActiveScopeIsANoOp() throws {
+        let defaults = makeDefaults()
+        let model = try makeInSeasonModel(defaults: defaults)
         model.selectScope(.today)
+        #expect(defaults.data(forKey: "chq-filters") != nil)
+        // Erase what that first, real selection persisted: anything present
+        // afterwards can only have been written by the re-tap.
+        defaults.removeObject(forKey: "chq-filters")
+
         model.selectScope(.today)
+
         #expect(model.filter.dateScope == .today)
+        #expect(defaults.data(forKey: "chq-filters") == nil)
     }
 
     @Test func selectingTheCurrentWeekIsAnOrdinaryWeekSelection() throws {

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1030,10 +1030,10 @@ struct AppModelTests {
     /// scope and silently re-widen the window when the user comes back to
     /// Now.
     /// Both window-expansion fields belong to the scope being left, not
-    /// just `windowEndDayKey` — `windowStartDayKey` has no writer today
-    /// (there is no `expandWindowStart()` yet), so it's set directly here
-    /// to pin that `clearScopeLocalDateState()` clears it too rather than
-    /// only the field the UI happens to exercise.
+    /// just `windowEndDayKey`. `expandWindowEnd` grows only the end edge, so
+    /// the start edge is seeded directly here — the point is to pin that
+    /// `clearScopeLocalDateState()` clears both, not only the one this path
+    /// writes.
     @Test func selectScopeResetsWindowExpansion() throws {
         let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
         #expect(model.filter.dateScope == .next)
@@ -1132,10 +1132,11 @@ struct AppModelTests {
     /// a name, not a job — the chip resets its scope, the rail control
     /// travels without touching the filter.
     ///
-    /// `windowStartDayKey` still has no writer of its own, so it is set
-    /// directly here for the same reason `selectScopeResetsWindowExpansion`
-    /// does it: to pin that both window fields are cleared, not only the one
-    /// the UI happens to exercise.
+    /// `expandWindowEnd` grows only the end edge, so the start edge is
+    /// seeded directly here — the point is to verify the reset on *both*
+    /// window fields, not just the one this particular path writes.
+    /// `reTappingTheActiveScopeClearsAWindowGrownByTheDayRail` below covers
+    /// the same reset with both edges driven through `goToDay` instead.
     @Test func reTappingTheActiveScopeClearsItsWidenedWindow() throws {
         let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
         #expect(model.filter.dateScope == .next)

--- a/ios/ChqCalendarTests/DiskCacheTests.swift
+++ b/ios/ChqCalendarTests/DiskCacheTests.swift
@@ -110,10 +110,16 @@ struct DiskCacheTests {
     // MARK: - triggerMigrationIfNeeded isAppProcess gate (F1, "for symmetry")
 
     /// Same rationale as `UserStateStoreTests`'s pair of the same name:
-    /// `AppGroup.containerURL()` is `nil` in the unit test host regardless
-    /// of `isAppProcess`, so both branches are no-ops here — this just pins
-    /// that the parameterized trigger is callable and total for both
-    /// values.
+    /// whether either branch actually migrates anything depends on the
+    /// host environment (`AppGroup.containerURL()` is `nil` on a simulator
+    /// with no provisioned App Group container, non-`nil` on one that has
+    /// it; `isAppProcess` is always `true` in this app-hosted test target),
+    /// so on a provisioned simulator the `isAppProcess: true` call really
+    /// does reach `AppGroup.migrateIfNeeded` against the test host's own
+    /// legacy cache directory — harmlessly, since that migration copies
+    /// rather than moves and is skipped entirely once the group directory
+    /// is non-empty. These two pin only that the parameterized trigger is
+    /// callable and total for both values.
     @Test func triggerMigrationIfNeededReturnsTrueWhenIsAppProcessIsTrue() {
         #expect(DiskCache.triggerMigrationIfNeeded(isAppProcess: true))
     }

--- a/ios/ChqCalendarTests/UITestScrollHooksTests.swift
+++ b/ios/ChqCalendarTests/UITestScrollHooksTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+/// `UITestScrollHooks.parse` is DEBUG-only production code (it compiles out
+/// of Release along with `CalendarView.applyUITestHooks`), so the whole
+/// suite is too — a Release-configuration test build would not see the type.
+#if DEBUG
+struct UITestScrollHooksTests {
+    // MARK: - Single-hook and no-hook launches are unchanged
+
+    @Test func noFlagsLeavesBothHooksInert() throws {
+        let hooks = try UITestScrollHooks.parse(["ChqCalendar", "-uitest-show-filters"])
+        #expect(hooks.delay == 0)
+        #expect(hooks.dropCount == 0)
+    }
+
+    @Test func delayFlagAloneParsesToThreeSeconds() throws {
+        let hooks = try UITestScrollHooks.parse(["ChqCalendar", "-uitest-delay-pending-scroll"])
+        #expect(hooks.delay == 3)
+        #expect(hooks.dropCount == 0)
+    }
+
+    /// The exact shape `DayRailUITests.testADayDeepLinkSurvivesADroppedScroll`
+    /// launches with — this pair of assertions is what pins that that test's
+    /// single-flag path is untouched by the mutual-exclusion check.
+    @Test func dropFlagAloneParsesItsCount() throws {
+        let hooks = try UITestScrollHooks.parse(["ChqCalendar", "-uitest-drop-scrolls", "3"])
+        #expect(hooks.delay == 0)
+        #expect(hooks.dropCount == 3)
+    }
+
+    /// A non-positive or unparseable count is ignored rather than rejected,
+    /// matching the `count > 0` guard this parsing was extracted from — the
+    /// hook stays inert instead of the app refusing to launch.
+    @Test func dropFlagWithANonPositiveOrNonNumericCountStaysInert() throws {
+        #expect(try UITestScrollHooks.parse(["ChqCalendar", "-uitest-drop-scrolls", "0"]).dropCount == 0)
+        #expect(try UITestScrollHooks.parse(["ChqCalendar", "-uitest-drop-scrolls", "-2"]).dropCount == 0)
+        #expect(try UITestScrollHooks.parse(["ChqCalendar", "-uitest-drop-scrolls", "many"]).dropCount == 0)
+        #expect(try UITestScrollHooks.parse(["ChqCalendar", "-uitest-drop-scrolls"]).dropCount == 0)
+    }
+
+    // MARK: - The two hooks are mutually exclusive (#252)
+
+    @Test func bothFlagsTogetherThrow() {
+        #expect(throws: UITestScrollHooks.HookConflict.self) {
+            try UITestScrollHooks.parse([
+                "ChqCalendar", "-uitest-delay-pending-scroll", "-uitest-drop-scrolls", "3",
+            ])
+        }
+    }
+
+    /// The whole point of #252 is that the failure names the incompatibility
+    /// rather than looking like a bug in the code under test, so the message
+    /// itself is part of the contract.
+    @Test func theConflictMessageNamesBothFlags() {
+        var message = ""
+        #expect(throws: (any Error).self) {
+            do {
+                _ = try UITestScrollHooks.parse([
+                    "ChqCalendar", "-uitest-drop-scrolls", "2", "-uitest-delay-pending-scroll",
+                ])
+            } catch {
+                message = String(describing: error)
+                throw error
+            }
+        }
+        #expect(message.contains("-uitest-delay-pending-scroll"))
+        #expect(message.contains("-uitest-drop-scrolls"))
+        #expect(message.contains("#252"))
+    }
+
+    /// Order-independent, and independent of whether the drop count would
+    /// itself have been inert: it is the *pair of flags* that is rejected,
+    /// so a launch can never half-arm one hook while silently dropping the
+    /// other.
+    @Test func bothFlagsThrowInEitherOrderAndEvenWithAnInertDropCount() {
+        #expect(throws: UITestScrollHooks.HookConflict.self) {
+            try UITestScrollHooks.parse([
+                "ChqCalendar", "-uitest-delay-pending-scroll", "-uitest-drop-scrolls", "0",
+            ])
+        }
+        #expect(throws: UITestScrollHooks.HookConflict.self) {
+            try UITestScrollHooks.parse([
+                "ChqCalendar", "-uitest-drop-scrolls", "nope", "-uitest-delay-pending-scroll",
+            ])
+        }
+    }
+}
+#endif

--- a/ios/ChqCalendarTests/UITestScrollHooksTests.swift
+++ b/ios/ChqCalendarTests/UITestScrollHooksTests.swift
@@ -22,7 +22,7 @@ struct UITestScrollHooksTests {
     }
 
     /// The exact shape `DayRailUITests.testADayDeepLinkSurvivesADroppedScroll`
-    /// launches with — this pair of assertions is what pins that that test's
+    /// launches with — this pair of assertions is what pins that the test's
     /// single-flag path is untouched by the mutual-exclusion check.
     @Test func dropFlagAloneParsesItsCount() throws {
         let hooks = try UITestScrollHooks.parse(["ChqCalendar", "-uitest-drop-scrolls", "3"])

--- a/ios/ChqCalendarTests/UserStateStoreTests.swift
+++ b/ios/ChqCalendarTests/UserStateStoreTests.swift
@@ -341,15 +341,27 @@ struct UserStateStoreTests {
 
     // MARK: - triggerMigrationIfNeeded isAppProcess gate (F1)
 
-    /// Neither branch touches the real `UserDefaults.standard` in the unit
-    /// test host, since `AppGroup.containerURL()` is `nil` there regardless
-    /// of `isAppProcess` — but both must be callable (independent of the
-    /// once-per-process `didMigrateDefaults` static let, which this
-    /// parameterized function exists separately from) and return `true`
-    /// without crashing. `AppGroup.shouldRunAppOnlyMigrationTests` pins the
-    /// actual `isAppProcess`-vs-`hasGroupContainer` decision matrix; this
-    /// just confirms the trigger wires that decision through correctly for
-    /// both values it's given.
+    /// What these two pin is only that the trigger is *total*: callable
+    /// (independent of the once-per-process `didMigrateDefaults` static
+    /// let, which this parameterized function exists separately from) and
+    /// returning `true` for either input without crashing.
+    ///
+    /// They deliberately assert nothing about whether a migration actually
+    /// ran, because that depends on the host environment rather than on
+    /// this code: `AppGroup.containerURL()` is `nil` on a simulator that
+    /// has never had the App Group container provisioned, but non-`nil` on
+    /// one that has — and `isAppProcess` is always `true` in this
+    /// app-hosted test target. So on a provisioned simulator the
+    /// `isAppProcess: true` call really does reach
+    /// `AppGroup.migrateDefaultsIfNeeded` against the test host's own
+    /// `.standard` suite. That is harmless — the migration is copy-only
+    /// (it never mutates or deletes the source), never overwrites a key
+    /// the destination already has, and is guarded by a one-shot
+    /// `chq-group-migrated` flag — but it is not something to assert on.
+    /// `AppGroupTests.shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer`
+    /// pins the actual `isAppProcess`-vs-`hasGroupContainer` decision
+    /// matrix against the pure gate; these two just confirm the trigger
+    /// wires that decision through for both values it is given.
     @Test func triggerMigrationIfNeededReturnsTrueWhenIsAppProcessIsTrue() {
         #expect(UserStateStore.triggerMigrationIfNeeded(isAppProcess: true))
     }


### PR DESCRIPTION
Closes #235. Closes #252. Closes #234.

[skip-screenshots: a test deletion, a DEBUG-only launch-arg guard, and a scope re-tap state reset; no shot in screenshot-plan.json re-taps a scope or shows a widened window]

Three small, independent iOS fixes, one commit each.

## #235 — drop the env-dependent App Group container assertion (`bc72dba`)

`AppGroupTests.containerURLIsNilInTheUnitTestHost` asserted a property of the machine: on any simulator whose App Group container is provisioned, `containerURL()` returns a URL and the test fails on a clean checkout. Deleted rather than replaced — the issue's option 1 (assert `shouldRunAppOnlyMigration` is false from this target) is not a code property either: with `isAppProcess` true in the hosted test target and a provisioned container, the real (idempotent, copy-only, flag-guarded) migration *is* reachable. The surviving `shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer` pins the actual gate matrix; every comment repeating the "container is always nil in the test host" claim (`AppGroup.swift`, `UserStateStoreTests`, `DiskCacheTests`) is rewritten to be true.

Note for posterity: three archived plan docs still cite the deleted test as the justification for `CODE_SIGNING_ALLOWED=NO`. The flag is still required; that test no longer exists and never proved it.

## #252 — the two UI-test scroll hooks refuse to combine (`640f7aa`)

`-uitest-delay-pending-scroll` and `-uitest-drop-scrolls` interfere (bisected in #250) and the combination produces a plausible-looking red pointing at the code under test. Parsing is extracted into a pure `UITestScrollHooks.parse` (`#if DEBUG`), which throws on the pair; `CalendarView` converts that to an immediate `preconditionFailure` naming both flags and citing #252. Either flag alone, or neither, is byte-for-byte unchanged — `testADayDeepLinkSurvivesADroppedScroll` (drop-flag alone) still passes. New unit tests cover all parse cases; the both-flags guard was proven by removing the check and watching the test fail.

## #234 — re-tapping the active scope clears its widened window (`d36e67d`)

`selectScope`'s early return skipped `clearScopeLocalDateState()` when the tapped scope was already active, so a window widened by "Show next day" — or, since #258, by any day-rail navigation (`goToDay` writes both window keys) — survived a re-tap of the active chip. The guard now returns early only when there is genuinely nothing to write (same scope, no weeks, no window keys, no selected day), preserving its no-spurious-`persistFilter` purpose, which is now directly asserted. New tests cover both writer paths ("Show next day" and `goToDay`), with intermediate assertions proving the window actually grew before the re-tap; falsified by reverting the guard.

The rail's `⟳ Now` is deliberately untouched: it is pure navigation and leaves the window alone (`nowLeavesAnyAccumulatedExpansionInPlace` pins that; #258 finding 2). The chip and the rail control share a name, not a job.

## Verification

- Full unit suite green before each commit (952 → 959 → 962 tests, 72 suites, iPhone 17 sim).
- `DayRailUITests` (the suite that exercises both #252 hooks at runtime) run on this branch: **18/18 passed**.
- Three falsification injections, each failing exactly the guard it targets, all reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adwf2e24aT5Nr3BiATm9xe