### PR TITLE
feat(web): bring the site header back on scroll up (#272)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -116,11 +116,13 @@ jobs:
       - name: Install all workspace dependencies
         run: npm ci
 
-      # Chromium only. These are geometry checks against one engine, not a
-      # browser-support matrix, and --with-deps pulls the system libraries
-      # headless Chromium needs on a bare runner.
-      - name: Install Chromium for Playwright
-        run: npx playwright install --with-deps chromium
+      # Chromium for the suites, plus WebKit for one of them. These are
+      # geometry checks against one engine rather than a browser-support
+      # matrix — with a single deliberate exception, see the WebKit step
+      # below. --with-deps pulls the system libraries the headless engines
+      # need on a bare runner.
+      - name: Install browsers for Playwright
+        run: npx playwright install --with-deps chromium webkit
         working-directory: frontend
 
       - name: Build frontend
@@ -151,6 +153,24 @@ jobs:
         run: npm run test:browser --workspace=frontend
         env:
           URL: http://localhost:3000/
+
+      # The one suite that runs twice, and the exception to "one engine".
+      #
+      # #272's header reads scroll direction, and scroll ANCHORING is what
+      # makes that hard — the two engines disagree about it in both
+      # directions. WebKit corrects the page 122px after a rail chip tap where
+      # Chromium corrects nothing; Chromium anchors when the filter panel is
+      # inserted where WebKit does not. Each of those was a real bug the other
+      # engine could not see, and the regression this suite's checks 9 and 10
+      # guard against reproduced identically in both. A guard for a two-engine
+      # bug that only ever runs against one engine is half a guard, and the
+      # half it is missing is not knowable from the half that passes.
+      - name: Run the header-reveal checks under WebKit
+        run: node e2e/verify-header-reveal.mjs
+        working-directory: frontend
+        env:
+          URL: http://localhost:3000/
+          E2E_ENGINE: webkit
 
   # Note: Integration tests removed due to DynamoDB service container complexity
   # Post-deployment tests in deploy-production.yml verify the actual production system

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -97,12 +97,34 @@ Everything not named in those two stubs stays live production data.
 
 ## In CI
 
-`.github/workflows/build-and-test.yml` runs all four (via
+`.github/workflows/build-and-test.yml` runs all five (via
 `npm run test:browser`) against a preview server built from the branch. That
 server proxies `/cache` to production, which is how the pinned regime matrix
 reaches the live feed. There is no path filtering — they run on every push
-and every fork PR, like the rest of that workflow. Chromium only: these are
+and every fork PR, like the rest of that workflow. Chromium: these are
 geometry checks against one engine, not a browser-support matrix.
+
+With one deliberate exception. `verify-header-reveal.mjs` also runs under
+WebKit, in a second step, selected with `E2E_ENGINE=webkit`:
+
+```bash
+E2E_ENGINE=webkit URL=http://localhost:3000/ node e2e/verify-header-reveal.mjs
+```
+
+The site header (#272) reads scroll direction, and scroll ANCHORING is what
+makes that hard — the two engines disagree about it in both directions.
+WebKit corrects the page 122px after a rail chip tap where Chromium corrects
+nothing; Chromium anchors when the filter panel is inserted where WebKit does
+not. Each was a real bug the other engine could not see, and the
+scroll-anchoring regression its checks 9 and 10 guard against reproduced
+identically in both. A guard for a two-engine bug that only ever runs against
+one engine is half a guard, and the half it is missing is not knowable from
+the half that passes.
+
+WebKit refuses `mouse.wheel` in a mobile context, so that suite emulates
+touch only under Chromium. The viewport width is what selects the mobile
+layout (`lg:hidden` keys off width, not touch), so both engines exercise the
+same header.
 
 The job carries the same `if:` guard as `test-backend` and `test-frontend`,
 which reads as though it disables the job for same-repo pull requests. It

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -111,17 +111,28 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
  * Polls rather than sleeps for a fixed time, because the settle's length
  * depends on how much list mounts — which depends on the day the suite runs.
  */
-const settle = async (p, { stableSamples = 4, gapMs = 120, timeoutMs = 8000 } = {}) => {
+const settle = async (p, { stableSamples = 4, gapMs = 120, timeoutMs = 8000, label = 'settle' } = {}) => {
   const deadline = Date.now() + timeoutMs;
+  const seen = [];
   let last = null;
   let stable = 0;
   while (Date.now() < deadline) {
     const y = await p.evaluate(() => Math.round(window.scrollY));
+    if (y !== last) seen.push(y);
     stable = y === last ? stable + 1 : 0;
     last = y;
     if (stable >= stableSamples) return y;
     await p.waitForTimeout(gapMs);
   }
+  // Timing out here used to return the last sample as though it had settled,
+  // and every check downstream then measured a page still in motion — flaky at
+  // best, and at worst green off a transient sample. A setup that did not hold
+  // still has to say so itself, or it is reported as whatever it broke.
+  //
+  // Recorded only on failure, so a healthy run's check list is unchanged and
+  // `finish()` still exits non-zero when this fires.
+  check(`${label}: the page stopped moving`, false,
+    `still moving after ${timeoutMs}ms; positions seen: ${seen.slice(-8).join(' → ')}`);
   return last;
 };
 

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -7,13 +7,13 @@
  * small scroll up and hides on scroll down.
  *
  * Everything that can go wrong with that is geometry, and jsdom has none. In
- * particular check 5 is the standing guard against the regression
+ * particular checks 9 and 10 are the standing guard against the regression
  * `frontend/src/app/filterHeaderLayout.ts` documents at length: a header that
  * collapses by leaving the document flow changes height ABOVE the reader,
  * scroll anchoring subtracts that from `scrollY`, and the page becomes
  * impossible to scroll slowly — 40 wheel ticks advanced it 0px, returning to
  * the top 20 times, in both Chromium and WebKit, with the whole unit suite
- * green. This header is sticky and never leaves flow; check 5 is what proves
+ * green. This header is sticky and never leaves flow; checks 9 and 10 prove
  * that claim rather than asserting it.
  *
  * Run against a dev server, or any deploy: `URL=https://… node <this>`.
@@ -440,6 +440,49 @@ const deepAndHidden = async (p, y = 6000) => {
   const shown = await geometry(p);
   check('18 reduced motion still reveals on the way up',
     shown.top === 0 && shown.bottom > 0, `top=${shown.top} bottom=${shown.bottom}`);
+  await p.context().close();
+}
+
+// ───────────────────── an open menu goes with the header it belongs to
+{
+  // A dropdown is positioned OUTSIDE the header's border box, so parking the
+  // box does not park the menu. Measured in Chromium before the fix: header at
+  // `bottom: 0` and `inert`, its menu still occupying -4 → 258 — a panel over
+  // most of the screen, at `z-40`, that nothing could click.
+  //
+  // Appended last on purpose: every previous check that was inserted before
+  // the reduced-motion block printed out of sequence and had to be renumbered.
+  const p = await phone();
+  await p.evaluate(() => document.querySelector('[data-testid="header-mobile"] button')?.click());
+  await p.waitForTimeout(500);
+  const opened = await p.evaluate(() =>
+    !!document.querySelector('[data-testid="header-mobile"] [role="group"]'));
+  if (!opened) {
+    skip('19 a parked header takes its open menu with it', 'the "more" menu did not open');
+  } else {
+    const parked = await deepAndHidden(p);
+    const menu = await p.evaluate(() => {
+      const header = document.querySelector('header');
+      const group = document.querySelector('[data-testid="header-mobile"] [role="group"]');
+      const r = group?.getBoundingClientRect();
+      return {
+        stillOpen: !!group,
+        bottom: r ? Math.round(r.bottom) : null,
+        overflow: getComputedStyle(header).overflow,
+        // Sticky must survive the clipping: `overflow` creates a formatting
+        // context, and this header's whole design rests on staying sticky.
+        position: getComputedStyle(header).position,
+      };
+    });
+    if (parked.bottom > 0) {
+      skip('19 a parked header takes its open menu with it',
+        `the header would not park (bottom=${parked.bottom})`);
+    } else {
+      check('19 a parked header takes its open menu with it',
+        menu.overflow === 'hidden' && menu.position === 'sticky',
+        `overflow=${menu.overflow} position=${menu.position} menuBottom=${menu.bottom} stillOpen=${menu.stillOpen}`);
+    }
+  }
   await p.context().close();
 }
 

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -371,7 +371,7 @@ const deepAndHidden = async (p, y = 6000) => {
   const p = await phone();
   const hidden = await deepAndHidden(p);
   if (hidden.bottom > 0) {
-    skip('18 a visible header is never inert', 'the header would not hide to begin with');
+    skip('15 a visible header is never inert', 'the header would not hide to begin with');
   } else {
     const emptied = await p.evaluate(() => {
       const field = document.querySelector('input[type="text"], input[type="search"]');
@@ -406,10 +406,10 @@ const deepAndHidden = async (p, y = 6000) => {
     if (!onScreen) {
       // The clamp did not bring the header back into view, so there is no
       // disagreement to catch. Said out loud rather than passed.
-      skip('18 a visible header is never inert',
+      skip('15 a visible header is never inert',
         `the header stayed parked (bottom=${after.bottom}, scrollY=${after.scrollY})`);
     } else {
-      check('18 a visible header is never inert',
+      check('15 a visible header is never inert',
         after.inert === false && after.ariaHidden === null,
         `bottom=${after.bottom} scrollY=${after.scrollY} inert=${after.inert} aria-hidden=${after.ariaHidden}`);
     }
@@ -422,16 +422,16 @@ const deepAndHidden = async (p, y = 6000) => {
   const p = await phone({ reducedMotion: true });
   const transitions = await p.evaluate(() =>
     getComputedStyle(document.documentElement).transitionProperty);
-  check('15 the reveal does not animate under prefers-reduced-motion',
+  check('16 the reveal does not animate under prefers-reduced-motion',
     !transitions.includes('--site-header-offset'), `transition-property=${transitions}`);
 
   // Not animating must still mean revealing. A reduced-motion reader gets the
   // header instantly, not never.
-  check('16 reduced motion still hides on the way down', (await deepAndHidden(p)).bottom <= 0);
+  check('17 reduced motion still hides on the way down', (await deepAndHidden(p)).bottom <= 0);
   await wheel(p, -40);
   await settle(p);
   const shown = await geometry(p);
-  check('17 reduced motion still reveals on the way up',
+  check('18 reduced motion still reveals on the way up',
     shown.top === 0 && shown.bottom > 0, `top=${shown.top} bottom=${shown.bottom}`);
   await p.context().close();
 }

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -95,6 +95,50 @@ const scrollY = p => p.evaluate(() => Math.round(window.scrollY));
 /** A wheel gesture at the middle of the list, away from the rail. */
 const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.wheel(0, dy); };
 
+/**
+ * Wait for the document to stop moving.
+ *
+ * Not a nicety — without it this suite was flaky 2 runs in 3, and it failed in
+ * CI. `window.scrollTo(0, 6000)` lands short (the render window has not
+ * mounted that far yet), the list then grows, and the app and the browser
+ * spend the best part of a second correcting for it in a long run of small
+ * scrolls. A wheel fired into the middle of that is measured NET of the
+ * correction: traced at 4,935 → 4,829, so a 120px wheel DOWN moved the reader
+ * 106px UP and the header stayed revealed, which the next check then reported
+ * as its own failure.
+ *
+ * Polls rather than sleeps for a fixed time, because the settle's length
+ * depends on how much list mounts — which depends on the day the suite runs.
+ */
+const settle = async (p, { stableSamples = 4, gapMs = 120, timeoutMs = 8000 } = {}) => {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  let stable = 0;
+  while (Date.now() < deadline) {
+    const y = await p.evaluate(() => Math.round(window.scrollY));
+    stable = y === last ? stable + 1 : 0;
+    last = y;
+    if (stable >= stableSamples) return y;
+    await p.waitForTimeout(gapMs);
+  }
+  return last;
+};
+
+/**
+ * Get to the state nearly every check below starts from: deep in the list
+ * with the header hidden.
+ *
+ * Returns the geometry so callers can assert the precondition rather than
+ * assume it — every one of them does.
+ */
+const deepAndHidden = async (p, y = 6000) => {
+  await p.evaluate((to) => window.scrollTo(0, to), y);
+  await settle(p);
+  await wheel(p, 120);
+  await settle(p);
+  return geometry(p);
+};
+
 // ───────────────────────────────────────── hide on the way down, reveal coming back
 {
   const p = await phone();
@@ -103,10 +147,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
     atTop.top === 0 && atTop.bottom > 0 && !atTop.inert,
     `top=${atTop.top} bottom=${atTop.bottom} inert=${atTop.inert}`);
 
-  await p.evaluate(() => window.scrollTo(0, 6000));
-  await wheel(p, 120);
-  await p.waitForTimeout(900);
-  const deep = await geometry(p);
+  const deep = await deepAndHidden(p);
   check('2 header is parked out of sight once scrolled down',
     deep.bottom <= 0, `bottom=${deep.bottom} scrollY=${deep.scrollY}`);
   // AC: "the day rail remains flush with the top edge and keeps working
@@ -117,7 +158,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
   // The acceptance criterion this whole suite exists for: a SMALL upward
   // scroll, from deep in the document, brings the whole header back.
   await wheel(p, -40);
-  await p.waitForTimeout(900);
+  await settle(p);
   const revealed = await geometry(p);
   check('4 a small scroll up reveals the header from deep in the list',
     revealed.top === 0 && revealed.bottom > 0 && revealed.scrollY > 3000,
@@ -154,7 +195,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
 
   await p.keyboard.press('Escape');
   await wheel(p, 120);
-  await p.waitForTimeout(900);
+  await settle(p);
   const hiddenAgain = await geometry(p);
   check('8 scrolling down hides it again, rail flush once more',
     hiddenAgain.bottom <= 0 && Math.abs(hiddenAgain.railTop) <= 1,
@@ -166,7 +207,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
 {
   const p = await phone();
   await p.evaluate(() => window.scrollTo(0, 0));
-  await p.waitForTimeout(400);
+  await settle(p);
 
   // The measurement that found the original bug, repeated exactly: 40 slow
   // ticks of 60px. The failing shape was not "slower than expected" — it was
@@ -203,9 +244,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
     await p.waitForTimeout(1400);
   };
 
-  await p.evaluate(() => window.scrollTo(0, 6000));
-  await wheel(p, 120);
-  await p.waitForTimeout(900);
+  const start = await deepAndHidden(p);
 
   // The jump has to go UP, and that is the whole design of this check. A chip
   // tap that scrolls DOWN proves nothing: without the resync it reads as a
@@ -215,13 +254,15 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
   // passed vacuously.
   const first = (await chipKeys())[0];
   const last = (await chipKeys()).slice(-1)[0];
-  if (!first || !last || first === last) {
+  if (start.bottom > 0) {
+    check('11 a rail chip tap does not reveal the header', false,
+      `SETUP: the header would not hide before the tap (bottom=${start.bottom}, scrollY=${start.scrollY})`);
+  } else if (!first || !last || first === last) {
     skip('11 a rail chip tap does not reveal the header',
       `need two navigable chips, found ${(await chipKeys()).length}`);
   } else {
     await tapChip(last);
-    await wheel(p, 120);
-    await p.waitForTimeout(700);
+    await settle(p);
     const before = await geometry(p);
     // The rail re-windows around the day it landed on, so re-read it.
     const back = (await chipKeys())[0];
@@ -253,10 +294,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
 // ─────────────────────────────────────────── a parked header is out of reach
 {
   const p = await phone();
-  await p.evaluate(() => window.scrollTo(0, 6000));
-  await wheel(p, 120);
-  await p.waitForTimeout(900);
-  const hidden = await geometry(p);
+  const hidden = await deepAndHidden(p);
   check('12 the parked header is marked inert and hidden from screen readers',
     hidden.inert === true && hidden.ariaHidden === 'true',
     `inert=${hidden.inert} aria-hidden=${hidden.ariaHidden}`);
@@ -285,16 +323,14 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
   // term were added in one state and not the other they would overlap here and
   // nowhere else.
   const p = await phone();
-  await p.evaluate(() => window.scrollTo(0, 6000));
-  await wheel(p, 120);
-  await p.waitForTimeout(900);
+  await deepAndHidden(p);
   await wheel(p, -40);
-  await p.waitForTimeout(900);
+  await settle(p);
 
   const revealed = await geometry(p);
   const toggle = p.locator('[data-day-rail] button[aria-expanded]').first();
   if (revealed.bottom <= 0 || await toggle.count() === 0) {
-    skip('17 the filter panel opens below a revealed header',
+    skip('14 the filter panel opens below a revealed header',
       revealed.bottom <= 0 ? 'the header did not reveal' : 'no Filters toggle on the rail');
   } else {
     // A DOM click, not `locator.click()`. Playwright scrolls an element into
@@ -310,7 +346,7 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
       return { top: Math.round(r.top), bottom: Math.round(r.bottom), h: Math.round(window.innerHeight) };
     });
     const after = await geometry(p);
-    check('17 the filter panel opens below a revealed header, inside the viewport',
+    check('14 the filter panel opens below a revealed header, inside the viewport',
       panel !== null && after.bottom > 0 && panel.top >= after.bottom - 1 && panel.bottom <= panel.h,
       panel ? `header bottom=${after.bottom}, panel ${panel.top}→${panel.bottom}, viewport=${panel.h}` : 'no filter card');
   }
@@ -322,19 +358,16 @@ const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.whe
   const p = await phone({ reducedMotion: true });
   const transitions = await p.evaluate(() =>
     getComputedStyle(document.documentElement).transitionProperty);
-  check('14 the reveal does not animate under prefers-reduced-motion',
+  check('15 the reveal does not animate under prefers-reduced-motion',
     !transitions.includes('--site-header-offset'), `transition-property=${transitions}`);
 
   // Not animating must still mean revealing. A reduced-motion reader gets the
   // header instantly, not never.
-  await p.evaluate(() => window.scrollTo(0, 6000));
-  await wheel(p, 120);
-  await p.waitForTimeout(700);
-  check('15 reduced motion still hides on the way down', (await geometry(p)).bottom <= 0);
+  check('16 reduced motion still hides on the way down', (await deepAndHidden(p)).bottom <= 0);
   await wheel(p, -40);
-  await p.waitForTimeout(700);
+  await settle(p);
   const shown = await geometry(p);
-  check('16 reduced motion still reveals on the way up',
+  check('17 reduced motion still reveals on the way up',
     shown.top === 0 && shown.bottom > 0, `top=${shown.top} bottom=${shown.bottom}`);
   await p.context().close();
 }

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -146,8 +146,20 @@ const settle = async (p, { stableSamples = 4, gapMs = 120, timeoutMs = 8000, lab
 const deepAndHidden = async (p, y = 6000) => {
   await p.evaluate((to) => window.scrollTo(0, to), y);
   await settle(p);
-  await wheel(p, 120);
-  await settle(p);
+  // Wheel until it is actually hidden, rather than assuming one tick does it.
+  //
+  // One tick is not a reliable unit of scrolling. WebKit on Linux splits a
+  // single tick across frames, and a correction still in flight can net
+  // against it — this block skipped in CI ("the header would not park") while
+  // passing three times in a row against macOS WebKit locally. A setup that
+  // depends on one tick landing is a setup that reports engine differences as
+  // failures of whatever it was testing.
+  for (let i = 0; i < 5; i++) {
+    const seen = await geometry(p);
+    if (seen.bottom <= 0) return seen;
+    await wheel(p, 120);
+    await settle(p);
+  }
   return geometry(p);
 };
 

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -1,0 +1,343 @@
+/**
+ * Browser verification for the site header's reveal on scroll up (#272).
+ *
+ * The header carries the "more" menu and the year selector, and below the
+ * fold it used to be unreachable without scrolling the whole document back to
+ * the top — from a rail tap, tens of thousands of pixels. It now reveals on a
+ * small scroll up and hides on scroll down.
+ *
+ * Everything that can go wrong with that is geometry, and jsdom has none. In
+ * particular check 5 is the standing guard against the regression
+ * `frontend/src/app/filterHeaderLayout.ts` documents at length: a header that
+ * collapses by leaving the document flow changes height ABOVE the reader,
+ * scroll anchoring subtracts that from `scrollY`, and the page becomes
+ * impossible to scroll slowly — 40 wheel ticks advanced it 0px, returning to
+ * the top 20 times, in both Chromium and WebKit, with the whole unit suite
+ * green. This header is sticky and never leaves flow; check 5 is what proves
+ * that claim rather than asserting it.
+ *
+ * Run against a dev server, or any deploy: `URL=https://… node <this>`.
+ */
+import { chromium, webkit } from 'playwright';
+import { pinClock } from './fixedNow.mjs';
+import { check, skip, finish } from './results.mjs';
+import { enterList } from './regime.mjs';
+
+const URL = process.env.URL ?? 'http://localhost:3000/';
+
+/**
+ * Chromium by default, so CI is unchanged and still installs one engine.
+ *
+ * `E2E_ENGINE=webkit` exists for one reason: the regression checks 9 and 10
+ * guard against reproduced identically in Chromium and WebKit, because scroll
+ * anchoring is in both. A guard for a two-engine bug that can only ever be
+ * run against one engine is half a guard, and the half it is missing is not
+ * knowable from the passing half. Verified under both before this shipped.
+ */
+const ENGINE = process.env.E2E_ENGINE ?? 'chromium';
+const engines = { chromium, webkit };
+if (!engines[ENGINE]) throw new Error(`E2E_ENGINE must be chromium or webkit, got "${ENGINE}"`);
+console.log(`engine: ${ENGINE}`);
+
+const browser = await engines[ENGINE].launch();
+
+async function phone({ reducedMotion } = {}) {
+  const ctx = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    // Touch emulation only under Chromium: WebKit refuses `mouse.wheel` in a
+    // mobile context ("Mouse wheel is not supported in mobile WebKit"), and
+    // the wheel is what checks 9 and 10 measure. The viewport is what selects
+    // the mobile header — Tailwind's `lg:hidden` keys off width, not off
+    // touch — so the WebKit run exercises the same layout either way.
+    ...(ENGINE === 'chromium' ? { isMobile: true, hasTouch: true } : {}),
+    // Not hour-sensitive, but pinned so `E2E_NOW` can reach this suite and its
+    // off-season branch stays testable on any date. See `fixedNow.mjs`.
+    timezoneId: 'America/New_York',
+    ...(reducedMotion ? { reducedMotion: 'reduce' } : {}),
+  });
+  const page = await ctx.newPage();
+  await pinClock(page);
+  // Tie the context's lifetime to the page's, or every check leaks one.
+  page.once('close', () => { ctx.close().catch(() => {}); });
+  await page.goto(URL, { waitUntil: 'networkidle' });
+  // Off-season the default screen is the landing, not a day list.
+  await enterList(page);
+  return page;
+}
+
+/**
+ * The header's viewport rect, plus the rail's top.
+ *
+ * Measured, never inferred from the reveal state: the whole point of a
+ * browser check is that it can disagree with what the app believes. A header
+ * marked revealed that is painting off-screen — because a `calc()` was
+ * dropped, or an ancestor gained a transform and broke `position: sticky` —
+ * fails here and nowhere else.
+ */
+const geometry = p => p.evaluate(() => {
+  const header = document.querySelector('header');
+  const rail = document.querySelector('[data-day-rail]');
+  const r = header?.getBoundingClientRect();
+  return {
+    top: r ? Math.round(r.top) : null,
+    bottom: r ? Math.round(r.bottom) : null,
+    height: r ? Math.round(r.height) : null,
+    railTop: rail ? Math.round(rail.getBoundingClientRect().top) : null,
+    inert: header?.hasAttribute('inert') ?? null,
+    ariaHidden: header?.getAttribute('aria-hidden') ?? null,
+    scrollY: Math.round(window.scrollY),
+  };
+});
+
+const moreButton = p => p.locator('[data-testid="header-mobile"] button').first();
+const scrollY = p => p.evaluate(() => Math.round(window.scrollY));
+
+/** A wheel gesture at the middle of the list, away from the rail. */
+const wheel = async (p, dy) => { await p.mouse.move(195, 600); await p.mouse.wheel(0, dy); };
+
+// ───────────────────────────────────────── hide on the way down, reveal coming back
+{
+  const p = await phone();
+  const atTop = await geometry(p);
+  check('1 header is on screen at the top of the document',
+    atTop.top === 0 && atTop.bottom > 0 && !atTop.inert,
+    `top=${atTop.top} bottom=${atTop.bottom} inert=${atTop.inert}`);
+
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await wheel(p, 120);
+  await p.waitForTimeout(900);
+  const deep = await geometry(p);
+  check('2 header is parked out of sight once scrolled down',
+    deep.bottom <= 0, `bottom=${deep.bottom} scrollY=${deep.scrollY}`);
+  // AC: "the day rail remains flush with the top edge and keeps working
+  // exactly as it does today."
+  check('3 the rail is flush with the top edge while the header is hidden',
+    deep.railTop !== null && Math.abs(deep.railTop) <= 1, `railTop=${deep.railTop}`);
+
+  // The acceptance criterion this whole suite exists for: a SMALL upward
+  // scroll, from deep in the document, brings the whole header back.
+  await wheel(p, -40);
+  await p.waitForTimeout(900);
+  const revealed = await geometry(p);
+  check('4 a small scroll up reveals the header from deep in the list',
+    revealed.top === 0 && revealed.bottom > 0 && revealed.scrollY > 3000,
+    `top=${revealed.top} bottom=${revealed.bottom} scrollY=${revealed.scrollY}`);
+  // The reader chose the rail riding down over being covered: both surfaces
+  // usable at once. One animated variable feeds both, so a drift here means
+  // the header's `top` and the rail's have come apart.
+  check('5 the rail rides down to sit below the revealed header',
+    revealed.railTop !== null && Math.abs(revealed.railTop - revealed.bottom) <= 2,
+    `railTop=${revealed.railTop} headerBottom=${revealed.bottom}`);
+
+  // Revealed is worth nothing if the menu behind it does not open.
+  await moreButton(p).click();
+  await p.waitForTimeout(400);
+  const menuOpen = await p.evaluate(() => {
+    const group = document.querySelector('[data-testid="header-mobile"] [role="group"]');
+    if (!group) return { open: false, items: 0 };
+    const r = group.getBoundingClientRect();
+    return {
+      open: r.height > 0 && r.bottom > 0 && r.top < window.innerHeight,
+      items: group.querySelectorAll('a').length,
+    };
+  });
+  check('6 the "more" menu opens and is on screen', menuOpen.open && menuOpen.items > 0,
+    `items=${menuOpen.items}`);
+  // The other feature the issue names as unreachable.
+  check('7 the year selector is on screen with the header', await p.evaluate(() => {
+    const el = [...document.querySelectorAll('header button')]
+      .find(b => /\d{4}/.test(b.textContent ?? ''));
+    if (!el) return false;
+    const r = el.getBoundingClientRect();
+    return r.height > 0 && r.top >= 0 && r.bottom <= window.innerHeight;
+  }));
+
+  await p.keyboard.press('Escape');
+  await wheel(p, 120);
+  await p.waitForTimeout(900);
+  const hiddenAgain = await geometry(p);
+  check('8 scrolling down hides it again, rail flush once more',
+    hiddenAgain.bottom <= 0 && Math.abs(hiddenAgain.railTop) <= 1,
+    `bottom=${hiddenAgain.bottom} railTop=${hiddenAgain.railTop}`);
+  await p.context().close();
+}
+
+// ─────────────────────────── the regression `filterHeaderLayout.ts` documents
+{
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 0));
+  await p.waitForTimeout(400);
+
+  // The measurement that found the original bug, repeated exactly: 40 slow
+  // ticks of 60px. The failing shape was not "slower than expected" — it was
+  // 0px of progress with the page snapping back to the top 20 times.
+  const TICKS = 40;
+  const PER_TICK = 60;
+  const trace = [];
+  await p.mouse.move(195, 600);
+  for (let i = 0; i < TICKS; i++) {
+    await p.mouse.wheel(0, PER_TICK);
+    await p.waitForTimeout(60);
+    trace.push(await scrollY(p));
+  }
+  const requested = TICKS * PER_TICK;
+  const final = trace[trace.length - 1];
+  const returnedToTop = trace.filter(y => y === 0).length;
+
+  check('9 slow scrolling makes real progress down the page',
+    final >= requested * 0.5,
+    `${final}px of ${requested}px requested over ${TICKS} ticks`);
+  check('10 slow scrolling never snaps back to the top',
+    returnedToTop === 0,
+    `returned to top ${returnedToTop}x; trace=${trace.join(',')}`);
+  await p.context().close();
+}
+
+// ─────────────────────────────────── a rail tap is not the reader scrolling up
+{
+  const p = await phone();
+  const chipKeys = () => p.$$eval(
+    '[data-day-rail] [data-chip]:not([aria-disabled="true"])', e => e.map(x => x.dataset.chip));
+  const tapChip = async (k) => {
+    await p.evaluate(key => document.querySelector(`[data-day-rail] [data-chip="${key}"]`).click(), k);
+    await p.waitForTimeout(1400);
+  };
+
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await wheel(p, 120);
+  await p.waitForTimeout(900);
+
+  // The jump has to go UP, and that is the whole design of this check. A chip
+  // tap that scrolls DOWN proves nothing: without the resync it reads as a
+  // huge scroll DOWN, which would keep the header hidden anyway and the check
+  // would pass on code with no resync at all. The first version of this check
+  // did exactly that — it tapped the last chip, jumped 6,120 → 12,916, and
+  // passed vacuously.
+  const first = (await chipKeys())[0];
+  const last = (await chipKeys()).slice(-1)[0];
+  if (!first || !last || first === last) {
+    skip('11 a rail chip tap does not reveal the header',
+      `need two navigable chips, found ${(await chipKeys()).length}`);
+  } else {
+    await tapChip(last);
+    await wheel(p, 120);
+    await p.waitForTimeout(700);
+    const before = await geometry(p);
+    // The rail re-windows around the day it landed on, so re-read it.
+    const back = (await chipKeys())[0];
+    await tapChip(back);
+    const after = await geometry(p);
+
+    const jumpedUp = before.scrollY - after.scrollY;
+    if (jumpedUp < 500) {
+      // Without an upward jump there is nothing here to mistake for a scroll
+      // up, so the check has no subject. Saying so beats a green tick.
+      skip('11 a rail chip tap does not reveal the header',
+        `the tap did not jump up (${before.scrollY} → ${after.scrollY})`);
+    } else {
+      // Conjoined with the precondition rather than assuming it. This check
+      // has already reported the wrong thing once: the setup wheel landed at
+      // the document's end where there was nothing left to scroll, so the
+      // header was never hidden going in, and "the tap revealed it" was a
+      // misdiagnosis of "it was already revealed".
+      check('11 a rail chip tap does not reveal the header',
+        before.bottom <= 0 && after.bottom <= 0,
+        before.bottom > 0
+          ? `SETUP: header was already revealed before the tap (bottom=${before.bottom})`
+          : `chip=${back}, jumped up ${jumpedUp}px, header bottom ${before.bottom} → ${after.bottom}`);
+    }
+  }
+  await p.context().close();
+}
+
+// ─────────────────────────────────────────── a parked header is out of reach
+{
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await wheel(p, 120);
+  await p.waitForTimeout(900);
+  const hidden = await geometry(p);
+  check('12 the parked header is marked inert and hidden from screen readers',
+    hidden.inert === true && hidden.ariaHidden === 'true',
+    `inert=${hidden.inert} aria-hidden=${hidden.ariaHidden}`);
+
+  // The attribute is the mechanism; this is the behaviour. Without `inert` the
+  // browser would move focus into the parked header and then try to scroll it
+  // into view — which it cannot do for a pinned sticky element, so it chases
+  // the position instead.
+  await p.evaluate(() => { document.activeElement?.blur?.(); });
+  let landedInHeader = false;
+  for (let i = 0; i < 12 && !landedInHeader; i++) {
+    await p.keyboard.press('Tab');
+    landedInHeader = await p.evaluate(() =>
+      !!document.querySelector('header')?.contains(document.activeElement));
+  }
+  check('13 tabbing never lands inside the parked header', !landedInHeader,
+    landedInHeader ? 'focus entered the hidden header' : '12 tabs, never entered');
+  await p.context().close();
+}
+
+// ────────────────────────── the filter panel, opened with the header revealed
+{
+  // A composition the reader reaches in two taps: scroll up to bring the
+  // header back, then open Filters from the rail. Both are overlays over the
+  // list and both are driven by the same sticky `top`, so if the site header's
+  // term were added in one state and not the other they would overlap here and
+  // nowhere else.
+  const p = await phone();
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await wheel(p, 120);
+  await p.waitForTimeout(900);
+  await wheel(p, -40);
+  await p.waitForTimeout(900);
+
+  const revealed = await geometry(p);
+  const toggle = p.locator('[data-day-rail] button[aria-expanded]').first();
+  if (revealed.bottom <= 0 || await toggle.count() === 0) {
+    skip('17 the filter panel opens below a revealed header',
+      revealed.bottom <= 0 ? 'the header did not reveal' : 'no Filters toggle on the rail');
+  } else {
+    // A DOM click, not `locator.click()`. Playwright scrolls an element into
+    // view before clicking it, and that scroll is a real one the app has no
+    // way to know is ours — it hid the header, and the check then passed
+    // vacuously with the panel at the top of an empty viewport.
+    await p.evaluate(() => document.querySelector('[data-day-rail] button[aria-expanded]').click());
+    await p.waitForTimeout(700);
+    const panel = await p.evaluate(() => {
+      const card = document.querySelector('[data-filter-card]');
+      if (!card) return null;
+      const r = card.getBoundingClientRect();
+      return { top: Math.round(r.top), bottom: Math.round(r.bottom), h: Math.round(window.innerHeight) };
+    });
+    const after = await geometry(p);
+    check('17 the filter panel opens below a revealed header, inside the viewport',
+      panel !== null && after.bottom > 0 && panel.top >= after.bottom - 1 && panel.bottom <= panel.h,
+      panel ? `header bottom=${after.bottom}, panel ${panel.top}→${panel.bottom}, viewport=${panel.h}` : 'no filter card');
+  }
+  await p.context().close();
+}
+
+// ───────────────────────────────────────────────── prefers-reduced-motion
+{
+  const p = await phone({ reducedMotion: true });
+  const transitions = await p.evaluate(() =>
+    getComputedStyle(document.documentElement).transitionProperty);
+  check('14 the reveal does not animate under prefers-reduced-motion',
+    !transitions.includes('--site-header-offset'), `transition-property=${transitions}`);
+
+  // Not animating must still mean revealing. A reduced-motion reader gets the
+  // header instantly, not never.
+  await p.evaluate(() => window.scrollTo(0, 6000));
+  await wheel(p, 120);
+  await p.waitForTimeout(700);
+  check('15 reduced motion still hides on the way down', (await geometry(p)).bottom <= 0);
+  await wheel(p, -40);
+  await p.waitForTimeout(700);
+  const shown = await geometry(p);
+  check('16 reduced motion still reveals on the way up',
+    shown.top === 0 && shown.bottom > 0, `top=${shown.top} bottom=${shown.bottom}`);
+  await p.context().close();
+}
+
+await browser.close();
+finish();

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -85,6 +85,7 @@ const geometry = p => p.evaluate(() => {
     railTop: rail ? Math.round(rail.getBoundingClientRect().top) : null,
     inert: header?.hasAttribute('inert') ?? null,
     ariaHidden: header?.getAttribute('aria-hidden') ?? null,
+    boxShadow: header ? getComputedStyle(header).boxShadow : null,
     scrollY: Math.round(window.scrollY),
   };
 });
@@ -296,9 +297,15 @@ const deepAndHidden = async (p, y = 6000) => {
 {
   const p = await phone();
   const hidden = await deepAndHidden(p);
-  check('12 the parked header is marked inert and hidden from screen readers',
-    hidden.inert === true && hidden.ariaHidden === 'true',
-    `inert=${hidden.inert} aria-hidden=${hidden.ariaHidden}`);
+  // Three ways a parked header can still be present: reachable, announced, or
+  // painting. A shadow paints OUTSIDE the border box, so with the box entirely
+  // above the viewport `shadow-lg` still reached ~15px below it and, at
+  // `z-40`, landed on the `z-30` rail. Found by screenshotting the top 24px
+  // with and without it and seeing the images differ.
+  check('12 the parked header is inert, unannounced, and paints nothing',
+    hidden.inert === true && hidden.ariaHidden === 'true'
+      && !/rgba?\((?!0, 0, 0, 0\))/.test(hidden.boxShadow ?? 'none'),
+    `inert=${hidden.inert} aria-hidden=${hidden.ariaHidden} box-shadow=${hidden.boxShadow}`);
 
   // The attribute is the mechanism; this is the behaviour. Without `inert` the
   // browser would move focus into the parked header and then try to scroll it

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -354,6 +354,69 @@ const deepAndHidden = async (p, y = 6000) => {
   await p.context().close();
 }
 
+// ─────────────────────── a header the reader can see is a header they can use
+{
+  // The seam a unit test cannot reach: `revealed` is a belief, and the sticky
+  // header's actual position is a fact. When they disagree the header is on
+  // screen and `inert` — unreachable by keyboard, unannounced by a screen
+  // reader — which is precisely the trap `filterCardParked` documents.
+  //
+  // Reproduced before the fix in three steps a reader can take: search until
+  // the list is empty (document 8,401px → 1,049px, `scrollY` clamped
+  // 5,436 → 205), then let the viewport grow — a rotation to landscape, or
+  // browser chrome collapsing — so the document is shorter than the viewport
+  // and the browser clamps `scrollY` to 0. None of those scrolls has a gesture
+  // behind it, so all of them were ignored, and the header stayed hidden while
+  // sitting in plain sight at `top: 0`.
+  const p = await phone();
+  const hidden = await deepAndHidden(p);
+  if (hidden.bottom > 0) {
+    skip('18 a visible header is never inert', 'the header would not hide to begin with');
+  } else {
+    const emptied = await p.evaluate(() => {
+      const field = document.querySelector('input[type="text"], input[type="search"]');
+      if (!field) return false;
+      // React/Preact listen for `input` on the native value setter.
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+      setter.call(field, 'zzzzzzzznomatch');
+      field.dispatchEvent(new Event('input', { bubbles: true }));
+      return true;
+    });
+    if (!emptied) {
+      // The search field lives in the filter panel; open it from the rail
+      // first if it is not already reachable.
+      await p.evaluate(() => document.querySelector('[data-day-rail] button[aria-expanded]')?.click());
+      await p.waitForTimeout(700);
+      await p.evaluate(() => {
+        const field = document.querySelector('input[type="text"], input[type="search"]');
+        if (!field) return;
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        setter.call(field, 'zzzzzzzznomatch');
+        field.dispatchEvent(new Event('input', { bubbles: true }));
+      });
+    }
+    await p.waitForTimeout(1800);
+
+    // The viewport grows. Nothing scrolls; the browser clamps.
+    await p.setViewportSize({ width: 390, height: 1200 });
+    await settle(p);
+    const after = await geometry(p);
+
+    const onScreen = after.bottom > 0;
+    if (!onScreen) {
+      // The clamp did not bring the header back into view, so there is no
+      // disagreement to catch. Said out loud rather than passed.
+      skip('18 a visible header is never inert',
+        `the header stayed parked (bottom=${after.bottom}, scrollY=${after.scrollY})`);
+    } else {
+      check('18 a visible header is never inert',
+        after.inert === false && after.ariaHidden === null,
+        `bottom=${after.bottom} scrollY=${after.scrollY} inert=${after.inert} aria-hidden=${after.ariaHidden}`);
+    }
+  }
+  await p.context().close();
+}
+
 // ───────────────────────────────────────────────── prefers-reduced-motion
 {
   const p = await phone({ reducedMotion: true });

--- a/frontend/e2e/verify-header-reveal.mjs
+++ b/frontend/e2e/verify-header-reveal.mjs
@@ -252,14 +252,15 @@ const deepAndHidden = async (p, y = 6000) => {
   // would pass on code with no resync at all. The first version of this check
   // did exactly that — it tapped the last chip, jumped 6,120 → 12,916, and
   // passed vacuously.
-  const first = (await chipKeys())[0];
-  const last = (await chipKeys()).slice(-1)[0];
+  const chips = await chipKeys();
+  const first = chips[0];
+  const last = chips[chips.length - 1];
   if (start.bottom > 0) {
     check('11 a rail chip tap does not reveal the header', false,
       `SETUP: the header would not hide before the tap (bottom=${start.bottom}, scrollY=${start.scrollY})`);
   } else if (!first || !last || first === last) {
     skip('11 a rail chip tap does not reveal the header',
-      `need two navigable chips, found ${(await chipKeys()).length}`);
+      `need two navigable chips, found ${chips.length}`);
   } else {
     await tapChip(last);
     await settle(p);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "about:screenshots:ios": "node scripts/prepare-about-screenshots.mjs",
     "about:screenshots:web": "node scripts/capture-web-screenshots.mjs",
     "about:screenshots": "npm run about:screenshots:ios && npm run about:screenshots:web",
-    "test:browser": "node e2e/verify-rail.mjs && node e2e/verify-filter-reveal.mjs && node e2e/verify-timezone.mjs && node e2e/verify-offseason.mjs"
+    "test:browser": "node e2e/verify-rail.mjs && node e2e/verify-filter-reveal.mjs && node e2e/verify-timezone.mjs && node e2e/verify-offseason.mjs && node e2e/verify-header-reveal.mjs"
   },
   "dependencies": {
     "preact": "^10.28.4"

--- a/frontend/src/__tests__/app/filterHeaderLayout.test.ts
+++ b/frontend/src/__tests__/app/filterHeaderLayout.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { filterCardParked, filterHeaderTop } from '@/app/filterHeaderLayout';
+import { dayHeaderTop, filterCardParked, filterHeaderTop, siteHeaderTop } from '@/app/filterHeaderLayout';
 
 // The rule these pin is the fix for a bug jsdom cannot reproduce: hiding the
 // filter card removed ~290px of flow height above the reader, scroll
@@ -12,11 +12,12 @@ import { filterCardParked, filterHeaderTop } from '@/app/filterHeaderLayout';
 // production.
 describe('filterHeaderTop', () => {
   it('parks the header by the filter card height when the panel is not overlaying', () => {
-    expect(filterHeaderTop({ overlaying: false })).toBe('calc(-1 * var(--filter-card-h, 0px))');
+    expect(filterHeaderTop({ overlaying: false }))
+      .toBe('calc(var(--site-header-offset, 0px) - var(--filter-card-h, 0px))');
   });
 
-  it('pins the header at the viewport top while the panel overlays the list', () => {
-    expect(filterHeaderTop({ overlaying: true })).toBe('0px');
+  it('pins the header below the site header while the panel overlays the list', () => {
+    expect(filterHeaderTop({ overlaying: true })).toBe('var(--site-header-offset, 0px)');
   });
 
   // The parked offset is what lets the card stay in flow. A `top` that never
@@ -24,8 +25,29 @@ describe('filterHeaderTop', () => {
   // flow, which is the bug.
   it('parks with a negative offset, never a zero or positive one', () => {
     const parked = filterHeaderTop({ overlaying: false });
-    expect(parked).toMatch(/^calc\(-1 \* var\(--filter-card-h/);
+    expect(parked).toContain('- var(--filter-card-h');
     expect(parked).not.toBe('0px');
+    expect(parked).not.toBe('var(--site-header-offset, 0px)');
+  });
+
+  // #272: the site header reveals on scroll up, and the reader chose to have
+  // the rail ride down below it rather than be covered by it. That is this
+  // one additive term — and it is a CSS variable rather than a parameter on
+  // purpose. Routing the reveal through React state would re-render the whole
+  // calendar page on every flick; as a variable the reveal touches only
+  // `Header`, and the rail follows without the page knowing anything happened.
+  it('offsets both states by the revealed site header, in the same direction', () => {
+    expect(filterHeaderTop({ overlaying: true })).toContain('var(--site-header-offset, 0px)');
+    expect(filterHeaderTop({ overlaying: false })).toContain('var(--site-header-offset, 0px) -');
+  });
+
+  // The two surfaces must move as one. The variable is animated once, on
+  // `:root`, so the header's own `top` and the rail's are the same value
+  // every frame; anything that transitioned `top` here instead would also
+  // animate the filter panel's reveal, which is choreographed separately.
+  it('falls back to 0px for the site header offset, so a missing reveal parks as before', () => {
+    expect(filterHeaderTop({ overlaying: false })).toContain('--site-header-offset, 0px');
+    expect(filterHeaderTop({ overlaying: true })).toContain('--site-header-offset, 0px');
   });
 
   // A missing measurement (no ResizeObserver, a render before mount) has to
@@ -65,5 +87,64 @@ describe('filterCardParked', () => {
   // card and must be able to use it.
   it('is not parked while the card is only partly scrolled away', () => {
     expect(filterCardParked({ outOfView: false, open: true, exitingVisible: false })).toBe(false);
+  });
+});
+
+/**
+ * The site header's own park (#272). It lives beside `filterHeaderTop`
+ * because the two have to compose: the site header's height is the term the
+ * filter header adds, and a change to one that is not mirrored in the other
+ * leaves the rail overlapping the header or floating below it.
+ */
+describe('siteHeaderTop', () => {
+  // Parked and revealed are the same expression evaluated at the two ends of
+  // the offset: at `0px` it is `-headerH` (just above the viewport), at
+  // `headerH` it is `0` (flush at the top edge). One expression means the two
+  // states cannot drift apart, and it means the transition has a single
+  // animated value rather than two that must agree every frame.
+  it('parks the header above the viewport by exactly its own height', () => {
+    expect(siteHeaderTop()).toBe('calc(var(--site-header-offset, 0px) - var(--site-header-h, 0px))');
+  });
+
+  // The negative park is what lets the header stay in flow. A `top` that
+  // never goes negative can only hide the header by removing it from flow —
+  // which is the scroll-anchoring loop this whole module exists to document.
+  it('subtracts the header height, so the parked offset is negative', () => {
+    expect(siteHeaderTop()).toContain('- var(--site-header-h');
+  });
+
+  // Before measurement both terms fall back to 0px, which evaluates to
+  // `top: 0` — a header pinned at the viewport top. Shown is the safe
+  // default; a wrong sign here would park an unmeasured header out of reach
+  // with no way to bring it back.
+  it('degrades to a shown header when nothing has been measured yet', () => {
+    expect(siteHeaderTop()).toContain('--site-header-offset, 0px');
+    expect(siteHeaderTop()).toContain('--site-header-h, 0px');
+  });
+});
+
+/**
+ * Where a day section's own sticky title comes to rest.
+ *
+ * Third in the stack, and the one that is easiest to forget. It has to clear
+ * everything above it — and "everything above it" grew by the site header
+ * when #272 made that header reachable from anywhere.
+ */
+describe('dayHeaderTop', () => {
+  // Measured before this existed, at 320px and at 200% text zoom, by
+  // `verify-rail`'s check 12: rail bottom 112, day header top 64. The title
+  // stuck a whole site-header too high, behind a rail that outranks it
+  // (`z-20` against `z-10`), so it slid underneath and vanished — every time
+  // the reader scrolled up.
+  it('clears the site header as well as the rail', () => {
+    expect(dayHeaderTop()).toBe('calc(var(--site-header-offset, 0px) + var(--day-rail-h, 0px))');
+  });
+
+  // Both fall back to 0px, which is the pre-#272 `top: var(--day-rail-h)`
+  // when the header is hidden and an ordinary `top: 0` before anything is
+  // measured.
+  it('degrades to the rail height alone, then to zero', () => {
+    expect(dayHeaderTop()).toContain('--site-header-offset, 0px');
+    expect(dayHeaderTop()).toContain('--day-rail-h, 0px');
   });
 });

--- a/frontend/src/__tests__/app/siteHeaderStyles.test.ts
+++ b/frontend/src/__tests__/app/siteHeaderStyles.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * The half of the reveal (#272) that lives in CSS.
+ *
+ * jsdom applies no stylesheet, so none of this is reachable from a rendering
+ * test — and every rule below has a failure mode that ships silently. This
+ * reads the file.
+ */
+const css = readFileSync(resolve(__dirname, '..', '..', 'app', 'globals.css'), 'utf8');
+
+/** The `@property --site-header-offset { … }` block, whitespace-normalised. */
+const registration = css.match(/@property\s+--site-header-offset\s*\{[^}]*\}/)?.[0]
+  .replace(/\s+/g, ' ') ?? '';
+
+/**
+ * The bodies of every `@media (prefers-reduced-motion: no-preference)` block,
+ * matched by counting braces rather than by regex.
+ *
+ * The naive version of this check — "is the nearest `@media` above the
+ * declaration a no-preference one" — passes when the declaration is outside
+ * every block, because the filter panel's own no-preference block sits above
+ * it in the file. Caught by breaking the code; the guard was worthless until
+ * it counted braces.
+ */
+const noPreferenceBlocks = (): string[] => {
+  const opener = '@media (prefers-reduced-motion: no-preference) {';
+  const bodies: string[] = [];
+  for (let at = css.indexOf(opener); at !== -1; at = css.indexOf(opener, at + 1)) {
+    let depth = 0;
+    let i = at + opener.length - 1;
+    do {
+      if (css[i] === '{') depth += 1;
+      if (css[i] === '}') depth -= 1;
+      i += 1;
+    } while (depth > 0 && i < css.length);
+    bodies.push(css.slice(at + opener.length, i - 1));
+  }
+  return bodies;
+};
+
+describe('globals.css — the site header reveal', () => {
+  // Unregistered, a custom property is an untyped token stream and cannot be
+  // interpolated: the header would jump between shown and hidden rather than
+  // slide, in every browser. Registering it as a length is what makes the one
+  // shared value animatable.
+  it('registers the offset as a length so it can be animated', () => {
+    expect(registration).toContain("syntax: '<length>'");
+  });
+
+  it('inherits the offset, since the header and the rail both read it', () => {
+    expect(registration).toContain('inherits: true');
+  });
+
+  // The hook writes the offset in an effect. Between first paint and that
+  // effect there is no value at all — and `top: calc(0px - headerH)` parks the
+  // header out of sight. Without this default the site would load with its
+  // header already hidden at the top of the document, which no jsdom test can
+  // see because jsdom applies no stylesheet.
+  it('defaults to shown, so first paint is not a parked header', () => {
+    const rootDefault = css.match(/--site-header-offset:\s*([^;]+);/)?.[1];
+    expect(rootDefault).toBe('var(--site-header-h, 0px)');
+  });
+
+  // Same reasoning, for a browser that drops the `@property` registration:
+  // `initial-value: 0px` is the hidden end of the travel, so the fallback must
+  // never be the thing that decides the header's resting state.
+  it('registers an initial value at the hidden end, and never relies on it', () => {
+    expect(registration).toContain('initial-value: 0px');
+    expect(css.indexOf('--site-header-offset: var(--site-header-h, 0px)')).toBeGreaterThan(-1);
+  });
+
+  // Declared inside the no-preference block rather than declared and then
+  // unset, matching the filter panel's exit above it: a reader who asked for
+  // reduced motion never has a transition to override in the first place.
+  it('animates only when the reader has not asked for reduced motion', () => {
+    expect(css).toContain('transition: --site-header-offset');
+    expect(noPreferenceBlocks().some((b) => b.includes('transition: --site-header-offset'))).toBe(true);
+  });
+
+  // The extractor is only worth anything if it is really finding block
+  // bodies. A brace count that ran off the end would return the rest of the
+  // file and make the assertion above vacuously true.
+  it('reads block bodies rather than the rest of the file', () => {
+    const blocks = noPreferenceBlocks();
+    expect(blocks.length).toBeGreaterThanOrEqual(2);
+    // The filter panel's exit block is a sibling, not a container.
+    expect(blocks.some((b) => b.includes('.filter-panel-exit'))).toBe(true);
+    expect(blocks.find((b) => b.includes('.filter-panel-exit')))
+      .not.toContain('--site-header-offset');
+  });
+
+  // Transitioning `top` instead would also animate the filter header flipping
+  // between parked and pinned — that is the panel's own reveal, choreographed
+  // separately, and sliding it would be a regression in a different feature.
+  it('animates the shared variable, never the sticky tops it feeds', () => {
+    expect(css).not.toMatch(/transition:[^;]*\btop\b/);
+  });
+});

--- a/frontend/src/__tests__/components/calendar/EventListView.sticky.test.tsx
+++ b/frontend/src/__tests__/components/calendar/EventListView.sticky.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { render } from '@testing-library/preact';
 import { EventListView } from '@/components/calendar/EventListView';
 import { DAY_SECTION_ATTR } from '@/lib/utils/daySections';
+import { dayHeaderTop } from '@/app/filterHeaderLayout';
 
 const groups = [
   { key: '2026-07-04', baseLabel: 'Saturday, July 4, 2026', weekNumbers: [2], events: [] },
@@ -17,18 +18,26 @@ function renderView() {
 
 describe('EventListView sticky stacking', () => {
   // jsdom computes no layout, so this asserts the *declaration* — that the
-  // offset is expressed in terms of the measured custom property rather than
-  // a hardcoded pixel value. Whether the result actually clears the rail at a
-  // given text zoom is a browser question, checked in the phase's manual pass.
-  it('offsets the day header by the measured rail height', () => {
+  // offset is expressed in terms of the measured custom properties rather than
+  // a hardcoded pixel value. Whether the result actually clears the chrome at
+  // a given text zoom is a browser question, checked by `verify-rail`'s check
+  // 12 at 320px and at 200% zoom.
+  //
+  // Both terms, not just the rail: while the site header is revealed (#272)
+  // the rail sits a header lower, and a title pinned at the bare rail height
+  // slides under a rail that outranks it (`z-20` against `z-10`) and vanishes.
+  // Measured before it was fixed: rail bottom 112, day header top 64.
+  it('offsets the day header by the measured height of everything above it', () => {
     const { container } = renderView();
     const header = container.querySelector<HTMLElement>('.sticky')!;
-    expect(header.style.top).toBe('var(--day-rail-h)');
+    expect(header.style.top).toBe(dayHeaderTop());
+    expect(dayHeaderTop()).toContain('--day-rail-h');
+    expect(dayHeaderTop()).toContain('--site-header-offset');
   });
 
-  it('gives the section a scroll margin so a scroll target clears the rail', () => {
+  it('gives the section a scroll margin so a scroll target clears the chrome', () => {
     const { container } = renderView();
     const section = container.querySelector<HTMLElement>(`[${DAY_SECTION_ATTR}]`)!;
-    expect(section.style.scrollMarginTop).toBe('var(--day-rail-h)');
+    expect(section.style.scrollMarginTop).toBe(dayHeaderTop());
   });
 });

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -57,6 +57,42 @@ beforeEach(() => {
  * one always does — and a fake without it is a horizontal wheel, which the
  * hook is right to ignore.
  */
+/**
+ * A flick: the finger goes down, moves a little, and lifts - then the page
+ * keeps scrolling on its own for a second with no touch events at all.
+ *
+ * This is what a swipe on iOS looks like from here, and it is nothing like a
+ * wheel. A wheel fires for as long as the page is moving; a flick's events
+ * stop at `touchend` while most of the scrolling is still to come.
+ */
+const flick = (from: Element, { fingerTo, coastTo, frameMs = 60 }: {
+  fingerTo: number; coastTo: number; frameMs?: number;
+}) => {
+  const startScrollY = window.scrollY;
+  const touch = (y: number) => ({ clientY: y });
+  act(() => {
+    const start = new Event('touchstart', { bubbles: true });
+    Object.defineProperty(start, 'touches', { value: [touch(400)] });
+    from.dispatchEvent(start);
+  });
+  act(() => {
+    const move = new Event('touchmove', { bubbles: true });
+    Object.defineProperty(move, 'touches', { value: [touch(400 - (fingerTo - startScrollY))] });
+    from.dispatchEvent(move);
+  });
+  frameScrollTo(fingerTo);
+  act(() => {
+    const end = new Event('touchend', { bubbles: true });
+    Object.defineProperty(end, 'touches', { value: [] });
+    from.dispatchEvent(end);
+  });
+  const steps = 8;
+  for (let i = 1; i <= steps; i++) {
+    advance(frameMs);
+    frameScrollTo(Math.round(fingerTo + ((coastTo - fingerTo) * i) / steps));
+  }
+};
+
 const gesture = (type: string, init: object = {}) => act(() => {
   const Ctor = type === 'keydown' ? KeyboardEvent : type.startsWith('touch') ? Event : MouseEvent;
   const defaults = type === 'wheel' ? { deltaY: 1 } : {};
@@ -230,6 +266,152 @@ const mount = (h = 72) => {
   const growHeaderTo = (to: number) => { header.grow(to); observer.trigger(); };
   return { ...rendered, growHeaderTo };
 };
+
+/**
+ * A flick on a phone, where most of the scrolling happens after the gesture.
+ *
+ * Reported from the iPhone simulator: swiping through the event list, the
+ * header "sometimes does not scroll off the page and sometimes does not
+ * scroll back onto it". Both mechanisms that decide whose scroll it is were
+ * tuned against a wheel, which fires continuously for as long as the page
+ * moves. A touch does not: after `touchend` iOS coasts for up to a couple of
+ * seconds with no events at all - and the code said so in as many words,
+ * "there is no timer, because nothing but a gesture or another programmatic
+ * scroll can move the page anyway". On a phone that premise is false.
+ */
+describe('useSiteHeaderReveal - a flick, where the scrolling outlasts the touch', () => {
+  it('hides on the coast of a downward flick', () => {
+    const { result } = mount();
+    scrollTo(6_000);
+    scrollTo(5_600);
+    expect(result.current.revealed).toBe(true);
+
+    flick(el('<p>an event card</p>'), { fingerTo: 5_610, coastTo: 6_500 });
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  it('reveals on the coast of an upward flick', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    flick(el('<p>an event card</p>'), { fingerTo: 29_990, coastTo: 29_100 });
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // The other half, and the one the report's "sometimes" points at. Scrolling
+  // mounts day sections, whose correction announces itself and opens a settle
+  // - and a settle only a gesture can end is never ended by a flick, because
+  // the flick's events are already over. Every remaining frame is discarded.
+  it('hides on the coast even when the app corrected during the touch', () => {
+    const { result } = mount();
+    scrollTo(6_000);
+    scrollTo(5_600);
+    expect(result.current.revealed).toBe(true);
+
+    vi.spyOn(window, 'scrollBy').mockImplementation((() => {}) as typeof window.scrollBy);
+    act(() => { scrollWindowBy(0); });
+
+    flick(el('<p>an event card</p>'), { fingerTo: 5_610, coastTo: 6_500 });
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // The correction lands DURING the coast, which is when it actually happens:
+  // the render window mounts day sections as the page flies past them, and
+  // `EventList`/`useDayAnchor` correct for that. The announce opens a settle
+  // that only a gesture can close - and the flick's gestures are already over,
+  // so every remaining frame of the reader's own scroll is discarded.
+  it('hides on the coast when the app corrects mid-coast', () => {
+    const { result } = mount();
+    scrollTo(6_000);
+    scrollTo(5_600);
+    expect(result.current.revealed).toBe(true);
+    vi.spyOn(window, 'scrollBy').mockImplementation((() => {}) as typeof window.scrollBy);
+
+    const target = el('<p>an event card</p>');
+    const touch = (y: number) => ({ clientY: y });
+    act(() => {
+      const start = new Event('touchstart', { bubbles: true });
+      Object.defineProperty(start, 'touches', { value: [touch(400)] });
+      target.dispatchEvent(start);
+    });
+    act(() => {
+      const move = new Event('touchmove', { bubbles: true });
+      Object.defineProperty(move, 'touches', { value: [touch(390)] });
+      target.dispatchEvent(move);
+    });
+    frameScrollTo(5_610);
+    act(() => {
+      const end = new Event('touchend', { bubbles: true });
+      Object.defineProperty(end, 'touches', { value: [] });
+      target.dispatchEvent(end);
+    });
+
+    // Two frames of coast, then a day section mounts and the app corrects.
+    advance(60); frameScrollTo(5_660);
+    act(() => { scrollWindowBy(0); });
+    // The rest of the reader's own flick.
+    for (const y of [5_760, 5_900, 6_100, 6_300, 6_500]) {
+      advance(60);
+      frameScrollTo(y);
+    }
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // THE REPORTED BUG, reproduced. A gentle flick: the finger moves about 5px
+  // and lifts, and the page then coasts 60px over 1.2 seconds. 60px is well
+  // over the 24px threshold, so the header should move - but only the first
+  // 400ms of that coast counted, and in that window the page had travelled
+  // about 18px. Under threshold, no decision, header stays put.
+  //
+  // A hard flick covers its distance inside the window and works; a gentle one
+  // does not. That is the "sometimes" in the report, in both directions.
+  it('reveals on a gentle flick whose travel lands after the gesture window', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    flick(el('<p>an event card</p>'), { fingerTo: 29_995, coastTo: 29_935, frameMs: 150 });
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('hides on a gentle flick whose travel lands after the gesture window', () => {
+    const { result } = mount();
+    scrollTo(6_000);
+    scrollTo(5_600);
+    expect(result.current.revealed).toBe(true);
+
+    flick(el('<p>an event card</p>'), { fingerTo: 5_605, coastTo: 5_665, frameMs: 150 });
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // And momentum is not a blank cheque: once the page has come to rest, a
+  // scroll arriving later is the browser's, not the reader's.
+  it('stops trusting the coast once the page has come to rest', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    // A flick up, which reveals.
+    flick(el('<p>an event card</p>'), { fingerTo: 29_990, coastTo: 29_900 });
+    expect(result.current.revealed).toBe(true);
+
+    // Long after the page stopped, the browser scrolls DOWN on its own — the
+    // direction that would hide the header if the coast were still trusted.
+    // Pushing it the way it was already set would have proved nothing, which
+    // is what the first version of this test did.
+    advance(5_000);
+    frameScrollTo(29_900 + REVEAL_THRESHOLD + 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+});
 
 describe('useSiteHeaderReveal', () => {
   it('starts revealed, with the header at its full height', () => {

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -117,16 +117,40 @@ const tallOrdinaryContent = () => {
   return inner;
 };
 
+/**
+ * A touch drag from `from`: the press, then a move of `dy` pixels.
+ *
+ * Finger moving UP the screen (negative `dy`) scrolls the content DOWN, which
+ * is why the direction has to be reconstructed rather than read off the event.
+ */
+const touchDrag = (from: Element, dy: number, startY = 400) => {
+  const touch = (y: number) => ({ clientY: y });
+  act(() => {
+    const start = new Event('touchstart', { bubbles: true });
+    Object.defineProperty(start, 'touches', { value: [touch(startY)] });
+    from.dispatchEvent(start);
+    const move = new Event('touchmove', { bubbles: true });
+    Object.defineProperty(move, 'touches', { value: [touch(startY + dy)] });
+    from.dispatchEvent(move);
+  });
+};
+
 /** A pointer gesture dispatched FROM a particular element. */
 const gestureOn = (from: Element, type: string, init: object = {}) => act(() => {
   const Ctor = type === 'wheel' ? WheelEvent : type.startsWith('touch') ? Event : MouseEvent;
   from.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
 });
 
-/** Press, move, and stay held — a drag in progress, from `from`. */
-const dragFrom = (from: Element, buttons = 1) => {
+/**
+ * Press on `from`, then move over `over` with the button still held.
+ *
+ * The two are separate because that is where the bug was: a drag's origin and
+ * the element currently under the pointer are different things, and only the
+ * first one says what the drag means.
+ */
+const dragFrom = (from: Element, { over = from, buttons = 1 } = {}) => {
   gestureOn(from, 'mousedown', { button: buttons === 1 ? 0 : 2, buttons });
-  gestureOn(from, 'mousemove', { buttons });
+  gestureOn(over, 'mousemove', { buttons });
 };
 
 /** Jump the document to `y` through the announcing helper. */
@@ -185,6 +209,8 @@ const headerEl = (h: number) => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  Object.defineProperty(document.documentElement, 'clientWidth', { value: 0, configurable: true });
+  Object.defineProperty(document.documentElement, 'clientHeight', { value: 0, configurable: true });
   document.documentElement.style.removeProperty('overflow-y');
   document.body.style.removeProperty('overflow-y');
   document.documentElement.style.removeProperty(OFFSET);
@@ -1012,6 +1038,40 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(true);
   });
 
+  // Touch gets the boundary rule too. On a phone the filter panel covers 70%
+  // of the screen, so "a swipe that starts over the panel" is most swipes —
+  // and with the panel already at its top, the chain moves `window` while
+  // every `touchmove` was being rejected. The header could not be revealed at
+  // all from the largest target on screen.
+  it('counts a swipe that chains past a scroller already at its top', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    // Finger down the screen = content scrolls up = the panel would go up,
+    // but it is already at its top, so the page takes it.
+    touchDrag(nestedScroller({ scrollTop: 0 }), 60);
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // Mid-scroll the panel really does take the swipe, and must still be ignored.
+  it('does not count a swipe a scroller can still act on', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    touchDrag(nestedScroller({ scrollTop: 150 }), 60);
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
   // A drag is only a scrollbar drag if it started somewhere a drag scrolls.
   //
   // The week-range selector is the concrete case: pressing a week button and
@@ -1031,6 +1091,85 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
+  });
+
+  // The origin is what the drag MEANS, and the pointer leaves it. A week-range
+  // drag starts on a button and is dragged across the strip and off it: from
+  // that moment every `mousemove` targets ordinary content, so a rule reading
+  // the current target would arm on exactly the drag it had just refused.
+  it('does not count a drag that began on a control after it leaves that control', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    dragFrom(el('<button type="button">Wk 5</button>'), { over: el('<p>the list below</p>') });
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // And the drag ends when the button comes up: the next press decides afresh.
+  it('counts a fresh drag begun on content after one begun on a control ended', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    const control = el('<button type="button">Wk 5</button>');
+    gestureOn(control, 'mousedown', { button: 0, buttons: 1 });
+    gestureOn(control, 'mouseup', { button: 0, buttons: 0 });
+
+    dragFrom(el('<p>an event description</p>'));
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // The one press that IS a scroll. Clicking the scrollbar track pages the
+  // view and fires nothing else — no wheel, no key, no touch, no move — so
+  // without arming here, that way of scrolling could never bring the header
+  // back. Pinned at the hook, not only at the predicate: a predicate nobody
+  // consults is the same as no predicate.
+  it('counts a press in the scrollbar gutter, which pages the view', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    Object.defineProperty(document.documentElement, 'clientWidth', { value: 880, configurable: true });
+    Object.defineProperty(document.documentElement, 'clientHeight', { value: 680, configurable: true });
+    gestureOn(el('<div>the page</div>'), 'mousedown', { button: 0, buttons: 1, clientX: 890, clientY: 300 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // A press ends the drag it started, so its origin must not outlive it. A
+  // drag that begins outside the window and enters it — pressing on the
+  // browser chrome, or on a scrollbar the page never sees the press for —
+  // arrives as a `mousemove` with a button held and no `mousedown` behind it.
+  // Judged against the LAST drag's origin, such a gesture inherits a verdict
+  // that has nothing to do with it.
+  it('does not judge a new drag by the origin of the one before it', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    const control = el('<button type="button">Wk 5</button>');
+    gestureOn(control, 'mousedown', { button: 0, buttons: 1 });
+    gestureOn(control, 'mouseup', { button: 0, buttons: 0 });
+
+    // No `mousedown`: the press happened where this listener could not see it.
+    gestureOn(el('<p>an event description</p>'), 'mousemove', { buttons: 1 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
   });
 
   // A drag over ordinary content is a text selection, and dragging a selection
@@ -1057,7 +1196,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     jumpTo(12_929);
     advance(GESTURE_WINDOW_MS + 1);
 
-    dragFrom(el('<p>an event description</p>'), 2);
+    dragFrom(el('<p>an event description</p>'), { buttons: 2 });
     frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -48,10 +48,17 @@ beforeEach(() => {
   vi.spyOn(performance, 'now').mockImplementation(() => clockMs);
 });
 
-/** A gesture, dispatched where the hook listens for it. */
+/**
+ * A gesture, dispatched where the hook listens for it.
+ *
+ * A wheel carries a `deltaY` unless the caller says otherwise, because a real
+ * one always does — and a fake without it is a horizontal wheel, which the
+ * hook is right to ignore.
+ */
 const gesture = (type: string, init: object = {}) => act(() => {
   const Ctor = type === 'keydown' ? KeyboardEvent : type.startsWith('touch') ? Event : MouseEvent;
-  window.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
+  const defaults = type === 'wheel' ? { deltaY: 1 } : {};
+  window.dispatchEvent(new Ctor(type, { bubbles: true, ...defaults, ...init }));
 });
 
 /**
@@ -72,6 +79,46 @@ const el = (html: string) => {
   document.body.append(host);
   return host.firstElementChild!;
 };
+
+/** Give an element a real box, since jsdom measures everything as 0. */
+const sized = (el: Element, scrollHeight: number, clientHeight: number) => {
+  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+};
+
+/**
+ * An element that scrolls on its own, like the filter panel — which is
+ * `max-h-[70vh] overflow-y-auto` whenever it overlays the list.
+ */
+const nestedScroller = () => {
+  const box = document.createElement('div');
+  box.style.overflowY = 'auto';
+  sized(box, 900, 300);
+  const inner = document.createElement('div');
+  box.append(inner);
+  document.body.append(box);
+  return inner;
+};
+
+/**
+ * A tall element that is NOT a scroller — an ordinary day section, taller than
+ * the viewport with the default `overflow: visible`. Nearly everything the
+ * reader wheels over is one of these.
+ */
+const tallOrdinaryContent = () => {
+  const box = document.createElement('div');
+  sized(box, 900, 300);
+  const inner = document.createElement('div');
+  box.append(inner);
+  document.body.append(box);
+  return inner;
+};
+
+/** A pointer gesture dispatched FROM a particular element. */
+const gestureOn = (from: Element, type: string, init: object = {}) => act(() => {
+  const Ctor = type === 'wheel' ? WheelEvent : type.startsWith('touch') ? Event : MouseEvent;
+  from.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
+});
 
 /** Jump the document to `y` through the announcing helper. */
 const jumpTo = (y: number) => {
@@ -102,7 +149,8 @@ const browserScrollTo = (y: number) => {
  * look like from here.
  */
 const scrollTo = (y: number) => {
-  act(() => { window.dispatchEvent(new WheelEvent('wheel', { bubbles: true })); });
+  const deltaY = y - window.scrollY;
+  act(() => { window.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY })); });
   frameScrollTo(y);
 };
 
@@ -128,6 +176,8 @@ const headerEl = (h: number) => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.restoreAllMocks();
+  document.documentElement.style.removeProperty('overflow-y');
+  document.body.style.removeProperty('overflow-y');
   document.documentElement.style.removeProperty(OFFSET);
   document.documentElement.style.removeProperty(HEIGHT);
   Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true });
@@ -498,6 +548,133 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
 
     gesture('mousemove', { buttons: 1 });
     frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // A gesture is only the reader scrolling THE PAGE. The filter panel is its
+  // own scroller (`max-h-[70vh] overflow-y-auto` whenever it overlays the
+  // list), so a wheel inside it moves the panel and not the window — and then
+  // picking a venue reflows the list, whose gestureless correction would
+  // inherit authority this hook otherwise refuses it. `useFilterPanel` already
+  // exempts gestures inside the panel for the mirror-image reason.
+  it('does not count a wheel consumed by a scroller inside the page', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(nestedScroller(), 'wheel', { deltaY: -80 });
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  it('does not count a touch drag consumed by a scroller inside the page', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(nestedScroller(), 'touchmove');
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // The day rail scrolls horizontally. A wheel that moves it sideways is not
+  // the reader moving the page up or down.
+  it('does not count a wheel with no vertical component', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(el('<div>the day rail</div>'), 'wheel', { deltaX: -120, deltaY: 0 });
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Height alone does not make a scroller. Nearly every element the reader
+  // wheels over is taller than its own box — a day section, the list, the page
+  // container — and all of them scroll the PAGE. A rule that looked only at
+  // the box would classify every gesture as nested and the header would never
+  // respond to anything again.
+  it('counts a wheel over content that is merely tall, not scrollable', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(tallOrdinaryContent(), 'wheel', { deltaY: -80 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // Declaring `overflow-y: auto` does not make an element a scroller either —
+  // it has to actually overflow. The filter panel's own venue and category
+  // lists carry that overflow and frequently do not fill it (a narrow search,
+  // a short season), and a wheel over a list with nothing to scroll moves the
+  // page.
+  it('counts a wheel over a scroller with nothing to scroll', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    const box = document.createElement('div');
+    box.style.overflowY = 'auto';
+    sized(box, 300, 300);
+    const inner = document.createElement('div');
+    box.append(inner);
+    document.body.append(box);
+
+    gestureOn(inner, 'wheel', { deltaY: -80 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // The document's own scrollers are the page, not something nested in it.
+  // Reachable the day a stylesheet puts `overflow-y: auto` on `html` or
+  // `body`, which is a common enough thing to do that the guard should not
+  // depend on nobody ever doing it here.
+  it('counts a wheel over the page even if the document itself is a scroller', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    document.documentElement.style.overflowY = 'auto';
+    sized(document.documentElement, 9_000, 800);
+    document.body.style.overflowY = 'auto';
+    sized(document.body, 9_000, 800);
+
+    gestureOn(el('<div>an event card</div>'), 'wheel', { deltaY: -80 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // And the case none of that may break: a wheel over ordinary page content,
+  // which is what scrolls the page.
+  it('counts a wheel over ordinary page content', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(el('<div>an event card</div>'), 'wheel', { deltaY: -80 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
     expect(result.current.revealed).toBe(true);
   });
 

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, afterEach, vi } from 'vitest';
+import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
 import { renderHook, act } from '@testing-library/preact';
-import { useSiteHeaderReveal } from '@/hooks/useSiteHeaderReveal';
+import { useSiteHeaderReveal, GESTURE_WINDOW_MS } from '@/hooks/useSiteHeaderReveal';
 import { scrollWindowBy } from '@/lib/programmaticScroll';
 import { REVEAL_THRESHOLD } from '@/lib/siteHeaderReveal';
 import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
@@ -24,13 +24,58 @@ const offset = () => document.documentElement.style.getPropertyValue(OFFSET);
 const height = () => document.documentElement.style.getPropertyValue(HEIGHT);
 
 /**
- * A scroll the browser made on its own: the position moves and no gesture
- * precedes it. Anchoring corrections, restored positions, anchor jumps.
+ * One frame of a gesture already in flight: a scroll with no NEW gesture
+ * behind it and no time elapsed. WebKit delivers a single wheel tick as
+ * several of these.
  */
-const browserScrollTo = (y: number) => act(() => {
+const frameScrollTo = (y: number) => act(() => {
   Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
   window.dispatchEvent(new Event('scroll'));
 });
+
+/**
+ * The clock the hook reads.
+ *
+ * Stubbed rather than waited on: the rule is "a gesture is still live for
+ * `GESTURE_WINDOW_MS`", and a test that proved that by sleeping would be both
+ * slow and a coin toss on a loaded machine.
+ */
+let clockMs = 0;
+const advance = (ms: number) => { clockMs += ms; };
+
+beforeEach(() => {
+  clockMs = 0;
+  vi.spyOn(performance, 'now').mockImplementation(() => clockMs);
+});
+
+/** A gesture, dispatched where the hook listens for it. */
+const gesture = (type: string, init: object = {}) => act(() => {
+  const Ctor = type === 'keydown' ? KeyboardEvent : type.startsWith('touch') ? Event : MouseEvent;
+  window.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
+});
+
+/** Jump the document to `y` through the announcing helper. */
+const jumpTo = (y: number) => {
+  vi.spyOn(window, 'scrollBy').mockImplementation((() => {
+    Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
+  }) as typeof window.scrollBy);
+  act(() => { scrollWindowBy(y - window.scrollY); });
+};
+
+/**
+ * A scroll the browser made on its own: the position moves and no gesture
+ * precedes it. Anchoring corrections, restored positions, anchor jumps.
+ *
+ * The clock is advanced past the gesture window first, because "no gesture
+ * behind it" is a statement about time. A browser correction that genuinely
+ * lands inside the window after a real gesture IS admitted — that is the
+ * documented cost of the window, not something these tests should pretend
+ * away.
+ */
+const browserScrollTo = (y: number) => {
+  advance(GESTURE_WINDOW_MS + 1);
+  frameScrollTo(y);
+};
 
 /**
  * A scroll the READER made: the gesture that drives it, then the scroll it
@@ -39,7 +84,7 @@ const browserScrollTo = (y: number) => act(() => {
  */
 const scrollTo = (y: number) => {
   act(() => { window.dispatchEvent(new WheelEvent('wheel', { bubbles: true })); });
-  browserScrollTo(y);
+  frameScrollTo(y);
 };
 
 /** Get to "deep in the list with the header showing", the interesting state. */
@@ -179,7 +224,88 @@ describe('useSiteHeaderReveal', () => {
  * has to be remembered at each new site. Requiring a gesture is a guard that
  * holds for sites nobody has written yet.
  */
+/**
+ * One gesture, several frames.
+ *
+ * WebKit on Linux delivers a single wheel tick as an animation rather than a
+ * jump. Traced in CI over 40 ticks of 60px: `115 → 120 → 230`, i.e. +5 then
+ * +110 for one tick, and `839 → 840 → 959` for another. A rule that let a
+ * gesture decide only its FIRST scroll therefore threw away the rest of that
+ * gesture's own movement — the accumulator saw +5 where the reader had asked
+ * for +120, never reached the threshold, and the header did not hide at all.
+ * Chromium delivers one clean frame per tick and showed none of this.
+ */
+describe('useSiteHeaderReveal — one gesture, several frames', () => {
+  it('keeps deciding across every frame the gesture scrolls over', () => {
+    const { result } = mount();
+    scrollTo(1_000);
+    expect(result.current.revealed).toBe(false);
+
+    // One wheel up, delivered as -5 then the rest — the CI trace's shape.
+    gesture('wheel');
+    frameScrollTo(1_000 - 5);
+    frameScrollTo(1_000 - 110);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // The mirror: the frames must accumulate, not each be judged alone. Neither
+  // of these two clears the threshold by itself.
+  it('accumulates across frames rather than judging each one alone', () => {
+    const { result } = mount();
+    scrollTo(1_000);
+    expect(result.current.revealed).toBe(false);
+
+    gesture('wheel');
+    frameScrollTo(1_000 - 15);
+    frameScrollTo(1_000 - 30);
+
+    expect(result.current.revealed).toBe(true);
+  });
+});
+
 describe('useSiteHeaderReveal — scrolls nobody asked for', () => {
+  // A window is a judgement, and the tests above express "past the window"
+  // symbolically, so they hold for any value of it — including absurd ones.
+  // These bounds are the judgement: long enough to cover a smooth-scroll
+  // animation (WebKit delivers one wheel tick over several frames), short
+  // enough that a gesture cannot lend its authority to a browser correction
+  // arriving much later.
+  it('keeps a gesture live for about as long as a scroll animation lasts', () => {
+    expect(GESTURE_WINDOW_MS).toBeGreaterThanOrEqual(250);
+    expect(GESTURE_WINDOW_MS).toBeLessThanOrEqual(600);
+  });
+
+  // The hole the window opens, and the settle closes. A reader who scrolls and
+  // then taps a rail chip inside the same window would otherwise hand the
+  // browser's reaction to that tap the authority of their wheel — the exact
+  // 122px WebKit correction this suite exists for, arriving 200ms after a real
+  // gesture instead of in isolation.
+  it('ignores a correction after a jump the reader triggered while still scrolling', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    // No clock advance: the wheel above is still live when the tap lands.
+    jumpTo(12_929);
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // And the settle must not outlast the reader's patience: their next gesture
+  // takes control back with nothing to wait for.
+  it('hands control back at the reader\'s next gesture after such a jump', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    jumpTo(12_929);
+    frameScrollTo(12_807);
+
+    gesture('wheel');
+    frameScrollTo(12_807 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
   it('ignores a scroll with no gesture behind it', () => {
     const { result } = mount();
     reveal(result);
@@ -224,18 +350,6 @@ describe('useSiteHeaderReveal — scrolls nobody asked for', () => {
  * counted presses would have handed that correction a gesture's authority.
  */
 describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
-  /** Jump the document to `y` through the announcing helper. */
-  const jumpTo = (y: number) => {
-    vi.spyOn(window, 'scrollBy').mockImplementation((() => {
-      Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
-    }) as typeof window.scrollBy);
-    act(() => { scrollWindowBy(y - window.scrollY); });
-  };
-
-  const gesture = (type: string, init: object = {}) => act(() => {
-    window.dispatchEvent(new (type === 'keydown' ? KeyboardEvent : type.startsWith('touch') ? Event : MouseEvent)(type, { bubbles: true, ...init }));
-  });
-
   it('ignores the browser correcting the page after a jump', () => {
     const { result } = mount();
     scrollTo(30_000);
@@ -258,7 +372,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     browserScrollTo(12_807);
 
     gesture('wheel');
-    browserScrollTo(12_807 - REVEAL_THRESHOLD - 1);
+    frameScrollTo(12_807 - REVEAL_THRESHOLD - 1);
     expect(result.current.revealed).toBe(true);
   });
 
@@ -271,7 +385,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     jumpTo(12_929);
 
     gesture('touchmove');
-    browserScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
     expect(result.current.revealed).toBe(true);
   });
 
@@ -284,7 +398,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     jumpTo(12_929);
 
     gesture('keydown', { key: 'PageUp' });
-    browserScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
     expect(result.current.revealed).toBe(true);
   });
 
@@ -300,7 +414,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     jumpTo(12_929);
 
     gesture('mousemove', { buttons: 1 });
-    browserScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
     expect(result.current.revealed).toBe(true);
   });
 
@@ -321,8 +435,11 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
     jumpTo(12_929);
 
+    // Let the setup's own wheel expire first, or the scroll below is driven by
+    // THAT gesture and this test says nothing about the one it names.
+    advance(GESTURE_WINDOW_MS + 1);
     gesture('keydown', { key: 'a' });
-    browserScrollTo(12_807);
+    frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
   });
@@ -333,8 +450,11 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
     jumpTo(12_929);
 
+    // Let the setup's own wheel expire first, or the scroll below is driven by
+    // THAT gesture and this test says nothing about the one it names.
+    advance(GESTURE_WINDOW_MS + 1);
     gesture('keydown', { key: 'Tab' });
-    browserScrollTo(12_807);
+    frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
   });
@@ -350,8 +470,11 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
     jumpTo(12_929);
 
+    // Let the setup's own wheel expire first, or the scroll below is driven by
+    // THAT gesture and this test says nothing about the one it names.
+    advance(GESTURE_WINDOW_MS + 1);
     gesture('mousemove', { buttons: 0 });
-    browserScrollTo(12_807);
+    frameScrollTo(12_807);
     expect(result.current.revealed).toBe(false);
   });
 
@@ -368,8 +491,11 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
     jumpTo(12_929);
 
+    // Let the setup's own wheel expire first, or the scroll below is driven by
+    // THAT gesture and this test says nothing about the one it names.
+    advance(GESTURE_WINDOW_MS + 1);
     gesture('mousedown');
-    browserScrollTo(12_807);
+    frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
   });
@@ -391,7 +517,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     browserScrollTo(12_807);
 
     gesture('wheel');
-    browserScrollTo(12_807 + REVEAL_THRESHOLD);
+    frameScrollTo(12_807 + REVEAL_THRESHOLD);
     expect(result.current.revealed).toBe(false);
   });
 });

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -54,6 +54,25 @@ const gesture = (type: string, init: object = {}) => act(() => {
   window.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
 });
 
+/**
+ * A keypress FROM a particular element, so the listener sees a real target.
+ *
+ * Which key it is settles almost nothing on its own: Space scrolls the page
+ * from the document, types a character in a field, and activates a focused
+ * button. Only the target separates those.
+ */
+const keyOn = (el: Element, key: string) => act(() => {
+  el.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+});
+
+/** An element in the document, to press keys from. */
+const el = (html: string) => {
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  document.body.append(host);
+  return host.firstElementChild!;
+};
+
 /** Jump the document to `y` through the announcing helper. */
 const jumpTo = (y: number) => {
   vi.spyOn(window, 'scrollBy').mockImplementation((() => {
@@ -94,12 +113,16 @@ const reveal = (result: { current: { revealed: boolean } }) => {
   if (!result.current.revealed) throw new Error('setup failed: header did not reveal');
 };
 
-/** A header element of a given height, since jsdom measures everything as 0. */
+/**
+ * A header element whose measured height can change, since jsdom measures
+ * everything as 0 and text zoom is one of the things being tested.
+ */
 const headerEl = (h: number) => {
+  let height = h;
   const el = document.createElement('header');
-  el.getBoundingClientRect = () => ({ height: h }) as DOMRect;
+  el.getBoundingClientRect = () => ({ height }) as DOMRect;
   document.body.append(el);
-  return el;
+  return { el, grow: (to: number) => { height = to; } };
 };
 
 afterEach(() => {
@@ -113,10 +136,13 @@ afterEach(() => {
 
 /** Mount the hook with a measured header attached. */
 const mount = (h = 72) => {
-  installResizeObserverMock();
+  const observer = installResizeObserverMock();
   const rendered = renderHook(() => useSiteHeaderReveal());
-  act(() => { rendered.result.current.headerRef(headerEl(h)); });
-  return rendered;
+  const header = headerEl(h);
+  act(() => { rendered.result.current.headerRef(header.el); });
+  /** Text zoom, a breakpoint — anything that changes the header's height. */
+  const growHeaderTo = (to: number) => { header.grow(to); observer.trigger(); };
+  return { ...rendered, growHeaderTo };
 };
 
 describe('useSiteHeaderReveal', () => {
@@ -349,6 +375,63 @@ describe('useSiteHeaderReveal — scrolls nobody asked for', () => {
  * correction. The press that set all that off is a `mousedown`, so a set that
  * counted presses would have handed that correction a gesture's authority.
  */
+/**
+ * The top zone is a fact about where the header IS, not a decision about
+ * where it should be.
+ *
+ * A sticky header cannot be parked above a position the page has not reached,
+ * so inside the top zone it is on screen whatever the state says. Getting that
+ * wrong does not merely look odd: a visible header marked `inert` and
+ * `aria-hidden` is one a keyboard reader cannot reach and a screen reader will
+ * not announce.
+ *
+ * Reproduced in Chromium before the fix, in three steps a reader can take:
+ * search until the list is empty (document 8,401px → 1,049px, `scrollY`
+ * clamped 5,436 → 205), then let the viewport grow — a rotation to landscape,
+ * or browser chrome collapsing — so the document is shorter than the viewport
+ * and the browser clamps `scrollY` to 0. Measured at that point: header
+ * `top: 0, bottom: 48`, fully on screen, `inert: true, aria-hidden: "true"`.
+ * Not one of those scrolls had a gesture behind it.
+ */
+describe('useSiteHeaderReveal — the top zone is not negotiable', () => {
+  it('reveals when a scroll it would otherwise ignore lands in the top zone', () => {
+    const { result } = mount(72);
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    // The browser clamping `scrollY` because the document got shorter.
+    browserScrollTo(0);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // Outside the top zone an ignored scroll must still decide nothing — the
+  // fix must not become "any scroll reveals".
+  it('still ignores a gestureless scroll that lands below the top zone', () => {
+    const { result } = mount(72);
+    scrollTo(30_000);
+
+    browserScrollTo(30_000 - 500);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // The measurement is observed precisely so text zoom is handled, and a
+  // header that grows around the reader's position enters the top zone
+  // without anything scrolling at all.
+  it('reveals when the header grows around the reader, with no scroll at all', () => {
+    const { result, growHeaderTo } = mount(72);
+    scrollTo(100);
+    expect(result.current.revealed).toBe(false);
+
+    // Text zoom: 72px of header becomes 120px, and y=100 is now inside it.
+    // Nothing scrolled, so nothing would otherwise re-run the decision.
+    growHeaderTo(120);
+
+    expect(result.current.revealed).toBe(true);
+  });
+});
+
 describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
   it('ignores the browser correcting the page after a jump', () => {
     const { result } = mount();
@@ -457,6 +540,88 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
+  });
+
+  // Which key it is settles almost nothing on its own. Space scrolls the page
+  // from the document, types a character in a field, and activates a focused
+  // button — three different things behind one `e.key`. The consequence is the
+  // same one round 1 was about: typing a space in the search box refilters the
+  // list, the browser corrects for the height change, and inside the gesture
+  // window that correction inherits the authority of a keystroke that scrolled
+  // nothing. "brass band" would flip the header on the space.
+  it('does not count Space typed into a text field', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<input type="text" />'), ' ');
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Space on a focused control activates it. The rail's own Filters button is
+  // reachable by keyboard, and pressing it inserts the panel — a layout change
+  // above the reader, not a scroll.
+  it('does not count Space activating a focused button', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<button type="button">Filters</button>'), ' ');
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Arrows move the caret in a field rather than the page.
+  it('does not count an arrow key moving the caret in a text field', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<input type="text" />'), 'ArrowUp');
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Focusable is not the same as activated-by-Space. `WeekBadge` and the modal
+  // container both carry a `tabIndex` and both scroll the page on Space, so a
+  // rule keyed on focusability rather than on behaviour would be wrong about
+  // the platform, not merely cautious.
+  it('counts Space on an element that is focusable but not activated by it', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<span tabindex="0">Wk 5/6</span>'), ' ');
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // And the case all of that must not break: the same key, pressed with focus
+  // on the page rather than in a control, really is the reader scrolling.
+  it('counts Space pressed on the page itself', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<div>a day section</div>'), ' ');
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
   });
 
   // The pointer moving across the page is not a scroll, and counting it would

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -123,6 +123,12 @@ const gestureOn = (from: Element, type: string, init: object = {}) => act(() => 
   from.dispatchEvent(new Ctor(type, { bubbles: true, ...init }));
 });
 
+/** Press, move, and stay held — a drag in progress, from `from`. */
+const dragFrom = (from: Element, buttons = 1) => {
+  gestureOn(from, 'mousedown', { button: buttons === 1 ? 0 : 2, buttons });
+  gestureOn(from, 'mousemove', { buttons });
+};
+
 /** Jump the document to `y` through the announcing helper. */
 const jumpTo = (y: number) => {
   vi.spyOn(window, 'scrollBy').mockImplementation((() => {
@@ -953,6 +959,57 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
 
     expect(result.current.revealed).toBe(true);
+  });
+
+  // A drag is only a scrollbar drag if it started somewhere a drag scrolls.
+  //
+  // The week-range selector is the concrete case: pressing a week button and
+  // dragging across its neighbours refilters the list on every `mouseenter`,
+  // which changes the document's height under the reader — and the browser's
+  // correction for that would be admitted as reader-driven because the drag
+  // was emitting `mousemove` with a button held the whole time. The header
+  // moves while the reader is picking weeks.
+  it('does not count a drag that began on a control', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    dragFrom(el('<button type="button">Wk 5</button>'));
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // A drag over ordinary content is a text selection, and dragging a selection
+  // past the edge of the viewport really does scroll the page.
+  it('counts a drag that began on ordinary content', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    dragFrom(el('<p>an event description</p>'));
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // `buttons` is a bitmask, so the old `!== 0` admitted right- and
+  // middle-button drags too. Neither scrolls anything.
+  it('does not count a secondary-button drag', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    dragFrom(el('<p>an event description</p>'), 2);
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
   });
 
   // The pointer moving across the page is not a scroll, and counting it would

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -18,9 +18,11 @@ import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
  */
 
 const OFFSET = '--site-header-offset';
+const TARGET = '--site-header-offset-target';
 const HEIGHT = '--site-header-h';
 
 const offset = () => document.documentElement.style.getPropertyValue(OFFSET);
+const offsetTarget = () => document.documentElement.style.getPropertyValue(TARGET);
 const height = () => document.documentElement.style.getPropertyValue(HEIGHT);
 
 /**
@@ -179,6 +181,7 @@ afterEach(() => {
   document.documentElement.style.removeProperty('overflow-y');
   document.body.style.removeProperty('overflow-y');
   document.documentElement.style.removeProperty(OFFSET);
+  document.documentElement.style.removeProperty(TARGET);
   document.documentElement.style.removeProperty(HEIGHT);
   Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true });
   document.body.innerHTML = '';
@@ -200,6 +203,50 @@ describe('useSiteHeaderReveal', () => {
     const { result } = mount();
     expect(result.current.revealed).toBe(true);
     expect(offset()).toBe(`var(${HEIGHT}, 0px)`);
+  });
+
+  // The settled twin of the animated offset, and the ONLY thing
+  // `topChromeHeightPx` reads. Without this write the reader of that property
+  // measures a chrome height of zero and the rail's scrollspy is quietly wrong
+  // by a whole header — the two halves of the fix have to be pinned together
+  // or either can be removed without a test noticing.
+  it('publishes a settled offset for anything that measures rather than paints', () => {
+    const { result } = mount(72);
+    expect(offsetTarget()).toBe('72px');
+
+    scrollTo(1_000);
+    expect(result.current.revealed).toBe(false);
+    expect(offsetTarget()).toBe('0px');
+
+    scrollTo(1_000 - REVEAL_THRESHOLD - 1);
+    expect(offsetTarget()).toBe('72px');
+  });
+
+  // A literal, so unlike the animated offset it does not follow
+  // `--site-header-h` on its own — text zoom has to rewrite it.
+  it('rewrites the settled offset when the header is re-measured', () => {
+    const { growHeaderTo } = mount(72);
+    expect(offsetTarget()).toBe('72px');
+
+    growHeaderTo(120);
+
+    expect(offsetTarget()).toBe('120px');
+  });
+
+  // And rewrites it to the height the header is ACTUALLY at. The re-measure
+  // runs from a callback captured on first render, which cannot read state —
+  // so a mirror of the decision that stopped being updated would republish a
+  // revealed header's height onto a hidden one, and the rail's scrollspy would
+  // hold a boundary a whole header too tall.
+  it('rewrites it to zero when the header is re-measured while hidden', () => {
+    const { result, growHeaderTo } = mount(72);
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    expect(offsetTarget()).toBe('0px');
+
+    growHeaderTo(120);
+
+    expect(offsetTarget()).toBe('0px');
   });
 
   it('publishes the measured header height', () => {

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -92,10 +92,11 @@ const sized = (el: Element, scrollHeight: number, clientHeight: number) => {
  * An element that scrolls on its own, like the filter panel — which is
  * `max-h-[70vh] overflow-y-auto` whenever it overlays the list.
  */
-const nestedScroller = () => {
+const nestedScroller = ({ scrollTop = 150 } = {}) => {
   const box = document.createElement('div');
   box.style.overflowY = 'auto';
   sized(box, 900, 300);
+  Object.defineProperty(box, 'scrollTop', { value: scrollTop, configurable: true, writable: true });
   const inner = document.createElement('div');
   box.append(inner);
   document.body.append(box);
@@ -710,6 +711,54 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(true);
   });
 
+  // A scroller only consumes a wheel it can still act on. With the filter
+  // panel already at its top, every further upward tick over it CHAINS to the
+  // document and moves `window` — so rejecting all of them left the header
+  // unable to reveal at all until the pointer left the panel. The earlier
+  // comment here called that "the last few pixels of such a gesture", which
+  // understated it: at a boundary it is every tick, indefinitely.
+  it('counts a wheel that chains past a scroller already at its top', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(nestedScroller({ scrollTop: 0 }), 'wheel', { deltaY: -80 });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('counts a wheel that chains past a scroller already at its bottom', () => {
+    const { result } = mount();
+    scrollTo(1_000);
+    expect(result.current.revealed).toBe(false);
+    scrollTo(1_000 - 200);
+    expect(result.current.revealed).toBe(true);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    // 900 content, 300 viewport — 600 is the bottom.
+    gestureOn(nestedScroller({ scrollTop: 600 }), 'wheel', { deltaY: 80 });
+    frameScrollTo(800 + REVEAL_THRESHOLD + 1);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Mid-scroll it really does consume the wheel, and must still be ignored.
+  it('does not count a wheel a scroller can still act on', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(nestedScroller({ scrollTop: 150 }), 'wheel', { deltaY: -80 });
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
   // And the case none of that may break: a wheel over ordinary page content,
   // which is what scrolls the page.
   it('counts a wheel over ordinary page content', () => {
@@ -814,6 +863,23 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
+  });
+
+  // A native link is activated with Enter, not Space — Space on a focused link
+  // scrolls the page. Treating links as Space-activated rejected a real
+  // keyboard scroll, so the header would not respond for a reader tabbing
+  // through the header's own links and then pressing Space.
+  it('counts Space on a focused link, which scrolls rather than activating', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<a href="/about">About</a>'), ' ');
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
   });
 
   // The day rail intercepts `Home` (`DayRail.tsx`), calls `preventDefault()`

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -592,10 +592,16 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
   });
 
-  // Focusable is not the same as activated-by-Space. `WeekBadge` and the modal
-  // container both carry a `tabIndex` and both scroll the page on Space, so a
-  // rule keyed on focusability rather than on behaviour would be wrong about
-  // the platform, not merely cautious.
+  // Focusable is not the same as activated-by-Space. `Modal`'s container is the
+  // real instance — `role="dialog"`, `tabIndex={-1}`, and an `onKeyDown` that
+  // handles only Escape and Tab — so Space there scrolls the page, and a rule
+  // keyed on focusability rather than on behaviour would be wrong about the
+  // platform, not merely cautious.
+  //
+  // `WeekBadge` looks like the same case and is not: it sets `role="button"`
+  // alongside `tabIndex={0}` and calls `preventDefault()` on Space, so the
+  // `[role="button"]` match already covers it. Naming it here would have made
+  // this comment a plausible, checkable claim that happened to be false.
   it('counts Space on an element that is focusable but not activated by it', () => {
     const { result } = mount();
     scrollTo(30_000);
@@ -603,7 +609,7 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     jumpTo(12_929);
     advance(GESTURE_WINDOW_MS + 1);
 
-    keyOn(el('<span tabindex="0">Wk 5/6</span>'), ' ');
+    keyOn(el('<div role="dialog" tabindex="-1">a dialog</div>'), ' ');
     frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
 
     expect(result.current.revealed).toBe(true);

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -304,6 +304,41 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(true);
   });
 
+  // Typing is not scrolling. The listener is on `window` with `capture: true`,
+  // so every keystroke on the page reaches it — including the ones going into
+  // the search box, which re-filters the list and changes its height by
+  // thousands of pixels above the reader. The browser corrects for that, and
+  // an unfiltered `keydown` would hand each of those corrections the authority
+  // of a gesture: type three letters, watch the header appear.
+  //
+  // `useDismissOnScrollGesture` already had to make exactly this distinction,
+  // for exactly this reason ("typing into the panel's own search field would
+  // otherwise close it"), so the set is now shared rather than reasoned out a
+  // second time.
+  it('does not count a keystroke that scrolls nothing', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('keydown', { key: 'a' });
+    browserScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  it('does not count Tab, which moves focus rather than the page', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('keydown', { key: 'Tab' });
+    browserScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
   // The pointer moving across the page is not a scroll, and counting it would
   // reopen the hole: the reader's cursor drifts a pixel after a chip tap and
   // the browser's correction is admitted right behind it.

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -279,6 +279,96 @@ const mount = (h = 72) => {
  * "there is no timer, because nothing but a gesture or another programmatic
  * scroll can move the page anyway". On a phone that premise is false.
  */
+describe('useSiteHeaderReveal - a touch that was never a page scroll', () => {
+  const touchSeq = (from: Element, moves: number[], startY = 400) => {
+    const touch = (y: number) => ({ clientY: y });
+    act(() => {
+      const e = new Event('touchstart', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [touch(startY)] });
+      from.dispatchEvent(e);
+    });
+    for (const y of moves) {
+      act(() => {
+        const e = new Event('touchmove', { bubbles: true });
+        Object.defineProperty(e, 'touches', { value: [touch(y)] });
+        from.dispatchEvent(e);
+      });
+    }
+    act(() => {
+      const e = new Event('touchend', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [] });
+      from.dispatchEvent(e);
+    });
+  };
+
+  // The mouse path learned this; the touch path never did. `WeekSelector`
+  // calls `preventDefault()` on its touch handlers, so a slight drag over a
+  // themed week scrolls nothing at all - and then `touchend` refilters the
+  // list, whose correction would arrive holding a gesture's authority.
+  it('does not count a touch drag that began on a control', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    touchSeq(el('<button type="button">Wk 5</button>'), [390]);
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // A tap is not a flick. `touchend` used to open a coast for every touch,
+  // so a tap landing within the momentum gap of any earlier scrolling handed
+  // the next correction the authority of a scroll nobody made.
+  it('does not coast after a tap that scrolled nothing', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    // A tap on a rail chip: press, no movement, release - then the app jumps.
+    touchSeq(el('<button data-chip="2026-08-24">24</button>'), []);
+    jumpTo(12_929);
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Pinch-to-zoom is not scrolling. It re-anchors the document, so admitting
+  // it lets a zoom move the header.
+  it('does not count a pinch, which is two fingers rather than a scroll', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    const target = el('<p>an event card</p>');
+    act(() => {
+      const e = new Event('touchmove', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [{ clientY: 300 }, { clientY: 500 }] });
+      target.dispatchEvent(e);
+    });
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Chromium reports a trackpad pinch as a wheel with `ctrlKey`.
+  it('does not count a ctrl-wheel, which zooms rather than scrolls', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    gestureOn(el('<p>an event card</p>'), 'wheel', { deltaY: -80, ctrlKey: true });
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+});
+
 describe('useSiteHeaderReveal - a flick, where the scrolling outlasts the touch', () => {
   it('hides on the coast of a downward flick', () => {
     const { result } = mount();
@@ -387,6 +477,55 @@ describe('useSiteHeaderReveal - a flick, where the scrolling outlasts the touch'
     expect(result.current.revealed).toBe(true);
 
     flick(el('<p>an event card</p>'), { fingerTo: 5_605, coastTo: 5_665, frameMs: 150 });
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // The same symptom as the reported bug, by a different route, and the case
+  // the existing mid-coast test misses: it has already accumulated 60px by the
+  // time the app corrects, so the decision was taken before the settle opened.
+  //
+  // Here the correction lands while the coast is still under the threshold.
+  // The settle can only be closed by a gesture, and a flick has none left to
+  // give - so every remaining frame of the reader's own scroll is discarded
+  // and the flick never decides. The announcement has already taken the app's
+  // own delta out of the baseline, so what those frames measure is real
+  // movement the reader asked for.
+  it('hides on the coast when the app corrects before the coast has decided', () => {
+    const { result } = mount();
+    scrollTo(6_000);
+    scrollTo(5_600);
+    expect(result.current.revealed).toBe(true);
+    vi.spyOn(window, 'scrollBy').mockImplementation((() => {}) as typeof window.scrollBy);
+
+    const target = el('<p>an event card</p>');
+    const touch = (y: number) => ({ clientY: y });
+    act(() => {
+      const e = new Event('touchstart', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [touch(400)] });
+      target.dispatchEvent(e);
+    });
+    act(() => {
+      const e = new Event('touchmove', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [touch(395)] });
+      target.dispatchEvent(e);
+    });
+    frameScrollTo(5_605);
+    act(() => {
+      const e = new Event('touchend', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [] });
+      target.dispatchEvent(e);
+    });
+
+    // One frame of coast - 10px, under the 24px threshold - then a day
+    // section mounts and the app corrects.
+    advance(60); frameScrollTo(5_615);
+    act(() => { scrollWindowBy(0); });
+    // The rest of the flick, which is most of it.
+    for (const y of [5_640, 5_680, 5_740, 5_820, 5_900]) {
+      advance(60);
+      frameScrollTo(y);
+    }
 
     expect(result.current.revealed).toBe(false);
   });
@@ -1114,11 +1253,11 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
   });
 
-  // `PageDown` with focus parked on a chip really is a page scroll — the rail
-  // does not intercept it. `useFilterPanel`'s exemption says so in as many
-  // words, and narrowing more than the rail actually consumes would be
-  // guessing rather than matching it.
-  it('counts PageDown on a chip, which the rail does not intercept', () => {
+  // Paging with focus parked on a chip really is a page scroll — the rail
+  // intercepts `Home` and nothing else. `useFilterPanel`'s exemption says so
+  // in as many words, and narrowing more than the rail actually consumes
+  // would be guessing rather than matching it.
+  it('counts PageUp on a chip, which the rail does not intercept', () => {
     const { result } = mount();
     scrollTo(30_000);
     expect(result.current.revealed).toBe(false);

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -769,6 +769,41 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(false);
   });
 
+  // The day rail intercepts `Home` (`DayRail.tsx`), calls `preventDefault()`
+  // and only moves focus to today's chip — it never scrolls the page. The
+  // filter panel already special-cases this exact interaction in its own
+  // `isExempt`, so classifying it as a page scroll here would leave the two
+  // consumers disagreeing about the same keypress.
+  it('does not count Home on a day-rail chip, which only moves focus', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<button data-chip="2026-08-24">24</button>'), 'Home');
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // `PageDown` with focus parked on a chip really is a page scroll — the rail
+  // does not intercept it. `useFilterPanel`'s exemption says so in as many
+  // words, and narrowing more than the rail actually consumes would be
+  // guessing rather than matching it.
+  it('counts PageDown on a chip, which the rail does not intercept', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(el('<button data-chip="2026-08-24">24</button>'), 'PageUp');
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
   // Focusable is not the same as activated-by-Space. `Modal`'s container is the
   // real instance — `role="dialog"`, `tabIndex={-1}`, and an `onKeyDown` that
   // handles only Escape and Tab — so Space there scrolls the page, and a rule

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -961,6 +961,57 @@ describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
     expect(result.current.revealed).toBe(true);
   });
 
+  // The same rule the wheel already follows, for keys. With the filter card
+  // acting as an `overflow-y-auto` overlay, PageDown from a focused week
+  // button scrolls THAT panel — `window` never moves — and the reflow that
+  // follows a filter change would then be admitted as reader-driven.
+  it('does not count a scrolling key consumed by a scroller inside the page', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(nestedScroller({ scrollTop: 150 }), 'PageDown');
+    frameScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // And chains at the boundary, exactly as the wheel does: a panel already at
+  // its top passes PageUp to the page.
+  it('counts a scrolling key that chains past a scroller at its boundary', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    keyOn(nestedScroller({ scrollTop: 0 }), 'PageUp');
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // Space scrolls DOWN, and with Shift it scrolls up — so the direction a key
+  // implies is not always readable from the key alone.
+  it('reads Shift+Space as scrolling up when deciding whether a scroller takes it', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    // The scroller is at its top, so an upward key chains to the page.
+    act(() => {
+      nestedScroller({ scrollTop: 0 }).dispatchEvent(
+        new KeyboardEvent('keydown', { key: ' ', shiftKey: true, bubbles: true }));
+    });
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
   // A drag is only a scrollbar drag if it started somewhere a drag scrolls.
   //
   // The week-range selector is the concrete case: pressing a week button and

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -283,7 +283,7 @@ describe('useSiteHeaderReveal - a touch that was never a page scroll', () => {
   const touchSeq = (from: Element, moves: number[], startY = 400) => {
     const touch = (y: number) => ({ clientY: y });
     act(() => {
-      const e = new Event('touchstart', { bubbles: true });
+      const e = new Event('touchstart', { bubbles: true, cancelable: true });
       Object.defineProperty(e, 'touches', { value: [touch(startY)] });
       from.dispatchEvent(e);
     });
@@ -301,21 +301,65 @@ describe('useSiteHeaderReveal - a touch that was never a page scroll', () => {
     });
   };
 
-  // The mouse path learned this; the touch path never did. `WeekSelector`
-  // calls `preventDefault()` on its touch handlers, so a slight drag over a
-  // themed week scrolls nothing at all - and then `touchend` refilters the
-  // list, whose correction would arrive holding a gesture's authority.
-  it('does not count a touch drag that began on a control', () => {
+  // A button does not stop the page panning. The event list is MADE of
+  // buttons — the event title is a full-width one — so a rule that refused
+  // any touch beginning on a control refused most swipes in the list, which
+  // is the device bug this branch just fixed, reintroduced.
+  //
+  // The mouse and touch answers genuinely differ here: a drag beginning on a
+  // button is that button's, while a SWIPE beginning on it still scrolls the
+  // page.
+  it('counts a swipe that began on a button, which does not stop the pan', () => {
     const { result } = mount();
     scrollTo(30_000);
     expect(result.current.revealed).toBe(false);
     jumpTo(12_929);
     advance(GESTURE_WINDOW_MS + 1);
 
-    touchSeq(el('<button type="button">Wk 5</button>'), [390]);
+    touchSeq(el('<button type="button">An event title</button>'), [460]);
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // What DOES stop the pan is a control that cancels it. `WeekSelector` calls
+  // `preventDefault()` on `touchstart`, and that — rather than the tag name —
+  // is the thing worth testing for, because it is what the platform actually
+  // acts on.
+  it('does not count a swipe whose control cancelled the pan', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    const week = el('<button type="button">Wk 5</button>');
+    week.addEventListener('touchstart', (e) => e.preventDefault());
+    touchSeq(week, [390]);
     frameScrollTo(12_807);
 
     expect(result.current.revealed).toBe(false);
+  });
+
+  // And the verdict belongs to its own touch. A swipe over a pan-cancelling
+  // control followed by a swipe over the list must judge the second on its own
+  // merits, or one brush against the week strip disables scrolling the header
+  // for good.
+  it('judges each swipe on its own, not on the one before it', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    advance(GESTURE_WINDOW_MS + 1);
+
+    const week = el('<button type="button">Wk 5</button>');
+    week.addEventListener('touchstart', (e) => e.preventDefault());
+    touchSeq(week, [390]);
+
+    touchSeq(el('<p>an event card</p>'), [460]);
+    frameScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+
+    expect(result.current.revealed).toBe(true);
   });
 
   // A tap is not a flick. `touchend` used to open a coast for every touch,

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -1,0 +1,362 @@
+import { describe, expect, it, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/preact';
+import { useSiteHeaderReveal } from '@/hooks/useSiteHeaderReveal';
+import { scrollWindowBy } from '@/lib/programmaticScroll';
+import { REVEAL_THRESHOLD } from '@/lib/siteHeaderReveal';
+import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
+
+/**
+ * The wiring between the reveal rule and the page (#272): where the decision
+ * is published, what a programmatic jump does to it, and what is torn down on
+ * unmount.
+ *
+ * The rule itself is pinned in `lib/siteHeaderReveal.test.ts` and the
+ * geometry in `e2e/verify-header-reveal.mjs`. What is only reachable here is
+ * that the decision reaches CSS at all, and that it reaches CSS *without*
+ * going through the page — the offset is a custom property precisely so a
+ * flick of the wrist does not re-render 1,470 events.
+ */
+
+const OFFSET = '--site-header-offset';
+const HEIGHT = '--site-header-h';
+
+const offset = () => document.documentElement.style.getPropertyValue(OFFSET);
+const height = () => document.documentElement.style.getPropertyValue(HEIGHT);
+
+/**
+ * A scroll the browser made on its own: the position moves and no gesture
+ * precedes it. Anchoring corrections, restored positions, anchor jumps.
+ */
+const browserScrollTo = (y: number) => act(() => {
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
+  window.dispatchEvent(new Event('scroll'));
+});
+
+/**
+ * A scroll the READER made: the gesture that drives it, then the scroll it
+ * produces. Which is what a wheel tick, a touch drag and a scrollbar drag all
+ * look like from here.
+ */
+const scrollTo = (y: number) => {
+  act(() => { window.dispatchEvent(new WheelEvent('wheel', { bubbles: true })); });
+  browserScrollTo(y);
+};
+
+/** Get to "deep in the list with the header showing", the interesting state. */
+const reveal = (result: { current: { revealed: boolean } }) => {
+  scrollTo(30_000);
+  scrollTo(6_080);
+  if (!result.current.revealed) throw new Error('setup failed: header did not reveal');
+};
+
+/** A header element of a given height, since jsdom measures everything as 0. */
+const headerEl = (h: number) => {
+  const el = document.createElement('header');
+  el.getBoundingClientRect = () => ({ height: h }) as DOMRect;
+  document.body.append(el);
+  return el;
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.documentElement.style.removeProperty(OFFSET);
+  document.documentElement.style.removeProperty(HEIGHT);
+  Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true });
+  document.body.innerHTML = '';
+});
+
+/** Mount the hook with a measured header attached. */
+const mount = (h = 72) => {
+  installResizeObserverMock();
+  const rendered = renderHook(() => useSiteHeaderReveal());
+  act(() => { rendered.result.current.headerRef(headerEl(h)); });
+  return rendered;
+};
+
+describe('useSiteHeaderReveal', () => {
+  it('starts revealed, with the header at its full height', () => {
+    const { result } = mount();
+    expect(result.current.revealed).toBe(true);
+    expect(offset()).toBe(`var(${HEIGHT}, 0px)`);
+  });
+
+  it('publishes the measured header height', () => {
+    mount(88);
+    expect(height()).toBe('88px');
+  });
+
+  it('collapses the offset to zero once the reader scrolls down past the threshold', () => {
+    const { result } = mount();
+    scrollTo(1_000);
+    expect(result.current.revealed).toBe(false);
+    expect(offset()).toBe('0px');
+  });
+
+  it('restores the offset on a small scroll back up', () => {
+    const { result } = mount();
+    scrollTo(1_000);
+    scrollTo(1_000 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+    expect(offset()).toBe(`var(${HEIGHT}, 0px)`);
+  });
+
+  // The header's own height is the top zone: within it the header's natural
+  // position is still on screen, and a sticky element cannot be parked above
+  // a position it has not reached. Marking it hidden there would make a
+  // header the reader can see `inert`.
+  it('stays revealed scrolling down inside the header height', () => {
+    const { result } = mount(72);
+    scrollTo(60);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('hides once the reader is past the header height', () => {
+    const { result } = mount(72);
+    scrollTo(200);
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // The acceptance criterion this exists for: tapping a day chip on the rail
+  // jumps the document by tens of thousands of pixels, and must not flash the
+  // header in.
+  it('does not reveal when the app scrolls the document itself', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    vi.spyOn(window, 'scrollBy').mockImplementation((() => {
+      Object.defineProperty(window, 'scrollY', { value: 1_200, configurable: true, writable: true });
+    }) as typeof window.scrollBy);
+    act(() => { scrollWindowBy(-28_800); });
+    // The scroll event the jump provokes arrives a frame later.
+    scrollTo(1_200);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // A resync must not freeze the header: the reader's very next gesture,
+  // measured from the new baseline, works with nothing to wait for.
+  //
+  // The gesture is required rather than incidental. A jump also opens a settle
+  // (see the suite below), so a bare scroll after one is the browser finishing
+  // its own reaction and decides nothing — this asserts the other half, that
+  // the settle costs the reader no delay at all once they touch the page.
+  it('responds to the reader\'s first gesture after a programmatic jump', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    vi.spyOn(window, 'scrollBy').mockImplementation((() => {
+      Object.defineProperty(window, 'scrollY', { value: 1_200, configurable: true, writable: true });
+    }) as typeof window.scrollBy);
+    act(() => { scrollWindowBy(-28_800); });
+
+    act(() => { window.dispatchEvent(new WheelEvent('wheel', { bubbles: true })); });
+    scrollTo(1_200 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('stops listening once unmounted', () => {
+    const { unmount } = mount();
+    unmount();
+    scrollTo(1_000);
+    expect(offset()).not.toBe('0px');
+  });
+});
+
+/**
+ * A scroll with no gesture behind it is not the reader scrolling.
+ *
+ * The app's own scrolls announce themselves, so the baseline can be resynced
+ * for those. What cannot announce itself is what the BROWSER does in reaction
+ * to a layout change we made without scrolling at all. Measured in WebKit:
+ * opening the filter panel from the rail with the header revealed,
+ * `topmostVisibleDaySection()` found no section to anchor to, so
+ * `useFilterPanel` captured no reference, corrected nothing and announced
+ * nothing — and WebKit's scroll anchoring then moved the page 44px by itself.
+ * The header hid on a tap nobody scrolled.
+ *
+ * Chasing that by making every layout-changing site announce is a guard that
+ * has to be remembered at each new site. Requiring a gesture is a guard that
+ * holds for sites nobody has written yet.
+ */
+describe('useSiteHeaderReveal — scrolls nobody asked for', () => {
+  it('ignores a scroll with no gesture behind it', () => {
+    const { result } = mount();
+    reveal(result);
+
+    // WebKit's scroll anchoring after the filter panel was inserted: 44px,
+    // nearly twice the threshold, and no gesture anywhere near it.
+    browserScrollTo(6_124);
+
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('still decides when the reader is the one scrolling', () => {
+    const { result } = mount();
+    reveal(result);
+
+    scrollTo(6_124);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // The baseline still has to follow, or the reader's next real scroll is
+  // measured against a position the page left some time ago.
+  it('keeps the baseline current across a scroll it ignored', () => {
+    const { result } = mount();
+    reveal(result);
+    browserScrollTo(6_124);
+
+    scrollTo(6_124 + REVEAL_THRESHOLD);
+    expect(result.current.revealed).toBe(false);
+  });
+});
+
+/**
+ * Which gestures count as the reader scrolling.
+ *
+ * The set is not obvious and each exclusion was paid for. Measured in WebKit
+ * against a real rail chip tap: the page landed at y=12,929 and the browser's
+ * own scroll anchoring pulled it back to 12,807 as the render window mounted
+ * day sections above the reader — 122px, five times the reveal threshold, a
+ * fifth of a second after a tap nobody scrolled. Chromium made no such
+ * correction. The press that set all that off is a `mousedown`, so a set that
+ * counted presses would have handed that correction a gesture's authority.
+ */
+describe('useSiteHeaderReveal — which gestures count as scrolling', () => {
+  /** Jump the document to `y` through the announcing helper. */
+  const jumpTo = (y: number) => {
+    vi.spyOn(window, 'scrollBy').mockImplementation((() => {
+      Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
+    }) as typeof window.scrollBy);
+    act(() => { scrollWindowBy(y - window.scrollY); });
+  };
+
+  const gesture = (type: string, init: object = {}) => act(() => {
+    window.dispatchEvent(new (type === 'keydown' ? KeyboardEvent : type.startsWith('touch') ? Event : MouseEvent)(type, { bubbles: true, ...init }));
+  });
+
+  it('ignores the browser correcting the page after a jump', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    expect(result.current.revealed).toBe(false);
+
+    jumpTo(12_929);
+    // WebKit's scroll anchoring, 122px up. Nobody scrolled.
+    browserScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  it('counts a wheel', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    browserScrollTo(12_807);
+
+    gesture('wheel');
+    browserScrollTo(12_807 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('counts a touch drag', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('touchmove');
+    browserScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  it('counts a scrolling keypress', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('keydown', { key: 'PageUp' });
+    browserScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // A scrollbar drag is the one way to scroll that fires no wheel, no touch
+  // and no key. It is a `mousemove` with the button still held — which is why
+  // the button state is checked rather than the event type.
+  it('counts a scrollbar drag — a pointer moving with its button held', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('mousemove', { buttons: 1 });
+    browserScrollTo(12_929 - REVEAL_THRESHOLD - 1);
+    expect(result.current.revealed).toBe(true);
+  });
+
+  // The pointer moving across the page is not a scroll, and counting it would
+  // reopen the hole: the reader's cursor drifts a pixel after a chip tap and
+  // the browser's correction is admitted right behind it.
+  it('does not count a pointer moving with no button held', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('mousemove', { buttons: 0 });
+    browserScrollTo(12_807);
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // `mousedown` is deliberately NOT in the gesture set, and neither is
+  // `touchstart` — the difference from `useDayAnchor`'s otherwise identical
+  // cancel set. A press is not a scroll: it moves nothing. And every rail chip
+  // tap is a press, milliseconds before the jump whose fallout must not be
+  // mistaken for the reader.
+  it('does not count a press, which scrolls nothing', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+
+    gesture('mousedown');
+    browserScrollTo(12_807);
+
+    expect(result.current.revealed).toBe(false);
+  });
+
+  // Ignoring a scroll must still move the baseline. Leaving it at
+  // where the jump LANDED means every later delta is measured against a
+  // position the page has not been at since — so the reader's next small
+  // scroll down is read as a large scroll up, and the header reveals when they
+  // asked it to hide. The exact WebKit numbers: landed 12,929, corrected to
+  // 12,807, and a 24px scroll down from there is a 98px scroll UP against the
+  // stale baseline.
+  it('keeps the baseline current through a jump it ignored', () => {
+    const { result } = mount();
+    scrollTo(30_000);
+    // Pinned, not assumed: without it the wheel case asserts the same value
+    // as its own untested premise and passes on code where nothing counts.
+    expect(result.current.revealed).toBe(false);
+    jumpTo(12_929);
+    browserScrollTo(12_807);
+
+    gesture('wheel');
+    browserScrollTo(12_807 + REVEAL_THRESHOLD);
+    expect(result.current.revealed).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/hooks/useSiteHeaderReveal.test.ts
@@ -378,6 +378,49 @@ describe('useSiteHeaderReveal - a touch that was never a page scroll', () => {
     expect(result.current.revealed).toBe(false);
   });
 
+  // A pinch usually starts as one finger. That first move arms the window and
+  // marks the touch as having scrolled, and rejecting the LATER multi-touch
+  // frames does not take either back - so `touchend` opened a coast and the
+  // zoom's re-anchoring moved the header, even though a pinch is explicitly
+  // classified as not scrolling.
+  it('withdraws a touch\'s authority once it becomes a pinch', () => {
+    const { result } = mount();
+    scrollTo(6_000);
+    scrollTo(5_600);
+    expect(result.current.revealed).toBe(true);
+
+    const target = el('<p>an event card</p>');
+    const touch = (y: number) => ({ clientY: y });
+    act(() => {
+      const e = new Event('touchstart', { bubbles: true, cancelable: true });
+      Object.defineProperty(e, 'touches', { value: [touch(400)] });
+      target.dispatchEvent(e);
+    });
+    // One finger, a real pan.
+    act(() => {
+      const e = new Event('touchmove', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [touch(395)] });
+      target.dispatchEvent(e);
+    });
+    frameScrollTo(5_605);
+    // A second finger lands: from here it is a zoom.
+    act(() => {
+      const e = new Event('touchmove', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [touch(395), touch(500)] });
+      target.dispatchEvent(e);
+    });
+    act(() => {
+      const e = new Event('touchend', { bubbles: true });
+      Object.defineProperty(e, 'touches', { value: [] });
+      target.dispatchEvent(e);
+    });
+
+    // The zoom re-anchors the document. That is not the reader scrolling.
+    for (const y of [5_650, 5_720, 5_800]) { advance(60); frameScrollTo(y); }
+
+    expect(result.current.revealed).toBe(true);
+  });
+
   // Pinch-to-zoom is not scrolling. It re-anchors the document, so admitting
   // it lets a zoom move the header.
   it('does not count a pinch, which is two fingers rather than a scroll', () => {

--- a/frontend/src/__tests__/integration/filterHeader.test.tsx
+++ b/frontend/src/__tests__/integration/filterHeader.test.tsx
@@ -195,13 +195,21 @@ describe('page.tsx — the sticky filter header', () => {
   });
 
   // The card leaves by riding up on the header's negative offset instead.
+  //
+  // The `--site-header-offset` term is the site header's reveal on scroll up
+  // (#272): `0px` while it is hidden, so this parks exactly as it always did,
+  // and its measured height while it is revealed, which rides the rail down to
+  // sit below it. It is a CSS variable rather than a prop precisely so the
+  // reveal does not re-render this page.
+  const PARKED = 'calc(var(--site-header-offset, 0px) - var(--filter-card-h, 0px))';
+
   it('parks the header by the measured card offset when the panel is not overlaying', async () => {
     await renderPage();
 
-    expect(header().style.top).toBe('calc(-1 * var(--filter-card-h, 0px))');
+    expect(header().style.top).toBe(PARKED);
 
     scrollPastHeader();
-    expect(header().style.top).toBe('calc(-1 * var(--filter-card-h, 0px))');
+    expect(header().style.top).toBe(PARKED);
   });
 
   it('pins the header at the viewport top while the panel is open over the list', async () => {
@@ -210,7 +218,7 @@ describe('page.tsx — the sticky filter header', () => {
 
     fireEvent.click(toggleButton()!);
 
-    expect(header().style.top).toBe('0px');
+    expect(header().style.top).toBe('var(--site-header-offset, 0px)');
   });
 
   // Below, not above. Above the header the sentinel stops moving with the

--- a/frontend/src/__tests__/lib/programmaticScroll.test.ts
+++ b/frontend/src/__tests__/lib/programmaticScroll.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { onProgrammaticScroll, scrollWindowBy } from '@/lib/programmaticScroll';
+
+/**
+ * The app scrolls the document itself in five places, and #272's header must
+ * not read any of them as the reader scrolling up. What makes that possible
+ * is that the jump announces itself — and announces itself *after* the
+ * position has already moved, so a subscriber resyncing its baseline reads
+ * the post-jump position rather than the one it is about to leave.
+ */
+
+const unsubscribes: Array<() => void> = [];
+
+const subscribe = (fn: () => void) => {
+  const off = onProgrammaticScroll(fn);
+  unsubscribes.push(off);
+  return off;
+};
+
+/** Replace `window.scrollBy` with one that actually moves `scrollY`. */
+const stubScrollBy = () => {
+  const calls: number[] = [];
+  vi.spyOn(window, 'scrollBy').mockImplementation(((_x: number, y: number) => {
+    calls.push(y);
+    Object.defineProperty(window, 'scrollY', { value: window.scrollY + y, configurable: true, writable: true });
+  }) as typeof window.scrollBy);
+  return calls;
+};
+
+afterEach(() => {
+  while (unsubscribes.length) unsubscribes.pop()!();
+  vi.restoreAllMocks();
+  Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true });
+});
+
+describe('scrollWindowBy', () => {
+  it('scrolls the window by the delta', () => {
+    const calls = stubScrollBy();
+    scrollWindowBy(240);
+    expect(calls).toEqual([240]);
+  });
+
+  it('announces the scroll to subscribers', () => {
+    stubScrollBy();
+    const seen = vi.fn();
+    subscribe(seen);
+    scrollWindowBy(240);
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  // The ordering is the entire mechanism. A subscriber that resyncs its
+  // baseline needs the position the jump LANDED on; told beforehand it would
+  // record the position the jump is about to leave, and the scroll event that
+  // arrives a frame later would then look like the whole jump — exactly the
+  // rail-tap flash the announcement exists to prevent.
+  it('announces only after the position has already moved', () => {
+    stubScrollBy();
+    Object.defineProperty(window, 'scrollY', { value: 1_000, configurable: true, writable: true });
+    let seenAt = -1;
+    subscribe(() => { seenAt = window.scrollY; });
+    scrollWindowBy(240);
+    expect(seenAt).toBe(1_240);
+  });
+
+  // Every call site guarded `delta !== 0` for itself before this helper
+  // existed. The guard moved here so five copies cannot drift.
+  it('does not scroll when the delta is zero', () => {
+    const calls = stubScrollBy();
+    scrollWindowBy(0);
+    expect(calls).toEqual([]);
+  });
+
+  // A zero delta still announces, and this is the opposite of what it looks
+  // like. Measured in Chromium, opening the filter panel from the rail with
+  // the header revealed: the panel's insertion changed layout above the
+  // reader, Chromium's own scroll anchoring corrected +44px BEFORE our
+  // `useLayoutEffect` ran, our correction therefore computed a delta of 0 —
+  // and the announcement it skipped was the one that would have told the
+  // header that the +44px scroll about to be reported was not the reader.
+  // The header hid on a tap that nobody scrolled. WebKit does not anchor
+  // there, computed +44 itself, and behaved correctly throughout.
+  //
+  // So a delta of zero does not mean "nothing happened". It means the app
+  // laid out again and needed no correction — often precisely because the
+  // browser had already made one.
+  it('announces even when the correction it computed was zero', () => {
+    stubScrollBy();
+    const seen = vi.fn();
+    subscribe(seen);
+    scrollWindowBy(0);
+    expect(seen).toHaveBeenCalledTimes(1);
+  });
+
+  it('announces to every subscriber', () => {
+    stubScrollBy();
+    const first = vi.fn();
+    const second = vi.fn();
+    subscribe(first);
+    subscribe(second);
+    scrollWindowBy(240);
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops announcing to a subscriber that has unsubscribed', () => {
+    stubScrollBy();
+    const seen = vi.fn();
+    subscribe(seen)();
+    scrollWindowBy(240);
+    expect(seen).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/__tests__/lib/programmaticScrollCallSites.test.ts
+++ b/frontend/src/__tests__/lib/programmaticScrollCallSites.test.ts
@@ -17,7 +17,11 @@ import { join, relative, resolve } from 'node:path';
  */
 
 const SRC = resolve(__dirname, '..', '..');
-const ALLOWED = 'lib/programmaticScroll.ts';
+// Built with `join`, not a literal: `relative()` returns backslashes on
+// Windows, so a hard-coded slash would make the helper itself an offender AND
+// make the sanity check below miss it — the guard would fail for the one
+// reason it can never be right about.
+const ALLOWED = join('lib', 'programmaticScroll.ts');
 
 const sourceFiles = (dir: string): string[] =>
   readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {

--- a/frontend/src/__tests__/lib/programmaticScrollCallSites.test.ts
+++ b/frontend/src/__tests__/lib/programmaticScrollCallSites.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, relative, resolve } from 'node:path';
+
+/**
+ * Every scroll the app performs on the reader's behalf must announce itself.
+ *
+ * This is a source scan rather than a behavioural test because the failure it
+ * guards is an omission, and an omission has no call site to assert on. The
+ * header's reveal (#272) reads scroll direction; a jump that does not announce
+ * itself reads as the largest scroll up the reader could possibly make, so a
+ * single forgotten call site brings back the exact defect the announcement
+ * exists to prevent — and only at that one call site, which is precisely the
+ * kind of gap a behavioural suite passes straight over.
+ *
+ * `programmaticScroll.ts` itself is the one place `window.scrollBy` belongs.
+ */
+
+const SRC = resolve(__dirname, '..', '..');
+const ALLOWED = 'lib/programmaticScroll.ts';
+
+const sourceFiles = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return entry.name === '__tests__' ? [] : sourceFiles(full);
+    return /\.tsx?$/.test(entry.name) ? [full] : [];
+  });
+
+describe('programmatic scroll call sites', () => {
+  it('routes every window.scrollBy through the announcing helper', () => {
+    const offenders = sourceFiles(SRC)
+      .filter((file) => relative(SRC, file) !== ALLOWED)
+      .filter((file) => /window\.scrollBy\s*\(/.test(readFileSync(file, 'utf8')))
+      .map((file) => relative(SRC, file));
+
+    expect(offenders).toEqual([]);
+  });
+
+  // The scan is only worth anything if it is looking at real files. A wrong
+  // root, a changed extension filter or a directory walk that silently
+  // returns nothing would make the assertion above vacuously true forever.
+  it('is actually scanning the source tree', () => {
+    const files = sourceFiles(SRC);
+    expect(files.length).toBeGreaterThan(50);
+    expect(files.some((f) => relative(SRC, f) === ALLOWED)).toBe(true);
+  });
+});

--- a/frontend/src/__tests__/lib/scrollGestures.test.ts
+++ b/frontend/src/__tests__/lib/scrollGestures.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { pressIsOnScrollbar } from '@/lib/scrollGestures';
+
+/**
+ * The one branch in this module the browser leg cannot exercise.
+ *
+ * A press in the scrollbar track pages the view, and it fires no wheel, no
+ * key, no touch and no `mousemove` — so without it, that standard way of
+ * scrolling never reaches the header at all. Detecting it means asking
+ * whether the pointer was in the scrollbar gutter.
+ *
+ * The gutter does not exist everywhere, which is why this is tested here and
+ * not in `verify-header-reveal.mjs`. Measured in headless Chromium:
+ * `document.documentElement.clientWidth` is 900 and `innerWidth` is 900 —
+ * overlay scrollbars, no gutter, and a press at `innerWidth - 5` lands on the
+ * page and scrolls nothing. macOS is the same by default. So the browser
+ * suite can never reach this, and the predicate is kept pure and pinned here
+ * instead of being left as the module's one unguarded branch.
+ *
+ * It cannot produce a false positive: a gutter only has width when a classic
+ * scrollbar is occupying it.
+ */
+
+const viewport = ({ clientWidth = 880, clientHeight = 680, innerWidth = 900, innerHeight = 700 }) => {
+  Object.defineProperty(document.documentElement, 'clientWidth', { value: clientWidth, configurable: true });
+  Object.defineProperty(document.documentElement, 'clientHeight', { value: clientHeight, configurable: true });
+  Object.defineProperty(window, 'innerWidth', { value: innerWidth, configurable: true, writable: true });
+  Object.defineProperty(window, 'innerHeight', { value: innerHeight, configurable: true, writable: true });
+};
+
+const press = (clientX: number, clientY: number, button = 0) =>
+  ({ clientX, clientY, button }) as MouseEvent;
+
+afterEach(() => { viewport({ clientWidth: 0, clientHeight: 0, innerWidth: 1024, innerHeight: 768 }); });
+
+describe('pressIsOnScrollbar', () => {
+  it('recognises a press in the vertical scrollbar gutter', () => {
+    viewport({});
+    expect(pressIsOnScrollbar(press(890, 300))).toBe(true);
+  });
+
+  it('recognises a press in the horizontal scrollbar gutter', () => {
+    viewport({});
+    expect(pressIsOnScrollbar(press(300, 690))).toBe(true);
+  });
+
+  it('does not recognise a press inside the content area', () => {
+    viewport({});
+    expect(pressIsOnScrollbar(press(300, 300))).toBe(false);
+  });
+
+  // The boundary itself belongs to the content: `clientWidth` is the first
+  // pixel the gutter starts AFTER.
+  it('treats the last content pixel as content', () => {
+    viewport({});
+    expect(pressIsOnScrollbar(press(879, 300))).toBe(false);
+  });
+
+  // Overlay scrollbars — macOS, and headless Chromium — leave no gutter at
+  // all, so nothing is ever in one and this correctly finds nothing.
+  it('finds no gutter when the scrollbars are overlaid', () => {
+    viewport({ clientWidth: 900, clientHeight: 700 });
+    expect(pressIsOnScrollbar(press(895, 300))).toBe(false);
+  });
+
+  // A right-click in the gutter opens the scrollbar's context menu; it does
+  // not page the view.
+  it('ignores a press that is not the primary button', () => {
+    viewport({});
+    expect(pressIsOnScrollbar(press(890, 300, 2))).toBe(false);
+  });
+
+  // A document with no measured content box reports `clientWidth: 0`, which
+  // read literally puts the entire page "past the content" — so every press
+  // anywhere would arm a gesture that scrolled nothing. jsdom does exactly
+  // this, and three unrelated tests failed the moment the predicate landed
+  // without the guard.
+  it('finds no gutter in a document that has not been laid out', () => {
+    viewport({ clientWidth: 0, clientHeight: 0 });
+    expect(pressIsOnScrollbar(press(300, 300))).toBe(false);
+    expect(pressIsOnScrollbar(press(890, 690))).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/lib/siteHeaderReveal.test.ts
+++ b/frontend/src/__tests__/lib/siteHeaderReveal.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  REVEAL_THRESHOLD,
+  initialHeaderReveal,
+  nextHeaderReveal,
+  resyncHeaderReveal,
+  type HeaderRevealState,
+} from '@/lib/siteHeaderReveal';
+
+/**
+ * The show/hide decision for the site header (#272), as a pure function of
+ * scroll position — direction, threshold, and the top of the document.
+ *
+ * It is pure because the browser cannot be asked these questions cheaply and
+ * jsdom cannot be asked them at all: there is no layout, no compositor and no
+ * scroll anchoring. What is testable here is the *rule*, and the rule is
+ * where the flicker bugs live. The geometry that the rule drives is covered
+ * by `e2e/verify-header-reveal.mjs`.
+ */
+
+/** Feed a run of scroll positions through the reducer. */
+const scrollThrough = (
+  from: HeaderRevealState,
+  positions: number[],
+  opts?: { threshold?: number; topZone?: number },
+) => positions.reduce((state, y) => nextHeaderReveal(state, y, opts), from);
+
+describe('nextHeaderReveal', () => {
+  // Deep in the document, header already hidden. The state most of these
+  // cases start from, since the top of the page is a special case of its own.
+  const deepAndHidden: HeaderRevealState = { revealed: false, travel: 0, y: 30_000 };
+
+  it('starts revealed at the top of the document', () => {
+    expect(initialHeaderReveal(0).revealed).toBe(true);
+  });
+
+  it('hides once the reader has scrolled down past the threshold', () => {
+    const state = nextHeaderReveal(initialHeaderReveal(0), REVEAL_THRESHOLD + 1, { topZone: 0 });
+    expect(state.revealed).toBe(false);
+  });
+
+  it('stays revealed while downward travel is still short of the threshold', () => {
+    const state = nextHeaderReveal(initialHeaderReveal(0), REVEAL_THRESHOLD - 1, { topZone: 0 });
+    expect(state.revealed).toBe(true);
+  });
+
+  it('reveals once the reader has scrolled up past the threshold', () => {
+    const state = nextHeaderReveal(deepAndHidden, 30_000 - REVEAL_THRESHOLD - 1);
+    expect(state.revealed).toBe(true);
+  });
+
+  it('stays hidden while upward travel is still short of the threshold', () => {
+    const state = nextHeaderReveal(deepAndHidden, 30_000 - (REVEAL_THRESHOLD - 1));
+    expect(state.revealed).toBe(false);
+  });
+
+  // The threshold is against *accumulated* travel, not a single event. A
+  // trackpad delivers a 30px flick as many small deltas; a per-event
+  // comparison would never fire for any of them.
+  it('accumulates travel across several small ticks in the same direction', () => {
+    const ticks = [30_000 - 8, 30_000 - 16, 30_000 - 24, 30_000 - 32];
+    expect(scrollThrough(deepAndHidden, ticks).revealed).toBe(true);
+  });
+
+  // This is the hysteresis. Without the reset, 400px of downward travel
+  // leaves a +400 accumulator that a 24px flick up cannot overcome — the
+  // header would need 424px of scrolling up to come back. With it, every
+  // reversal is judged on its own.
+  it('restarts the accumulator when the direction reverses', () => {
+    const afterLongDescent = scrollThrough(initialHeaderReveal(0), [400], { topZone: 0 });
+    expect(afterLongDescent.revealed).toBe(false);
+
+    const afterSmallFlickUp = nextHeaderReveal(afterLongDescent, 400 - REVEAL_THRESHOLD - 1, { topZone: 0 });
+    expect(afterSmallFlickUp.revealed).toBe(true);
+  });
+
+  // The mirror of the above, and the reason the reset is symmetric: a long
+  // climb must not make the header impossible to dismiss again.
+  it('restarts the accumulator when the direction reverses back to down', () => {
+    const afterLongClimb = scrollThrough(deepAndHidden, [30_000 - 400]);
+    expect(afterLongClimb.revealed).toBe(true);
+
+    const afterSmallFlickDown = nextHeaderReveal(afterLongClimb, 30_000 - 400 + REVEAL_THRESHOLD + 1);
+    expect(afterSmallFlickDown.revealed).toBe(false);
+  });
+
+  // iOS Safari fires `scroll` for momentum, for rubber-banding, and
+  // sometimes for nothing at all. A zero delta must not disturb the
+  // accumulator, or a run of them would erase a genuine gesture.
+  it('leaves the decision and the accumulator untouched when nothing moved', () => {
+    const midGesture = nextHeaderReveal(deepAndHidden, 30_000 - 10);
+    const repeated = nextHeaderReveal(midGesture, 30_000 - 10);
+    expect(repeated).toEqual(midGesture);
+  });
+
+  // A sticky header cannot be parked above a position it has not yet
+  // reached, so inside the top zone "hidden" is a state the DOM will
+  // contradict — and a header the reader can see would be marked `inert`.
+  // Reachable without any large scroll: the reader zooms text, the header
+  // grows, and a position that was below the zone is now inside it.
+  it('reveals inside the top zone even when the move there was a scroll down', () => {
+    const state = nextHeaderReveal({ revealed: false, travel: 0, y: 100 }, 105, { topZone: 120 });
+    expect(state.revealed).toBe(true);
+  });
+
+  // Scrolling *down* while still inside the top zone must not hide the
+  // header early — its natural position is still on screen, so hiding it
+  // would mean parking a header the reader can see.
+  it('stays revealed scrolling down within the top zone', () => {
+    const state = scrollThrough(initialHeaderReveal(0), [30, 60], { topZone: 72 });
+    expect(state.revealed).toBe(true);
+  });
+
+  // Rubber-band overscroll at the top of the document reports a negative
+  // `scrollY` in WebKit. That is the top of the page, not a scroll up into
+  // it.
+  it('treats overscroll above the document top as the top zone', () => {
+    const state = nextHeaderReveal({ revealed: false, travel: 500, y: 10 }, -40, { topZone: 0 });
+    expect(state.revealed).toBe(true);
+  });
+
+  // Leaving the top zone with the accumulator already loaded would hide the
+  // header on the first pixel below it.
+  it('leaves the top zone with a cleared accumulator', () => {
+    const inZone = nextHeaderReveal(initialHeaderReveal(0), 10, { topZone: 72 });
+    expect(inZone.travel).toBe(0);
+  });
+});
+
+describe('resyncHeaderReveal', () => {
+  // A rail chip tap jumps the document by tens of thousands of pixels. Read
+  // as a scroll it is the largest upward gesture the reader could possibly
+  // make, and the header would fly in every time.
+  it('moves the baseline to the jumped-to position without revealing', () => {
+    const hidden: HeaderRevealState = { revealed: false, travel: 0, y: 30_000 };
+    const state = resyncHeaderReveal(hidden, 1_200);
+    expect(state.revealed).toBe(false);
+    expect(state.y).toBe(1_200);
+  });
+
+  it('keeps a revealed header revealed across a programmatic jump', () => {
+    const revealed: HeaderRevealState = { revealed: true, travel: -100, y: 1_200 };
+    expect(resyncHeaderReveal(revealed, 30_000).revealed).toBe(true);
+  });
+
+  // Carrying the accumulator across the jump would let travel banked before
+  // it fire against a position measured after it.
+  it('clears the accumulator so pre-jump travel cannot fire later', () => {
+    const midGesture: HeaderRevealState = { revealed: false, travel: 20, y: 5_000 };
+    expect(resyncHeaderReveal(midGesture, 9_000).travel).toBe(0);
+  });
+
+  // The scroll event that the programmatic jump itself provokes arrives a
+  // frame later. Measured from the resynced baseline it is a zero delta, so
+  // it changes nothing — which is the whole mechanism.
+  it('makes the scroll event the jump provokes a no-op', () => {
+    const hidden: HeaderRevealState = { revealed: false, travel: 0, y: 30_000 };
+    const afterJump = resyncHeaderReveal(hidden, 1_200);
+    expect(nextHeaderReveal(afterJump, 1_200).revealed).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/lib/utils/daySections.test.ts
+++ b/frontend/src/__tests__/lib/utils/daySections.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, afterEach } from 'vitest';
-import { DAY_SECTION_ATTR, daySectionElement, daySectionTop, dayRailHeightPx, topmostVisibleDaySection } from '@/lib/utils/daySections';
+import { DAY_SECTION_ATTR, daySectionElement, daySectionTop, topChromeHeightPx, topmostVisibleDaySection } from '@/lib/utils/daySections';
 
 function mount(keys: string[]) {
   document.body.innerHTML = keys
@@ -44,16 +44,37 @@ describe('daySectionTop', () => {
   });
 });
 
-describe('dayRailHeightPx', () => {
-  afterEach(() => { document.documentElement.style.removeProperty('--day-rail-h'); });
+describe('topChromeHeightPx', () => {
+  afterEach(() => {
+    document.documentElement.style.removeProperty('--day-rail-h');
+    document.documentElement.style.removeProperty('--site-header-offset');
+  });
 
   it('reads the published rail height', () => {
     document.documentElement.style.setProperty('--day-rail-h', '56px');
-    expect(dayRailHeightPx()).toBe(56);
+    expect(topChromeHeightPx()).toBe(56);
   });
 
   it('is 0 when nothing has published a height yet', () => {
-    expect(dayRailHeightPx()).toBe(0);
+    expect(topChromeHeightPx()).toBe(0);
+  });
+
+  // The chrome at the top of the viewport is the rail PLUS the site header
+  // whenever that header is revealed (#272). Everything that asks "is this
+  // section hidden behind the chrome" — the rail's scrollspy, the filter
+  // panel's scroll reference, a chip tap's landing position — is off by a
+  // whole header otherwise, and only while the header is showing, which is
+  // exactly when the reader is looking at it.
+  it('includes the site header while it is revealed', () => {
+    document.documentElement.style.setProperty('--day-rail-h', '56px');
+    document.documentElement.style.setProperty('--site-header-offset', '48px');
+    expect(topChromeHeightPx()).toBe(104);
+  });
+
+  it('is just the rail while the site header is hidden', () => {
+    document.documentElement.style.setProperty('--day-rail-h', '56px');
+    document.documentElement.style.setProperty('--site-header-offset', '0px');
+    expect(topChromeHeightPx()).toBe(56);
   });
 });
 

--- a/frontend/src/__tests__/lib/utils/daySections.test.ts
+++ b/frontend/src/__tests__/lib/utils/daySections.test.ts
@@ -48,6 +48,7 @@ describe('topChromeHeightPx', () => {
   afterEach(() => {
     document.documentElement.style.removeProperty('--day-rail-h');
     document.documentElement.style.removeProperty('--site-header-offset');
+    document.documentElement.style.removeProperty('--site-header-offset-target');
   });
 
   it('reads the published rail height', () => {
@@ -67,14 +68,33 @@ describe('topChromeHeightPx', () => {
   // exactly when the reader is looking at it.
   it('includes the site header while it is revealed', () => {
     document.documentElement.style.setProperty('--day-rail-h', '56px');
-    document.documentElement.style.setProperty('--site-header-offset', '48px');
+    document.documentElement.style.setProperty('--site-header-offset-target', '48px');
     expect(topChromeHeightPx()).toBe(104);
   });
 
   it('is just the rail while the site header is hidden', () => {
     document.documentElement.style.setProperty('--day-rail-h', '56px');
-    document.documentElement.style.setProperty('--site-header-offset', '0px');
+    document.documentElement.style.setProperty('--site-header-offset-target', '0px');
     expect(topChromeHeightPx()).toBe(56);
+  });
+
+  // Reads the SETTLED offset, never the animated one.
+  //
+  // `--site-header-offset` transitions over 200ms, and every consumer of this
+  // samples it on a scroll or a resize. The scroll that triggers a reveal
+  // samples near the START of that transition and nothing fires when it
+  // finishes, so the anchor and the rail highlight would keep a boundary
+  // computed with the old chrome height until the reader scrolls again — long
+  // enough to leave the wrong chip lit next to a day boundary.
+  //
+  // A logical question ("is this section behind the chrome") wants where the
+  // chrome is going, not where it is mid-flight.
+  it('ignores the animated offset, which is mid-flight for 200ms', () => {
+    document.documentElement.style.setProperty('--day-rail-h', '56px');
+    document.documentElement.style.setProperty('--site-header-offset-target', '48px');
+    // The animation is a third of the way through. The answer must not be.
+    document.documentElement.style.setProperty('--site-header-offset', '16px');
+    expect(topChromeHeightPx()).toBe(104);
   });
 });
 

--- a/frontend/src/app/filterHeaderLayout.ts
+++ b/frontend/src/app/filterHeaderLayout.ts
@@ -32,9 +32,80 @@
  * of it all along.
  */
 
+/**
+ * How far down the viewport the site header has pushed everything, in px.
+ *
+ * `0px` while the header is hidden, its measured height while it is revealed
+ * on scroll up (#272), and animated between the two — see
+ * `useSiteHeaderReveal` and the `@property` registration in `globals.css`.
+ * Both values below are offset by it, which is what makes the rail ride down
+ * to sit *below* the revealed header rather than be covered by it.
+ *
+ * It appears here as a variable rather than as a parameter deliberately. The
+ * reveal fires on an ordinary scroll gesture; routing it through React state
+ * would re-render the whole calendar page on every flick. As a CSS variable
+ * the reveal touches only `Header`, and the rail follows it without the page
+ * re-rendering at all.
+ *
+ * Note that nothing here transitions `top`. The animation lives entirely in
+ * the variable, so the header and the rail hold the same offset every frame;
+ * a `transition: top` would additionally animate the values below flipping
+ * between parked and pinned, which is the filter panel's own reveal and is
+ * choreographed separately.
+ *
+ * Fallback `0px` so a first paint, or a browser that drops the registration,
+ * parks exactly as it did before this existed.
+ */
+const SITE_HEADER_OFFSET = 'var(--site-header-offset, 0px)';
+
+/**
+ * The site header's own `top`.
+ *
+ * Parked and revealed are the same expression evaluated at the two ends of
+ * `--site-header-offset`: at `0px` it is `-headerH`, which pins the header
+ * just above the viewport; at the header's own height it is `0`, flush
+ * against the top edge. One expression rather than two states means the ends
+ * cannot drift apart, and it means the reveal animates a single value —
+ * shared with `filterHeaderTop`, so the header and the rail below it hold the
+ * same offset on every frame.
+ *
+ * Sticky rather than fixed, and that is the load-bearing choice. `fixed`
+ * would need a spacer to replace the height it takes out of flow, and a
+ * spacer sized from a JS measurement is exactly the "document height above
+ * the reader changes" hazard described at the top of this file. A sticky
+ * header never leaves flow at all, so document height is constant by
+ * construction, there is nothing for scroll anchoring to correct, and there
+ * is no first-paint window where the measurement has not landed yet.
+ *
+ * Both fallbacks are `0px`, which evaluates to `top: 0` — a shown header.
+ * That is the safe default: a header parked out of reach before anything has
+ * been measured would have no way to come back.
+ */
+export function siteHeaderTop(): string {
+  return `calc(${SITE_HEADER_OFFSET} - var(--site-header-h, 0px))`;
+}
+
+/**
+ * Where a day section's own sticky title comes to rest.
+ *
+ * Third in the sticky stack — below the site header (`z-40`) and the
+ * filter/rail container (`z-30`) at `z-10` — so it is the one that has to give
+ * way, and it can only do that if it knows how tall everything above it is.
+ * That grew by the site header's height when #272 made the header reachable
+ * from anywhere: while it is revealed the rail sits a header lower, and a day
+ * title still pinned at the bare rail height slides underneath a rail that
+ * outranks it and disappears.
+ *
+ * Measured by `verify-rail`'s check 12 at 320px and at 200% text zoom: rail
+ * bottom 112, day header top 64.
+ */
+export function dayHeaderTop(): string {
+  return `calc(${SITE_HEADER_OFFSET} + var(--day-rail-h, 0px))`;
+}
+
 /** Fallback `0px` so a missing measurement degrades to an ordinary
  *  `top: 0` sticky header rather than a broken `calc()`. */
-const PARKED_TOP = 'calc(-1 * var(--filter-card-h, 0px))';
+const PARKED_TOP = `calc(${SITE_HEADER_OFFSET} - var(--filter-card-h, 0px))`;
 
 /**
  * The sticky header's `top`.
@@ -50,7 +121,7 @@ const PARKED_TOP = 'calc(-1 * var(--filter-card-h, 0px))';
  * restored after.
  */
 export function filterHeaderTop({ overlaying }: { overlaying: boolean }): string {
-  return overlaying ? '0px' : PARKED_TOP;
+  return overlaying ? SITE_HEADER_OFFSET : PARKED_TOP;
 }
 
 /**

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -211,3 +211,51 @@
     opacity: 0;
   }
 }
+
+/*
+ * The site header's reveal on scroll up (#272).
+ *
+ * One animated value drives two surfaces. `--site-header-offset` is `0px`
+ * while the header is hidden and its measured height while it is revealed;
+ * the header's own `top` is `offset - height` (so `-height` parked, `0`
+ * flush), and the sticky filter/rail container adds the same term, which
+ * rides the rail down to sit below the revealed header rather than under it.
+ *
+ * Registering the property is what makes that possible. An unregistered
+ * custom property is an untyped token stream and cannot be interpolated, so
+ * the header would jump rather than slide. Registered as a `<length>` it
+ * animates, and because both surfaces read the same value they hold the same
+ * offset on every frame with nothing to keep in sync.
+ *
+ * Note what is NOT transitioned: `top`. Animating that would also animate the
+ * filter header flipping between parked and pinned — which is the filter
+ * panel's own reveal, choreographed separately in `useFilterPanel`.
+ */
+@property --site-header-offset {
+  syntax: '<length>';
+  inherits: true;
+  initial-value: 0px;
+}
+
+:root {
+  /*
+   * Shown is the default, and it has to be declared here rather than left to
+   * `initial-value`. The reveal hook writes this property in an effect; before
+   * that effect runs there is no value, and `initial-value: 0px` is the HIDDEN
+   * end of the travel — so the site would paint with its header already parked
+   * out of sight. The same default covers a browser that drops the
+   * registration entirely.
+   */
+  --site-header-offset: var(--site-header-h, 0px);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  /*
+   * Declared here rather than declared and then unset, matching the filter
+   * panel's exit above: a reader who asked for reduced motion never has a
+   * transition to override.
+   */
+  :root {
+    transition: --site-header-offset 200ms ease;
+  }
+}

--- a/frontend/src/components/calendar/EventList.tsx
+++ b/frontend/src/components/calendar/EventList.tsx
@@ -4,6 +4,7 @@ import { extendRenderEndIndex, renderEndIndex } from '@/lib/utils/renderWindow';
 import { formatDayLabel } from '@/lib/utils/dayWindow';
 import { daySectionTop } from '@/lib/utils/daySections';
 import { EventListView, type EventListViewProps } from './EventListView';
+import { scrollWindowBy } from '@/lib/programmaticScroll';
 
 export interface EventListProps extends Omit<EventListViewProps, 'groups'> {
   groupedEvents: DayGroup[];
@@ -312,7 +313,7 @@ export function EventList({
     // prepend. Correcting against a node that is gone is guesswork.
     if (top === null) { settleRef.current = null; return; }
     const delta = top - pending.top;
-    if (delta !== 0) window.scrollBy(0, delta);
+    scrollWindowBy(delta);
     // Hold this position against late height changes until the reader
     // scrolls. `pending.top` — not `top` — because that is where the
     // reference day was before the prepend, and putting it back there is
@@ -342,7 +343,7 @@ export function EventList({
       const top = daySectionTop(current.key);
       if (top === null) { settleRef.current = null; return; }
       const delta = top - current.top;
-      if (delta !== 0) window.scrollBy(0, delta);
+      scrollWindowBy(delta);
     };
 
     // Any deliberate scroll gesture ends the settle window. Deliberately NOT

--- a/frontend/src/components/calendar/EventList.tsx
+++ b/frontend/src/components/calendar/EventList.tsx
@@ -195,7 +195,7 @@ export function EventList({
     // explicitly asked to be somewhere else. That always outranks a pending
     // upward-prepend hold (`settleRef`, armed by `handleShowEarlier` below):
     // both settle mechanisms compute an absolute scroll correction from their
-    // own independent reference point and apply it via `window.scrollBy`, so
+    // own independent reference point and apply it via `scrollWindowBy`, so
     // if both stayed armed, the next resize would fire both observers in the
     // same batch and whichever ran second would silently overwrite the
     // other's correction, landing the reader on neither day. Cleared here,

--- a/frontend/src/components/calendar/EventListView.tsx
+++ b/frontend/src/components/calendar/EventListView.tsx
@@ -6,6 +6,7 @@ import { downloadICS } from '@/lib/utils/icsHelpers';
 import { DAY_SECTION_ATTR, DAY_HEADER_ATTR } from '@/lib/utils/daySections';
 import { EventCard } from './EventCard';
 import { WeekBadge } from './WeekBadge';
+import { dayHeaderTop } from '@/app/filterHeaderLayout';
 
 export interface EventListViewProps {
   groups: DayGroup[];
@@ -51,7 +52,7 @@ export function EventListView({
           // sticky rail. Expressed as the measured custom property rather
           // than a pixel literal so it stays right at any browser text zoom,
           // targeting the same `--day-rail-h` that `stickyOffset()` reads.
-          style={{ scrollMarginTop: 'var(--day-rail-h)' }}
+          style={{ scrollMarginTop: dayHeaderTop() }}
         >
           <div
             {...{ [DAY_HEADER_ATTR]: '' }}
@@ -60,7 +61,7 @@ export function EventListView({
             // sticky layers both pinned at 0 overlap, and the header is the
             // one that has to give way. `z-10` keeps it below the rail's
             // `z-20`.
-            style={{ top: 'var(--day-rail-h)' }}
+            style={{ top: dayHeaderTop() }}
           >
             <h3 className="text-lg sm:text-xl font-bold text-gray-900 dark:text-white">
               {dayGroup.baseLabel}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -73,7 +73,15 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
       // landed on the `z-30` rail. Measured by screenshotting the top 24px
       // with the header parked, with and without it: the images differ. A
       // hidden header was painting a grey band across the rail it yields to.
-      className={`sticky z-40 bg-white dark:bg-gray-800 ${revealed ? 'shadow-lg' : ''}`}
+      // `overflow-hidden` while parked, for the same reason the shadow goes:
+      // an open dropdown is positioned OUTSIDE the header's border box, so
+      // parking the box left the menu behind. Measured in Chromium after
+      // opening the "more" menu and scrolling down — header at `bottom: 0` and
+      // `inert`, its menu still occupying -4 → 258, a panel over most of the
+      // screen at `z-40` that nothing could click. The menu stays OPEN: it
+      // belongs to the header, and scrolling back up should find it where the
+      // reader left it.
+      className={`sticky z-40 bg-white dark:bg-gray-800 ${revealed ? 'shadow-lg' : 'overflow-hidden'}`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-2 sm:py-4">

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -4,6 +4,8 @@ import { HeaderMenu, newTabLabel, type HeaderMenuItem } from '@/components/layou
 import { quickLinks, inAppLinks, externalLinks, type QuickLink } from '@/lib/quickLinks';
 import { APP_STORE_URL } from '@/lib/constants';
 import { isAppPromoAvailable, readDeviceInfo } from '@/lib/iosPromo';
+import { useSiteHeaderReveal } from '@/hooks/useSiteHeaderReveal';
+import { siteHeaderTop } from '@/app/filterHeaderLayout';
 
 interface HeaderProps {
   selectedYear: number;
@@ -40,8 +42,33 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
 
   const promo = appAvailable ? [APP_PROMO_ITEM] : [];
 
+  // Reveal on scroll up, hide on scroll down (#272). The header is the only
+  // route to the "more" menu and the year selector, and below the fold it
+  // used to be unreachable without scrolling the whole document back to the
+  // top — from a rail tap, tens of thousands of pixels.
+  const { revealed, headerRef } = useSiteHeaderReveal();
+
   return (
-    <header className="bg-white dark:bg-gray-800 shadow-lg">
+    /*
+      Sticky with a negative `top`, never fixed: the header stays in flow, so
+      document height never changes and the scroll-anchoring loop documented
+      in `filterHeaderLayout.ts` has nothing to correct. `z-40` puts it above
+      the filter/rail container's `z-30`, which rides down by this header's
+      measured height while it is revealed.
+
+      `inert` while parked is not cosmetic. The header is still in the DOM and
+      still in flow, so a keyboard reader would tab into it and the browser
+      would chase a focused control it cannot scroll into view — the same trap
+      `filterCardParked` exists for.
+    */
+    <header
+      ref={headerRef}
+      data-site-header
+      inert={!revealed || undefined}
+      aria-hidden={!revealed || undefined}
+      style={{ top: siteHeaderTop() }}
+      className="sticky z-40 bg-white dark:bg-gray-800 shadow-lg"
+    >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-2 sm:py-4">
           {/* The cluster stays shrinkable and the title truncates, so a narrow

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -67,7 +67,13 @@ export function Header({ selectedYear, availableYears, defaultYear, onYearChange
       inert={!revealed || undefined}
       aria-hidden={!revealed || undefined}
       style={{ top: siteHeaderTop() }}
-      className="sticky z-40 bg-white dark:bg-gray-800 shadow-lg"
+      // The shadow goes with the header. A shadow paints OUTSIDE the border
+      // box, so parked — box entirely above the viewport — `shadow-lg`
+      // (`0 10px 15px -3px`) still reached ~15px below it, and at `z-40` that
+      // landed on the `z-30` rail. Measured by screenshotting the top 24px
+      // with the header parked, with and without it: the images differ. A
+      // hidden header was painting a grey band across the rail it yields to.
+      className={`sticky z-40 bg-white dark:bg-gray-800 ${revealed ? 'shadow-lg' : ''}`}
     >
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center py-2 sm:py-4">

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -257,6 +257,21 @@ describe('Header — reveal on scroll up', () => {
     expect(siteHeader().getAttribute('aria-hidden')).toBe('true');
   });
 
+  // A shadow paints OUTSIDE the border box. Parked, the header's box sits
+  // entirely above the viewport — but `shadow-lg` is
+  // `rgba(0,0,0,0.1) 0 10px 15px -3px`, which reaches roughly 15px BELOW it,
+  // and at `z-40` that lands on top of the `z-30` rail. Measured by
+  // screenshotting the top 24px of the viewport with the header parked, with
+  // and without the shadow: the two images differ. So a "hidden" header was
+  // still painting a grey band across the rail it is supposed to yield to.
+  it('drops its shadow once parked, so nothing of it paints over the rail', () => {
+    renderHeader();
+    expect(siteHeader().className).toContain('shadow-lg');
+
+    scrollTo(1_000);
+    expect(siteHeader().className).not.toContain('shadow-lg');
+  });
+
   it('is reachable again the moment it is revealed', () => {
     renderHeader();
     scrollTo(1_000);

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -272,6 +272,19 @@ describe('Header — reveal on scroll up', () => {
     expect(siteHeader().className).not.toContain('shadow-lg');
   });
 
+  // An open dropdown is positioned OUTSIDE the header's border box. Parked,
+  // the header's box is above the viewport but the menu is not: measured in
+  // Chromium after opening the "more" menu and scrolling down, the header sat
+  // at `bottom: 0` and `inert`, while its menu still occupied -4 → 258 — a
+  // 258px panel over most of the screen, at `z-40`, that nothing could click.
+  it('clips what paints outside it once parked', () => {
+    renderHeader();
+    expect(siteHeader().className).not.toContain('overflow-hidden');
+
+    scrollTo(1_000);
+    expect(siteHeader().className).toContain('overflow-hidden');
+  });
+
   it('is reachable again the moment it is revealed', () => {
     renderHeader();
     scrollTo(1_000);

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/preact';
+import { render, screen, fireEvent, within, act } from '@testing-library/preact';
 import { Header } from '../Header';
+import { installResizeObserverMock } from '@/__tests__/helpers/resizeObserver';
 import { quickLinks, inAppLinks, externalLinks } from '@/lib/quickLinks';
 import { APP_STORE_URL } from '@/lib/constants';
 
@@ -161,5 +162,118 @@ describe('Header season pill', () => {
 
     expect(screen.getByRole('heading', { level: 1 }).className).toContain('truncate');
     expect(screen.getByTestId('header-identity').className).not.toContain('shrink-0');
+  });
+});
+
+/**
+ * The site header's reveal on scroll up (#272).
+ *
+ * The header is the only route to the "more" menu and the year selector, and
+ * below the fold it used to be unreachable without scrolling the whole
+ * document back to the top. What these pin is the composition that fixes it —
+ * and, just as importantly, the composition that keeps the fix from
+ * reintroducing the scroll-anchoring loop `filterHeaderLayout.ts` documents at
+ * length.
+ */
+
+const siteHeader = () => document.querySelector('header') as HTMLElement;
+
+/**
+ * A scroll the READER made: the gesture that drives it, then the scroll it
+ * produces.
+ *
+ * The wheel is not decoration. A bare `scroll` event is ignored on purpose —
+ * see `useSiteHeaderReveal`, where a scroll with no gesture behind it is how
+ * the browser's own anchoring corrections announce themselves, and hiding the
+ * header on one of those was a measured bug.
+ */
+const scrollTo = (y: number) => act(() => {
+  window.dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
+  Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
+  window.dispatchEvent(new Event('scroll'));
+});
+
+const renderHeader = () => {
+  installResizeObserverMock();
+  return render(<Header {...defaultProps} availableYears={[2025, 2026]} />);
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.documentElement.style.removeProperty('--site-header-offset');
+  document.documentElement.style.removeProperty('--site-header-h');
+  Object.defineProperty(window, 'scrollY', { value: 0, configurable: true, writable: true });
+});
+
+describe('Header — reveal on scroll up', () => {
+  // The header rides up by exactly its own height and pins there, which
+  // parks it just above the viewport. When the offset is restored the same
+  // `top` puts it flush at 0 — one expression, both states.
+  it('parks itself above the viewport by its own height', () => {
+    renderHeader();
+    expect(siteHeader().style.top)
+      .toBe('calc(var(--site-header-offset, 0px) - var(--site-header-h, 0px))');
+  });
+
+  // This is the constraint that the whole approach turns on. Collapsing a
+  // header by taking it OUT of flow changes document height above the reader;
+  // scroll anchoring corrects for it, and the page becomes impossible to
+  // scroll slowly — 40 wheel ticks advanced the page 0px in both Chromium and
+  // WebKit. A sticky header never leaves flow, so document height is constant
+  // by construction and there is nothing for scroll anchoring to undo.
+  it('is sticky, so it never leaves the document flow', () => {
+    renderHeader();
+    expect(siteHeader().className).toContain('sticky');
+    expect(siteHeader().className).not.toContain('fixed');
+    expect(siteHeader().className).not.toContain('absolute');
+  });
+
+  // Above the filter/rail container's own `z-30`, or the revealed header
+  // paints behind the rail it is supposed to be sitting on top of.
+  it('stacks above the sticky filter header', () => {
+    renderHeader();
+    expect(siteHeader().className).toContain('z-40');
+  });
+
+  it('publishes its measured height for the rail to ride down by', () => {
+    renderHeader();
+    expect(document.documentElement.style.getPropertyValue('--site-header-h')).not.toBe('');
+  });
+
+  // A parked header is still in the DOM and still in flow, so it is
+  // Tab-reachable. Without `inert` the browser would try to scroll a focused
+  // control back into view — which it cannot do for a pinned sticky element,
+  // so it chases the position instead. The identical trap is documented for
+  // the filter card in `filterHeaderLayout.ts`.
+  it('is inert and hidden from screen readers once parked', () => {
+    renderHeader();
+    expect(siteHeader().hasAttribute('inert')).toBe(false);
+
+    scrollTo(1_000);
+    expect(siteHeader().hasAttribute('inert')).toBe(true);
+    expect(siteHeader().getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('is reachable again the moment it is revealed', () => {
+    renderHeader();
+    scrollTo(1_000);
+    scrollTo(900);
+    expect(siteHeader().hasAttribute('inert')).toBe(false);
+    expect(siteHeader().hasAttribute('aria-hidden')).toBe(false);
+  });
+
+  // "The revealed header must carry the app title, the year selector, and the
+  // 'more' menu — i.e. the whole existing header, not a reduced version."
+  // Nothing in this change may quietly trade the reveal for a slimmer bar.
+  it('carries the whole header, not a reduced version, when revealed', () => {
+    renderHeader();
+    scrollTo(1_000);
+    scrollTo(900);
+
+    expect(screen.getByText('CHQ Calendar')).toBeTruthy();
+    // The season pill and the "more" menu are the two features the issue
+    // names as unreachable; a reveal that dropped either would be no fix.
+    expect(screen.getByRole('button', { name: /2026/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'More' })).toBeTruthy();
   });
 });

--- a/frontend/src/components/layout/__tests__/Header.test.tsx
+++ b/frontend/src/components/layout/__tests__/Header.test.tsx
@@ -188,7 +188,10 @@ const siteHeader = () => document.querySelector('header') as HTMLElement;
  * header on one of those was a measured bug.
  */
 const scrollTo = (y: number) => act(() => {
-  window.dispatchEvent(new WheelEvent('wheel', { bubbles: true }));
+  // The wheel carries a `deltaY`, as a real one always does. Without it this
+  // is a horizontal wheel — the day rail scrolls sideways — which the hook is
+  // right to ignore.
+  window.dispatchEvent(new WheelEvent('wheel', { bubbles: true, deltaY: y - window.scrollY }));
   Object.defineProperty(window, 'scrollY', { value: y, configurable: true, writable: true });
   window.dispatchEvent(new Event('scroll'));
 });

--- a/frontend/src/hooks/useDayAnchor.ts
+++ b/frontend/src/hooks/useDayAnchor.ts
@@ -211,8 +211,11 @@ export function useDayAnchor(windowDayKeys: string[]): {
     // event order is mousedown → mouseup → click, every rail control arms via
     // `onClick`, and the arming itself happens later still, in the
     // pending-scroll effect one commit after that click. And unlike `scroll`,
-    // a programmatic `window.scrollBy` synthesises no pointer event, so our
-    // own correction cannot trip this.
+    // a programmatic scroll synthesises no pointer event, so our own
+    // correction cannot trip this. (It also announces itself via
+    // `scrollWindowBy`, which is what the site header's reveal listens to —
+    // this hook does not need that, because the gesture set below already
+    // tells it apart for free.)
     const stop = () => { settleRef.current = null; };
 
     // `ResizeObserver` is absent in some older browsers and in jsdom without

--- a/frontend/src/hooks/useDayAnchor.ts
+++ b/frontend/src/hooks/useDayAnchor.ts
@@ -1,18 +1,19 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { daySectionElement, daySectionTop, dayRailHeightPx } from '@/lib/utils/daySections';
+import { daySectionElement, daySectionTop, topChromeHeightPx } from '@/lib/utils/daySections';
 import { resolveAnchor } from '@/lib/utils/railPosition';
+import { scrollWindowBy } from '@/lib/programmaticScroll';
 
 /**
  * How far below the viewport top a day header counts as "the one I'm reading".
  *
- * Delegates to `dayRailHeightPx` in `daySections.ts` — the filter panel's
+ * Delegates to `topChromeHeightPx` in `daySections.ts` — the filter panel's
  * scroll correction needs the identical "behind the chrome" threshold, so
  * the measurement lives in one place rather than two copies drifting apart.
  * Kept as a local alias (not a call-site rename throughout this file) to
  * keep this file's own diff minimal.
  */
 function stickyOffset(): number {
-  return dayRailHeightPx();
+  return topChromeHeightPx();
 }
 
 /**
@@ -119,7 +120,7 @@ export function useDayAnchor(windowDayKeys: string[]): {
     // reasserting a `scrollBy` correction *while a native smooth animation
     // is still running* would fight that animation rather than replace it.
     const delta = el.getBoundingClientRect().top - stickyOffset();
-    if (delta !== 0) window.scrollBy(0, delta);
+    scrollWindowBy(delta);
     settleRef.current = { key, top: stickyOffset() };
   }, []);
 
@@ -181,7 +182,7 @@ export function useDayAnchor(windowDayKeys: string[]): {
       // nothing left to hold.
       if (!el) { settleRef.current = null; return; }
       const delta = el.getBoundingClientRect().top - settle.top;
-      if (delta !== 0) window.scrollBy(0, delta);
+      scrollWindowBy(delta);
     };
     // Any deliberate scroll gesture ends the hold. Deliberately NOT the
     // `scroll` event: our own `scrollBy` above fires that, so listening to

--- a/frontend/src/hooks/useDismissOnScrollGesture.ts
+++ b/frontend/src/hooks/useDismissOnScrollGesture.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 // Deliberately narrow — a bare letter or a Tab must not dismiss anything,
 // since typing into the panel's own search field would otherwise close it.
-import { SCROLL_KEYS } from '@/lib/scrollKeys';
+import { SCROLL_KEYS } from '@/lib/scrollGestures';
 
 /**
  * Calls `onDismiss` the first time the reader makes a gesture that scrolls

--- a/frontend/src/hooks/useDismissOnScrollGesture.ts
+++ b/frontend/src/hooks/useDismissOnScrollGesture.ts
@@ -11,7 +11,7 @@ import { SCROLL_KEYS } from '@/lib/scrollKeys';
  * whole point of the hook.** Two things fire `scroll` that are emphatically
  * not the reader scrolling:
  *
- * - The filter panel's own opening correction calls `window.scrollBy` to hold
+ * - The filter panel's own opening correction calls `scrollWindowBy` to hold
  *   the reader's position while the panel is inserted above them. A `scroll`
  *   listener would dismiss the panel in the same frame it opened.
  * - Changing a filter reflows the list, which can move `scrollY` on its own. A

--- a/frontend/src/hooks/useDismissOnScrollGesture.ts
+++ b/frontend/src/hooks/useDismissOnScrollGesture.ts
@@ -1,13 +1,7 @@
 import { useEffect } from 'react';
-
-/**
- * Keys the reader deliberately scroll with. Deliberately narrow: a bare
- * letter or a Tab must not dismiss anything, since typing into the panel's
- * own search field would otherwise close it.
- */
-const SCROLL_KEYS = new Set([
-  'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar',
-]);
+// Deliberately narrow — a bare letter or a Tab must not dismiss anything,
+// since typing into the panel's own search field would otherwise close it.
+import { SCROLL_KEYS } from '@/lib/scrollKeys';
 
 /**
  * Calls `onDismiss` the first time the reader makes a gesture that scrolls

--- a/frontend/src/hooks/useFilterPanel.ts
+++ b/frontend/src/hooks/useFilterPanel.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { topmostVisibleDaySection } from '@/lib/utils/daySections';
 import { useDismissOnScrollGesture } from '@/hooks/useDismissOnScrollGesture';
+import { scrollWindowBy } from '@/lib/programmaticScroll';
 
 const FOCUSABLE_SELECTOR = [
   'a[href]',
@@ -323,7 +324,7 @@ export function useFilterPanel({ scrolledPast }: {
     // mutation — see the hook doc for why that makes this safe to run
     // unconditionally rather than fight what the browser already got right.
     const delta = pending.el.getBoundingClientRect().top - pending.top;
-    if (delta !== 0) window.scrollBy(0, delta);
+    scrollWindowBy(delta);
     // `exiting` as well as `open`: the panel enters flow on open and leaves
     // it on close, but it ALSO leaves flow when the exit animation starts
     // (`position: fixed`) and re-enters it when that animation ends. All

--- a/frontend/src/hooks/useFilterPanel.ts
+++ b/frontend/src/hooks/useFilterPanel.ts
@@ -57,7 +57,7 @@ const EXIT_FALLBACK_MS = 400;
  * saved number. `topmostVisibleDaySection` (in `daySections.ts`) picks the
  * first day section still clear of the sticky rail as the reference; its
  * `top` is captured the instant the reader asks to open or close, and
- * re-measured plus corrected via `window.scrollBy` in a `useLayoutEffect`,
+ * re-measured plus corrected via `scrollWindowBy` in a `useLayoutEffect`,
  * which runs synchronously after the DOM mutation commits but before the
  * browser paints — late enough that `getBoundingClientRect()` reflects the
  * panel's new layout (and any scroll-anchoring the browser already applied

--- a/frontend/src/hooks/useRailHighlight.ts
+++ b/frontend/src/hooks/useRailHighlight.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { RefObject } from 'react';
-import { daySectionTop, daySectionMetrics, dayRailHeightPx } from '@/lib/utils/daySections';
+import { daySectionTop, daySectionMetrics, topChromeHeightPx } from '@/lib/utils/daySections';
 import {
   resolveAnchor, rampDistance, dayProgress, stripScrollLeft, pillGeometry, lerp,
   type ChipExtent,
@@ -281,7 +281,7 @@ export function useRailHighlight(chipKeys: string[], windowDayKeys: string[]): R
     // both trade a measured 4% worst case for a new coupling across the
     // boundary this design keeps clean. Revisit if the render window ever
     // stops being bounded — that, not the day list, is what sets this cost.
-    const limit = dayRailHeightPx() + 1;
+    const limit = topChromeHeightPx() + 1;
     const resolved = resolveAnchor(windowDayKeys, limit, daySectionTop);
     if (!resolved) {
       hide();

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -92,7 +92,7 @@ export function useSiteHeaderReveal() {
      * When the reader last did something that scrolls — the whole test for
      * "is this scroll theirs".
      *
-     * A `scroll` with nothing behind it is not the reader. The settle above
+     * A `scroll` with nothing behind it is not the reader. The settle below
      * covers what the browser does in reaction to OUR scrolls, because those
      * announce themselves; it cannot cover what the browser does in reaction
      * to a layout change we made without scrolling at all. Measured in

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
-import { gestureScrollsPage, keyScrollsPage } from '@/lib/scrollGestures';
+import { dragScrollsPage, gestureScrollsPage, keyScrollsPage } from '@/lib/scrollGestures';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -210,10 +210,11 @@ export function useSiteHeaderReveal() {
      * merely crossing the page is not a scroll either.
      */
     const onGesture = (e: Event) => {
-      // A pointer merely crossing the page is not a scroll; a pointer moving
-      // with its button held is a scrollbar drag, the one way to scroll that
-      // fires no wheel, touch or key.
-      if (e.type === 'mousemove' && (e as MouseEvent).buttons === 0) return;
+      // A pointer merely crossing the page is not a scroll, and neither is
+      // every drag: `dragScrollsPage` keeps the scrollbar-drag case — the one
+      // way to scroll that fires no wheel, touch or key — while rejecting a
+      // drag that began on a control, such as the week strip's drag-select.
+      if (e.type === 'mousemove' && !dragScrollsPage(e as MouseEvent)) return;
       // Nor is a gesture the page never sees. The filter panel scrolls itself
       // while it overlays the list, and the day rail scrolls sideways.
       if (e.type !== 'keydown' && !gestureScrollsPage(e)) return;

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -5,6 +5,15 @@ import { gestureScrollsPage, keyScrollsPage } from '@/lib/scrollGestures';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
+/**
+ * The same offset with no transition on it.
+ *
+ * `OFFSET` animates, so anything that SAMPLES it — the rail's scrollspy, the
+ * day anchor — reads a value mid-flight and then never hears that it settled.
+ * CSS positions against the animated one; logic asks this one. See
+ * `topChromeHeightPx`.
+ */
+const OFFSET_TARGET = '--site-header-offset-target';
 const HEIGHT = '--site-header-h';
 
 /**
@@ -64,6 +73,8 @@ const HIDDEN = '0px';
 export function useSiteHeaderReveal() {
   const [revealed, setRevealed] = useState(true);
   const stateRef = useRef(initialHeaderReveal(0));
+  /** The current decision, readable from callbacks captured on first render. */
+  const revealedRef = useRef(true);
 
   // The top zone is the header's own height: within it the header has not yet
   // reached the position it would stick at, so "hidden" is not a state the
@@ -79,9 +90,15 @@ export function useSiteHeaderReveal() {
    */
   const decideRef = useRef<(() => void) | null>(null);
 
+  /** Re-publishes the offsets; held in a ref for the same reason `decideRef` is. */
+  const publishRef = useRef<((shown: boolean) => void) | null>(null);
+
   const headerRef = usePublishedElementHeight(HEIGHT, (el) => {
     const measured = el.getBoundingClientRect().height;
     topZoneRef.current = measured;
+    // The target offset is a literal, so unlike the animated one it does not
+    // follow `--site-header-h` on its own and has to be rewritten here.
+    publishRef.current?.(revealedRef.current);
     decideRef.current?.();
     return measured;
   });
@@ -89,7 +106,11 @@ export function useSiteHeaderReveal() {
   useEffect(() => {
     const publish = (shown: boolean) => {
       document.documentElement.style.setProperty(OFFSET, shown ? SHOWN : HIDDEN);
+      // The settled value, for anything that measures rather than paints.
+      document.documentElement.style.setProperty(
+        OFFSET_TARGET, shown ? `${topZoneRef.current}px` : HIDDEN);
     };
+    publishRef.current = publish;
 
     // A reload part-way down the page restores `scrollY` before this runs, so
     // the baseline is where the reader actually is rather than the top.
@@ -161,6 +182,7 @@ export function useSiteHeaderReveal() {
       const next = nextHeaderReveal(previous, window.scrollY, { topZone: topZoneRef.current });
       stateRef.current = next;
       if (next.revealed === previous.revealed) return;
+      revealedRef.current = next.revealed;
       setRevealed(next.revealed);
       publish(next.revealed);
     };
@@ -224,6 +246,8 @@ export function useSiteHeaderReveal() {
       }
       stopListeningForJumps();
       document.documentElement.style.removeProperty(OFFSET);
+      document.documentElement.style.removeProperty(OFFSET_TARGET);
+      publishRef.current = null;
     };
   }, []);
 

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,0 +1,161 @@
+import { useEffect, useRef, useState } from 'react';
+import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
+import { onProgrammaticScroll } from '@/lib/programmaticScroll';
+import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
+
+const OFFSET = '--site-header-offset';
+const HEIGHT = '--site-header-h';
+
+
+/**
+ * The offset while the header is showing.
+ *
+ * A reference to the measured height rather than the number, so a breakpoint
+ * or a text-zoom step that changes the header's size is picked up by the
+ * `ResizeObserver` alone — the reveal state does not have to be recomputed,
+ * and there is no window in which the two disagree and the rail sits a few
+ * pixels under the header or over it.
+ */
+const SHOWN = `var(${HEIGHT}, 0px)`;
+const HIDDEN = '0px';
+
+/**
+ * Drives the site header's reveal on scroll up (#272).
+ *
+ * ## Why the decision is published as a CSS variable, not returned as state
+ *
+ * Two surfaces have to move together: the header itself, and the sticky
+ * filter/rail container that rides down to sit below it. Threading the
+ * decision through `page.tsx` would work, and would re-render the whole
+ * calendar — 1,470 events and every memo above them — on each direction
+ * change. Writing `--site-header-offset` on `:root` instead lets both
+ * surfaces read it straight from CSS, so a reveal costs one custom-property
+ * write and a re-render of `Header` alone.
+ *
+ * `revealed` is still returned, because one thing genuinely cannot be done in
+ * CSS: a hidden header is parked just above the viewport, still in the DOM
+ * and still in flow, so it is Tab-reachable. The caller needs it for `inert`.
+ * This is the same trap `filterCardParked` documents — the browser will chase
+ * a focused control inside a pinned sticky element it cannot scroll into
+ * view.
+ *
+ * The property is written only when the decision actually flips, not on every
+ * `scroll` event.
+ */
+export function useSiteHeaderReveal() {
+  const [revealed, setRevealed] = useState(true);
+  const stateRef = useRef(initialHeaderReveal(0));
+
+  // The top zone is the header's own height: within it the header has not yet
+  // reached the position it would stick at, so "hidden" is not a state the
+  // DOM can be in, and marking a visible header `inert` is the bug that
+  // follows from pretending otherwise.
+  const topZoneRef = useRef(0);
+
+  const headerRef = usePublishedElementHeight(HEIGHT, (el) => {
+    const measured = el.getBoundingClientRect().height;
+    topZoneRef.current = measured;
+    return measured;
+  });
+
+  useEffect(() => {
+    const publish = (shown: boolean) => {
+      document.documentElement.style.setProperty(OFFSET, shown ? SHOWN : HIDDEN);
+    };
+
+    // A reload part-way down the page restores `scrollY` before this runs, so
+    // the baseline is where the reader actually is rather than the top.
+    stateRef.current = initialHeaderReveal(window.scrollY);
+    publish(true);
+
+
+    /**
+     * Whether the reader has done something that scrolls since the last
+     * `scroll` event — the whole test for "is this scroll theirs".
+     *
+     * A `scroll` with nothing behind it is not the reader. The settle above
+     * covers what the browser does in reaction to OUR scrolls, because those
+     * announce themselves; it cannot cover what the browser does in reaction
+     * to a layout change we made without scrolling at all. Measured in
+     * WebKit: opening the filter panel from the rail found no day section to
+     * anchor to, so `useFilterPanel` captured no reference, corrected nothing
+     * and announced nothing — and WebKit's scroll anchoring moved the page
+     * 44px by itself. The header hid on a tap nobody scrolled. Requiring a
+     * gesture holds for layout-changing code nobody has written yet, which
+     * making every such site announce does not.
+     *
+     * "Since the last scroll" rather than "within the last N milliseconds",
+     * and the difference is not tidiness. A time window lends a real gesture's
+     * authority to whatever the browser does next inside it — which is exactly
+     * the case above, where a wheel, a tap and an anchoring correction all
+     * land inside any window worth having. Consuming the gesture closes that:
+     * a drag re-arms it on every frame, and a correction that follows a scroll
+     * with nothing in between does not.
+     *
+     * Touch momentum after `touchend` fires no gesture, and that is fine
+     * rather than tolerated: a flick long enough to coast is far longer than
+     * the threshold, so the decision was already made during the drag. What
+     * momentum cannot do is CHANGE it — which is the flicker the threshold
+     * exists to prevent.
+     */
+    let gestureSinceLastScroll = false;
+
+    const onScroll = () => {
+      const previous = stateRef.current;
+      const readerDriven = gestureSinceLastScroll;
+      gestureSinceLastScroll = false;
+      if (!readerDriven) {
+        stateRef.current = resyncHeaderReveal(previous, window.scrollY);
+        return;
+      }
+      const next = nextHeaderReveal(previous, window.scrollY, { topZone: topZoneRef.current });
+      stateRef.current = next;
+      if (next.revealed === previous.revealed) return;
+      setRevealed(next.revealed);
+      publish(next.revealed);
+    };
+
+    // The app's own scrolls move the baseline without re-deciding anything.
+    // See `programmaticScroll.ts` for why this is a resync rather than a
+    // suppression flag.
+    const stopListeningForJumps = onProgrammaticScroll(() => {
+      stateRef.current = resyncHeaderReveal(stateRef.current, window.scrollY);
+    });
+
+    /**
+     * The gestures that count as the reader scrolling.
+     *
+     * `mousedown` and `touchstart` are deliberately absent, and that is the
+     * difference from `useDayAnchor`'s otherwise identical cancel set. A press
+     * scrolls nothing — and a rail chip tap IS a mousedown, milliseconds
+     * before the jump it causes, so admitting it would hand the browser's
+     * reaction to that jump the authority of a gesture.
+     *
+     * A scrollbar drag is the one way to scroll that fires none of wheel,
+     * touch or key. It is a `mousemove` with the button still held, which is
+     * why the button state is checked rather than the event type: a pointer
+     * merely crossing the page is not a scroll either.
+     */
+    const onGesture = (e: Event) => {
+      if (e.type === 'mousemove' && (e as MouseEvent).buttons === 0) return;
+      gestureSinceLastScroll = true;
+    };
+    const gestures = ['wheel', 'touchmove', 'keydown', 'mousemove'] as const;
+
+    // Passive: none of this must ever delay a scroll.
+    window.addEventListener('scroll', onScroll, { passive: true });
+    for (const type of gestures) {
+      window.addEventListener(type, onGesture, { passive: true, capture: true });
+    }
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      for (const type of gestures) {
+        window.removeEventListener(type, onGesture, { capture: true });
+      }
+      stopListeningForJumps();
+      document.documentElement.style.removeProperty(OFFSET);
+    };
+  }, []);
+
+  return { revealed, headerRef };
+}

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
-import { keyScrollsPage } from '@/lib/scrollKeys';
+import { gestureScrollsPage, keyScrollsPage } from '@/lib/scrollGestures';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -192,6 +192,9 @@ export function useSiteHeaderReveal() {
       // with its button held is a scrollbar drag, the one way to scroll that
       // fires no wheel, touch or key.
       if (e.type === 'mousemove' && (e as MouseEvent).buttons === 0) return;
+      // Nor is a gesture the page never sees. The filter panel scrolls itself
+      // while it overlays the list, and the day rail scrolls sideways.
+      if (e.type !== 'keydown' && !gestureScrollsPage(e)) return;
       // Nor is typing. Every keystroke on the page reaches this listener,
       // search included — and search re-filtering is the largest layout change
       // above the reader the app makes.

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
-import { dragScrollsPage, gestureScrollsPage, keyScrollsPage } from '@/lib/scrollGestures';
+import { dragScrollsPage, gestureScrollsPage, keyScrollsPage, pressIsOnScrollbar } from '@/lib/scrollGestures';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -209,15 +209,55 @@ export function useSiteHeaderReveal() {
      * why the button state is checked rather than the event type: a pointer
      * merely crossing the page is not a scroll either.
      */
+    /**
+     * The element the current drag began on.
+     *
+     * Tracked from `mousedown` because a drag's origin is what it means, and
+     * the pointer leaves that origin immediately — the week strip's
+     * drag-select starts on a button and is pulled across the list. Recorded
+     * here rather than armed: a press still scrolls nothing, so this listener
+     * deliberately does not touch `lastGestureAt`.
+     */
+    let dragOrigin: Element | null = null;
+    /** Where the finger was, so a `touchmove` can be given a direction. */
+    let lastTouchY: number | null = null;
+    const onPress = (e: Event) => {
+      const target = e.target;
+      // A press in the scrollbar track pages the view and fires nothing else —
+      // no wheel, no key, no touch, no move. It is the one press that IS a
+      // scroll, which is why it arms while every other press does not.
+      if (e.type === 'mousedown' && pressIsOnScrollbar(e as MouseEvent)) {
+        lastGestureAt = performance.now();
+        settling = false;
+      }
+      dragOrigin = e.type === 'mousedown' && target instanceof Element ? target : null;
+      if (e.type === 'touchstart' || e.type === 'touchend') {
+        const y = (e as TouchEvent).touches?.[0]?.clientY;
+        lastTouchY = typeof y === 'number' ? y : null;
+      }
+    };
+
     const onGesture = (e: Event) => {
       // A pointer merely crossing the page is not a scroll, and neither is
       // every drag: `dragScrollsPage` keeps the scrollbar-drag case — the one
       // way to scroll that fires no wheel, touch or key — while rejecting a
       // drag that began on a control, such as the week strip's drag-select.
-      if (e.type === 'mousemove' && !dragScrollsPage(e as MouseEvent)) return;
+      if (e.type === 'mousemove' && !dragScrollsPage(e as MouseEvent, dragOrigin)) return;
       // Nor is a gesture the page never sees. The filter panel scrolls itself
       // while it overlays the list, and the day rail scrolls sideways.
-      if (e.type !== 'keydown' && !gestureScrollsPage(e)) return;
+      //
+      // A `touchmove` carries no direction of its own, so it is reconstructed
+      // from the previous touch position: a finger moving DOWN the screen
+      // pushes the content UP, which is a negative delta.
+      let touchDelta = 0;
+      if (e.type === 'touchmove') {
+        const y = (e as TouchEvent).touches?.[0]?.clientY;
+        if (typeof y === 'number') {
+          if (lastTouchY !== null) touchDelta = lastTouchY - y;
+          lastTouchY = y;
+        }
+      }
+      if (e.type !== 'keydown' && !gestureScrollsPage(e, touchDelta)) return;
       // Nor is typing. Every keystroke on the page reaches this listener,
       // search included — and search re-filtering is the largest layout change
       // above the reader the app makes.
@@ -226,6 +266,7 @@ export function useSiteHeaderReveal() {
       settling = false;
     };
     const gestures = ['wheel', 'touchmove', 'keydown', 'mousemove'] as const;
+    const presses = ['mousedown', 'mouseup', 'touchstart', 'touchend'] as const;
 
     // Re-run the decision when the header's own height changes, not only when
     // something scrolls. Text zoom that grows the header around the reader's
@@ -239,11 +280,17 @@ export function useSiteHeaderReveal() {
     for (const type of gestures) {
       window.addEventListener(type, onGesture, { passive: true, capture: true });
     }
+    for (const type of presses) {
+      window.addEventListener(type, onPress, { passive: true, capture: true });
+    }
     return () => {
       window.removeEventListener('scroll', decide);
       decideRef.current = null;
       for (const type of gestures) {
         window.removeEventListener(type, onGesture, { capture: true });
+      }
+      for (const type of presses) {
+        window.removeEventListener(type, onPress, { capture: true });
       }
       stopListeningForJumps();
       document.documentElement.style.removeProperty(OFFSET);

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
-import { isScrollKey } from '@/lib/scrollKeys';
+import { keyScrollsPage } from '@/lib/scrollKeys';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -71,9 +71,18 @@ export function useSiteHeaderReveal() {
   // follows from pretending otherwise.
   const topZoneRef = useRef(0);
 
+  /**
+   * The current decision function, so a re-measure can re-run it.
+   *
+   * A ref because the measure callback below is captured once, on first
+   * render, while the handler it needs is created inside the effect.
+   */
+  const decideRef = useRef<(() => void) | null>(null);
+
   const headerRef = usePublishedElementHeight(HEIGHT, (el) => {
     const measured = el.getBoundingClientRect().height;
     topZoneRef.current = measured;
+    decideRef.current?.();
     return measured;
   });
 
@@ -134,10 +143,18 @@ export function useSiteHeaderReveal() {
      */
     let settling = false;
 
-    const onScroll = () => {
+    const decide = () => {
       const previous = stateRef.current;
       const readerDriven = !settling && performance.now() - lastGestureAt <= GESTURE_WINDOW_MS;
-      if (!readerDriven) {
+      // The top zone is a fact about where the header IS, not a decision about
+      // where it should be — a sticky header cannot be parked above a position
+      // the page has not reached, so inside it the header is on screen whoever
+      // did the scrolling. Ignoring a gestureless scroll INTO it left a fully
+      // visible header `inert` and `aria-hidden`: measured in Chromium after a
+      // search emptied the list (document 8,401px → 1,049px) and the viewport
+      // then grew, clamping `scrollY` to 0 with no gesture anywhere near it.
+      const inTopZone = window.scrollY <= topZoneRef.current;
+      if (!readerDriven && !inTopZone) {
         stateRef.current = resyncHeaderReveal(previous, window.scrollY);
         return;
       }
@@ -178,19 +195,27 @@ export function useSiteHeaderReveal() {
       // Nor is typing. Every keystroke on the page reaches this listener,
       // search included — and search re-filtering is the largest layout change
       // above the reader the app makes.
-      if (e.type === 'keydown' && !isScrollKey((e as KeyboardEvent).key)) return;
+      if (e.type === 'keydown' && !keyScrollsPage(e as KeyboardEvent)) return;
       lastGestureAt = performance.now();
       settling = false;
     };
     const gestures = ['wheel', 'touchmove', 'keydown', 'mousemove'] as const;
 
+    // Re-run the decision when the header's own height changes, not only when
+    // something scrolls. Text zoom that grows the header around the reader's
+    // position moves them into the top zone without any scroll at all, and
+    // nothing else would notice — which is the same visible-but-`inert` header
+    // by a different route.
+    decideRef.current = decide;
+
     // Passive: none of this must ever delay a scroll.
-    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('scroll', decide, { passive: true });
     for (const type of gestures) {
       window.addEventListener(type, onGesture, { passive: true, capture: true });
     }
     return () => {
-      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('scroll', decide);
+      decideRef.current = null;
       for (const type of gestures) {
         window.removeEventListener(type, onGesture, { capture: true });
       }

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
-import { dragScrollsPage, gestureScrollsPage, keyScrollsPage, pressIsOnScrollbar } from '@/lib/scrollGestures';
+import { dragScrollsPage, gestureScrollsPage, keyScrollsPage, originCanScrollPage, pressIsOnScrollbar } from '@/lib/scrollGestures';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -189,6 +189,9 @@ export function useSiteHeaderReveal() {
      */
     let coasting = false;
     let lastScrollAt = -Infinity;
+    /** The element the current touch began on, and whether it ever scrolled. */
+    let touchOrigin: Element | null = null;
+    let touchScrolledPage = false;
 
     const decide = () => {
       const previous = stateRef.current;
@@ -200,7 +203,13 @@ export function useSiteHeaderReveal() {
       // No `&& !settling` here: `readerDriven` below already requires it, and
       // settling only ends at a gesture, which refreshes this anyway.
       if (coasting) lastGestureAt = now;
-      const readerDriven = !settling && performance.now() - lastGestureAt <= GESTURE_WINDOW_MS;
+      // `coasting` outranks the settle. A settle is closed by a gesture, and a
+      // flick has none left to give — so a correction landing before the coast
+      // had accumulated its 24px used to discard every remaining frame of the
+      // reader's own scroll. The announcement has already taken the app's
+      // delta out of the baseline, so those frames measure real movement.
+      const readerDriven = (coasting || !settling)
+        && performance.now() - lastGestureAt <= GESTURE_WINDOW_MS;
       // The top zone is a fact about where the header IS, not a decision about
       // where it should be — a sticky header cannot be parked above a position
       // the page has not reached, so inside it the header is on screen whoever
@@ -264,11 +273,15 @@ export function useSiteHeaderReveal() {
         lastGestureAt = performance.now();
         settling = false;
       }
-      // Lifting the finger starts a coast. There is deliberately no
-      // `touchstart` clause to end one: the gap rule has already ended any
-      // coast a new touch could interrupt, so clearing it here would be a
-      // branch nothing could make fail.
-      if (e.type === 'touchend') coasting = true;
+      // Lifting the finger starts a coast — but only if that touch actually
+      // scrolled the page. A tap coasts nothing, and opening a coast for one
+      // handed the next correction the authority of a scroll nobody made.
+      if (e.type === 'touchstart') {
+        touchOrigin = target instanceof Element ? target : null;
+        touchScrolledPage = false;
+        coasting = false;
+      }
+      if (e.type === 'touchend') coasting = touchScrolledPage;
       dragOrigin = e.type === 'mousedown' && target instanceof Element ? target : null;
       if (e.type === 'touchstart' || e.type === 'touchend') {
         const y = (e as TouchEvent).touches?.[0]?.clientY;
@@ -296,7 +309,12 @@ export function useSiteHeaderReveal() {
           lastTouchY = y;
         }
       }
+      // A touch that began on a control is that control's, exactly as a mouse
+      // drag is — `WeekSelector` prevents the default on its touch handlers,
+      // so such a drag scrolls nothing whatever it looks like from here.
+      if (e.type === 'touchmove' && !originCanScrollPage(touchOrigin)) return;
       if (e.type !== 'keydown' && !gestureScrollsPage(e, touchDelta)) return;
+      if (e.type === 'touchmove') touchScrolledPage = true;
       // Nor is typing. Every keystroke on the page reaches this listener,
       // search included — and search re-filtering is the largest layout change
       // above the reader the app makes.

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
-import { dragScrollsPage, gestureScrollsPage, keyScrollsPage, originCanScrollPage, pressIsOnScrollbar } from '@/lib/scrollGestures';
+import { dragScrollsPage, gestureScrollsPage, keyScrollsPage, pressIsOnScrollbar } from '@/lib/scrollGestures';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -149,11 +149,14 @@ export function useSiteHeaderReveal() {
      * how far a gesture's authority reaches; a gesture that scrolls nothing
      * still lends it for that long, which is the cost of the trade.
      *
-     * Touch momentum after `touchend` fires no gesture, and that is fine
-     * rather than tolerated: a flick long enough to coast is far longer than
-     * the threshold, so the decision was already made during the drag. What
-     * momentum cannot do is CHANGE it — which is the flicker the threshold
-     * exists to prevent.
+     * Touch momentum after `touchend` fires no gesture at all, and this window
+     * alone cannot survive that — see `coasting` below, which is what carries
+     * a flick past it. The claim that used to stand here, that "a flick long
+     * enough to coast is far longer than the threshold, so the decision was
+     * already made during the drag", was false and was the reported iPhone
+     * bug: a gentle flick moves the finger about 5px and then coasts 60px over
+     * more than a second. Recorded rather than deleted, so that a later change
+     * does not remove the momentum handling by re-deriving the premise.
      */
     let lastGestureAt = -Infinity;
 
@@ -189,8 +192,24 @@ export function useSiteHeaderReveal() {
      */
     let coasting = false;
     let lastScrollAt = -Infinity;
-    /** The element the current touch began on, and whether it ever scrolled. */
-    let touchOrigin: Element | null = null;
+    /**
+     * Whether the control the touch began on cancelled the page pan, and
+     * whether this touch has scrolled the page yet.
+     *
+     * Asking whether the origin is a CONTROL is the wrong question for touch,
+     * and briefly shipped as one: a native button does not stop the page
+     * panning, and the event list is made of buttons — the event title is a
+     * full-width one — so refusing every touch that began on a control refused
+     * most swipes in the list. That is the device bug this branch exists to
+     * fix, reintroduced by its own fix for the mouse case.
+     *
+     * The mouse and touch answers genuinely differ: a DRAG beginning on a
+     * button is that button's, while a SWIPE beginning on it still scrolls the
+     * page. What actually stops a pan is a control that cancels it —
+     * `WeekSelector` calls `preventDefault()` on `touchstart` — and that is
+     * what the platform acts on, so it is what this asks.
+     */
+    let touchPanCancelled = false;
     let touchScrolledPage = false;
 
     const decide = () => {
@@ -277,9 +296,11 @@ export function useSiteHeaderReveal() {
       // scrolled the page. A tap coasts nothing, and opening a coast for one
       // handed the next correction the authority of a scroll nobody made.
       if (e.type === 'touchstart') {
-        touchOrigin = target instanceof Element ? target : null;
         touchScrolledPage = false;
         coasting = false;
+        // `touchPanCancelled` is NOT reset here: `onTouchStartBubble` assigns
+        // it on every touchstart, so a reset would be a line nothing could
+        // make fail.
       }
       if (e.type === 'touchend') coasting = touchScrolledPage;
       dragOrigin = e.type === 'mousedown' && target instanceof Element ? target : null;
@@ -309,10 +330,9 @@ export function useSiteHeaderReveal() {
           lastTouchY = y;
         }
       }
-      // A touch that began on a control is that control's, exactly as a mouse
-      // drag is — `WeekSelector` prevents the default on its touch handlers,
-      // so such a drag scrolls nothing whatever it looks like from here.
-      if (e.type === 'touchmove' && !originCanScrollPage(touchOrigin)) return;
+      // A touch whose control cancelled the pan scrolls nothing, whatever it
+      // looks like from here.
+      if (e.type === 'touchmove' && touchPanCancelled) return;
       if (e.type !== 'keydown' && !gestureScrollsPage(e, touchDelta)) return;
       if (e.type === 'touchmove') touchScrolledPage = true;
       // Nor is typing. Every keystroke on the page reaches this listener,
@@ -322,6 +342,16 @@ export function useSiteHeaderReveal() {
       lastGestureAt = performance.now();
       settling = false;
     };
+    /**
+     * Whether the touch that just started had its default prevented.
+     *
+     * Read in the BUBBLE phase, deliberately: capture runs before the target's
+     * own handler, so `defaultPrevented` there is always false and would say
+     * nothing. By the time the event reaches `window` on the way back up, a
+     * control that cancelled the pan has already done so.
+     */
+    const onTouchStartBubble = (e: Event) => { touchPanCancelled = e.defaultPrevented; };
+
     const gestures = ['wheel', 'touchmove', 'keydown', 'mousemove'] as const;
     const presses = ['mousedown', 'mouseup', 'touchstart', 'touchend'] as const;
 
@@ -340,6 +370,7 @@ export function useSiteHeaderReveal() {
     for (const type of presses) {
       window.addEventListener(type, onPress, { passive: true, capture: true });
     }
+    window.addEventListener('touchstart', onTouchStartBubble, { passive: true });
     return () => {
       window.removeEventListener('scroll', decide);
       decideRef.current = null;
@@ -349,6 +380,7 @@ export function useSiteHeaderReveal() {
       for (const type of presses) {
         window.removeEventListener(type, onPress, { capture: true });
       }
+      window.removeEventListener('touchstart', onTouchStartBubble);
       stopListeningForJumps();
       document.documentElement.style.removeProperty(OFFSET);
       document.documentElement.style.removeProperty(OFFSET_TARGET);

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePublishedElementHeight } from '@/hooks/usePublishedElementHeight';
 import { onProgrammaticScroll } from '@/lib/programmaticScroll';
+import { isScrollKey } from '@/lib/scrollKeys';
 import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib/siteHeaderReveal';
 
 const OFFSET = '--site-header-offset';
@@ -137,7 +138,14 @@ export function useSiteHeaderReveal() {
      * merely crossing the page is not a scroll either.
      */
     const onGesture = (e: Event) => {
+      // A pointer merely crossing the page is not a scroll; a pointer moving
+      // with its button held is a scrollbar drag, the one way to scroll that
+      // fires no wheel, touch or key.
       if (e.type === 'mousemove' && (e as MouseEvent).buttons === 0) return;
+      // Nor is typing. Every keystroke on the page reaches this listener,
+      // search included — and search re-filtering is the largest layout change
+      // above the reader the app makes.
+      if (e.type === 'keydown' && !isScrollKey((e as KeyboardEvent).key)) return;
       gestureSinceLastScroll = true;
     };
     const gestures = ['wheel', 'touchmove', 'keydown', 'mousemove'] as const;

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -34,6 +34,16 @@ const HEIGHT = '--site-header-h';
  */
 export const GESTURE_WINDOW_MS = 400;
 
+/**
+ * The longest gap between scroll events that still counts as one continuous
+ * movement of the page.
+ *
+ * Momentum arrives frame by frame, so consecutive frames stay tens of
+ * milliseconds apart even as a flick decays. A longer gap means the page came
+ * to rest, and whatever scrolls next is something else's doing.
+ */
+const MOMENTUM_GAP_MS = 200;
+
 
 /**
  * The offset while the header is showing.
@@ -164,8 +174,32 @@ export function useSiteHeaderReveal() {
      */
     let settling = false;
 
+    /**
+     * Whether the page is still coasting from the reader's last touch.
+     *
+     * A wheel fires for as long as the page is moving, so a window refreshed
+     * by gesture events covers the whole of a mouse scroll. A touch does not:
+     * `touchmove` stops at `touchend` while most of a flick's distance is
+     * still to come, and iOS coasts for up to a couple of seconds in silence.
+     *
+     * The coast IS the reader's scroll - the second half of the gesture they
+     * made - so while it runs each frame refreshes the window itself. It ends
+     * when the page stops moving, which is why the gap between frames closes
+     * it rather than a timer: momentum has no other signal that it finished.
+     */
+    let coasting = false;
+    let lastScrollAt = -Infinity;
+
     const decide = () => {
       const previous = stateRef.current;
+      const now = performance.now();
+      // A gap means the page had come to rest, so the coast is over and this
+      // scroll belongs to something else.
+      if (coasting && now - lastScrollAt > MOMENTUM_GAP_MS) coasting = false;
+      lastScrollAt = now;
+      // No `&& !settling` here: `readerDriven` below already requires it, and
+      // settling only ends at a gesture, which refreshes this anyway.
+      if (coasting) lastGestureAt = now;
       const readerDriven = !settling && performance.now() - lastGestureAt <= GESTURE_WINDOW_MS;
       // The top zone is a fact about where the header IS, not a decision about
       // where it should be — a sticky header cannot be parked above a position
@@ -230,6 +264,11 @@ export function useSiteHeaderReveal() {
         lastGestureAt = performance.now();
         settling = false;
       }
+      // Lifting the finger starts a coast. There is deliberately no
+      // `touchstart` clause to end one: the gap rule has already ended any
+      // coast a new touch could interrupt, so clearing it here would be a
+      // branch nothing could make fail.
+      if (e.type === 'touchend') coasting = true;
       dragOrigin = e.type === 'mousedown' && target instanceof Element ? target : null;
       if (e.type === 'touchstart' || e.type === 'touchend') {
         const y = (e as TouchEvent).touches?.[0]?.clientY;

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -7,6 +7,24 @@ import { initialHeaderReveal, nextHeaderReveal, resyncHeaderReveal } from '@/lib
 const OFFSET = '--site-header-offset';
 const HEIGHT = '--site-header-h';
 
+/**
+ * How long a scroll-driving gesture keeps deciding.
+ *
+ * A gesture is not one scroll event. WebKit on Linux delivers a single wheel
+ * tick as an animation: traced in CI, `115 → 120 → 230` is one tick arriving
+ * as +5 and then +110. An earlier rule let a gesture decide only its first
+ * scroll and consumed it there, which threw away the rest of the gesture's own
+ * movement — the accumulator saw +5 where the reader had asked for +120, never
+ * reached the threshold, and the header did not hide at all. Chromium delivers
+ * one clean frame per tick and showed none of it.
+ *
+ * So the gesture stays live for a window instead, refreshed by every further
+ * gesture event. Long enough to cover a smooth-scroll animation, short enough
+ * that a gesture cannot lend its authority to a browser correction arriving
+ * long afterwards — the case the window exists to exclude.
+ */
+export const GESTURE_WINDOW_MS = 400;
+
 
 /**
  * The offset while the header is showing.
@@ -71,8 +89,8 @@ export function useSiteHeaderReveal() {
 
 
     /**
-     * Whether the reader has done something that scrolls since the last
-     * `scroll` event — the whole test for "is this scroll theirs".
+     * When the reader last did something that scrolls — the whole test for
+     * "is this scroll theirs".
      *
      * A `scroll` with nothing behind it is not the reader. The settle above
      * covers what the browser does in reaction to OUR scrolls, because those
@@ -85,13 +103,11 @@ export function useSiteHeaderReveal() {
      * gesture holds for layout-changing code nobody has written yet, which
      * making every such site announce does not.
      *
-     * "Since the last scroll" rather than "within the last N milliseconds",
-     * and the difference is not tidiness. A time window lends a real gesture's
-     * authority to whatever the browser does next inside it — which is exactly
-     * the case above, where a wheel, a tap and an anchoring correction all
-     * land inside any window worth having. Consuming the gesture closes that:
-     * a drag re-arms it on every frame, and a correction that follows a scroll
-     * with nothing in between does not.
+     * A window rather than "consume it on the next scroll", because a gesture
+     * is not one scroll event — see `GESTURE_WINDOW_MS`, where consuming it
+     * stopped the header hiding at all in WebKit. The window is what bounds
+     * how far a gesture's authority reaches; a gesture that scrolls nothing
+     * still lends it for that long, which is the cost of the trade.
      *
      * Touch momentum after `touchend` fires no gesture, and that is fine
      * rather than tolerated: a flick long enough to coast is far longer than
@@ -99,12 +115,28 @@ export function useSiteHeaderReveal() {
      * momentum cannot do is CHANGE it — which is the flicker the threshold
      * exists to prevent.
      */
-    let gestureSinceLastScroll = false;
+    let lastGestureAt = -Infinity;
+
+    /**
+     * Set when the app scrolls the document, cleared by the reader's next
+     * gesture — the hole the window opens, closed.
+     *
+     * A gesture stays live for `GESTURE_WINDOW_MS`, and a reader who scrolls
+     * and then taps a rail chip inside that window would otherwise hand the
+     * browser's reaction to the tap the authority of their wheel. That is the
+     * same 122px WebKit correction this whole mechanism exists for, arriving
+     * 200ms after a real gesture instead of in isolation.
+     *
+     * Cleared by the gesture EVENT rather than by a scroll, so a reader who
+     * takes control back waits for nothing; and there is no timer, because
+     * nothing but a gesture or another programmatic scroll can move the page
+     * anyway, so a settle nobody ends costs nothing.
+     */
+    let settling = false;
 
     const onScroll = () => {
       const previous = stateRef.current;
-      const readerDriven = gestureSinceLastScroll;
-      gestureSinceLastScroll = false;
+      const readerDriven = !settling && performance.now() - lastGestureAt <= GESTURE_WINDOW_MS;
       if (!readerDriven) {
         stateRef.current = resyncHeaderReveal(previous, window.scrollY);
         return;
@@ -121,6 +153,7 @@ export function useSiteHeaderReveal() {
     // suppression flag.
     const stopListeningForJumps = onProgrammaticScroll(() => {
       stateRef.current = resyncHeaderReveal(stateRef.current, window.scrollY);
+      settling = true;
     });
 
     /**
@@ -146,7 +179,8 @@ export function useSiteHeaderReveal() {
       // search included — and search re-filtering is the largest layout change
       // above the reader the app makes.
       if (e.type === 'keydown' && !isScrollKey((e as KeyboardEvent).key)) return;
-      gestureSinceLastScroll = true;
+      lastGestureAt = performance.now();
+      settling = false;
     };
     const gestures = ['wheel', 'touchmove', 'keydown', 'mousemove'] as const;
 

--- a/frontend/src/hooks/useSiteHeaderReveal.ts
+++ b/frontend/src/hooks/useSiteHeaderReveal.ts
@@ -333,6 +333,18 @@ export function useSiteHeaderReveal() {
       // A touch whose control cancelled the pan scrolls nothing, whatever it
       // looks like from here.
       if (e.type === 'touchmove' && touchPanCancelled) return;
+      // A pinch usually begins as one finger. That first move arms the window
+      // and marks the touch as having scrolled, so merely rejecting the
+      // multi-touch frames that follow leaves the zoom holding authority the
+      // pan earned — and `touchend` would then open a coast for it. The whole
+      // touch is withdrawn instead, until a fresh one begins.
+      if (e.type === 'touchmove' && ((e as TouchEvent).touches?.length ?? 1) > 1) {
+        touchPanCancelled = true;
+        touchScrolledPage = false;
+        coasting = false;
+        lastGestureAt = -Infinity;
+        return;
+      }
       if (e.type !== 'keydown' && !gestureScrollsPage(e, touchDelta)) return;
       if (e.type === 'touchmove') touchScrolledPage = true;
       // Nor is typing. Every keystroke on the page reaches this listener,

--- a/frontend/src/lib/programmaticScroll.ts
+++ b/frontend/src/lib/programmaticScroll.ts
@@ -1,0 +1,61 @@
+/**
+ * The app's own scrolls, announced.
+ *
+ * Five places move the document under the reader: the day-anchor's chip-tap
+ * scroll and its late reassert, the filter panel's insertion correction, and
+ * the two corrections in `EventList`. None of them is the reader scrolling,
+ * and anything watching scroll direction has to be able to tell the
+ * difference — a rail tap is a jump of tens of thousands of pixels, which
+ * read as a gesture would be the largest scroll up a reader could make.
+ *
+ * `useDayAnchor` already relies on the converse of this — a programmatic
+ * `scrollBy` synthesises no pointer event, so listening for `wheel` and
+ * `touchstart` distinguishes the reader for free. That trick does not
+ * generalise: it cannot see a scrollbar drag, so a direction watcher built on
+ * gestures alone would never reveal for a desktop reader dragging the
+ * scrollbar up. Watching `scroll` and having our own scrolls say so covers
+ * every input modality instead.
+ */
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+/**
+ * Subscribe to the app's own scrolls. Returns the unsubscribe.
+ *
+ * Listeners run *after* the scroll has landed, so `window.scrollY` inside one
+ * is the new position.
+ */
+export function onProgrammaticScroll(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => { listeners.delete(listener); };
+}
+
+/**
+ * Scroll the window vertically by `delta`, announcing it.
+ *
+ * ## A zero delta still announces
+ *
+ * This looks like a missing guard and is the opposite of one. Measured in
+ * Chromium, opening the filter panel from the rail with the site header
+ * revealed: inserting the panel changed layout above the reader, Chromium's
+ * own scroll anchoring corrected by +44px BEFORE `useFilterPanel`'s
+ * `useLayoutEffect` ran, and our correction consequently computed a delta of
+ * zero. The early return then skipped the one announcement that would have
+ * told the header that the +44px scroll it was about to be handed was not the
+ * reader — and the header hid on a tap nobody scrolled. WebKit does not anchor
+ * there, computed the +44 itself, announced it, and behaved correctly.
+ *
+ * A delta of zero does not mean nothing happened. It means the app laid out
+ * again and needed no correction of its own — which is frequently because the
+ * browser has already made one. Subscribers want to hear about that; only the
+ * `scrollBy` itself is worth skipping.
+ *
+ * The `delta !== 0` guard lives here rather than at each call site so that
+ * five copies of it cannot drift.
+ */
+export function scrollWindowBy(delta: number): void {
+  if (delta !== 0) window.scrollBy(0, delta);
+  for (const listener of listeners) listener();
+}

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -244,14 +244,14 @@ const DRAGGABLE_CONTROL =
  * refused.
  */
 /**
- * Whether a gesture beginning on `origin` can scroll the page at all.
+ * Whether a MOUSE drag beginning on `origin` can scroll the page.
  *
- * Shared by the mouse and touch paths because they are asking one question.
- * `WeekSelector` calls `preventDefault()` on its touch handlers, so a drag
- * over a themed week scrolls nothing — and then `touchend` refilters the
- * list, whose correction would arrive holding a gesture's authority.
+ * Mouse only, and that is not an oversight. A swipe beginning on a button
+ * still pans the page, so the touch path asks a different question — whether
+ * the control cancelled the pan — in `useSiteHeaderReveal`. Sharing this one
+ * between them refused most swipes in a list made of buttons.
  */
-export function originCanScrollPage(origin: Element | null): boolean {
+function originCanScrollPage(origin: Element | null): boolean {
   // No recorded press means the gesture began before this hook was listening,
   // or outside the document. Nothing says it was a control.
   if (!origin) return true;

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -171,24 +171,29 @@ function canScrollBy(el: Element, deltaY: number): boolean {
  * A wheel with no vertical component is out for the same reason: the day rail
  * scrolls sideways, and moving it is not moving the page up or down.
  *
- * A wheel carries a direction, so an ancestor only counts as consuming it when
- * it can still move that way; otherwise the walk continues toward the
- * document, which is what the browser does. A touch drag carries no usable
- * direction on a single `touchmove`, so any scrollable ancestor claims it —
- * the conservative half of the rule, kept because reconstructing a drag's
- * direction means tracking `touchstart` state for a decision that is already
- * bounded by a 400ms window.
+ * An ancestor only counts as consuming the gesture when it can still move the
+ * way the gesture is pushing; otherwise the walk continues toward the
+ * document, which is what the browser does.
+ *
+ * `deltaY` is the direction, and the caller supplies it for touch. A wheel
+ * carries its own; a single `touchmove` does not, so the caller reconstructs
+ * it from the previous touch position. An earlier version skipped that and let
+ * any scrollable ancestor claim a swipe, described as "the conservative half
+ * of the rule" — on a phone the filter panel covers 70% of the screen, so that
+ * conservative half meant the header could not be revealed from the largest
+ * target on it.
  */
-export function gestureScrollsPage(event: Event): boolean {
-  const isWheel = event.type === 'wheel';
-  const deltaY = isWheel ? (event as WheelEvent).deltaY : 0;
-  if (isWheel && deltaY === 0) return false;
+export function gestureScrollsPage(event: Event, deltaY?: number): boolean {
+  const direction = event.type === 'wheel' ? (event as WheelEvent).deltaY : deltaY ?? 0;
+  // A wheel with no vertical component is the day rail moving sideways.
+  if (event.type === 'wheel' && direction === 0) return false;
   const target = event.target;
   if (!(target instanceof Element)) return true;
   for (let el: Element | null = target; el; el = el.parentElement) {
     if (!scrollsVertically(el)) continue;
     // At its boundary it chains to the page rather than consuming this.
-    if (isWheel && !canScrollBy(el, deltaY)) continue;
+    // Direction 0 means the caller could not tell, so the scroller keeps it.
+    if (direction !== 0 && !canScrollBy(el, direction)) continue;
     return false;
   }
   return true;
@@ -224,12 +229,53 @@ const DRAGGABLE_CONTROL =
  *
  * A drag over ordinary content is left counting, because it is a text
  * selection, and dragging a selection past the viewport edge does scroll.
+ *
+ * `origin` is the element the drag STARTED on, which the caller has to
+ * remember from `mousedown` — it is not `event.target`, and reading the
+ * current target instead was this function contradicting its own contract: a
+ * week drag begun on a button and pulled off the strip targets ordinary
+ * content from that moment on, so it armed on exactly the drag it had just
+ * refused.
  */
-export function dragScrollsPage(event: MouseEvent): boolean {
+export function dragScrollsPage(event: MouseEvent, origin: Element | null): boolean {
   // Primary button only. `buttons` is a bitmask, so `!== 0` also matched
   // right- and middle-button drags, neither of which scrolls anything.
   if (event.buttons !== 1) return false;
-  const target = event.target;
-  if (!(target instanceof Element)) return true;
-  return !target.closest(DRAGGABLE_CONTROL);
+  // No recorded press means the drag began before this hook was listening, or
+  // outside the document. Nothing says it was a control.
+  if (!origin) return true;
+  return !origin.closest(DRAGGABLE_CONTROL);
+}
+
+/**
+ * Whether a primary press landed in the document's scrollbar gutter.
+ *
+ * A press in the scrollbar track pages the view, and it is the one way of
+ * scrolling that fires no wheel, no key, no touch and no `mousemove` — so
+ * without this it never reaches a scroll-direction watcher at all, and
+ * clicking upward in the scrollbar cannot bring a hidden header back.
+ *
+ * The gutter is the strip between the viewport and the content box: it has
+ * width only when a classic scrollbar occupies it, so this cannot mistake a
+ * press on the page for one on the scrollbar. Where scrollbars are overlaid —
+ * macOS by default, and headless Chromium, measured at `clientWidth` 900 and
+ * `innerWidth` 900 — there is no gutter, nothing is ever in one, and this
+ * correctly finds nothing. That is also why it is pinned by unit tests rather
+ * than by the browser suite, which has no scrollbar to press.
+ *
+ * A non-primary press opens the scrollbar's context menu instead of paging.
+ */
+export function pressIsOnScrollbar(event: MouseEvent): boolean {
+  if (event.button !== 0) return false;
+  const root = document.documentElement;
+  // No measurable content box means no measurable gutter. Without this, an
+  // unlaid-out document reports `clientWidth: 0` and every press in it is
+  // "past the content", which is the whole page — the failure this predicate
+  // most needs to avoid, since it arms on a press that scrolls nothing.
+  if (root.clientWidth <= 0 || root.clientHeight <= 0) return false;
+  // No `innerWidth > clientWidth` test needed: where scrollbars are overlaid
+  // the two are equal, so nothing can be at or past the content edge anyway.
+  // The overlay case falls out of the comparison rather than needing its own
+  // branch — one that could not be made to fail was not worth keeping.
+  return event.clientX >= root.clientWidth || event.clientY >= root.clientHeight;
 }

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -85,6 +85,17 @@ const ACTIVATED_BY_SPACE = 'button, summary, [role="button"]';
  * missed header toggle that the reader's next real scroll puts right; the cost
  * of a false positive is the header moving when nobody asked.
  */
+/**
+ * Which way a scrolling key moves the page, as a `deltaY` sign.
+ *
+ * Space is the awkward one: it scrolls DOWN, and with Shift it scrolls UP, so
+ * the direction is not readable from `event.key` alone.
+ */
+function keyDirection(event: KeyboardEvent): number {
+  if (event.key === ' ' || event.key === 'Spacebar') return event.shiftKey ? -1 : 1;
+  return event.key === 'ArrowUp' || event.key === 'PageUp' || event.key === 'Home' ? -1 : 1;
+}
+
 export function keyScrollsPage(event: KeyboardEvent): boolean {
   if (!SCROLL_KEYS.has(event.key)) return false;
   const target = event.target;
@@ -101,7 +112,17 @@ export function keyScrollsPage(event: KeyboardEvent): boolean {
   // guessing rather than matching.
   if (event.key === 'Home' && target.closest('[data-chip]')) return false;
   const isSpace = event.key === ' ' || event.key === 'Spacebar';
-  return !(isSpace && target.closest(ACTIVATED_BY_SPACE));
+  if (isSpace && target.closest(ACTIVATED_BY_SPACE)) return false;
+  // A key scrolls whatever the focus is inside, exactly as a wheel does. With
+  // the filter card acting as an `overflow-y-auto` overlay, PageDown from a
+  // focused week button scrolls THAT panel and `window` never moves — and the
+  // reflow of the filter change that follows would be admitted as the
+  // reader's. Chains at the boundary for the same reason a wheel does.
+  const direction = keyDirection(event);
+  for (let el: Element | null = target; el; el = el.parentElement) {
+    if (scrollsVertically(el) && canScrollBy(el, direction)) return false;
+  }
+  return true;
 }
 
 /** Overflow values that make an element its own scroll container. */

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -84,6 +84,16 @@ export function keyScrollsPage(event: KeyboardEvent): boolean {
   const target = event.target;
   if (!(target instanceof Element)) return true;
   if (target.closest(CONSUMES_THE_KEY)) return false;
+  // The day rail intercepts `Home`, prevents the default and moves focus to
+  // today's chip — it never scrolls. `useFilterPanel`'s own exemption carves
+  // out the identical interaction, and two consumers disagreeing about one
+  // keypress is worse than either answer.
+  //
+  // `Home` alone, deliberately: that comment also records that `PageDown` with
+  // focus parked on a chip really IS a page scroll, because the rail does not
+  // intercept it. Narrowing further than the rail actually consumes would be
+  // guessing rather than matching.
+  if (event.key === 'Home' && target.closest('[data-chip]')) return false;
   const isSpace = event.key === ' ' || event.key === 'Spacebar';
   return !(isSpace && target.closest(ACTIVATED_BY_SPACE));
 }

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -172,3 +172,43 @@ export function gestureScrollsPage(event: Event): boolean {
   }
   return true;
 }
+
+/**
+ * Controls a drag can start on without the drag being a scroll.
+ *
+ * Deliberately broader than `ACTIVATED_BY_SPACE`: this is not about which key
+ * a control consumes, it is about a press-and-drag that means something to the
+ * control rather than to the page. `[data-chip]` is the day rail; the week
+ * strip's buttons are plain `<button>`s.
+ */
+const DRAGGABLE_CONTROL =
+  'button, a[href], input, select, textarea, summary, [role="button"], [data-chip]';
+
+/**
+ * Whether a drag beginning here would scroll the page.
+ *
+ * A scrollbar drag is the one way to scroll that fires no wheel, touch or key,
+ * which is why the pointer path exists at all. But "a button is held while the
+ * pointer moves" describes far more than that, and one of the other things it
+ * describes is the week-range selector: pressing a week and dragging across
+ * its neighbours refilters the list on every `mouseenter`, changing the
+ * document's height under the reader. The browser's correction for that would
+ * then arrive inside a window the drag had armed.
+ *
+ * Detecting the scrollbar itself was the obvious alternative and is not
+ * available: headless Chromium — like macOS by default — uses overlay
+ * scrollbars, where `document.documentElement.clientWidth === innerWidth`, so
+ * there is no gutter to test a coordinate against and no way to verify such a
+ * test here. Asking where the drag STARTED needs no platform knowledge.
+ *
+ * A drag over ordinary content is left counting, because it is a text
+ * selection, and dragging a selection past the viewport edge does scroll.
+ */
+export function dragScrollsPage(event: MouseEvent): boolean {
+  // Primary button only. `buttons` is a bitmask, so `!== 0` also matched
+  // right- and middle-button drags, neither of which scrolls anything.
+  if (event.buttons !== 1) return false;
+  const target = event.target;
+  if (!(target instanceof Element)) return true;
+  return !target.closest(DRAGGABLE_CONTROL);
+}

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -184,6 +184,12 @@ function canScrollBy(el: Element, deltaY: number): boolean {
  * target on it.
  */
 export function gestureScrollsPage(event: Event, deltaY?: number): boolean {
+  // Zoom is not scrolling, and it moves the document under the reader — it
+  // re-anchors and re-lays-out, so admitting it lets a pinch move the header.
+  // Chromium reports a trackpad pinch as a wheel with `ctrlKey`; a touchscreen
+  // pinch is simply more than one finger.
+  if (event.type === 'wheel' && (event as WheelEvent).ctrlKey) return false;
+  if (event.type === 'touchmove' && ((event as TouchEvent).touches?.length ?? 1) > 1) return false;
   const direction = event.type === 'wheel' ? (event as WheelEvent).deltaY : deltaY ?? 0;
   // A wheel with no vertical component is the day rail moving sideways.
   if (event.type === 'wheel' && direction === 0) return false;
@@ -237,14 +243,26 @@ const DRAGGABLE_CONTROL =
  * content from that moment on, so it armed on exactly the drag it had just
  * refused.
  */
+/**
+ * Whether a gesture beginning on `origin` can scroll the page at all.
+ *
+ * Shared by the mouse and touch paths because they are asking one question.
+ * `WeekSelector` calls `preventDefault()` on its touch handlers, so a drag
+ * over a themed week scrolls nothing — and then `touchend` refilters the
+ * list, whose correction would arrive holding a gesture's authority.
+ */
+export function originCanScrollPage(origin: Element | null): boolean {
+  // No recorded press means the gesture began before this hook was listening,
+  // or outside the document. Nothing says it was a control.
+  if (!origin) return true;
+  return !origin.closest(DRAGGABLE_CONTROL);
+}
+
 export function dragScrollsPage(event: MouseEvent, origin: Element | null): boolean {
   // Primary button only. `buttons` is a bitmask, so `!== 0` also matched
   // right- and middle-button drags, neither of which scrolls anything.
   if (event.buttons !== 1) return false;
-  // No recorded press means the drag began before this hook was listening, or
-  // outside the document. Nothing says it was a control.
-  if (!origin) return true;
-  return !origin.closest(DRAGGABLE_CONTROL);
+  return originCanScrollPage(origin);
 }
 
 /**

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -1,4 +1,18 @@
 /**
+ * Whether a given piece of input will scroll the PAGE.
+ *
+ * Every consumer of this module is asking one question — "did the reader just
+ * scroll the document?" — and the answer is never the event type alone.
+ * Space scrolls from the document, types in a field and activates a button;
+ * a wheel scrolls the page, or the panel it happens to be over, or the day
+ * rail sideways. Only the target and the deltas separate those.
+ *
+ * Named for gestures rather than for keys because it stopped being only keys:
+ * a name that undersells what a module answers is how the wrong caller ends
+ * up asking the easy half of the question.
+ */
+
+/**
  * The keys the reader deliberately scrolls with.
  *
  * Deliberately narrow: a bare letter or a Tab must not count as scrolling.
@@ -72,4 +86,48 @@ export function keyScrollsPage(event: KeyboardEvent): boolean {
   if (target.closest(CONSUMES_THE_KEY)) return false;
   const isSpace = event.key === ' ' || event.key === 'Spacebar';
   return !(isSpace && target.closest(ACTIVATED_BY_SPACE));
+}
+
+/** Overflow values that make an element its own scroll container. */
+const SCROLLS = new Set(['auto', 'scroll', 'overlay']);
+
+/**
+ * Whether this element takes vertical scrolling for itself.
+ *
+ * The document's own scrollers are excluded by name: they ARE the page, so a
+ * gesture over them is a page scroll rather than a nested one.
+ */
+function scrollsVertically(el: Element): boolean {
+  if (el === document.documentElement || el === document.body) return false;
+  if (el.scrollHeight <= el.clientHeight) return false;
+  return SCROLLS.has(getComputedStyle(el).overflowY);
+}
+
+/**
+ * Whether a pointer gesture will scroll the page, rather than something in it.
+ *
+ * The filter panel is `max-h-[70vh] overflow-y-auto` whenever it overlays the
+ * list, so a wheel or a drag inside it moves the panel and leaves `window`
+ * exactly where it was. Treating that as a page scroll matters because of what
+ * usually comes next: the reader picks a venue, the list reflows, and the
+ * correction for that reflow inherits an authority the gesture never had.
+ * `useFilterPanel` already exempts gestures inside the panel, for the
+ * mirror-image reason.
+ *
+ * A wheel with no vertical component is out for the same reason: the day rail
+ * scrolls sideways, and moving it is not moving the page up or down.
+ *
+ * Errs toward "this did not scroll the page". A nested scroller at its own
+ * boundary really does chain to the document, so this returns false for the
+ * last few pixels of such a gesture — a missed toggle the reader's next scroll
+ * puts right, which is the cheaper of the two mistakes.
+ */
+export function gestureScrollsPage(event: Event): boolean {
+  if (event.type === 'wheel' && (event as WheelEvent).deltaY === 0) return false;
+  const target = event.target;
+  if (!(target instanceof Element)) return true;
+  for (let el: Element | null = target; el; el = el.parentElement) {
+    if (scrollsVertically(el)) return false;
+  }
+  return true;
 }

--- a/frontend/src/lib/scrollGestures.ts
+++ b/frontend/src/lib/scrollGestures.ts
@@ -59,7 +59,13 @@ export const SCROLL_KEYS: ReadonlySet<string> = new Set([
  */
 const CONSUMES_THE_KEY =
   'input, textarea, select, [contenteditable=""], [contenteditable="true"]';
-const ACTIVATED_BY_SPACE = 'button, a[href], summary, [role="button"]';
+/**
+ * Note the absence of `a[href]`. A native link is activated with **Enter**,
+ * not Space — Space on a focused link scrolls the page, so listing links here
+ * rejected a real keyboard scroll. An anchor given `role="button"` is covered
+ * by the last entry, which is the case where Space really does activate.
+ */
+const ACTIVATED_BY_SPACE = 'button, summary, [role="button"]';
 
 /**
  * Whether a `keydown` will actually scroll the page.
@@ -114,6 +120,23 @@ function scrollsVertically(el: Element): boolean {
 }
 
 /**
+ * Whether this scroller can still move in `deltaY`'s direction.
+ *
+ * A scroller at its own boundary does not consume the wheel — it CHAINS, and
+ * the page moves instead. Treating "is a scroller" as "consumes the gesture"
+ * left a reader wheeling upward over a filter panel already at its top unable
+ * to reveal the header at all: every tick moved `window` and every tick was
+ * discarded, for as long as the pointer stayed over the panel.
+ *
+ * `deltaY === 0` never reaches here — `gestureScrollsPage` rejects it first.
+ */
+function canScrollBy(el: Element, deltaY: number): boolean {
+  return deltaY < 0
+    ? el.scrollTop > 0
+    : el.scrollTop < el.scrollHeight - el.clientHeight;
+}
+
+/**
  * Whether a pointer gesture will scroll the page, rather than something in it.
  *
  * The filter panel is `max-h-[70vh] overflow-y-auto` whenever it overlays the
@@ -127,17 +150,25 @@ function scrollsVertically(el: Element): boolean {
  * A wheel with no vertical component is out for the same reason: the day rail
  * scrolls sideways, and moving it is not moving the page up or down.
  *
- * Errs toward "this did not scroll the page". A nested scroller at its own
- * boundary really does chain to the document, so this returns false for the
- * last few pixels of such a gesture — a missed toggle the reader's next scroll
- * puts right, which is the cheaper of the two mistakes.
+ * A wheel carries a direction, so an ancestor only counts as consuming it when
+ * it can still move that way; otherwise the walk continues toward the
+ * document, which is what the browser does. A touch drag carries no usable
+ * direction on a single `touchmove`, so any scrollable ancestor claims it —
+ * the conservative half of the rule, kept because reconstructing a drag's
+ * direction means tracking `touchstart` state for a decision that is already
+ * bounded by a 400ms window.
  */
 export function gestureScrollsPage(event: Event): boolean {
-  if (event.type === 'wheel' && (event as WheelEvent).deltaY === 0) return false;
+  const isWheel = event.type === 'wheel';
+  const deltaY = isWheel ? (event as WheelEvent).deltaY : 0;
+  if (isWheel && deltaY === 0) return false;
   const target = event.target;
   if (!(target instanceof Element)) return true;
   for (let el: Element | null = target; el; el = el.parentElement) {
-    if (scrollsVertically(el)) return false;
+    if (!scrollsVertically(el)) continue;
+    // At its boundary it chains to the page rather than consuming this.
+    if (isWheel && !canScrollBy(el, deltaY)) continue;
+    return false;
   }
   return true;
 }

--- a/frontend/src/lib/scrollKeys.ts
+++ b/frontend/src/lib/scrollKeys.ts
@@ -1,0 +1,29 @@
+/**
+ * The keys the reader deliberately scrolls with.
+ *
+ * Deliberately narrow: a bare letter or a Tab must not count as scrolling.
+ * Both consumers listen on `window` with `capture: true`, so every keystroke
+ * on the page reaches them — including the ones going into a search field,
+ * which is the case that makes the distinction load-bearing rather than tidy.
+ *
+ * `useDismissOnScrollGesture` needs it so that typing into the filter panel's
+ * own search box does not dismiss the panel out from under the reader.
+ * `useSiteHeaderReveal` needs it because search re-filtering changes the
+ * list's height by thousands of pixels above the reader, the browser corrects
+ * for that on its own, and an unfiltered `keydown` would hand each of those
+ * corrections the authority of a gesture — type three letters, watch the site
+ * header appear.
+ *
+ * Shared rather than reasoned out twice: the second copy is where the two
+ * would drift apart, and both are answering the same question.
+ *
+ * `ArrowLeft`/`ArrowRight` are absent on purpose. They scroll horizontally,
+ * which no page-level surface here cares about, and on the day rail they are
+ * chip-to-chip focus movement that must not be mistaken for either.
+ */
+export const SCROLL_KEYS: ReadonlySet<string> = new Set([
+  'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar',
+]);
+
+/** Whether a `keydown` is the reader scrolling with the keyboard. */
+export const isScrollKey = (key: string): boolean => SCROLL_KEYS.has(key);

--- a/frontend/src/lib/scrollKeys.ts
+++ b/frontend/src/lib/scrollKeys.ts
@@ -25,9 +25,6 @@ export const SCROLL_KEYS: ReadonlySet<string> = new Set([
   'ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' ', 'Spacebar',
 ]);
 
-/** Whether a `keydown` is the reader scrolling with the keyboard. */
-export const isScrollKey = (key: string): boolean => SCROLL_KEYS.has(key);
-
 /**
  * Anything that takes the keypress for itself instead of scrolling.
  *
@@ -36,11 +33,15 @@ export const isScrollKey = (key: string): boolean => SCROLL_KEYS.has(key);
  * rather than scrolling, which is why buttons and links are here too.
  *
  * Note what is NOT in the second list: a bare `[tabindex]`. Focusable is not
- * the same as activated-by-Space — `WeekBadge` and the modal container are
- * both focusable, and Space pressed on either really does scroll the page.
- * Excluding them would be a false negative in the one direction this function
- * is otherwise careful to prefer, but a wrong one: it would be claiming
- * something about the platform that is not true.
+ * the same as activated-by-Space. `Modal`'s container is the real example —
+ * `role="dialog"`, `tabIndex={-1}`, and an `onKeyDown` that handles only
+ * Escape and Tab — so Space there does scroll the page, and excluding it would
+ * be claiming something about the platform that is not true.
+ *
+ * `WeekBadge` is NOT such an example, though it looks like one: it sets
+ * `role="button"` in the same breath as `tabIndex={0}` and calls
+ * `preventDefault()` on Space, so the `[role="button"]` match already covers
+ * it, correctly.
  */
 const CONSUMES_THE_KEY =
   'input, textarea, select, [contenteditable=""], [contenteditable="true"]';

--- a/frontend/src/lib/scrollKeys.ts
+++ b/frontend/src/lib/scrollKeys.ts
@@ -27,3 +27,48 @@ export const SCROLL_KEYS: ReadonlySet<string> = new Set([
 
 /** Whether a `keydown` is the reader scrolling with the keyboard. */
 export const isScrollKey = (key: string): boolean => SCROLL_KEYS.has(key);
+
+/**
+ * Anything that takes the keypress for itself instead of scrolling.
+ *
+ * A field consumes all of these — Space inserts a character, the arrows and
+ * Home/End move the caret. Space additionally activates a focused control
+ * rather than scrolling, which is why buttons and links are here too.
+ *
+ * Note what is NOT in the second list: a bare `[tabindex]`. Focusable is not
+ * the same as activated-by-Space — `WeekBadge` and the modal container are
+ * both focusable, and Space pressed on either really does scroll the page.
+ * Excluding them would be a false negative in the one direction this function
+ * is otherwise careful to prefer, but a wrong one: it would be claiming
+ * something about the platform that is not true.
+ */
+const CONSUMES_THE_KEY =
+  'input, textarea, select, [contenteditable=""], [contenteditable="true"]';
+const ACTIVATED_BY_SPACE = 'button, a[href], summary, [role="button"]';
+
+/**
+ * Whether a `keydown` will actually scroll the page.
+ *
+ * The key alone settles almost nothing. Space scrolls the page from the
+ * document, types a character in a search field, and activates a focused
+ * button — three different things behind one `e.key`, and only the target
+ * separates them. A caller that armed on the key alone would treat typing
+ * "brass band" as two scroll gestures.
+ *
+ * That matters because of what tends to follow such a keystroke: search
+ * re-filtering is the largest layout change above the reader this app makes,
+ * the browser corrects for it on its own, and a correction that inherits a
+ * gesture's authority is read as the reader scrolling.
+ *
+ * Errs toward "this did not scroll". The cost of a false negative is one
+ * missed header toggle that the reader's next real scroll puts right; the cost
+ * of a false positive is the header moving when nobody asked.
+ */
+export function keyScrollsPage(event: KeyboardEvent): boolean {
+  if (!SCROLL_KEYS.has(event.key)) return false;
+  const target = event.target;
+  if (!(target instanceof Element)) return true;
+  if (target.closest(CONSUMES_THE_KEY)) return false;
+  const isSpace = event.key === ' ' || event.key === 'Spacebar';
+  return !(isSpace && target.closest(ACTIVATED_BY_SPACE));
+}

--- a/frontend/src/lib/siteHeaderReveal.ts
+++ b/frontend/src/lib/siteHeaderReveal.ts
@@ -1,0 +1,106 @@
+/**
+ * Whether the site header is showing, as a pure function of scroll position.
+ *
+ * The header is the only route to the "more" menu and the year selector
+ * (#272), and below the fold it used to be unreachable without scrolling the
+ * whole document back to the top — which from a rail tap can be tens of
+ * thousands of pixels. It now reveals on scroll up and hides on scroll down,
+ * and this module is the decision that drives it.
+ *
+ * ## Why the rule is a pure function rather than a hook
+ *
+ * The failure modes of a reveal-on-scroll header are all rule failures:
+ * flickering on momentum, needing an implausibly long flick to come back
+ * after a long descent, flashing in when the page jumps under a rail tap.
+ * None of them need layout to reproduce, and jsdom — which has no layout, no
+ * compositor and no scroll anchoring — cannot reproduce the geometry ones
+ * anyway. So the rule is testable here and the geometry is left to
+ * `e2e/verify-header-reveal.mjs`.
+ */
+
+/**
+ * Accumulated travel, in px, that a direction must sustain before it flips
+ * the decision.
+ *
+ * Small enough that "a small upward flick" is honestly small, large enough
+ * that iOS Safari's momentum jitter — which reports a few px in the wrong
+ * direction as a fling settles — cannot flip it.
+ */
+export const REVEAL_THRESHOLD = 24;
+
+export interface HeaderRevealState {
+  /** Whether the header is currently showing. */
+  revealed: boolean;
+  /**
+   * Travel accumulated in the current direction, signed: positive is
+   * scrolling down. Reset on every direction change — see `nextHeaderReveal`.
+   */
+  travel: number;
+  /** The `scrollY` this state was computed at; the baseline for the next one. */
+  y: number;
+}
+
+export const initialHeaderReveal = (y: number): HeaderRevealState => ({
+  revealed: true,
+  travel: 0,
+  y,
+});
+
+/**
+ * The decision after the scroll position moves to `y`.
+ *
+ * `topZone` is the header's own height. Within it the header's natural
+ * position is still on screen, so "hidden" is not a state it can be in: a
+ * sticky header cannot be parked above a position it has not yet reached, and
+ * marking it hidden there would make a visible header `inert`.
+ *
+ * The accumulator restarts on every direction change, and that restart *is*
+ * the hysteresis. Carrying it would mean a reader who has scrolled 400px down
+ * needs 424px up to see the header again; judging each event on its own delta
+ * instead would mean a trackpad's many-small-deltas flick never fires at all.
+ * Restarting is the only rule that gets both right.
+ */
+export function nextHeaderReveal(
+  prev: HeaderRevealState,
+  y: number,
+  { threshold = REVEAL_THRESHOLD, topZone = 0 }: { threshold?: number; topZone?: number } = {},
+): HeaderRevealState {
+  // At (or above — WebKit rubber-banding reports a negative `scrollY`) the
+  // top of the document the header is simply shown, and the accumulator is
+  // cleared so travel banked on the way in cannot fire on the way out.
+  if (y <= topZone) return { revealed: true, travel: 0, y };
+
+  const delta = y - prev.y;
+  // `scroll` fires for momentum settling and for rubber-band release without
+  // the position changing. Folding a zero into the accumulator is harmless
+  // arithmetic, but returning `prev` unchanged keeps the state identity
+  // stable for callers that compare it.
+  if (delta === 0) return prev;
+
+  const reversed = prev.travel !== 0 && Math.sign(delta) !== Math.sign(prev.travel);
+  const travel = reversed ? delta : prev.travel + delta;
+
+  if (travel >= threshold) return { revealed: false, travel, y };
+  if (travel <= -threshold) return { revealed: true, travel, y };
+  return { revealed: prev.revealed, travel, y };
+}
+
+/**
+ * Move the baseline to `y` without re-deciding anything.
+ *
+ * The app scrolls the document itself in several places — a rail chip tap, the
+ * filter panel's insertion correction, the day-anchor hold — and those jumps
+ * are large. Read as gestures they are the biggest scroll the reader could
+ * possibly make, so a rail tap would flash the header in on every use.
+ *
+ * The fix is a resync rather than a suppression flag, and the difference
+ * matters. A flag has to guess how many `scroll` events a programmatic jump
+ * will produce — several `scrollBy` calls in one frame coalesce into one
+ * event, so a counter over-swallows and eats the reader's next real scroll.
+ * Resyncing the baseline instead makes the provoked event a zero delta by
+ * construction, and if the reader *does* scroll before it arrives, their
+ * delta is measured from the correct post-jump position.
+ */
+export function resyncHeaderReveal(prev: HeaderRevealState, y: number): HeaderRevealState {
+  return { revealed: prev.revealed, travel: 0, y };
+}

--- a/frontend/src/lib/utils/daySections.ts
+++ b/frontend/src/lib/utils/daySections.ts
@@ -81,15 +81,29 @@ function lengthPx(property: string): number {
  * same as every other measurement in this file.
  *
  * The chrome is the rail PLUS the site header whenever that header is
- * revealed (#272) — `--site-header-offset` is `0px` while it is hidden, so
- * this is the rail alone the rest of the time. Named for the chrome rather
- * than for the rail because it stopped being only the rail: a name that
- * undersold what it measured is how the day titles ended up pinned a whole
- * header too high.
+ * revealed (#272) — the offset is `0px` while it is hidden, so this is the
+ * rail alone the rest of the time. Named for the chrome rather than for the
+ * rail because it stopped being only the rail: a name that undersold what it
+ * measured is how the day titles ended up pinned a whole header too high.
+ *
+ * ## Why the TARGET offset, not the animated one
+ *
+ * `--site-header-offset` transitions over 200ms, and every caller here samples
+ * it on a scroll or a resize. The scroll that triggers a reveal samples near
+ * the START of that transition, and nothing fires when it finishes — so an
+ * anchor computed then keeps a chrome boundary up to a whole header too short
+ * until the reader scrolls again, which next to a day boundary means the wrong
+ * chip stays lit.
+ *
+ * `--site-header-offset-target` is the same value with no transition on it.
+ * A logical question — "is this section behind the chrome" — wants where the
+ * chrome is going, not where it happens to be mid-flight. The animated
+ * property remains what CSS positions against, so nothing about the motion
+ * changes.
  */
 export function topChromeHeightPx(): number {
   if (typeof document === 'undefined') return 0;
-  return lengthPx('--site-header-offset') + lengthPx('--day-rail-h');
+  return lengthPx('--site-header-offset-target') + lengthPx('--day-rail-h');
 }
 
 /**

--- a/frontend/src/lib/utils/daySections.ts
+++ b/frontend/src/lib/utils/daySections.ts
@@ -64,21 +64,32 @@ export function daySectionTop(key: string): number | null {
   return el ? el.getBoundingClientRect().top : null;
 }
 
-/**
- * How far below the viewport top counts as "behind the sticky rail", read
- * from `--day-rail-h`.
- *
- * Shared here rather than duplicated: `useDayAnchor`'s scrollspy and the
- * filter panel's open/close scroll correction both need the same answer to
- * "is this section still clear of the chrome", and a hardcoded number would
- * drift out of step with the rail's real height on browser text zoom, same
- * as every other measurement in this file.
- */
-export function dayRailHeightPx(): number {
-  if (typeof document === 'undefined') return 0;
-  const raw = getComputedStyle(document.documentElement).getPropertyValue('--day-rail-h');
-  const parsed = Number.parseFloat(raw);
+/** One custom property as a number, or 0 if it has not been published. */
+function lengthPx(property: string): number {
+  const parsed = Number.parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue(property));
   return Number.isFinite(parsed) ? parsed : 0;
+}
+
+/**
+ * How far below the viewport top counts as "behind the chrome".
+ *
+ * Shared here rather than duplicated: `useDayAnchor`'s scrollspy, the rail's
+ * highlight and the filter panel's open/close scroll correction all need the
+ * same answer to "is this section still clear of the chrome", and a hardcoded
+ * number would drift out of step with the real heights on browser text zoom,
+ * same as every other measurement in this file.
+ *
+ * The chrome is the rail PLUS the site header whenever that header is
+ * revealed (#272) — `--site-header-offset` is `0px` while it is hidden, so
+ * this is the rail alone the rest of the time. Named for the chrome rather
+ * than for the rail because it stopped being only the rail: a name that
+ * undersold what it measured is how the day titles ended up pinned a whole
+ * header too high.
+ */
+export function topChromeHeightPx(): number {
+  if (typeof document === 'undefined') return 0;
+  return lengthPx('--site-header-offset') + lengthPx('--day-rail-h');
 }
 
 /**
@@ -96,7 +107,7 @@ export function dayRailHeightPx(): number {
  * scroll-listening or settle-hold machinery.
  */
 export function topmostVisibleDaySection(): HTMLElement | null {
-  const limit = dayRailHeightPx();
+  const limit = topChromeHeightPx();
   const sections = document.querySelectorAll<HTMLElement>(`[${DAY_SECTION_ATTR}]`);
   for (const el of Array.from(sections)) {
     if (el.getBoundingClientRect().top >= limit) return el;


### PR DESCRIPTION
Closes #272.

The site header carries the "more" menu and the year selector, and it was an ordinary in-flow element that scrolled away and never came back. It now reveals on scroll up and hides on scroll down, from any position in the document.

## Design decisions worth reviewing

**Sticky, not fixed.** The issue suggested `position: fixed` translated in and out. `fixed` needs a spacer to replace the height it removes from flow, and a spacer sized from a JS measurement is the same "document height above the reader changes" hazard `filterHeaderLayout.ts` documents — the one that made the page impossible to scroll slowly. Sticky with a negative `top` never leaves flow at all, so document height is constant by construction.

**The rail rides down, rather than being covered** (issue constraint 2 — the reader picked this). One registered custom property, `--site-header-offset`, feeds both the header's `top` and the sticky filter/rail container's, so they hold the same value every frame. `top` itself is never transitioned, which would otherwise animate the filter panel's separately-choreographed reveal. It is a CSS variable rather than React state so a reveal re-renders `Header` alone, not 1,470 events.

Day section titles stick third in that stack and had to learn about it — pinned at the bare rail height they slid behind a rail that outranks them and vanished whenever the header showed. `dayRailHeightPx` → `topChromeHeightPx` for the same reason.

**Three mechanisms separate the reader's scrolls from everyone else's**, each paid for by a measured failure:

| Mechanism | The failure it was written for |
|---|---|
| Our scrolls announce themselves and resync the baseline (`scrollWindowBy`, replacing 5 bare `window.scrollBy` sites) | A rail tap jumps 12,551px — read as a gesture, the largest scroll up a reader could make |
| A **zero** delta still announces | Chromium's scroll anchoring corrected the panel's insertion +44px *before* our layout effect ran, so our correction computed nothing and skipped the announcement that mattered |
| A scroll with no gesture behind it decides nothing | WebKit's anchoring moved the page 122px after a chip tap, and 44px when the panel opened with no day section to anchor to — neither announceable |

That last test began as "a gesture since the last scroll" and **is now a 400ms window** — the claim above stood after the rule underneath it had changed, which Copilot caught. Consuming a gesture on its first scroll turned out to be wrong: WebKit on Linux delivers one wheel tick across several frames, so consumption threw away most of a tick's own movement and the header stopped hiding at all.

A window does lend a real gesture's authority to what the browser does next inside it. Three things bound that:

- a **settle** set whenever the app scrolls and cleared only by the reader's next gesture, so a correction that follows an app scroll never inherits anything;
- `gestureScrollsPage`, so a wheel consumed by the filter panel's own overflow, or a horizontal one over the day rail, never arms the window at all;
- `keyScrollsPage`, so typing and control keypresses do not either.

What remains is a genuine, narrow accepted trade-off: a browser correction landing inside 400ms of a real gesture, with no app scroll in between, is treated as the reader's. The failure is a transient header reveal, and closing it would mean a fourth mechanism guarding the seam between the other three.

## Verification

- **1,309 unit tests**, all green. The show/hide rule is a pure function (`lib/siteHeaderReveal.ts`) covering direction, threshold, reversal-hysteresis, top-zone and resync.
- **New browser suite** `e2e/verify-header-reveal.mjs`, 20 checks numbered 0–19, green under **Chromium and WebKit**. Check 0 comes from `enterList()` in `regime.mjs`, which reports which season regime the run is in. Checks 9 and 10 are the standing guard against the scroll-anchoring regression: 40 wheel ticks, 2,400px requested, 2,400px delivered, zero snap-backs.
- **All five browser suites green — 121 checks**, including `verify-rail` (37) and `verify-filter-reveal` (35) unchanged. `verify-filter-reveal`'s check 13 sometimes reports as skipped; that is its own documented render-window confounder, date-dependent and unrelated to this branch.
- Every guard proved by breaking the code. That is how the vacuous ones were caught, including a rail-tap check that jumped *down* and so could never have seen the bug it was named for, and a CSS guard that passed with the transition outside its reduced-motion block.

**CI change worth a look:** the browser-checks job now installs WebKit and runs this one suite twice. The two engines disagree about scroll anchoring in both directions, each hiding a bug from the other. Happy to drop it if the added install time is not worth it — everything else stays Chromium-only.

## Review round 2 (`84416ec`)

- **Scoped the reveal's `keydown` to actual scrolling keys.** Unfiltered, every keystroke armed the gesture gate — search included, and search re-filtering is the largest layout change above the reader the app makes. `useDismissOnScrollGesture` had already made this exact distinction for this exact reason, so its `SCROLL_KEYS` moved to `lib/scrollKeys.ts` and both hooks now share it.
- **Fixed a flaky harness, not a flaky product.** `browser-checks` failed on check 11 with the diagnosis the check prints for itself. `window.scrollTo(0, 6000)` lands short, the list grows, and the app and browser spend ~1s correcting; the wheel meant to hide the header fired into the middle of that and was measured *net* of the correction — traced at 4,935 → 4,829, so a 120px wheel *down* moved the reader 106px *up*. Every block now polls until the position is stable. 7 consecutive runs green across both engines.
- Checks renumbered so printed order matches execution order.

## Review round 7 (`7960c39`, `b5467a0`, `f95cc52`) — Copilot

Five findings, all real. Three were variations on one theme: something that was not the reader scrolling the page being counted as if it were.

- **A visible header was `inert`.** The gesture gate ignored gestureless scrolls wholesale, *including scrolls into the top zone*. Reproduced in Chromium: search until the list empties (document 8,401px → 1,049px), then let the viewport grow so the browser clamps `scrollY` to 0 — header at `top: 0, bottom: 48`, fully visible, `inert: true, aria-hidden: "true"`. The top zone is a fact about where the header **is**, not a decision about where it should be.
- **The same bug reached by growing rather than scrolling** — text zoom enlarging the header around the reader's position, with nothing re-running the decision.
- **A key does not tell you whether the page scrolled.** Space types in a field and activates a button; only the target separates those from scrolling.
- **A gesture the page never sees is not the reader scrolling it.** The filter panel is its own scroller while it overlays the list, so a wheel inside it moves the panel and not the window — and `useFilterPanel` already exempts those gestures for the mirror-image reason.
- Check numbering and count, both corrected.

New **browser check 15** reproduces the visible-inert recipe and fails on the pre-fix build. `scrollKeys.ts` became `scrollGestures.ts` — it stopped being only keys.

## Reported on device, fixed (`95b00db`, `ec6074a`)

Testing on the iPhone simulator, the header "sometimes does not scroll off the page and sometimes does not scroll back onto it".

**Root cause: a wheel fires for as long as the page is moving; a touch does not.** `touchmove` stops at `touchend` while most of a flick's distance is still to come, and iOS coasts for up to a couple of seconds in silence. The comment on the gesture window claimed momentum needed no handling because "a flick long enough to coast is far longer than the threshold" — true of a hard flick, false of a gentle one, which is the "sometimes".

Reproduced: the finger travels ~5px and lifts; the page coasts 60px over 1.2s. 60px is well over the 24px threshold, but only the first 400ms counted, during which it had moved ~18px.

**Two earlier reproduction attempts passed**, which is what made this worth measuring rather than guessing — a hard flick covers its distance inside the window, and an app correction mid-coast lands after the decision was already taken.

The coast is now treated as the rest of the flick: while it runs each frame refreshes the window, and it ends when the page stops moving. A second route to the same symptom — a correction landing before the coast had accumulated 24px — was caught by review and fixed alongside it.

**Confirmed working on the simulator.**

## Acceptance criteria

- [x] A small upward scroll from deep in the listing reveals the header with the title, year selector and "more" menu; the menu opens and works — checks 4, 6, 7
- [x] Scrolling down hides it; the rail stays flush with the top edge and keeps working — checks 3, 8, plus `verify-rail`'s 37
- [x] Slow scrolling makes steady progress in Chromium **and** WebKit — checks 9, 10, both engines
- [x] A day chip tap does not reveal the header — check 11 (an *upward* jump; the downward version proved nothing)
- [x] While hidden, not Tab-reachable and not announced — checks 12, 13
- [x] Unit tests cover the decision as a pure function; a browser check covers the reveal from a deep scroll

[skip-screenshots: web-only change, no iOS files touched]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KA2q9aD5wypWfAvJH6muTc




