### PR TITLE
test(ios): pin where a cold launch lands when no date is saved (#278)

### DIFF
--- a/docs/plans/2026-08-23-issue-batch-235-252-234-257-254-244.md
+++ b/docs/plans/2026-08-23-issue-batch-235-252-234-257-254-244.md
@@ -1,0 +1,189 @@
+# Issue batch plan — #235, #252, #234, #257, #254, #244
+
+**Status:** DONE (2026-08-24). All six issues (#235, #252, #234, #257, #254,
+#244) are closed and every PR merged: #266 (stream A), #265 (B), #267 (C),
+#264 (D), plus #268 — an e2e follow-up this batch surfaced, not part of the
+original plan. The merge-order and rebase notes below (#266 → #265 → #267 →
+#264, rebasing #267 for the known `selectScope` conflict) were the plan as
+written on 08-23 and are kept for the record; nothing in them is outstanding.
+
+Originally: Six issues grouped into four PR streams that
+run in isolated worktrees. Streams A, B, D run in parallel first; C starts
+once A finishes (C needs the UI suite, which is flaky while other
+`xcodebuild`s are compiling on this machine).
+
+| Stream | PR branch | Worktree | Tasks | Issues |
+|---|---|---|---|---|
+| A | `fix/ios-small-fixes-235-252-234` | `.worktrees/ios-small-fixes` | 1, 2, 3 | #235, #252, #234 |
+| B | `fix/week-filter-boundary-saturdays-257` | `.worktrees/week-filter-257` | 4 | #257 |
+| C | `refactor/ios-scroll-window-stamp-254` | `.worktrees/scroll-state-254` | 5 | #254 |
+| D | `feat/web-title-opens-details-244` | `.worktrees/web-title-details-244` | 6 | #244 |
+
+Suggested merge order: A → B → C → D (D is web-only and can merge any time).
+
+## Global Constraints
+
+These bind every task. Specs are the GitHub issues themselves (`gh issue view N`).
+
+1. **Never commit to `main`.** Work only on the stream's branch in its worktree.
+2. **TDD.** Write the failing test first, watch it fail for the expected reason, then implement. The report must show the RED and GREEN commands and output.
+3. **Prove every guard by breaking the code.** For any new test that protects a behaviour, temporarily inject the defect it guards against, confirm the test fails, revert the injection, and record that in the report. A test that cannot fail is a defect.
+4. **Verification before commit.** iOS: `xcodebuild test … -only-testing:ChqCalendarTests CODE_SIGNING_ALLOWED=NO` must pass (full compile gate over all three targets; run the UI suite only where the task says so). Web: `cd frontend && npm run build` (runs type-check + lint + unit tests + bundle). Backend is untouched by every task here.
+5. **iOS simulator per stream** (so concurrent streams don't fight over one device): Stream A `name=iPhone 17`, Stream B `name=iPhone 17 Pro`, Stream C `name=iPhone Air`. Always `-parallel-testing-enabled NO` for any run that includes `ChqCalendarUITests`. Omit `OS=`; resolve the default.
+6. **Commit messages**: concise subject (`fix(ios): …`, `feat(web): …`, `refactor(ios): …`), body explaining why, and end with:
+   ```
+   Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+   Claude-Session: https://claude.ai/code/session_01Adwf2e24aT5Nr3BiATm9xe
+   ```
+7. **No personal names, emails, phone numbers, or addresses** in committed content.
+8. **Keep the diff to the task.** No drive-by refactors outside the files the task names, no new abstractions that only one caller uses.
+9. **Doc comments are contracts.** If a task changes behaviour that an existing doc comment describes, update that comment in the same commit. Stale comments were the direct cause of two wasted investigations on this project.
+10. **App Store screenshot guard.** Any PR touching `ios/ChqCalendar/Features/**`, `ios/ChqCalendar/App/**`, or `ios/ChqCalendarShared/**` must either regenerate screenshots or carry `[skip-screenshots: <reason>]` in the PR body. No task in this plan alters a pixel any covered shot captures (`ios/Scripts/screenshot-plan.json` has no week-filter or scope-re-tap shot), so each iOS PR opts out with a specific reason. The PR body is written by the controller, not the implementer — but the implementer's report must state whether any covered shot could change.
+11. **Both-platform parity for #257**: the iOS and web week filters must return the same event set for the same selection. Ship in one PR.
+
+---
+
+## Stream A — three small iOS fixes
+
+### Task 1: #235 — delete the environment-dependent `containerURLIsNilInTheUnitTestHost` test and make the surrounding doc comments true
+
+**Issue:** #235. **Files:** `ios/ChqCalendarTests/AppGroupTests.swift`, `ios/ChqCalendarShared/Data/AppGroup.swift`, `ios/ChqCalendarTests/UserStateStoreTests.swift`, `ios/ChqCalendarTests/DiskCacheTests.swift`.
+
+**Finding that changes the issue's option 1.** The issue suggests asserting "`shouldRunAppOnlyMigration` is false from this target." That is not a code property either: `shouldRunAppOnlyMigration(isAppProcess:hasGroupContainer:)` is pure, and from the test host `isAppProcess` is `true` (the test target is hosted inside `ChqCalendar.app`) while `containerURL()` is non-nil on any simulator whose App Group container has ever been provisioned. On such a simulator `UserStateStore.triggerMigrationIfNeeded(isAppProcess: true)` really does reach `AppGroup.migrateDefaultsIfNeeded` — the "neither branch can reach the real migration call" assumption the test pins is simply false there. The dependent tests still pass because they assert only the `true` return value.
+
+**Ruling (controller):** take option 3 — delete the test — and make every comment that repeats the false assumption true. Do not add a replacement assertion that depends on the environment.
+
+**Do:**
+1. Delete `containerURLIsNilInTheUnitTestHost` (`AppGroupTests.swift:~190-198`) and its doc comment.
+2. `AppGroup.swift` `shouldRunAppOnlyMigration` doc comment (~lines 55-63): it says `containerURL()` "is always `nil` there (see `AppGroupTests.containerURLIsNilInTheUnitTestHost`)". Rewrite: the live values cannot be *flipped* from the test host (`isAppProcess` is always `true`; `containerURL()` depends on whether the simulator has the group container provisioned), which is why the gate is a pure function of two `Bool`s. Remove the reference to the deleted test.
+3. `UserStateStoreTests.swift` (~342-352) and `DiskCacheTests.swift` (~110-116): the MARK comments claim neither branch touches real defaults/files "since `AppGroup.containerURL()` is `nil` there". Rewrite honestly: on a simulator with the container provisioned, the `isAppProcess: true` call does run the real (idempotent, copy-only, flag-guarded) migration against the test host's own `.standard`/legacy cache; the tests pin only that the trigger is total and returns `true` for both inputs, and `shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer` pins the decision matrix.
+4. Confirm `shouldRunAppOnlyMigrationRequiresBothAppProcessAndGroupContainer` still exists unchanged — it is the test that actually pins the gate.
+
+**Tests:** no new test (the point is removing an environment assertion). Run `-only-testing:ChqCalendarTests/AppGroupTests -only-testing:ChqCalendarTests/UserStateStoreTests -only-testing:ChqCalendarTests/DiskCacheTests` while iterating; full unit suite before commit. Report whether the full unit suite is now green on this machine (the simulator here has the container provisioned, so before this change it was 1 red).
+
+**Commit:** `test(ios): drop the env-dependent App Group container assertion (#235)`.
+
+### Task 2: #252 — make the two UI-test scroll hooks refuse to be combined
+
+**Issue:** #252. **Files:** `ios/ChqCalendar/Features/Calendar/CalendarView.swift` (argument parsing, ~lines 245-260), `ios/ChqCalendar/App/AppModel.swift` (doc comments on `uiTestPendingScrollDelay` ~1697-1717 and `uiTestScrollsToDrop` ~1719-1741), and a unit test.
+
+**Ruling (controller):** "fail loudly" rather than "make them compose". The interference is between a deferred `resolvePendingScroll` and the drop-retry chain; composing them would mean redesigning DEBUG-only harness code nobody needs composed. A hard, named failure at launch is the fix the issue asks for.
+
+**Do:**
+1. Extract the parsing of `-uitest-delay-pending-scroll` and `-uitest-drop-scrolls <n>` into one small pure, testable function (e.g. `nonisolated enum UITestScrollHooks { static func parse(_ arguments: [String]) throws -> (delay: TimeInterval, dropCount: Int) }` or a struct — your call on shape, keep it minimal) that **throws / returns a descriptive error** when both are present. Keep it `#if DEBUG` like the surrounding code, in the same file or a small new file under `ios/ChqCalendar/Features/Calendar/`. The error message must name both flags and say they do not compose (cite #252).
+2. `CalendarView` calls it; on the incompatible combination it must terminate the app immediately with that message (`fatalError(...)` / `preconditionFailure` — a DEBUG-only launch path, so a crash with a clear message is the intended "loud" failure). Behaviour with either flag alone, or neither, is unchanged byte-for-byte: delay stays 3 s, drop count stays the parsed `n > 0`.
+3. Update both `AppModel` doc comments with one sentence each: the two hooks are mutually exclusive and the launch parser rejects the pair.
+4. Unit tests (new file in `ios/ChqCalendarTests/`): neither flag → (0, 0); delay alone → (3, 0); drop alone with `3` → (0, 3); drop with `0` or non-numeric → (0, 0) (matches today's `count > 0` guard); both → throws, and the error's description mentions both flag names. Prove the "both → throws" test by breaking the code (temporarily remove the check) per Global Constraint 3.
+
+**Tests:** the new unit test file while iterating; full unit suite before commit. Do **not** run the UI suite for this task; `testADayDeepLinkSurvivesADroppedScroll` uses `-uitest-drop-scrolls` alone and must keep working — verify by reading that the single-flag path is unchanged, and state so in the report.
+
+**Commit:** `fix(ios): reject -uitest-delay-pending-scroll combined with -uitest-drop-scrolls (#252)`.
+
+### Task 3: #234 — re-tapping the active scope resets its scope-local date state
+
+**Issue:** #234. **Files:** `ios/ChqCalendar/App/AppModel.swift` (`selectScope`, ~line 1090), `ios/ChqCalendarTests/AppModelTests.swift`.
+
+**Ruling (controller):** re-tapping the active scope means "reset it". With #258's rail `⟳ Now` shipped, the two must agree; the early-return guard is the one path that skips `clearScopeLocalDateState()`.
+
+**Do:**
+1. Replace the guard with the issue's proposed shape:
+   ```swift
+   let unchanged = filter.dateScope == scope
+       && filter.selectedWeeks.isEmpty
+       && filter.windowStartDayKey == nil
+       && filter.windowEndDayKey == nil
+       && filter.selectedDayKey == nil
+   guard !unchanged else { return }
+   ```
+   The guard's purpose (not writing `filter` — and so not firing its `didSet`/`persistFilter` — when genuinely nothing changes) is preserved; update `selectScope`'s doc comment to say that a re-tap with scope-local state clears it.
+2. Tests in `AppModelTests.swift` next to `reselectingTheActiveScopeIsANoOp` (~line 1122):
+   - **RED first:** re-tapping the active `.next` scope after widening the window (use the same mechanism the existing `selectScopeResetsWindowExpansion` test uses to set `windowEndDayKey`) clears `windowStartDayKey`/`windowEndDayKey`. This must fail on the current code.
+   - Re-tapping `.day` scope with a `selectedDayKey` set: decide deliberately. `browseDay` sets `.day` + `selectedDayKey` together; a re-tap of `.day` via `selectScope(.day)` would clear `selectedDayKey`, leaving `.day` with no day. Check how `DateScope.day` behaves with a nil `selectedDayKey` (`EventFilter`, `DateFilterLabel`, `FilterChipState` — the "exemption trio" from #192) and whether `.day` is even offered as a tappable scope chip in `FilterSheet`. If `.day` is never a chip, document that in the test/comment and keep the proposed guard; if it is, report it as a concern rather than guessing.
+   - Keep `reselectingTheActiveScopeIsANoOp` but make it genuinely assert the no-op: with no scope-local state, re-tapping must not call `persistFilter` — assert via the store/defaults the existing tests use (e.g. the persisted payload's `lastSaved` or a save count does not change), not just `dateScope == .today`.
+3. Falsify: with the fix in place, revert the guard to the old one-liner and confirm the new test fails; restore. Record in the report.
+
+**Tests:** `-only-testing:ChqCalendarTests/AppModelTests` while iterating; full unit suite before commit.
+
+**Commit:** `fix(ios): re-tapping the active scope clears its widened window (#234)`.
+
+---
+
+## Stream B
+
+### Task 4: #257 — week filters include the full boundary Saturdays on both platforms
+
+**Issue:** #257 (read it in full — it has the exact code for both platforms and the "must NOT change" list).
+
+**Files — iOS:** `ios/ChqCalendarShared/Domain/EventFilter.swift` (~lines 82-85); tests in `ios/ChqCalendarTests/` (`FilterChipStateTests`, `DateScopeExemptionTests`, `ViewWindowTests`, and wherever the week-filter predicate is currently asserted — grep for `selectedWeeks` in the tests).
+**Files — web:** `frontend/src/lib/utils/filterHelpers.ts` (~43-45), `frontend/src/lib/utils/eventHelpers.ts` (`weekNumbersForCalendarDate`, module-private at ~96 — export it, or move it to `dateHelpers.ts` beside `isInChautauquaWeek`; moving is preferred so the two week predicates live together), plus the `filterHelpers` / `dateHelpers` / `eventHelpers` tests.
+
+**Do (iOS):** replace the noon-bounded `SeasonWeek.contains` predicate with
+```swift
+result = result.filter { event in
+    !Set(SeasonCalendar.weekNumbers(spanningDayOf: event.start, in: weeks))
+        .isDisjoint(with: sel.selectedWeeks)
+}
+```
+(`weeks` is already computed once in `apply`; use the `in:` overload so the weeks array isn't rebuilt per event.) Check whether `sel.selectedWeeks` is a `Set<Int>` or `[Int]` and adapt. Do **not** touch `SeasonCalendar.weeks` (noon bounds are the gate-program turnover and `GatePassPolicy` reads them), `SeasonWeek.contains`, or `currentWeekNumber(at:)` (Siri needs a single answer). `WeekStripState`, `ViewWindow`, and `WeekBands` keep using `contains` — they answer "which week is *now* in", a different question.
+
+**Do (web):** same substitution in `filterEvents`: an event matches if `weekNumbersForCalendarDate(parseEventDate(event.startDate), seasonWeeks)` shares any number with `selectedWeeks`. Note `parseEventDate` is expensive (see the memo in `groupEventsByDay`); compute it once per event inside the predicate, not once per selected week. `isInChautauquaWeek` — check for other callers; if the filter was its only caller, delete it along with its tests rather than leaving a dead noon-split predicate beside the day-granular one. If other callers remain, leave it and say so.
+
+**Tests (both platforms), TDD order:** an event at 10:00 on a boundary Saturday (e.g. the Saturday opening week 6) matches **both** week 5 and week 6 selections; the opening Saturday's morning matches week 1; the closing Saturday's afternoon matches week 9; a mid-week event still matches only its own week; selecting weeks 5+6 yields the union with no duplicates. Existing tests that assert the noon split must be updated, not deleted — each one becomes the day-granular assertion. Falsify at least one new test per platform by reverting the predicate.
+
+**Verification:** iOS unit suite (`-only-testing:ChqCalendarTests`, simulator `iPhone 17 Pro`); web `cd frontend && npm run build`. Also run the web e2e harness only if it has a week-filter check (`frontend/e2e/README.md` — read it; if no week check exists, say so and skip).
+
+**Commit(s):** one commit per platform is fine (`fix(ios): …`, `fix(web): …`) or one combined `fix: week filters include the full boundary Saturdays (#257)`; both land in the same PR.
+
+**Report must state:** whether any App Store screenshot shot could change (expected: none — `ios/Scripts/screenshot-plan.json` has no week-filter shot), and the list of callers of `SeasonWeek.contains` / `isInChautauquaWeek` you left in place and why.
+
+---
+
+## Stream C
+
+### Task 5: #254 — make the day list carry the window it was built from, so `shouldAbandonScroll` can never compare live state against captured state
+
+**Issue:** #254 (read it in full). **Files:** `ios/ChqCalendar/App/AppModel.swift` (`dayGroups` ~306, `currentWindow` ~1537, `filteredEvents` ~347), `ios/ChqCalendar/Features/Calendar/EventListView.swift` (`content` ~780-800, `list(days:)` ~801, `landPendingScroll` ~613, `resolvePendingScroll` ~640-700, `autoExpandIfAtTheEnd` ~954), `ios/ChqCalendarShared/Domain/DayRailNavigation.swift` (`shouldAbandonScroll` ~55), `ios/ChqCalendarShared/Domain/EventFilter.swift` (computes its own `ViewWindow` inside `apply` ~60-80), tests `DayRailNavigationTests`, `PendingDayScrollTests`, `AppModelTests`, UI test `DayRailUITests.testADayDeepLinkLandsOnThatDay` (+ siblings at ~569-713).
+
+**The defect class (from the issue):** `resolvePendingScroll` compares `model.currentWindow` (live) against `days` (captured by the enclosing render). They disagree exactly once — the update that mounts `list(days:)` and consumes a day deep link in the same pass — and the `!visibleDays.isEmpty` guard added in #250 treats that symptom. Four bugs shared the signature "window grew, rail highlight moved, list never scrolled".
+
+**Ruling (controller): make the disagreement unrepresentable.** The model exposes one value per render pass that bundles the grouped days with the window they were filtered by — e.g.
+
+```swift
+/// What one render of the list is built from: the grouped days and the
+/// window that produced them, computed together so no caller can pair a
+/// day list from one pass with a window from another.
+struct RenderedDays { let days: [DayGroup]; let window: ViewWindow? }
+var renderedDays: RenderedDays
+```
+
+`content` binds `let rendered = model.renderedDays` once (as it binds `days` today — keep the single-read discipline the existing comment explains) and threads `rendered` (not `days`) into `list`, `landPendingScroll`, `resolvePendingScroll`. `shouldAbandonScroll` is called with `rendered.window`. `model.currentWindow` stays for its other callers (`AppModel` ~1334, ~1359) — those are model-side and not paired with a captured list.
+
+**Key design question you must settle, and document in the report:** today the window used for *filtering* is computed inside `EventFilter.apply` (with cheaper season-only bounds on the common path), while `currentWindow` recomputes with `navigableBounds`. `RenderedDays.window` must be the window the days were actually filtered by, or provably equal to it for everything `shouldAbandonScroll` reads (`startDay`/`endDay`). Either (a) have `EventFilter.apply` return the window it used alongside the events (a new overload; keep the existing signature for other callers), or (b) compute the window once in `AppModel` and pass it into a new `EventFilter.apply(..., window:)` entry point. Read `EventFilter.swift` ~45-80 and `ViewWindow.make`'s doc before choosing; (a) is the smaller diff if the two windows can differ in `startDay`/`endDay`, (b) is cleaner if they cannot. Do not leave two window computations that can disagree.
+
+**Then remove the symptom guard:** with both values from one pass, the `!visibleDays.isEmpty` condition in `resolvePendingScroll` is no longer load-bearing. Remove it **only after** proving the cold-launch deep-link case still lands: run `DayRailUITests/testADayDeepLinkLandsOnThatDay`, `testADayDeepLinkSurvivesADroppedScroll`, `testADayDeepLinkIsConsumedEvenWithNoDayGroupsOnScreen`, and `testChangingScopeAfterADistantTapDoesNotLaterHijackTheList` at least **5× each** (the original failure was ~3 in 8). If any fails, the guard stays and the report says why. Rewrite the long #250 comment block in `resolvePendingScroll` to describe the new invariant in a few lines and keep a one-line pointer to #254.
+
+**Unit tests (TDD):** a test that constructs the pre-growth/post-growth situation directly — a `RenderedDays` whose window does not cover the target must *not* abandon (the day may still arrive), and one whose window covers the target with no section *does* abandon — against whatever pure function you extract (e.g. a `DayRailNavigation.shouldAbandonScroll(target:rendered:)` or keep the existing signature and test the call site's pairing through `AppModel.renderedDays`). Add an `AppModelTests` case proving `renderedDays.window` equals the window `EventFilter` filtered by for a selection with expansion set (the path where the two computations could have diverged). Falsify each new test by breaking the code.
+
+**Verification:** unit suite `-only-testing:ChqCalendarTests` (simulator `iPhone Air`); then the four UI tests above with `-only-testing:ChqCalendarUITests/DayRailUITests/<name>` and `-parallel-testing-enabled NO`, repeated as stated; finally one full `xcodebuild test` run (everything) before the final commit.
+
+**Commit:** `refactor(ios): stamp the day list with the window it was built from (#254)`, plus a separate commit if you remove the guard: `fix(ios): drop the visibleDays symptom guard now that window and days come from one pass (#254)`.
+
+**Report must state:** the design choice (a)/(b) and why; the UI-test repetition counts and results; whether any App Store screenshot could change (expected none — no pixel changes).
+
+---
+
+## Stream D
+
+### Task 6: #244 — tapping the event name opens its details, with "Open on chq.org" inside
+
+**Issue:** #244 (read it in full — it is the spec: behaviour, markup, labels, edge cases, persistence decision, and the test list). **Files:** `frontend/src/components/calendar/EventCard.tsx` (all UI changes), tests `frontend/src/__tests__/components/calendar/EventCard.articleLinks.test.tsx`, `EventCard.programLinks.test.tsx`, `EventList.test.tsx`, `EventCard.publisherSource.test.tsx` (check for title-link assumptions), plus a new `EventCard.titleDetails.test.tsx` (or similar) for the new coverage the issue lists.
+
+**Decisions already taken in the issue (do not re-open):** title becomes a `<button>` inside the `<h4>`; no `🔗` on the title; chevron `▸`/`▾` `aria-hidden`; "Show more"/"Show less" removed; 📖/📰 move to the title line, not separately focusable; link at the bottom of the panel labelled **"Open on chq.org"** when the URL host is `chq.org` or a subdomain, else **"Open event page"**; cancelled events keep the panel openable and keep the link; title is plain text (no button, no chevron) when the event has nothing expandable (no description, no non-week categories, no program links, no article links, no `url`); `aria-expanded` + `aria-controls` on the button, matching `id` on the panel; panel stays unmounted when collapsed; keep the multi-open persisted `expandedDescriptions` set as-is (no state change, no migration); do not make the whole card clickable; no iOS changes.
+
+**Host check:** write a tiny pure helper (in `EventCard.tsx` or `frontend/src/lib/utils/`) `isChqOrgUrl(url: string): boolean` using `new URL()` in a try/catch (malformed `url` → `false` → "Open event page"). Test it directly: `https://www.chq.org/x` → true, `https://chq.org` → true, `https://tickets.chq.org/` → true, `https://notchq.org` → false, `https://chq.org.evil.com` → false, `garbage` → false.
+
+**Tests (TDD):** the issue's list — clicking the title calls `onToggleDescription(event.id)`; keyboard Enter/Space work because it is a real `<button>` (assert the element's tag/role rather than simulating key events); expanded panel renders the link with the right label for a chq.org URL and for a publisher URL; no link when `url` is absent; plain-text title for an event with no expandable content; `aria-expanded` flips with `isExpanded`; 📖/📰 render on the title line and are not focusable. Retarget the two existing glyph tests. Falsify at least the host-label test and the plain-text-title test by breaking the code.
+
+**Verification:** `cd frontend && npm run build` (type-check + lint + unit tests + bundle). Then, because this is a visible web change, run the dev server and exercise it in a real browser once: expand/collapse via the title, open the chq.org link in a new tab, confirm a card with nothing expandable has no chevron — describe what you saw in the report (no screenshot required). `frontend/e2e/README.md` documents the Playwright harness; run `verify-rail.mjs` only if it references `Show more` (it does not appear to).
+
+**Commit:** `feat(web): tapping the event name opens its details, with an "Open on chq.org" link inside (#244)`.

--- a/docs/plans/2026-08-23-open-issue-triage.md
+++ b/docs/plans/2026-08-23-open-issue-triage.md
@@ -1,0 +1,40 @@
+# Open-issue triage — 2026-08-23
+
+**Status:** Reference. Ordering for the 19 issues left open after this pass.
+Re-triage when a batch ships or when the next season's dates change the calculus.
+
+Context that drove the order: the 2026 season ends ~Aug 30, iOS 1.1.3 (build 6)
+is waiting on the user's archive/upload, and the off-season (Sep → May) is the
+window for larger features. Small fixes that clear the local test gate and the
+iOS scroll machinery come first; season-dependent features are placed where
+they must land before June 2027.
+
+## Closed this pass
+
+| # | Why |
+|---|---|
+| #259 | Resolved by #260 (41 → ~20 min). Option 1 (paid larger runner) deliberately declined for a public repo. Comment left on the issue. |
+
+## Keep — in recommended order
+
+| Order | # | Title | Why here |
+|---|---|---|---|
+| 1 | #246 | web: Special Studies classes page (Woodwell) | **Not code — a decision.** Contributor has it built on a branch and has waited since 08-22 for a read on direction/cadence/infra and whether to split the PR. Their late-season fixtures lose value as sessions vanish after Aug 30. |
+| 2 | #235 | iOS: `containerURLIsNilInTheUnitTestHost` asserts the environment | Tiny. Makes a local suite run actually green — precondition for every iOS item below. Option 1 (assert `shouldRunAppOnlyMigration`). |
+| 3 | #252 | iOS: two UI-test hooks don't compose | Tiny. Fail loudly at launch when both are passed. Removes a known trap before anyone touches scroll tests again. |
+| 4 | #234 | iOS: re-tapping the active scope keeps a widened window | Small. #258 shipped the rail's `⟳ Now`; "re-tap the active scope" and "⟳ Now" must now agree. Fix is the widened `unchanged` guard in `selectScope`. |
+| 5 | #257 | week filters include full boundary Saturdays | Well-specced, both platforms together, predicate swap + tests. Filed by the user this week. |
+| 6 | #254 | iOS: `shouldAbandonScroll` mixes live and captured state | Phase-4 churn is over, so this is the moment to fix the bug *class* (4 instances) before the next scroll change becomes the fifth. Do after 2–4 so the suite is clean. |
+| 7 | #244 | web: event title opens details, "Open on chq.org" inside | Web-only, fully specced, one file + tests. One line shorter per card. |
+| 8 | #237 | iOS: My Day ↔ Events round trip, gaps in a day | Prerequisite (day rail / anchor day) shipped in #245/#258. Layer 1 (round trip) first; layers 2–3 later. Screenshot regen required. |
+| 9 | #174 | iOS: venue-name shortcuts | Content decision first (which abbreviations stay recognisable), then dictionary entries; keep web `getLocationDisplayName` in parity. |
+| 10 | #253 | iOS: Siri day intent silent on archived year | Cheapest honest fix is option 2 (intent carries its year and says so). Low traffic; off-season only. |
+| 11 | #186 | iOS: `browsePastSeason(year:)` for pre-season archive | Recurs Feb–Jun; must land before Feb 2027. Good off-season work. |
+| 12 | #217 | deploy scripts still do per-workspace `npm install` | No workflow uses them; `deploy-production.yml` is the real path. Recommend **delete** `deploy.sh`/`deploy-frontend.sh` and fix the README/DEPLOYMENT.md references rather than maintain a shadow deploy. |
+| 13 | #216 | docs: local dev "has no backend" but Compose runs one | Per-route audit, then a table in DEPLOYMENT.md + README. Drop the orphan `dynamodb_data` volume. |
+| 14 | #215 | ci: nothing exercises the Docker dev setup | Woodwell is an active contributor on it (#248 merged 08-20). Path-filtered build+boot job; add a bash-only shell-test harness for `setup-local.sh`. |
+| 15 | #143 | matcher: fuzzy presenter/title matching | No Daily articles until June 2027; do before next season with the unmatched-article audit. Bump `MATCHER_VERSION`. |
+| 16 | #198 | iOS: Home Base | Biggest next-season UX win with zero location permission; unblocks first-event departure alerts. Exclude from any future preference sync. |
+| 17 | #194 | iOS: Apple Watch app | Design done; build after #198 (its origin) and iOS-first since notifications already mirror. |
+| 18 | #132 | accounts + settings sync | Large. Before implementing, settle #246's question: federate with CHQ's own login or not. Start on a fresh branch, re-verify the 07-03 spec's facts. |
+| 19 | #200 | shared favorite lists | Hard-blocked on #132. |

--- a/ios/ChqCalendarTests/ColdLaunchDateAnchorTests.swift
+++ b/ios/ChqCalendarTests/ColdLaunchDateAnchorTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import Testing
+@testable import ChqCalendar
+
+/// Where a cold launch lands when nothing is persisted (#278).
+///
+/// #278 reported that a launch with no saved date opens on the **start of
+/// the dataset** rather than on today. It did not reproduce, and these
+/// tests pin why — the report's two plausible paths are both closed, and
+/// closed for reasons that a future change could reopen without any other
+/// test noticing:
+///
+/// 1. `.day` is the one scope with no "now" of its own, and
+///    `EffectiveScope.resolve` degrades a keyless `.day` to `.all` — whose
+///    window is the whole dataset. A cold launch never has one:
+///    `UserStateStore` persists a live `.day` as `.next` and drops
+///    `selectedDayKey` entirely (#192), so `loadFilters()` cannot return a
+///    `.day`, and `AppModel` falls back to `FilterSelection()`, which is
+///    `.next`. Persisting `selectedDayKey` "so the day survives a relaunch"
+///    is the change that would reopen this.
+/// 2. `EventListView`'s anchor chain (`pendingScroll?.day ??
+///    pinnedSelectionDay ?? scrollAnchor ?? anchorDay`) really does fall
+///    through to the first rendered day at launch, as the report says. That
+///    is only correct while the first rendered day *is* today, which holds
+///    because `.next`'s window starts at `now - 1h`. A default scope that
+///    is not `now`-relative would reopen this too.
+///
+/// The two acceptance criteria that a naive "fix" for #278 would most
+/// easily break — a saved scope still winning, and an archived year still
+/// opening at the season start — are pinned here alongside, so the guard
+/// cannot be satisfied by simply forcing today everywhere.
+@MainActor
+struct ColdLaunchDateAnchorTests {
+    /// A fresh, isolated `UserDefaults` suite per test so runs never collide.
+    private func makeDefaults() -> UserDefaults {
+        UserDefaults(suiteName: UUID().uuidString)!
+    }
+
+    private static func at(_ s: String) throws -> Date {
+        try #require(ChqTime.parse(s))
+    }
+
+    private func seasonBounds() -> ClosedRange<String> {
+        DayWindow.bounds(year: 2026, starredDays: [])
+    }
+
+    // MARK: - what a cold launch actually starts from
+
+    @Test func aFreshInstallHasNoPersistedFilters() {
+        let store = UserStateStore(defaults: makeDefaults(), now: { Date() })
+        #expect(store.loadFilters() == nil)
+    }
+
+    /// The fallback `AppModel` uses when `loadFilters()` is `nil`. `.next`
+    /// rather than `.day` is what makes path 1 above unreachable.
+    @Test func theColdLaunchFallbackIsNextWithNoDayKey() {
+        let selection = FilterSelection()
+        #expect(selection.dateScope == .next)
+        #expect(selection.selectedDayKey == nil)
+        #expect(EffectiveScope.resolve(selection, isCurrentYear: true) == .next)
+    }
+
+    // MARK: - the reported symptom
+
+    /// `.next` is `now`-relative, so its window opens on today — not on
+    /// `bounds.lowerBound`, which is what `.all` would have given.
+    @Test func theColdLaunchWindowStartsOnTodayNotTheDatasetStart() throws {
+        let now = try Self.at("2026-07-15 09:00:00")
+        let events = [
+            makeEvent(id: "before", start: try Self.at("2026-06-28 10:00:00")),
+            makeEvent(id: "today", start: try Self.at("2026-07-15 19:00:00")),
+            makeEvent(id: "after", start: try Self.at("2026-07-20 19:00:00")),
+        ]
+        let bounds = seasonBounds()
+        let window = try #require(ViewWindow.make(
+            selection: FilterSelection(), events: events, now: now,
+            year: 2026, isCurrentYear: true, bounds: bounds))
+
+        #expect(window.startDay == "2026-07-15")
+        // Stated separately from the equality above so a failure says which
+        // of the two things went wrong: the window is on today, AND it is
+        // not the whole-dataset window `.all` would produce.
+        #expect(window.startDay != bounds.lowerBound)
+    }
+
+    /// End to end, through the real `AppModel`: the first day the list
+    /// renders on a cold launch. `events-sample`'s earliest event is
+    /// 2026-07-01 and `now` is pinned two days later, so "opened on today"
+    /// and "opened at the start of the dataset" are distinguishable — which
+    /// is the whole point of the fixture choice.
+    @Test func theColdLaunchListOpensOnToday() async throws {
+        let cache = MockCache()
+        cache.write("events-2026", data: fixtureData("events-sample"), etag: "e1", fetchedAt: Date())
+        let api = MockAPI()
+        // The years manifest is not cached; hanging that call proves the
+        // list is correct before any network work finishes, matching
+        // `AppModelTests.startWithWarmCacheIsReadyBeforeAnyNetworkCompletes`.
+        await api.setNeverResolves(for: .years)
+        let repo = EventRepository(api: api, cache: cache)
+        let fixedNow = try Self.at("2026-07-03 09:00:00")
+        let model = AppModel(
+            repository: repo,
+            store: UserStateStore(defaults: makeDefaults(), now: { Date() }),
+            now: { fixedNow })
+
+        Task { await model.start() }
+        await waitUntil("model reaches .ready phase") { model.phase == .ready }
+
+        #expect(model.dayGroups.first?.id == "2026-07-03")
+        // The dataset's own first day must be filtered out, not merely
+        // scrolled past: asserting only `first` would still pass if the
+        // list opened on today while `.all` quietly widened what's below.
+        #expect(!model.dayGroups.contains { $0.id < "2026-07-03" })
+    }
+
+    // MARK: - what a fix for #278 must not break
+
+    /// #278's third acceptance criterion. A saved scope is a preference,
+    /// and outranks the today default.
+    @Test func aSavedScopeStillWinsOverTheTodayDefault() {
+        let defaults = makeDefaults()
+        UserStateStore(defaults: defaults, now: { Date() })
+            .saveFilters(FilterSelection(dateScope: .season))
+
+        let model = AppModel(
+            repository: EventRepository(api: MockAPI(), cache: MockCache()),
+            store: UserStateStore(defaults: defaults, now: { Date() }))
+
+        #expect(model.filter.dateScope == .season)
+    }
+
+    /// #278's second acceptance criterion. An archived season has no "now"
+    /// to anchor on, so every `now`-relative scope degrades to `.all` and
+    /// the window is the season — which is the *correct* answer there, and
+    /// the one a "always start on today" change would break.
+    @Test func anArchivedYearStillOpensAtTheSeasonStart() throws {
+        let now = try Self.at("2026-07-15 09:00:00")
+        let bounds = seasonBounds()
+        let window = try #require(ViewWindow.make(
+            selection: FilterSelection(), events: [], now: now,
+            year: 2026, isCurrentYear: false, bounds: bounds))
+
+        #expect(window.startDay == bounds.lowerBound)
+        #expect(window.endDay == bounds.upperBound)
+    }
+}


### PR DESCRIPTION
Closes out #278, which was closed as not reproducible. This adds the regression guard its acceptance criteria asked for.

## Why a test for a bug that doesn't exist

#278 reported that launching with no saved date opens the list on the start of the dataset rather than on today. It didn't reproduce — but both of the report's candidate paths are closed for reasons a future change could reopen with nothing else noticing:

1. **A keyless `.day` degrading to `.all`.** `EffectiveScope.resolve` does exactly that, and `.all`'s window is the whole dataset. A cold launch never has a `.day`: `UserStateStore` persists a live `.day` as `.next` and drops `selectedDayKey` entirely (#192), so `loadFilters()` cannot return one, and `AppModel.swift:288` falls back to `FilterSelection()` — which is `.next`. **Persisting `selectedDayKey` "so the day survives a relaunch" is the change that reopens this.**
2. **The anchor chain falling through to the first rendered day.** `EventListView.swift:395` does exactly that at launch, as the report says. That day is today only because `.next`'s window starts at `now - 1h`. **A default scope that isn't `now`-relative reopens this.**

## What's pinned

The two forward guards say the cold-launch fallback stays `now`-relative and the list opens on today rather than at `bounds.lowerBound`. The end-to-end case runs the real `AppModel` against `events-sample` — whose earliest event is 2026-07-01 — with `now` pinned to 2026-07-03, so "opened on today" and "opened at the start of the dataset" give different answers. That distinction is the entire issue.

The other two guard the opposite direction. #278's own acceptance criteria required that a saved date still wins and that archived seasons are unaffected, and both are what a naive "always start on today" fix would quietly break. So a saved `.season` surviving a relaunch, and a non-current year still opening at the season start, are pinned alongside — **the guard can't be satisfied by forcing today everywhere.**

## Falsification

Every assertion was proven able to fail, in two rounds with no collateral failures in either:

| Injected defect | Test that went red |
|---|---|
| `AppModel:288` ignores the store | `aSavedScopeStillWinsOverTheTodayDefault` |
| `EffectiveScope` drops the non-current-year downgrade | `anArchivedYearStillOpensAtTheSeasonStart` |
| `loadFilters()` returns a default instead of `nil` | `aFreshInstallHasNoPersistedFilters` |
| `FilterSelection.dateScope` defaults to `.all` | `theColdLaunchFallbackIsNextWithNoDayKey` |
| `ViewWindow`'s `.next` returns the unbounded window | `theColdLaunchWindowStartsOnTodayNotTheDatasetStart`, `theColdLaunchListOpensOnToday` |

That last one reproduces the reported symptom exactly — `firstDay = "2026-07-01"` instead of `"2026-07-03"`.

## Verification

Full unit suite green: **986 tests in 73 suites**, on an iPhone 17 Pro / iOS 26.1 simulator.

No production code changes. `440c14b` is tests only; `5a7f30e` adds two plan docs (see below).

[skip-screenshots: tests only, no user-visible change]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NLERoZNvAF76QAZZhP2wdc

---

## Second commit: two plan docs that were never committed

`5a7f30e` is unrelated to the test above and separated into its own commit — repo cleanup that was sitting in the working tree.

`docs/plans/2026-08-23-open-issue-triage.md` and `docs/plans/2026-08-23-issue-batch-235-252-234-257-254-244.md` were written on 2026-08-23, drove work that has since shipped, and were never tracked. Both stay in `docs/plans/` rather than `archive/`, matching where every other August doc lives.

The batch plan's Status banner was stale — it claimed "all four PRs open and merge-ready" with a merge order still to run. Verified against GitHub: all six issues are closed and all five PRs merged on 2026-08-24 (#266, #265, #267, #264, plus #268, an e2e follow-up the batch surfaced). The banner now says so; the now-moot merge-order notes are kept as the record of the plan at the time. The triage doc is unmodified.

