### PR TITLE
refactor(ios): stamp the day list with the window it was built from (#254)

### DIFF
--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1074,6 +1074,10 @@ final class AppModel {
     /// also calls `select(year:)` is the future path if pre-season archive
     /// browsing is wanted; not implemented here (follow-up).
     func browseArchiveSeason() {
+        // No `scopeResetCount` bump needed: only reachable from
+        // `OffSeasonLandingView`, which renders solely under
+        // `filter.isDefault` — so this always changes `dateScope`
+        // (`.next` → `.season`), a `PendingDayScroll.Key` field (#254).
         filter = FilterSelection(dateScope: .season)
     }
 
@@ -1094,6 +1098,9 @@ final class AppModel {
     func previewNextSeason() async {
         guard case .postSeason(_, let nextSeasonYear?, _, _) = landingState else { return }
         await select(year: nextSeasonYear)
+        // No `scopeResetCount` bump needed: same `OffSeasonLandingView`-only
+        // reachability as `browseArchiveSeason()`, and `select(year:)` above
+        // changes `Key.year` on every path this runs (#254).
         filter = FilterSelection(dateScope: .all)
     }
 
@@ -1333,6 +1340,14 @@ final class AppModel {
     /// row and individually removable, so leaving it behind after "Clear
     /// all" would be the surprising behavior.
     func clearAll() {
+        // A whole-selection replacement is a scope-local reset too: from an
+        // `.all` selection whose only non-default state is a window
+        // expansion, this clears ONLY the window fields, which
+        // `PendingDayScroll.Key` excludes — the epoch is what stales a
+        // target or pinned highlight armed before it (#254). Harmless in
+        // every other case: this method can never fire on pure window
+        // growth.
+        scopeResetCount += 1
         filter = FilterSelection(dateScope: .all)
         persistFilter()
     }

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1118,9 +1118,14 @@ final class AppModel {
     /// selection as a whole (#156, #197).
     func selectScope(_ scope: DateScope) {
         guard filter.dateScope != scope || !filter.selectedWeeks.isEmpty else { return }
-        filter.dateScope = scope
-        filter.selectedWeeks = []
-        clearScopeLocalDateState()
+        // Copy-modify-assign, like `goToDay`: `filter`'s `didSet` runs a
+        // full `rebuildDerivedCounts()` per changed assignment, so the
+        // action batches its writes into one (#267 review finding).
+        var next = filter
+        next.dateScope = scope
+        next.selectedWeeks = []
+        clearScopeLocalDateState(in: &next)
+        filter = next
         persistFilter()
     }
 
@@ -1142,13 +1147,19 @@ final class AppModel {
     ///   `DateFilterLabel` would have to describe (#197 item 5).
     ///
     /// `browseDay` deliberately does *not* call this: it is the one writer
-    /// that sets `selectedDayKey` and clears the window fields in the same
-    /// assignment, in that order.
-    private func clearScopeLocalDateState() {
+    /// that *sets* `selectedDayKey` while clearing the window fields, in
+    /// its own single batched assignment.
+    ///
+    /// Operates on the caller's pending copy rather than on `filter`
+    /// directly, so the caller's whole action lands in one assignment and
+    /// `filter`'s `didSet` rebuilds derived data once, not once per field
+    /// (#267 review finding). Still bumps the reset epoch itself — the
+    /// bump belongs to the reset, wherever it is applied from.
+    private func clearScopeLocalDateState(in next: inout FilterSelection) {
         scopeResetCount += 1
-        filter.selectedDayKey = nil
-        filter.windowStartDayKey = nil
-        filter.windowEndDayKey = nil
+        next.selectedDayKey = nil
+        next.windowStartDayKey = nil
+        next.windowEndDayKey = nil
     }
 
     /// Monotonic count of scope-local date resets — every
@@ -1174,9 +1185,12 @@ final class AppModel {
     /// `clearScopeLocalDateState()` cleanup `selectScope` does — this is the
     /// other route out of `.day` and out of a `.next`-widened window.
     func setWeekSelection(_ weeks: Set<Int>) {
-        filter.dateScope = .all
-        filter.selectedWeeks = weeks
-        clearScopeLocalDateState()
+        // Copy-modify-assign — see `selectScope` (#267 review finding).
+        var next = filter
+        next.dateScope = .all
+        next.selectedWeeks = weeks
+        clearScopeLocalDateState(in: &next)
+        filter = next
         persistFilter()
     }
 
@@ -1204,16 +1218,23 @@ final class AppModel {
     func browseDay(_ dayKey: String) {
         guard let parsed = ChqTime.parse("\(dayKey) 00:00:00") else { return }
         // The inlined scope-local reset below owes the same epoch bump as
-        // `clearScopeLocalDateState()`: re-browsing the day already browsed
-        // changes no `PendingDayScroll.Key` field, and without the bump a
-        // pinned highlight or pending scroll from before the re-browse
-        // survived the window reset (#254 scope addition).
+        // `clearScopeLocalDateState(in:)`: re-browsing the day already
+        // browsed changes no `PendingDayScroll.Key` field, and without the
+        // bump a pinned highlight or pending scroll from before the
+        // re-browse survived the window reset (#254 scope addition). Bumped
+        // BEFORE the assignment so the `didSet`'s rebuild captures the
+        // fresh epoch in `NavMatchingInputs`.
         scopeResetCount += 1
-        filter.dateScope = .day
-        filter.selectedDayKey = ChqTime.dayKey(for: parsed)
-        filter.selectedWeeks = []
-        filter.windowStartDayKey = nil
-        filter.windowEndDayKey = nil
+        // One batched assignment — the day is set while the window fields
+        // clear, and `filter`'s `didSet` rebuilds derived data once for the
+        // whole action (#267 review finding; `goToDay` set the pattern).
+        var next = filter
+        next.dateScope = .day
+        next.selectedDayKey = ChqTime.dayKey(for: parsed)
+        next.selectedWeeks = []
+        next.windowStartDayKey = nil
+        next.windowEndDayKey = nil
+        filter = next
         persistFilter()
     }
 

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -300,11 +300,33 @@ final class AppModel {
 
     // MARK: - Derived
 
-    /// The events currently shown, filtered then grouped by NY calendar day.
-    /// Recomputed on every access rather than cached — at ~1.6k events this
-    /// is cheap enough that memoization isn't worth the extra state.
+    /// The events currently shown, filtered then grouped by NY calendar
+    /// day, stamped with the window they were filtered by — one value per
+    /// render pass, so a view that binds it once can never pair a day list
+    /// from one pass with a window from another (#254). Recomputed on every
+    /// access rather than cached — at ~1.6k events this is cheap enough
+    /// that memoization isn't worth the extra state.
+    ///
+    /// The stamp is `currentWindow` — the same value the rail's model-side
+    /// callers read — and the filter pass here uses that exact window via
+    /// `EventFilter`'s window-taking entry point, so the stamp *is* the
+    /// filtering window rather than a second computation that could drift.
+    /// `currentWindow` reads `navigableBounds`, which is cached in
+    /// `navMatching`, so this costs no per-render O(n) bounds scan.
+    var renderedDays: RenderedDays {
+        guard let snapshot else { return RenderedDays(days: [], window: nil) }
+        let window = currentWindow
+        let events = EventFilter.apply(
+            filter, to: snapshot.events, favorites: favorites,
+            year: selectedYear, window: window)
+        return RenderedDays(
+            days: EventGrouping.byDay(events, year: selectedYear), window: window)
+    }
+
+    /// `renderedDays` without the stamp, for callers that only need the
+    /// days. Costs the same full filter+group pass — bind it once.
     var dayGroups: [DayGroup] {
-        EventGrouping.byDay(filteredEvents(filter), year: selectedYear)
+        renderedDays.days
     }
 
     /// How many events the current selection matches — the same number as
@@ -1748,7 +1770,7 @@ final class AppModel {
     /// latter has anything to open. `nil` when nothing in the current
     /// selection has a themed week.
     ///
-    /// Takes the caller's already-computed `days` — `EventListView.list(days:)`'s
+    /// Takes the caller's already-computed `days` — `EventListView.list(rendered:)`'s
     /// own `days` parameter — rather than reading `dayGroups` itself.
     /// `dayGroups` is deliberately uncached (see the comment above) and
     /// re-runs the whole filter+group pipeline on every access, so this used

--- a/ios/ChqCalendar/App/AppModel.swift
+++ b/ios/ChqCalendar/App/AppModel.swift
@@ -1138,10 +1138,23 @@ final class AppModel {
     /// that sets `selectedDayKey` and clears the window fields in the same
     /// assignment, in that order.
     private func clearScopeLocalDateState() {
+        scopeResetCount += 1
         filter.selectedDayKey = nil
         filter.windowStartDayKey = nil
         filter.windowEndDayKey = nil
     }
+
+    /// Monotonic count of scope-local date resets — every
+    /// `clearScopeLocalDateState()` call plus `browseDay`'s inlined
+    /// equivalent. Rides in `PendingDayScroll.Key` so a reset that clears
+    /// ONLY the window-expansion fields (re-browsing the same day; #266's
+    /// re-tap of the active scope) still stales a pending scroll or pinned
+    /// rail highlight armed before it — those fields are excluded from the
+    /// key by design, so without this epoch such a reset changed nothing
+    /// the key could see (#254 scope addition). Window *growth*
+    /// (`goToDay`/`expandWindowEnd`) never bumps it: a pending deep-link
+    /// scroll is literally waiting for that growth, so it must never stale.
+    private(set) var scopeResetCount = 0
 
     /// Replaces the week selection wholesale — the strip owns tap/drag
     /// semantics (`WeekStripDrag.commit`); the model just stores the result.
@@ -1183,6 +1196,12 @@ final class AppModel {
     /// date state.
     func browseDay(_ dayKey: String) {
         guard let parsed = ChqTime.parse("\(dayKey) 00:00:00") else { return }
+        // The inlined scope-local reset below owes the same epoch bump as
+        // `clearScopeLocalDateState()`: re-browsing the day already browsed
+        // changes no `PendingDayScroll.Key` field, and without the bump a
+        // pinned highlight or pending scroll from before the re-browse
+        // survived the window reset (#254 scope addition).
+        scopeResetCount += 1
         filter.dateScope = .day
         filter.selectedDayKey = ChqTime.dayKey(for: parsed)
         filter.selectedWeeks = []
@@ -1483,8 +1502,10 @@ final class AppModel {
         // The expensive case this guard exists for is `expandWindowEnd()`
         // firing repeatedly as the reader scrolls — window-only changes, which
         // the key excludes and which are therefore correctly skipped. What
-        // remains is one redundant pass per deliberate scope tap, which no
-        // reader can perceive. A narrower, purpose-built fingerprint would
+        // remains is one redundant pass per deliberate scope tap — and,
+        // since the key now carries `scopeResetCount` (#254), one per
+        // same-day re-browse or same-scope re-tap — which no reader can
+        // perceive. A narrower, purpose-built fingerprint would
         // save that pass and introduce a far worse failure mode: omit one
         // input that does matter (weeks, venues, categories, favourites-only,
         // search) and `navMatching` goes silently stale, which shows up as a
@@ -1494,7 +1515,8 @@ final class AppModel {
         let inputs = NavMatchingInputs(
             snapshotFetchedAt: snapshot.fetchedAt,
             favorites: favorites,
-            filterKey: PendingDayScroll.key(for: filter, year: selectedYear))
+            filterKey: PendingDayScroll.key(
+                for: filter, year: selectedYear, scopeResets: scopeResetCount))
         guard inputs != lastNavMatchingInputs else { return }
         lastNavMatchingInputs = inputs
         rebuildNavMatching()

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -138,7 +138,7 @@ struct EventListView: View {
     /// which keeps this whole path inert.
     ///
     /// A *deadline* rather than a countdown consumed by the first caller:
-    /// `list(days:)` wires two independent triggers onto `landPendingScroll`
+    /// `list(rendered:)` wires two independent triggers onto `landPendingScroll`
     /// (`days.map(\.id)` and `pendingScroll` itself), and a distant tap can
     /// fire both in the same SwiftUI commit. A one-shot delay let whichever
     /// trigger ran second see it already spent and resolve synchronously —
@@ -155,7 +155,7 @@ struct EventListView: View {
     /// landing one.
     ///
     /// Measured from the first *attempt*, not from `selectDay` arming the
-    /// target — `list(days:)`, where every attempt happens, is not mounted
+    /// target — `list(rendered:)`, where every attempt happens, is not mounted
     /// when `model.dayGroups` is empty (a favourites-only filter with
     /// nothing upcoming, say). A deadline stamped at arm time would burn down
     /// in real time while the list is unmounted and nothing can even try;
@@ -185,7 +185,7 @@ struct EventListView: View {
     /// arm time. `selectDay` only resets this to `nil`. The two used to be
     /// the same moment, and that was itself a bug fixed on this branch
     /// (`resolvePendingScroll`'s `!visibleDays.isEmpty` guard, for #250): a
-    /// deep link consumed while `list(days:)` is unmounted (a
+    /// deep link consumed while `list(rendered:)` is unmounted (a
     /// favourites-only filter with nothing upcoming, showing
     /// `noMatchesView`) has no `resolvePendingScroll` call to stamp anything
     /// — arming at `selectDay` would burn the whole window in real time
@@ -203,14 +203,14 @@ struct EventListView: View {
     /// stops being true.
     ///
     /// A deadline rather than an attempt counter for the same reason
-    /// `pendingScrollDeadline` is one: `list(days:)` wires several
+    /// `pendingScrollDeadline` is one: `list(rendered:)` wires several
     /// independent triggers onto `landPendingScroll`, more than one can fire
     /// from a single commit, and two concurrent retry chains sharing a
     /// counter would burn the budget at twice the rate. Sharing a wall-clock
     /// deadline, they simply stop at the same moment.
     @State private var scrollRetryDeadline: Date?
 
-    /// Bumped by a scheduled re-check so `list(days:)` re-runs
+    /// Bumped by a scheduled re-check so `list(rendered:)` re-runs
     /// `landPendingScroll` — see its `.onChange(of: scrollRetryTick)`.
     ///
     /// The retry goes through view state rather than re-entering
@@ -225,7 +225,7 @@ struct EventListView: View {
     /// flight at once.
     ///
     /// `resolvePendingScroll` runs once per triggering `.onChange`, and
-    /// `list(days:)` wires several independent triggers onto
+    /// `list(rendered:)` wires several independent triggers onto
     /// `landPendingScroll` — more than one can fire from a single SwiftUI
     /// commit (see `scrollRetryDeadline`'s doc). Before this guard, each of
     /// those calls that failed to land its target scheduled its own
@@ -292,7 +292,7 @@ struct EventListView: View {
             // launch sets `phase = .ready` immediately and never changes it
             // again when the background refresh replaces the snapshot.
             //
-            // **On `body`, deliberately — not inside `list(days:)`.** `content`
+            // **On `body`, deliberately — not inside `list(rendered:)`.** `content`
             // only builds the list when `model.dayGroups` is non-empty, so
             // triggers hosted there are unmounted in exactly the states a
             // pending link most needs resolving: a persisted favourites-only
@@ -304,7 +304,7 @@ struct EventListView: View {
             // always mounted, which is also where the `.event` resolver has
             // always lived (`CalendarView`). Nothing here needs the list:
             // `selectDay` takes no `ScrollViewProxy` (it arms `pendingScroll`,
-            // which `list(days:)` resolves whenever it does mount), and
+            // which `list(rendered:)` resolves whenever it does mount), and
             // `resolvePendingDayDeepLinkIfPossible` already gates on
             // `snapshot != nil`.
             .onChange(of: model.pendingDeepLink) { _, _ in
@@ -356,7 +356,7 @@ struct EventListView: View {
     }
 
     /// Non-nil only for the single badge `-uitest-show-week-theme` targets
-    /// (`target`, computed once per render by `list(days:)` via
+    /// (`target`, computed once per render by `list(rendered:)` via
     /// `AppModel.uiTestFirstThemedWeek(in:)`) — every other badge in
     /// `dayHeader` gets `nil` and behaves exactly as it did before this hook
     /// existed. See `WeekThemeBadge.uiTestAutoShow` for how the binding is
@@ -506,7 +506,7 @@ struct EventListView: View {
     }
 
     /// A day rail chip was tapped. Grows at most one edge of the window if
-    /// the day lies past it, then queues a scroll for `list(days:)` to land
+    /// the day lies past it, then queues a scroll for `list(rendered:)` to land
     /// once the day mounts. Refused targets (outside the navigable bounds)
     /// leave `pendingScroll` untouched, so no scroll is queued for a day
     /// that will never arrive.
@@ -610,7 +610,7 @@ struct EventListView: View {
     /// document grew 1020px beneath it, and the tap landed ~1058px short of
     /// its target. Growing content plus a smooth scroll is a race the scroll
     /// loses.
-    private func landPendingScroll(_ proxy: ScrollViewProxy, days: [DayGroup]) {
+    private func landPendingScroll(_ proxy: ScrollViewProxy, rendered: RenderedDays) {
         guard pendingScroll != nil else { return }
 
         #if DEBUG
@@ -620,25 +620,26 @@ struct EventListView: View {
                 // Re-enter this same function once the deadline is actually
                 // up, rather than resolving unconditionally — any number of
                 // calls landing here before then (the two triggers on
-                // `list(days:)` can both fire from one commit) just
+                // `list(rendered:)` can both fire from one commit) just
                 // re-schedule against the same still-future deadline and
                 // return, so none of them can jump the line.
                 DispatchQueue.main.asyncAfter(deadline: .now() + remaining) { [self] in
-                    landPendingScroll(proxy, days: days)
+                    landPendingScroll(proxy, rendered: rendered)
                 }
                 return
             }
             pendingScrollDeadline = nil
         }
         #endif
-        resolvePendingScroll(proxy, days: days)
+        resolvePendingScroll(proxy, rendered: rendered)
     }
 
     /// The actual staleness/mount decision, factored out of `landPendingScroll`
     /// so `-uitest-delay-pending-scroll` can defer *when* this runs without
     /// duplicating *what* it does.
-    private func resolvePendingScroll(_ proxy: ScrollViewProxy, days: [DayGroup]) {
+    private func resolvePendingScroll(_ proxy: ScrollViewProxy, rendered: RenderedDays) {
         guard let pending = pendingScroll else { return }
+        let days = rendered.days
 
         // The retry window starts here, on the first real attempt at this
         // target — not back when `selectDay` armed it. `selectDay` only
@@ -671,33 +672,24 @@ struct EventListView: View {
             issueScroll(proxy, to: pending.day)
         } else if !visibleDays.isEmpty,
                   DayRailNavigation.shouldAbandonScroll(
-                    target: pending.day, window: model.currentWindow) {
-            // `!visibleDays.isEmpty` is the fix for #250, and it is load-
-            // bearing. `shouldAbandonScroll` reads `model.currentWindow` —
-            // live state — while `days` is whatever array the enclosing
-            // render captured. On a cold launch consuming a day deep link
-            // those two disagree exactly once, and fatally: `content` builds
-            // `list(days:)` the moment `snapshot` lands, then `body`'s
-            // `.onChange(of: model.pendingDeepLink)` runs `selectDay` in that
-            // same update, so `goToDay` has already grown the window by the
-            // time the freshly-mounted list's `.onAppear` fires — carrying
-            // the *pre-growth* `days`. The rule then reads "the window covers
-            // this day and it has no section", concludes it is an ordinary
-            // empty day, and drops the target. The two `.onChange` triggers
-            // arrive with correct data about two milliseconds later and are
-            // swallowed by `landPendingScroll`'s `pendingScroll != nil`
-            // guard, because there is no longer anything pending. Measured
-            // on an iPhone 17 Pro / iOS 26.1 simulator: 5 failures in 18
-            // runs, every one of them logging that single stale-`days` call
-            // and nothing after it; 12 for 12 with this guard, with 9 of
-            // those runs still hitting the stale call.
+                    target: pending.day, rendered: rendered) {
+            // The abandon rule reads the window stamped onto `rendered` —
+            // the same render pass that produced `days` — never live model
+            // state. On the cold-launch update that mounts the list and
+            // consumes a day deep link in one pass, the live window has
+            // already grown while the captured days are still pre-growth;
+            // reading the live window there dropped the target as an
+            // "ordinary empty day" (#250, ~3 failures in 8 runs). With the
+            // stamped window the rule sees the pre-growth window, which
+            // does not cover the target, so the wait correctly continues
+            // until the grown render's own trigger fires. #254 has the full
+            // history of the four bugs sharing this signature.
             //
-            // An empty `visibleDays` means the list has not rendered a single
-            // day header yet, which is true only of that first-mount call —
-            // and is precisely when `days` cannot be trusted to correspond to
-            // the current window. Any settled render (every chip tap, which
-            // is what this rule was written for) has headers on screen and
-            // still abandons immediately.
+            // `!visibleDays.isEmpty` was #250's symptom guard for exactly
+            // that disagreement and is no longer load-bearing now that the
+            // window and days come from one pass; it is removed in the
+            // follow-up commit once the deep-link UI tests prove the
+            // stamped path on its own.
             clearPendingScroll()
             return
         }
@@ -727,7 +719,7 @@ struct EventListView: View {
         scrollRetryDeadline = nil
     }
 
-    /// Ask `list(days:)` to run `landPendingScroll` again shortly, with the
+    /// Ask `list(rendered:)` to run `landPendingScroll` again shortly, with the
     /// `days` of whatever render is current by then — see `scrollRetryTick`.
     ///
     /// Guarded by the same `pendingScroll != nil` check `landPendingScroll`
@@ -781,24 +773,30 @@ struct EventListView: View {
             }
         } else {
             // Bound once here rather than read separately by an `.isEmpty`
-            // check and then `list`: `model.dayGroups` reruns the whole
+            // check and then `list`: `model.renderedDays` reruns the whole
             // filter+group pipeline on every access (six `EventFilter`
             // stages over ~1,637 events plus `EventGrouping.byDay`), so
-            // reading it twice would cost two full passes per render.
-            let days = model.dayGroups
-            if days.isEmpty {
+            // reading it twice would cost two full passes per render. The
+            // single read also carries the #254 invariant: the window
+            // stamped on `rendered` is the one these days were filtered by,
+            // and everything downstream (`list`, `landPendingScroll`,
+            // `resolvePendingScroll`) reads this one value rather than
+            // re-reading live model state.
+            let rendered = model.renderedDays
+            if rendered.days.isEmpty {
                 if model.filter.isDefault && model.landingState != .inSeason {
                     OffSeasonLandingView(model: model)
                 } else {
                     noMatchesView
                 }
             } else {
-                list(days: days)
+                list(rendered: rendered)
             }
         }
     }
 
-    private func list(days: [DayGroup]) -> some View {
+    private func list(rendered: RenderedDays) -> some View {
+        let days = rendered.days
         let filtered = days.reduce(0) { $0 + $1.events.count }
 
         #if DEBUG
@@ -876,7 +874,7 @@ struct EventListView: View {
             // is what tells the retry a commit actually landed without
             // paying for a second filter+group pass.
             .onChange(of: days.map(\.id)) { _, _ in
-                landPendingScroll(proxy, days: days)
+                landPendingScroll(proxy, rendered: rendered)
             }
             // A tap that lands inside the window already (no expansion
             // needed) never changes `days`, so the trigger above never
@@ -888,7 +886,7 @@ struct EventListView: View {
             // `pendingScroll != nil` guard makes that second call a no-op,
             // so this cannot re-arm itself in a loop.
             .onChange(of: pendingScroll) { _, _ in
-                landPendingScroll(proxy, days: days)
+                landPendingScroll(proxy, rendered: rendered)
             }
             // The third trigger. The two above each fire at most once per
             // arm and `.onAppear` fires exactly once, so between them a
@@ -904,10 +902,10 @@ struct EventListView: View {
             // unchecked assumption, and `testADayDeepLinkSurvivesADroppedScroll`
             // pins it.
             .onChange(of: scrollRetryTick) { _, _ in
-                landPendingScroll(proxy, days: days)
+                landPendingScroll(proxy, rendered: rendered)
             }
             .onAppear {
-                landPendingScroll(proxy, days: days)
+                landPendingScroll(proxy, rendered: rendered)
             }
         }
     }

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -259,7 +259,8 @@ struct EventListView: View {
     /// a day that was in range when it was tapped).
     private func pinnedSelectionDay(in nav: NavMatching) -> String? {
         guard let pinnedSelection else { return nil }
-        let currentKey = PendingDayScroll.key(for: model.filter, year: model.selectedYear)
+        let currentKey = PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)
         guard !PendingDayScroll.isStale(pinnedSelection, currentKey: currentKey) else { return nil }
         guard nav.bounds.contains(pinnedSelection.day) else { return nil }
         return pinnedSelection.day
@@ -520,7 +521,8 @@ struct EventListView: View {
         anchorDay = dayKey
         let target = PendingDayScroll.Target(
             day: dayKey,
-            key: PendingDayScroll.key(for: model.filter, year: model.selectedYear))
+            key: PendingDayScroll.key(
+                for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount))
         pendingScroll = target
         pinnedSelection = target
         // Reset, not stamped: a fresh arm must not inherit whatever deadline
@@ -662,7 +664,8 @@ struct EventListView: View {
             existing: scrollRetryDeadline, now: Date(), window: Self.scrollRetryWindow)
         scrollRetryDeadline = retryDeadline
 
-        let currentKey = PendingDayScroll.key(for: model.filter, year: model.selectedYear)
+        let currentKey = PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)
         if PendingDayScroll.isStale(pending, currentKey: currentKey) {
             clearPendingScroll()
             return

--- a/ios/ChqCalendar/Features/Calendar/EventListView.swift
+++ b/ios/ChqCalendar/Features/Calendar/EventListView.swift
@@ -673,26 +673,21 @@ struct EventListView: View {
 
         if days.contains(where: { $0.id == pending.day }) {
             issueScroll(proxy, to: pending.day)
-        } else if !visibleDays.isEmpty,
-                  DayRailNavigation.shouldAbandonScroll(
-                    target: pending.day, rendered: rendered) {
+        } else if DayRailNavigation.shouldAbandonScroll(
+            target: pending.day, rendered: rendered) {
             // The abandon rule reads the window stamped onto `rendered` —
             // the same render pass that produced `days` — never live model
             // state. On the cold-launch update that mounts the list and
             // consumes a day deep link in one pass, the live window has
             // already grown while the captured days are still pre-growth;
             // reading the live window there dropped the target as an
-            // "ordinary empty day" (#250, ~3 failures in 8 runs). With the
-            // stamped window the rule sees the pre-growth window, which
-            // does not cover the target, so the wait correctly continues
-            // until the grown render's own trigger fires. #254 has the full
-            // history of the four bugs sharing this signature.
-            //
-            // `!visibleDays.isEmpty` was #250's symptom guard for exactly
-            // that disagreement and is no longer load-bearing now that the
-            // window and days come from one pass; it is removed in the
-            // follow-up commit once the deep-link UI tests prove the
-            // stamped path on its own.
+            // "ordinary empty day" (#250, ~3 failures in 8 runs; a
+            // `!visibleDays.isEmpty` guard treated that symptom until the
+            // stamp made it unrepresentable). With the stamped window the
+            // rule sees the pre-growth window, which does not cover the
+            // target, so the wait correctly continues until the grown
+            // render's own trigger fires. #254 has the full history of the
+            // four bugs sharing this signature.
             clearPendingScroll()
             return
         }

--- a/ios/ChqCalendar/Features/Calendar/PendingDayScroll.swift
+++ b/ios/ChqCalendar/Features/Calendar/PendingDayScroll.swift
@@ -22,10 +22,22 @@ import Foundation
 /// pending scroll stale. Everything else changing — scope, weeks, the named
 /// day, search text, venues, categories, favorites-only, or the selected
 /// year — means the reader has left the context the tap was made under.
+///
+/// Excluding the window fields left one gap (#254 scope addition): a reset
+/// that clears ONLY the window — re-browsing the day already browsed, or
+/// re-tapping the active scope — changes no `Key` field, so a target (or a
+/// pinned rail highlight, which shares `Key`) armed before the reset could
+/// never go stale and survived pointing outside the freshly reset window.
+/// `scopeResets` closes it: `AppModel` bumps a monotonic counter on every
+/// scope-local date reset and it rides in the key, so a reset stales what
+/// was armed before it while window *growth* — which never bumps the
+/// counter — still never does.
 nonisolated enum PendingDayScroll {
     /// Everything a pending target must still match to be honored. Two
     /// `FilterSelection`s that differ only in `windowStartDayKey`/
-    /// `windowEndDayKey` produce the same `Key` — that's the whole point.
+    /// `windowEndDayKey` produce the same `Key` — that's the whole point —
+    /// unless a scope-local reset happened in between, which `scopeResets`
+    /// records (see the enum doc above).
     struct Key: Equatable, Sendable {
         let searchText: String
         let dateScope: DateScope
@@ -35,6 +47,7 @@ nonisolated enum PendingDayScroll {
         let selectedCategories: [String]
         let showFavoritesOnly: Bool
         let year: Int
+        let scopeResets: Int
     }
 
     /// A day the reader tapped, stamped with the filter identity it was
@@ -44,7 +57,10 @@ nonisolated enum PendingDayScroll {
         let key: Key
     }
 
-    static func key(for selection: FilterSelection, year: Int) -> Key {
+    /// `scopeResets` is the model's live `AppModel.scopeResetCount` —
+    /// deliberately not defaulted, so no call site can silently opt out of
+    /// reset staleness by forgetting it.
+    static func key(for selection: FilterSelection, year: Int, scopeResets: Int) -> Key {
         Key(
             searchText: selection.searchText,
             dateScope: selection.dateScope,
@@ -53,7 +69,8 @@ nonisolated enum PendingDayScroll {
             selectedLocations: selection.selectedLocations,
             selectedCategories: selection.selectedCategories,
             showFavoritesOnly: selection.showFavoritesOnly,
-            year: year)
+            year: year,
+            scopeResets: scopeResets)
     }
 
     /// Whether `target` — armed under `target.key` — should be dropped

--- a/ios/ChqCalendarShared/Domain/DayRailNavigation.swift
+++ b/ios/ChqCalendarShared/Domain/DayRailNavigation.swift
@@ -57,6 +57,17 @@ nonisolated enum DayRailNavigation {
         return target >= window.startDay && target <= window.endDay
     }
 
+    /// The render-pass form of the rule above: decides against the window
+    /// stamped onto the very day list the caller is inspecting, so live
+    /// model state can never be paired with a render-captured list. During
+    /// the one update where the live window has grown but the captured days
+    /// are still pre-growth, the stamped window is the *pre-growth* one —
+    /// it does not cover the target yet, so the scroll correctly keeps
+    /// waiting instead of being dropped as an "empty day" (#254).
+    static func shouldAbandonScroll(target: String, rendered: RenderedDays) -> Bool {
+        shouldAbandonScroll(target: target, window: rendered.window)
+    }
+
     /// The nearest day with events on either side of `anchor`.
     ///
     /// `eventDays` is every day that has an event under the current

--- a/ios/ChqCalendarShared/Domain/EventFilter.swift
+++ b/ios/ChqCalendarShared/Domain/EventFilter.swift
@@ -5,14 +5,12 @@ import Foundation
 /// search → dateScope → weeks → locations → categories → favorites. Each
 /// stage narrows the set produced by the previous one.
 nonisolated enum EventFilter {
-    /// Runs the full pipeline. `now`/`year`/`isCurrentYear` govern the
-    /// date-relative stages: `now` is the reference instant, `year` selects
-    /// the season used for week math, and `isCurrentYear == false` forces
-    /// any time-relative `dateScope` (`.next`/`.today`/`.thisWeek`) to
-    /// behave as `.all` — a past/future season has no "now". `.day` is
-    /// excluded from that downgrade: it names an absolute date rather than a
-    /// window relative to "now", so it is just as meaningful off the current
-    /// year.
+    /// Runs the full pipeline with the date window supplied by the caller —
+    /// the entry point `AppModel.renderedDays` uses so the exact window the
+    /// events were filtered by can be stamped onto the grouped days (#254).
+    /// The convenience overload below computes the window itself and
+    /// delegates here; the two select identical events (see its doc), which
+    /// is what `EventFilterTests`' equivalence cases pin.
     ///
     /// `SeasonCalendar.weeks(forYear:)` is computed once here, for the weeks
     /// filter below — it rebuilds all 9 `SeasonWeek` structs, so
@@ -21,17 +19,13 @@ nonisolated enum EventFilter {
     /// read it (`.season`, `.thisWeek`), not on every call — and it isn't
     /// shared with the copy here, since threading a `[SeasonWeek]` across
     /// that boundary would trade one cheap 9-struct build for coupling the
-    /// two call sites together. `bounds` below is `DayWindow.bounds`'s
-    /// cheaper season-only range on the common path, not
-    /// `navigableBounds`'s O(n) per-event scan — see the comment at its
-    /// call site for why that scan is skippable here.
+    /// two call sites together.
     static func apply(
         _ sel: FilterSelection,
         to events: [Event],
         favorites: Set<String>,
-        now: Date,
         year: Int,
-        isCurrentYear: Bool
+        window: ViewWindow?
     ) -> [Event] {
         var result = events
 
@@ -58,25 +52,10 @@ nonisolated enum EventFilter {
         // `ViewWindow.base` gives it a seven-day fallback and never returns
         // `nil` for it.
         //
-        // `navigableBounds` is an O(n) scan over every event (via
-        // `ChqTime.dayKey(for:)`) to build the season-and-starred-and-event
-        // widened bounds. `EventFilter` reads only `window.contains(_:)`
-        // below, never `startDay`/`endDay`, so those bounds matter only to
-        // clamp `ViewWindow.make`'s expansion inputs — and those inputs are
-        // `nil` on almost every call, since expansion only happens once the
-        // user has actually navigated. When neither is set, the cheaper
-        // season-only `DayWindow.bounds` is enough: it can't disagree with
-        // `navigableBounds` about anything this function reads, only about
-        // the `.all` scope's (here-unused) day-key projection — see
-        // `ViewWindow.make`'s doc for that.
-        let hasExpansion = sel.windowStartDayKey != nil || sel.windowEndDayKey != nil
-        let bounds = hasExpansion
-            ? ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
-            : DayWindow.bounds(year: year, starredDays: [])
-        guard let window = ViewWindow.make(
-            selection: sel, events: events, now: now,
-            year: year, isCurrentYear: isCurrentYear, bounds: bounds)
-        else { return [] }
+        // Only `window.contains(_:)` is read here — never `startDay`/
+        // `endDay` — which is what lets the convenience overload below get
+        // away with cheaper bounds when it computes this window itself.
+        guard let window else { return [] }
         result = result.filter { window.contains($0.start) }
 
         if !sel.selectedWeeks.isEmpty {
@@ -106,6 +85,47 @@ nonisolated enum EventFilter {
         }
 
         return result
+    }
+
+    /// The self-contained form: computes the date window and runs the
+    /// pipeline above. `now`/`year`/`isCurrentYear` govern the date-relative
+    /// stages: `now` is the reference instant, `year` selects the season
+    /// used for week math, and `isCurrentYear == false` forces any
+    /// time-relative `dateScope` (`.next`/`.today`/`.thisWeek`) to behave
+    /// as `.all` — a past/future season has no "now". `.day` is excluded
+    /// from that downgrade: it names an absolute date rather than a window
+    /// relative to "now", so it is just as meaningful off the current year.
+    ///
+    /// `bounds` below is `DayWindow.bounds`'s cheaper season-only range on
+    /// the common path, not `navigableBounds`'s O(n) per-event scan: that
+    /// scan builds the season-and-starred-and-event widened bounds, which
+    /// matter only to clamp `ViewWindow.make`'s expansion inputs — `nil` on
+    /// almost every call, since expansion only happens once the user has
+    /// actually navigated — and to the `.all` scope's day-key projection,
+    /// which the pipeline never reads (it reads `window.contains(_:)`
+    /// only). So the window computed here can differ from a caller-computed
+    /// `navigableBounds` one in `startDay`/`endDay` for `.all`, but never
+    /// in which events it selects — `EventFilterTests` pins that
+    /// equivalence. A caller that needs the day projection to be honest
+    /// about what a rendered list covers (`AppModel.renderedDays`) must
+    /// compute the window itself against `navigableBounds` and use the
+    /// window-taking entry point above, not this one.
+    static func apply(
+        _ sel: FilterSelection,
+        to events: [Event],
+        favorites: Set<String>,
+        now: Date,
+        year: Int,
+        isCurrentYear: Bool
+    ) -> [Event] {
+        let hasExpansion = sel.windowStartDayKey != nil || sel.windowEndDayKey != nil
+        let bounds = hasExpansion
+            ? ViewWindow.navigableBounds(year: year, events: events, starredDays: [])
+            : DayWindow.bounds(year: year, starredDays: [])
+        let window = ViewWindow.make(
+            selection: sel, events: events, now: now,
+            year: year, isCurrentYear: isCurrentYear, bounds: bounds)
+        return apply(sel, to: events, favorites: favorites, year: year, window: window)
     }
 
     /// Relevance score for `event` against `term` (already free-form, not

--- a/ios/ChqCalendarShared/Domain/EventGrouping.swift
+++ b/ios/ChqCalendarShared/Domain/EventGrouping.swift
@@ -9,6 +9,23 @@ nonisolated struct DayGroup: Identifiable, Sendable {
     let events: [Event]
 }
 
+/// What one render of the event list is built from: the grouped days and
+/// the window they were filtered by, computed together in one pass
+/// (`AppModel.renderedDays`) so no caller can pair a day list from one
+/// render pass with a window from another. That pairing — a live window
+/// read against a render-captured `days` array — is the defect class
+/// behind #254's four scroll bugs: they disagree exactly once, on the
+/// update that mounts the list and consumes a day deep link in the same
+/// pass, when the window has already grown while the captured days are
+/// still pre-growth.
+///
+/// `window` is `nil` when no snapshot has loaded or the scope resolves to
+/// no window at all — the same conditions under which `days` is empty.
+nonisolated struct RenderedDays: Sendable {
+    let days: [DayGroup]
+    let window: ViewWindow?
+}
+
 /// Groups events into `DayGroup`s by NY calendar day.
 nonisolated enum EventGrouping {
     /// Groups `events` by NY calendar day. Groups are returned in ascending

--- a/ios/ChqCalendarShared/Domain/EventGrouping.swift
+++ b/ios/ChqCalendarShared/Domain/EventGrouping.swift
@@ -20,7 +20,9 @@ nonisolated struct DayGroup: Identifiable, Sendable {
 /// still pre-growth.
 ///
 /// `window` is `nil` when no snapshot has loaded or the scope resolves to
-/// no window at all — the same conditions under which `days` is empty.
+/// no window at all; `days` is empty in both of those states too, though
+/// it can also be empty under a non-nil window when the filters simply
+/// match nothing.
 nonisolated struct RenderedDays: Sendable {
     let days: [DayGroup]
     let window: ViewWindow?

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1416,6 +1416,41 @@ struct AppModelTests {
         #expect(eventCalls.isEmpty)
     }
 
+    // MARK: - renderedDays (#254)
+
+    /// `renderedDays.window` must be the window the days were actually
+    /// filtered by — with expansion set, the path where the filter's
+    /// internal window computation and `currentWindow` could historically
+    /// diverge. The days are recomputed here through the same
+    /// window-taking `EventFilter` entry point with the stamped window, so
+    /// a `renderedDays` that filtered with one window and stamped another
+    /// cannot pass.
+    @Test func renderedDaysStampsTheWindowTheDaysWereFilteredBy() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.expandWindowEnd()
+        #expect(model.filter.windowEndDayKey == "2026-08-06")
+
+        let rendered = model.renderedDays
+
+        let window = try #require(rendered.window)
+        // The stamped window reflects the expansion the days were built under…
+        #expect(window.endDay == "2026-08-06")
+        // …and is the same value the rail's model-side callers read.
+        #expect(rendered.window == model.currentWindow)
+
+        // The days are exactly what filtering by the stamped window yields.
+        let snapshot = try #require(model.snapshot)
+        let expected = EventGrouping.byDay(
+            EventFilter.apply(
+                model.filter, to: snapshot.events, favorites: model.favorites,
+                year: model.selectedYear, window: window),
+            year: model.selectedYear)
+        #expect(rendered.days.map(\.id) == expected.map(\.id))
+        #expect(rendered.days.map { $0.events.map(\.id) } == expected.map { $0.events.map(\.id) })
+        // The expansion actually reached the list this window was stamped on.
+        #expect(rendered.days.last?.id == "2026-08-06")
+    }
+
     // MARK: - expandWindowEnd
 
     /// The correction phase 2 learned, applied to the model: a step lands on

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1416,6 +1416,81 @@ struct AppModelTests {
         #expect(eventCalls.isEmpty)
     }
 
+    // MARK: - scope-local resets stale pending targets (#254 scope addition)
+
+    /// Entrance (2), live on `main`: `browseDay` of the day already browsed
+    /// clears only the window-expansion fields, leaving every filter field
+    /// of `PendingDayScroll.Key` unchanged — so before the reset epoch was
+    /// part of the key, a target armed before the re-browse could never go
+    /// stale and its pinned highlight survived pointing outside the freshly
+    /// reset window.
+    @Test func reBrowsingTheSameDayStalesATargetArmedUnderIt() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.browseDay("2026-08-03")
+        let armed = PendingDayScroll.Target(
+            day: "2026-08-06",
+            key: PendingDayScroll.key(
+                for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount))
+
+        // Growth toward the target must not stale it while we wait.
+        model.filter.windowEndDayKey = "2026-08-06"
+        #expect(!PendingDayScroll.isStale(armed, currentKey: PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
+
+        model.browseDay("2026-08-03")
+
+        #expect(model.filter.windowEndDayKey == nil)
+        #expect(PendingDayScroll.isStale(armed, currentKey: PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
+    }
+
+    /// Entrance (1)'s state transition — a reset that clears ONLY the window
+    /// fields while every `Key` filter field stays identical. Written against
+    /// `clearScopeLocalDateState()`'s public route that exists on this base
+    /// (`setWeekSelection([])` under an unchanged `.all`/no-weeks selection)
+    /// rather than against #266's `selectScope` re-tap guard, which merges
+    /// before this branch and calls the same reset — the epoch bump inside
+    /// the reset covers it identically. Two selections differing only in
+    /// window fields produce equal `Key` filter fields BY DESIGN (growth must
+    /// never stale), so the reset epoch is the only thing that can mark this
+    /// transition.
+    @Test func aWindowOnlyResetStalesATargetThroughTheResetEpochAlone() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.selectScope(.all)
+        model.filter.windowEndDayKey = "2026-08-06"
+        let armed = PendingDayScroll.Target(
+            day: "2026-08-06",
+            key: PendingDayScroll.key(
+                for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount))
+
+        // Same scope (.all), same (empty) weeks: only the window is cleared.
+        model.setWeekSelection([])
+
+        #expect(model.filter.dateScope == .all)
+        #expect(model.filter.windowEndDayKey == nil)
+        #expect(PendingDayScroll.isStale(armed, currentKey: PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
+    }
+
+    /// The load-bearing property the epoch must not break: window *growth* —
+    /// the very thing a pending deep-link scroll is waiting for — never
+    /// stales the target. `expandWindowEnd()` is the real growth writer;
+    /// `windowStartDayKey` is set directly since no start-edge writer exists
+    /// yet.
+    @Test func windowGrowthAloneNeverStalesAPendingTarget() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        let armed = PendingDayScroll.Target(
+            day: "2026-08-06",
+            key: PendingDayScroll.key(
+                for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount))
+
+        model.expandWindowEnd()
+        model.filter.windowStartDayKey = "2026-08-01"
+
+        #expect(!PendingDayScroll.isStale(armed, currentKey: PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
+    }
+
     // MARK: - renderedDays (#254)
 
     /// `renderedDays.window` must be the window the days were actually

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1515,6 +1515,28 @@ struct AppModelTests {
             for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
     }
 
+    /// One user action = one derived-data rebuild. `selectScope` and
+    /// `browseDay` mutate several `filter` fields; written field-by-field,
+    /// each changed field fires `filter`'s `didSet` and a full
+    /// `rebuildDerivedCounts()` pass (#267 review finding). Pinned through
+    /// the same DEBUG counter `windowExpansionDoesNotRecomputeIt` uses,
+    /// against actions arranged so at least two `Key`-visible fields really
+    /// change (from a default selection most of the writes are no-ops and
+    /// even the unbatched code fired once).
+    @Test func scopeAndBrowseActionsRebuildNavMatchingOncePerAction() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.setWeekSelection([3])
+
+        var before = model.navMatchingRebuildCount
+        model.selectScope(.thisWeek)
+        #expect(model.navMatchingRebuildCount == before + 1)
+
+        model.expandWindowEnd()
+        before = model.navMatchingRebuildCount
+        model.browseDay("2026-08-06")
+        #expect(model.navMatchingRebuildCount == before + 1)
+    }
+
     // MARK: - renderedDays (#254)
 
     /// `renderedDays.window` must be the window the days were actually

--- a/ios/ChqCalendarTests/AppModelTests.swift
+++ b/ios/ChqCalendarTests/AppModelTests.swift
@@ -1472,6 +1472,30 @@ struct AppModelTests {
             for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
     }
 
+    /// `clearAll()` replaces the whole selection — window fields included —
+    /// without going through `clearScopeLocalDateState()`. From an `.all`
+    /// selection whose only non-default state is a window expansion, that
+    /// replacement changes no `Key` filter field, so the epoch is the only
+    /// thing that can stale a target (or pinned highlight) armed before it.
+    /// No current writer produces that armed state through the UI — which
+    /// is exactly the #192 "can't happen until the next task adds a caller"
+    /// trap this test refuses to rely on.
+    @Test func clearAllStalesATargetArmedUnderIt() throws {
+        let model = try makeInSeasonModelWithSeedEvents(defaults: makeDefaults())
+        model.selectScope(.all)
+        model.filter.windowEndDayKey = "2026-08-06"
+        let armed = PendingDayScroll.Target(
+            day: "2026-08-06",
+            key: PendingDayScroll.key(
+                for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount))
+
+        model.clearAll()
+
+        #expect(model.filter.windowEndDayKey == nil)
+        #expect(PendingDayScroll.isStale(armed, currentKey: PendingDayScroll.key(
+            for: model.filter, year: model.selectedYear, scopeResets: model.scopeResetCount)))
+    }
+
     /// The load-bearing property the epoch must not break: window *growth* —
     /// the very thing a pending deep-link scroll is waiting for — never
     /// stales the target. `expandWindowEnd()` is the real growth writer;

--- a/ios/ChqCalendarTests/DayRailNavigationTests.swift
+++ b/ios/ChqCalendarTests/DayRailNavigationTests.swift
@@ -91,6 +91,45 @@ struct DayRailNavigationTests {
         #expect(DayRailNavigation.shouldAbandonScroll(target: "2026-07-15", window: nil))
     }
 
+    // MARK: - shouldAbandonScroll(rendered:) — #254
+
+    /// The pre-growth render: the update that consumes a day deep link can
+    /// run against a day list built before `goToDay` grew the window. With
+    /// the window stamped onto that same list, the rule sees the *pre-growth*
+    /// window, which does not cover the target — so the scroll keeps
+    /// waiting for the grown render instead of being dropped as an "empty
+    /// day". This is the exact one-render disagreement #250 guarded around.
+    @Test func aRenderBuiltBeforeTheWindowGrewKeepsItsPendingScroll() {
+        let preGrowth = RenderedDays(
+            days: [
+                DayGroup(dayKey: "2026-07-10", title: "Friday, July 10", weekNumbers: [2], events: []),
+            ],
+            window: window("2026-07-10", "2026-07-20"))
+
+        #expect(!DayRailNavigation.shouldAbandonScroll(
+            target: "2026-08-21", rendered: preGrowth))
+    }
+
+    /// The post-growth render: the stamped window covers the target and the
+    /// list built from that same window still has no section for it — an
+    /// ordinary empty day, so the wait ends.
+    @Test func aRenderWhoseWindowCoversTheTargetWithNoSectionAbandons() {
+        let postGrowth = RenderedDays(
+            days: [
+                DayGroup(dayKey: "2026-07-10", title: "Friday, July 10", weekNumbers: [2], events: []),
+            ],
+            window: window("2026-07-10", "2026-08-21"))
+
+        #expect(DayRailNavigation.shouldAbandonScroll(
+            target: "2026-08-21", rendered: postGrowth))
+    }
+
+    /// Same rule as the window overload: no window to land in ends the wait.
+    @Test func aRenderWithNoWindowAbandons() {
+        let rendered = RenderedDays(days: [], window: nil)
+        #expect(DayRailNavigation.shouldAbandonScroll(target: "2026-07-15", rendered: rendered))
+    }
+
     // MARK: - stepTargets
 
     /// A chevron steps to the nearest day that has something to show, not the

--- a/ios/ChqCalendarTests/EventFilterTests.swift
+++ b/ios/ChqCalendarTests/EventFilterTests.swift
@@ -401,4 +401,71 @@ struct EventFilterTests {
 
         #expect(result.map(\.id) == ["a", "b"])
     }
+
+    // MARK: - apply(window:) equivalence — #254
+
+    /// The convenience `apply` computes its own window (with the cheaper
+    /// season-only bounds on the no-expansion path); the window-taking entry
+    /// point filters by whatever the caller computed against
+    /// `navigableBounds`. The two must select identical events — that
+    /// equivalence is what lets `AppModel.renderedDays` stamp the
+    /// navigable-bounds window onto the days as "the window these were
+    /// filtered by". The expansion target here lies past the season's end
+    /// but inside the event-widened navigable bounds, so a bounds choice
+    /// that clamps differently cannot hide.
+    @Test func windowTakingApplyMatchesTheConvenienceApplyWithExpansionBeyondTheSeason() throws {
+        let now = try #require(ChqTime.parse("2026-08-01 09:00:00"))
+        // 50 events inside `.next`'s one-hour grace so `adaptiveEndDate`
+        // settles on day 0 — the expansion below is then what carries the
+        // window past the season's end, not the sparse-snapshot fallback.
+        let from = now.addingTimeInterval(-3600)
+        var events: [Event] = try (0..<50).map { i in
+            makeEvent(
+                id: "seed\(i)",
+                start: try #require(ChqTime.calendar.date(byAdding: .minute, value: i, to: from)))
+        }
+        events.append(
+            makeEvent(id: "past-season", start: try #require(ChqTime.parse("2026-09-15 10:00:00"))))
+        var sel = FilterSelection()
+        sel.dateScope = .next
+        sel.windowEndDayKey = "2026-09-15"
+
+        let convenience = EventFilter.apply(
+            sel, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
+
+        let window = ViewWindow.make(
+            selection: sel, events: events, now: now, year: 2026, isCurrentYear: true,
+            bounds: ViewWindow.navigableBounds(year: 2026, events: events, starredDays: []))
+        let windowTaking = EventFilter.apply(
+            sel, to: events, favorites: [], year: 2026, window: window)
+
+        // The expansion genuinely reached past the season: a bounds choice
+        // that clamped it to the season's edge would drop this event.
+        #expect(convenience.contains { $0.id == "past-season" })
+        #expect(windowTaking.map(\.id) == convenience.map(\.id))
+    }
+
+    /// The `.all` no-expansion path — where the convenience form's internal
+    /// window carries a season-only day projection while the caller-computed
+    /// one is event-widened. `contains` must not notice the difference.
+    @Test func windowTakingApplyMatchesTheConvenienceApplyForAllScope() throws {
+        let now = try #require(ChqTime.parse("2026-08-01 09:00:00"))
+        let events = [
+            makeEvent(id: "in-season", start: try #require(ChqTime.parse("2026-08-02 10:00:00"))),
+            makeEvent(id: "past-season", start: try #require(ChqTime.parse("2026-09-15 10:00:00"))),
+        ]
+        var sel = FilterSelection()
+        sel.dateScope = .all
+
+        let convenience = EventFilter.apply(
+            sel, to: events, favorites: [], now: now, year: 2026, isCurrentYear: true)
+        let window = ViewWindow.make(
+            selection: sel, events: events, now: now, year: 2026, isCurrentYear: true,
+            bounds: ViewWindow.navigableBounds(year: 2026, events: events, starredDays: []))
+        let windowTaking = EventFilter.apply(
+            sel, to: events, favorites: [], year: 2026, window: window)
+
+        #expect(convenience.map(\.id) == ["in-season", "past-season"])
+        #expect(windowTaking.map(\.id) == convenience.map(\.id))
+    }
 }

--- a/ios/ChqCalendarTests/PendingDayScrollTests.swift
+++ b/ios/ChqCalendarTests/PendingDayScrollTests.swift
@@ -184,7 +184,7 @@ struct PendingDayScrollTests {
     /// gets its full window measured from *that* moment.
     ///
     /// This is the fix: the deadline used to be stamped by `selectDay` at arm
-    /// time, but every attempt happens inside `EventListView.list(days:)`,
+    /// time, but every attempt happens inside `EventListView.list(rendered:)`,
     /// which is not mounted while `dayGroups` is empty. A deep link consumed
     /// against an unmounted list burned its whole window in real time before
     /// one attempt could run — and the first attempt after the list finally

--- a/ios/ChqCalendarTests/PendingDayScrollTests.swift
+++ b/ios/ChqCalendarTests/PendingDayScrollTests.swift
@@ -36,9 +36,9 @@ struct PendingDayScrollTests {
     /// The steady-state case: nothing about the filter has changed since the
     /// tap, so the target is still waiting, not stale.
     @Test func sameKeyIsNotStale() {
-        let armed = PendingDayScroll.key(for: selection(), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(), year: 2026)
+        let current = PendingDayScroll.key(for: selection(), year: 2026, scopeResets: 0)
         #expect(!PendingDayScroll.isStale(target, currentKey: current))
     }
 
@@ -47,9 +47,9 @@ struct PendingDayScrollTests {
     /// window ever covering the tapped day, so `shouldAbandonScroll` alone
     /// never fires. The stamped key must catch it instead.
     @Test func scopeChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(dateScope: .next), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(dateScope: .next), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(dateScope: .thisWeek), year: 2026)
+        let current = PendingDayScroll.key(for: selection(dateScope: .thisWeek), year: 2026, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
@@ -57,9 +57,9 @@ struct PendingDayScrollTests {
     /// and replaces the week set) — the key must catch a bare week-set
     /// change too, independent of `dateScope`.
     @Test func weekSelectionChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(selectedWeeks: [3]), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(selectedWeeks: [3]), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(selectedWeeks: [3, 4]), year: 2026)
+        let current = PendingDayScroll.key(for: selection(selectedWeeks: [3, 4]), year: 2026, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
@@ -70,48 +70,48 @@ struct PendingDayScrollTests {
     /// requested landed.
     @Test func pureWindowExpansionIsNotStale() {
         let armed = PendingDayScroll.key(
-            for: selection(windowStartDayKey: nil, windowEndDayKey: nil), year: 2026)
+            for: selection(windowStartDayKey: nil, windowEndDayKey: nil), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
         let current = PendingDayScroll.key(
             for: selection(windowStartDayKey: "2026-06-27", windowEndDayKey: "2026-08-21"),
-            year: 2026)
+            year: 2026, scopeResets: 0)
         #expect(!PendingDayScroll.isStale(target, currentKey: current))
     }
 
     @Test func searchTextChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(searchText: "opera"), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(searchText: "opera"), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(searchText: "jazz"), year: 2026)
+        let current = PendingDayScroll.key(for: selection(searchText: "jazz"), year: 2026, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
     @Test func venueSelectionChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(selectedLocations: ["Amp"]), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(selectedLocations: ["Amp"]), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(selectedLocations: []), year: 2026)
+        let current = PendingDayScroll.key(for: selection(selectedLocations: []), year: 2026, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
     @Test func categorySelectionChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(selectedCategories: ["Lecture"]), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(selectedCategories: ["Lecture"]), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(selectedCategories: []), year: 2026)
+        let current = PendingDayScroll.key(for: selection(selectedCategories: []), year: 2026, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
     @Test func favoritesOnlyChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(showFavoritesOnly: false), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(showFavoritesOnly: false), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(showFavoritesOnly: true), year: 2026)
+        let current = PendingDayScroll.key(for: selection(showFavoritesOnly: true), year: 2026, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
     /// A year switch is a full snapshot swap — a target armed under 2026
     /// must not survive into 2027.
     @Test func yearChangeIsStale() {
-        let armed = PendingDayScroll.key(for: selection(), year: 2026)
+        let armed = PendingDayScroll.key(for: selection(), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
-        let current = PendingDayScroll.key(for: selection(), year: 2027)
+        let current = PendingDayScroll.key(for: selection(), year: 2027, scopeResets: 0)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 
@@ -119,10 +119,22 @@ struct PendingDayScrollTests {
     /// `dateScope` alone changing — the key must catch that route too.
     @Test func selectedDayKeyChangeIsStale() {
         let armed = PendingDayScroll.key(
-            for: selection(dateScope: .day, selectedDayKey: "2026-07-04"), year: 2026)
+            for: selection(dateScope: .day, selectedDayKey: "2026-07-04"), year: 2026, scopeResets: 0)
         let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
         let current = PendingDayScroll.key(
-            for: selection(dateScope: .day, selectedDayKey: "2026-07-05"), year: 2026)
+            for: selection(dateScope: .day, selectedDayKey: "2026-07-05"), year: 2026, scopeResets: 0)
+        #expect(PendingDayScroll.isStale(target, currentKey: current))
+    }
+
+    /// The counterpart boundary to `pureWindowExpansionIsNotStale`: a
+    /// scope-local reset (re-browsing the same day, re-tapping the active
+    /// scope) changes no filter field at all — the reset epoch is the only
+    /// thing that can mark it (#254 scope addition). `AppModelTests` covers
+    /// the model routes that bump it.
+    @Test func aScopeResetEpochBumpAloneIsStale() {
+        let armed = PendingDayScroll.key(for: selection(), year: 2026, scopeResets: 0)
+        let target = PendingDayScroll.Target(day: "2026-08-21", key: armed)
+        let current = PendingDayScroll.key(for: selection(), year: 2026, scopeResets: 1)
         #expect(PendingDayScroll.isStale(target, currentKey: current))
     }
 


### PR DESCRIPTION
Closes #254.

[skip-screenshots: scroll-state plumbing and staleness bookkeeping only; no pixel any covered shot captures changes]

## The defect class

Four bugs on #250 shared one signature — the window grew, the rail's highlight moved, and the list never scrolled — because `resolvePendingScroll` compared `model.currentWindow` (live) against `days` (whatever the enclosing render captured). The `!visibleDays.isEmpty` guard treated the one-render disagreement; this PR makes the disagreement unrepresentable.

## What changed

- **`RenderedDays`** (`00532b8`): the model exposes one value per render pass bundling the grouped days with the `ViewWindow` they were filtered by. The window is computed once in `AppModel` and passed into a new `EventFilter.apply(..., window:)` entry point, so the stamp is definitionally the filtering window. Option (a) — returning the window `apply` computes internally — was rejected because under `.all` it would hand `shouldAbandonScroll` the season-only day projection instead of the navigable bounds, a silent behavior regression; two equivalence tests pin that the convenience overload and the window-taking one agree, including past the season's edge. `EventListView` no longer reads `model.currentWindow` at all; `shouldAbandonScroll(target:rendered:)` can't be handed live state from that call site.
- **Reset epoch** (`f97802a`, `4daa4b8`): `PendingDayScroll.Key` deliberately excludes the window fields so pure window growth never stales an armed deep-link scroll — but that meant a state change clearing ONLY the window (scope re-tap after #266; same-day re-browse via `browseDay`, pre-existing on main; `clearAll`) kept an identical key, leaving the rail highlight pinned outside the fresh window and a not-yet-landed scroll revivable. Raised by Copilot and @claude on #266 (thread there cites this branch); closed here with `AppModel.scopeResetCount` riding in the key as a non-defaulted parameter — every reset path bumps (including `browseDay`, which never calls `clearScopeLocalDateState`, and `clearAll`), growth writers provably never do, and each non-bumping path carries a recorded reachability argument.
- **Guard removal** (`60aeaed`): with days and window from one pass, the `!visibleDays.isEmpty` symptom guard is gone and the long #250 comment block is rewritten to the new invariant.

## Verification

- 964 unit tests / 71 suites green; 11 new tests, all TDD (RED → GREEN), **ten falsification injections** each failing exactly the predicted test (both epoch entrances, the growth-never-stales property, the `.all` equivalence, the `clearAll` bump, and more).
- The four deep-link `DayRailUITests` that #250's bug lived in, run **5× each against the guard-removed build: 20/20** (the original defect failed ~3 in 8).
- One full `xcodebuild test` (all targets, serial) green before the final commit.

## Sequencing

`EventFilter`'s week stage is untouched, so this merges cleanly after #257 (#265). Merge after #266 (#234's re-tap is one of the epoch's entrances; its test here is written to be robust to either order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Adwf2e24aT5Nr3BiATm9xe