### PR TITLE
test: filterHeader was exercising a page with no events in it

### DIFF
--- a/frontend/src/__tests__/integration/filterHeader.test.tsx
+++ b/frontend/src/__tests__/integration/filterHeader.test.tsx
@@ -138,13 +138,22 @@ describe('page.tsx — the sticky filter header', () => {
   // Asking for the right file is not the same as the app being able to read
   // it, and the difference is invisible from everything else in this suite.
   //
-  // `useEventData` derives categories via `event.categories.map(c => c.name)`.
-  // A fixture using a bare string array yields `undefined`, `normalizeTag`
-  // then calls `.toLowerCase()` on it, and the whole parse throws into a
-  // `catch` that only logs — so `events` stays empty and the page renders as
-  // though the feed were down. Every other assertion in this file still
-  // passed, because they are all about header geometry, which renders with or
-  // without events. This file spent its life exercising a page that had none.
+  // A fixture using a bare string array for `categories` throws before the
+  // fetch result is ever stored. `useEventData` maps every raw event through
+  // `decodeEventHtmlEntities` first (`useEventData.ts`, before `setEvents`),
+  // and that reads `cat.name` — `undefined` on a string — then calls
+  // `.toLowerCase()` on it while building `_tagsLowerSet`
+  // (`eventHelpers.ts:63`, confirmed as the throw site by stack frame, not by
+  // reading). The outer `catch` only logs, so `events` stays empty and the
+  // page renders as though the feed were down.
+  //
+  // Note it is NOT `useEventData`'s own category/tag derivation that chokes —
+  // that code never runs on this path. An earlier version of this comment
+  // said it did, which would have sent the next reader to the wrong function.
+  //
+  // Every other assertion in this file still passed throughout, because they
+  // are all about header geometry, which renders with or without events. This
+  // file spent its life exercising a page that had none.
   //
   // The count comes from `ActiveFilters`, so it is the app's own reading of
   // how many events it holds. The denominator is pinned and the numerator is

--- a/frontend/src/__tests__/integration/filterHeader.test.tsx
+++ b/frontend/src/__tests__/integration/filterHeader.test.tsx
@@ -47,7 +47,9 @@ function eventsPayload() {
         endDate: `${YEAR}-07-06T11:45:00`,
         location: 'Amphitheater',
         description: 'A lecture.',
-        categories: ['Lecture'],
+        // `Array<{ name: string }>`, per `Event` in lib/types — NOT a bare
+        // string array. See the parse guard below for what that costs.
+        categories: [{ name: 'Lecture' }],
       },
       {
         id: 'e2',
@@ -56,7 +58,7 @@ function eventsPayload() {
         endDate: `${YEAR}-07-07T22:00:00`,
         location: 'Amphitheater',
         description: 'A concert.',
-        categories: ['Music'],
+        categories: [{ name: 'Music' }],
       },
     ],
   };
@@ -104,7 +106,11 @@ const toggleButton = () =>
 
 async function renderPage() {
   render(<Home />);
-  // The rail only exists once events have loaded.
+  // Waits for the first commit that has the header in it. Deliberately NOT
+  // described as "once events have loaded" any more, which is what it used to
+  // say and was never true: the rail is built from the season's navigable
+  // bounds, so it renders whether the feed brought anything back or not. That
+  // wording is part of why an empty fixture went unnoticed here for so long.
   await waitFor(() => expect(document.querySelector('[data-day-rail]')).toBeTruthy());
 }
 
@@ -127,6 +133,29 @@ describe('page.tsx — the sticky filter header', () => {
 
     expect(requested.length).toBeGreaterThan(0);
     expect(requested.every(p => p.endsWith(`all-events-${YEAR}.json`))).toBe(true);
+  });
+
+  // Asking for the right file is not the same as the app being able to read
+  // it, and the difference is invisible from everything else in this suite.
+  //
+  // `useEventData` derives categories via `event.categories.map(c => c.name)`.
+  // A fixture using a bare string array yields `undefined`, `normalizeTag`
+  // then calls `.toLowerCase()` on it, and the whole parse throws into a
+  // `catch` that only logs — so `events` stays empty and the page renders as
+  // though the feed were down. Every other assertion in this file still
+  // passed, because they are all about header geometry, which renders with or
+  // without events. This file spent its life exercising a page that had none.
+  //
+  // The count comes from `ActiveFilters`, so it is the app's own reading of
+  // how many events it holds. The denominator is pinned and the numerator is
+  // not: the fixture is dated mid-season, so how many fall inside the default
+  // scope depends on when the suite runs, but how many were LOADED does not.
+  it('parses the fixture into the page, rather than silently loading none', async () => {
+    await renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/^Events \(\d+\/2\)$/)).toBeInTheDocument()
+    );
   });
 
   it('renders the filter card in flow at the top of the page, with no toggle', async () => {


### PR DESCRIPTION
Found while working on #269 ([#270](https://github.com/bbernstein/chq-calendar/pull/270)), deliberately left out of that PR's scope. Independent of it — different file, no overlap.

## The defect

`Event.categories` is `Array<{ name: string }>`, but `filterHeader.test.tsx`'s fixture used a bare string array:

```ts
categories: ['Lecture'],
```

`useEventData` maps every raw event through `decodeEventHtmlEntities` before `setEvents` is reached. That reads `cat.name` — `undefined` on a string — and then lowercases it while building `_tagsLowerSet`, throwing at `eventHelpers.ts:63`. The outer `catch` only logs, so `events` stays empty and the page renders as though the feed were down.

Throw site confirmed by stack frame rather than by reading:

```
message="Cannot read properties of undefined (reading 'toLowerCase')"
firstAppFrame=at map (src/lib/utils/eventHelpers.ts:63:56)
```

(An earlier version of this description, and of the comment in the test file, blamed `useEventData`'s own `normalizeTag`. That code never runs on this path — corrected in `840a5d8`.)

Measured both shapes against `page.tsx`:

| fixture | events loaded | parse errors | `Events (…)` readout |
|---|---|---|---|
| `['Lecture']` | 0 | 1 (swallowed) | `Events (0/0)` |
| `[{ name: 'Lecture' }]` | 1 | 0 | `Events (0/1)` |

## Why nothing noticed

Every assertion in the file is about header geometry — the sticky card, the sentinel, the parked and `inert` states — and all of it renders with or without events. The file has been green for its whole life while exercising a page holding zero of the two events it defines.

`renderPage`'s own comment said the rail *"only exists once events have loaded"*. It never did: the rail is built from the season's navigable bounds and renders regardless. That wording is part of why this went unnoticed, so it's corrected here too.

## The fix

The fixture is corrected, **and** a guard is added — swapping the fixture alone would leave the same door open for the next person. It asserts the app's own count from `ActiveFilters`:

```ts
expect(screen.getByText(/^Events \(\d+\/2\)$/)).toBeInTheDocument()
```

The denominator is pinned at 2; the numerator deliberately is not. How many events fall inside the default scope depends on when the suite runs — how many were *loaded* does not.

**Falsified:** reverting only the fixture, with the guard left in place, fails exactly that one test and nothing else.

## Scope

Swept the rest of the suite — `EventCard.titleDetails.test.tsx` already uses the object shape, and no other test feeds `useEventData`. This was the only offender.

Full suite: 1,151 tests, 89 files, build and lint clean.

**Not fixed here, worth its own decision:** `useEventData` swallows a malformed-feed parse failure into a `console.error` and renders an empty calendar. In production that means a bad feed looks like an empty season rather than an error. #270's `determineLandingState` rule 3 already ensures such a visitor gets the honest generic empty state rather than "See you next season", but the swallowing itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZUXs5vAgdfPGRx8GtCRAn
