### PR TITLE
docs: open-issue triage pass and a resumable work queue

### DIFF
--- a/docs/plans/2026-08-27-open-issue-triage.md
+++ b/docs/plans/2026-08-27-open-issue-triage.md
@@ -19,9 +19,13 @@ Both were assumed wrong in the 08-23 pass:
 - **The 2026 feed's last event is `2026-09-10`**, not "~Aug 30". The nine-week
   season ends in late August; the feed carries programming for two more weeks.
 - **2027 is already published** — 5 events, `2027-06-27` to `2027-08-09`.
-  `years.json` is `{"years":[2025,2026,2027],"defaultYear":2026}`.
-  `defaultYear` flips to 2027 on **2026-10-01**, which is what opens the
-  pre-season window #186 is about.
+  The **production** manifest,
+  `https://www.chqcal.org/cache/calendar-cache/years.json`, is
+  `{"years":[2025,2026,2027],"defaultYear":2026}`. `defaultYear` flips to 2027
+  on **2026-10-01**, which is what opens the pre-season window #186 is about.
+  Note this is *not* the repo's tracked dev fixture
+  `frontend/public/data/years.json`, which still reads `[2025, 2026]` and is
+  six months stale — that gap is part of #286.
 
 ## Closed this pass
 

--- a/docs/plans/2026-08-27-open-issue-triage.md
+++ b/docs/plans/2026-08-27-open-issue-triage.md
@@ -1,0 +1,119 @@
+# Open-issue triage — 2026-08-27
+
+**Status:** Reference. Supersedes `2026-08-23-open-issue-triage.md`, whose
+ordering is spent: items 2–7 of that list (#235, #252, #234, #257, #254, #244)
+all shipped between 08-23 and 08-24.
+
+Every claim below was re-verified against `main` (`909a68f`) and, where the
+issue made a data claim, against the live production feed. Verification
+comments are on each issue.
+
+## Season facts that moved the calculus
+
+Both were assumed wrong in the 08-23 pass:
+
+- **The 2026 feed's last event is `2026-09-10`**, not "~Aug 30". The nine-week
+  season ends in late August; the feed carries programming for two more weeks.
+- **2027 is already published** — 5 events, `2027-06-27` to `2027-08-09`.
+  `years.json` is `{"years":[2025,2026,2027],"defaultYear":2026}`.
+  `defaultYear` flips to 2027 on **2026-10-01**, which is what opens the
+  pre-season window #186 is about.
+
+## Closed this pass
+
+| # | Why |
+|---|---|
+| #274 | All four phases merged (`d75e1a1`, `0e854fe`, `d3a82fc`, `3ac557b`). Every acceptance criterion verified against code and tests, including the localStorage-migration one, which has a real test at `useFilterState.test.ts:14-29`. All four open questions answered by what shipped. |
+
+## Opened this pass
+
+| # | Why |
+|---|---|
+| #285 | web/iOS date-filtering divergence. #274 phase 4 deleted date filtering on web; iOS still ships scope chips and a week-filter grid, with a doc comment saying so deliberately (`FilterSheet.swift:138-144`). Both design docs currently claim iOS deleted this machinery — it relocated it. A decision, not a bug. |
+| #286 | A fresh clone renders an empty calendar. `useEventData.ts:87` reads `/data` in dev; `all-events-2026.json` is gitignored; `backend/README-LOCAL-SYNC.md` has zero referrers. Same class as #214 and #247, both found by an outside contributor. |
+| #287 | **P0.** `browser-checks` aborts from 2026-09-11. Reproduced: `E2E_NOW=2026-09-15 node e2e/verify-rail.mjs` crashes at `regime.mjs:228`. `test:browser` is `&&`-chained with `verify-rail` first, so the other five suites never run. Plus an unguarded off-season check in `verify-full-list.mjs:704`. Both halves introduced by #282 three days ago. |
+| #288 | From 2026-10-01 web says `in-season` and iOS says `.preSeason` for the same date, because web's rule-1 input is unbounded and iOS's is capped at 90 days (`EventFilter.swift:203-206`). `landingState.ts`'s header promises they will not disagree. Six-month window; 2027's 5-event feed is what exposed it. |
+
+## Kept — recommended order
+
+| Order | # | Why here |
+|---|---|---|
+| 1 | #287 | **Ships red in 15 days.** Reproduced locally, both halves. Small fix — the two seeded-filter pages must declare they intentionally leave the landing regime. Do this before anything else touches the e2e suite. |
+| 2 | #246 | **Still not code — still a decision, now 5 days old.** No PR exists. The work is on `Woodwell/chq-calendar:feat/classes-catalog`, 57 commits / 62 files ahead, **pushed again 2026-08-27T02:47Z** — the contributor is still building against an unanswered question. Their late-season fixtures decay as sessions vanish. |
+| 3 | #286 | Onboarding defect, cheap, and it is the third fresh-clone breakage. Fixing it makes #215's boot check meaningful (assert a rendered event, not just a 200). |
+| 4 | #215 | The CI job that catches the #214 / #247 / #286 class. #248 changed three dev-stack files on 08-24 with zero CI coverage — a second rot event since this was filed. Per-PR path-filtered, build **and boot**. |
+| 5 | #216 | Docs half of #286. The per-route audit it was blocked on is now done and posted; its own premise about CloudFront event data was wrong. Mechanical from here. |
+| 6 | #217 | Recommend **delete** `deploy.sh` / `deploy-frontend.sh` / `deploy-with-validation.sh`. No workflow uses them; `deploy.sh:79-86` applies Terraform, which CI deliberately never does. A fifth uncited `npm install` at `deploy.sh:147`. |
+| 7 | #186 | **Window opens 2026-10-01**, not February — five weeks out, and it bites hardest on day one, when the just-ended 2026 season is what users want and the archive button vanishes. Mitigated by the year menu, so a discoverability regression, not a block. |
+| 8 | #288 | Same 2026-10-01 date as #186, and #186's fix is one of its two halves. Web's behaviour is the correct one by its own recorded reasoning (`landingState.ts:103-107` rejected exactly iOS's rule). Also: **no iOS UI test covers the off-season landing at all** — the fixture serves a single-year manifest. |
+| 9 | #285 | Decide before either platform's date UI moves again. Cheapest outcome (option 3, record the divergence) is a docs fix in two design docs. |
+| 10 | #253 | Off-season only. Note from verification: option 2 ("refuse and say so") is **not** the cheap option it looks — the intent cannot read the app's live `selectedYear`, so it needs most of option 1's plumbing. #186 wants the same missing capability; build it once. |
+| 11 | #237 | Prerequisite satisfied — the anchor day exists (`EventListView.scrollAnchor:254`). Two things the issue lists as pending have already shipped: `DayChipCountStyle` and the `EffectiveScope` collapse. Layer 1 is smaller than the body assumes. ~10 line refs drifted. |
+| 12 | #174 | Content decision. The divergence premise inverted: web already has 11 shortcuts to iOS's 2, so this is reconciling two lists, not writing one. All five claimed event counts verified exactly. Two high-weight venues missed (`Sports Club, Lawn Bowling Green`, `Sports Club, Waterfront`). |
+| 13 | #283 | Retitled — the app fetches the ~5MB per-year file, never the 10MB combined one. The year-level split already shipped; what is left is a sub-year split, and a warm path that parses and decodes a second time (`useEventData.ts:66-69`). |
+| 14 | #275 | Reachability shrank materially. `EventList` is deleted, and the reassert path self-cancels on `wheel`. Suggest inverting: make **middle-click autoscroll** the subject and keep the wheel case as a note on why `settling` cannot be generalised away. |
+| 15 | #143 | No Daily articles until June 2027. Verified live: the Michael Chan pair scores **0.40**; either fuzzing the token *or* correcting the spelling reaches 0.75. So **the misspelling alone is the blocker** — the title-fallback half needs its own justification. `MATCHER_VERSION` is 7, not 4. |
+| 16 | #198 | Biggest next-season UX win, zero location permission. Unchanged and accurate. No spec written yet. |
+| 17 | #194 | Design done (`2026-08-09-apple-watch-app-design.md`). Build after #198. |
+| 18 | #132 | Large. Settle #246's federation question first. Fresh branch, re-verify the 07-03 spec. |
+| 19 | #200 | Hard-blocked on #132. Spec merged, `ReminderPlanner.maxPending` still 60 as pinned. |
+
+## Verified accurate, no comment needed
+
+#200, #198, #194, #132 — all referenced design docs still exist and their
+pinned code facts are unchanged.
+
+## The 2026-09-10 App Store deadline is dead
+
+A note carried since the 4.2 rejection recorded **2026-09-10 as a hard
+deadline**, on the reasoning that after the season's last event day the
+default screen is empty until June 2027, so any later App Review would
+auto-fail Guideline 4.2. Checked directly, and it no longer holds:
+
+- **Web** — `verify-offseason.mjs` passes 14/14, and both landing buttons
+  still work after phase 4 deleted `dateFilter`. Driven with real clicks at
+  two pinned dates: "Browse the 2026 season" mounts 89 sections, "Preview the
+  2027 season" switches to 2027 and mounts 5. `browseArchiveSeason` no longer
+  sets a date filter at all — it flips `browsingArchive` in
+  `useLandingDismissal.ts`.
+- **iOS** — on 2026-09-15 `LandingState.determine` returns
+  `.postSeason(2026, next: 2027, …)`, and `OffSeasonLandingView` renders the
+  copy, the countdown card and **both** buttons. Covered by pinned unit tests
+  (`AppModelTests.swift:761, 840, 863`; `LandingStateTests.swift:38, 48`).
+
+So a review during 2026-09-11 → 09-30 lands on a usable screen on both
+platforms. What replaces the cliff is thinner and later: from 2026-10-01 the
+iOS landing has **no buttons** for about six months — see #288.
+
+## How this pass was verified
+
+Not a read-through. Where an issue made a claim about code, it was checked at
+the named symbol; where it made a claim about data, it was checked against the
+live production feed; where it described a failure, it was reproduced.
+
+- #287 reproduced locally against a fresh `npx vite build` + `vite preview`,
+  both halves, with the in-season control run for contrast.
+- #143's Michael Chan pair scored against the real event and the real
+  chqdaily article (post 49433), with two counterfactuals.
+- #174's five venue counts recomputed from the feed using iOS's own
+  `displayLocation` rule. All five exact.
+- #274's acceptance criteria checked against code *and* the tests that guard
+  them; unit suite green at 1,325 tests.
+- One local `verify-rail` check-12 failure was chased and dismissed: three
+  further runs came back 46/46, `railBottom` and `headerTop` both exactly
+  273.0. The first run had overlapped another Playwright suite on the same
+  machine.
+
+## Nothing else outstanding
+
+- No open PRs. #144 (SEO phase 1) and #137 (PWA auto-update) both merged in
+  July; earlier notes calling them open are stale. Their post-merge
+  follow-ups (run the GSC runbook; verify live cache-control headers) may
+  still be outstanding.
+- No open issue duplicates a closed one (checked against all 100 closed,
+  which bottoms out at #43).
+- No unfiled `TODO`/`FIXME` anywhere in `frontend/src`, `backend/src`,
+  `ios/ChqCalendar*`, or `shared/`.
+- No recently-closed issue left a follow-up undocumented.
+- `APP_STORE_URL` is set (`frontend/src/lib/constants.ts:16`) — the gate
+  recorded against the marketing site is closed.

--- a/docs/plans/2026-08-27-open-issue-triage.md
+++ b/docs/plans/2026-08-27-open-issue-triage.md
@@ -1,8 +1,12 @@
 # Open-issue triage — 2026-08-27
 
-**Status:** Reference. Supersedes `2026-08-23-open-issue-triage.md`, whose
-ordering is spent: items 2–7 of that list (#235, #252, #234, #257, #254, #244)
-all shipped between 08-23 and 08-24.
+**Status:** Reference — the point-in-time *record* of this pass. The live
+work queue derived from it is **`2026-08-27-work-queue.md`**; read that one
+first if you are picking up work.
+
+Supersedes `2026-08-23-open-issue-triage.md`, whose ordering is spent: items
+2–7 of that list (#235, #252, #234, #257, #254, #244) all shipped between
+08-23 and 08-24.
 
 Every claim below was re-verified against `main` (`909a68f`) and, where the
 issue made a data claim, against the live production feed. Verification

--- a/docs/plans/2026-08-27-work-queue.md
+++ b/docs/plans/2026-08-27-work-queue.md
@@ -1,0 +1,315 @@
+# Work queue — chq-calendar
+
+**Status:** Living document. This is the queue a new session should read
+first. Opened 2026-08-27 from the triage pass in
+`2026-08-27-open-issue-triage.md` (which is the point-in-time *record*; this
+is the *plan*).
+
+---
+
+## How to use this file
+
+**Starting a session and asked to "continue":**
+
+1. Read **Status at a glance** below. Anything marked `IN PROGRESS` is where
+   you are — check out its branch and read its PR.
+2. If nothing is in progress, take the topmost `NOT STARTED` item whose
+   entry criteria are met.
+3. Check **The dated calendar** — items there stop being optional on a date.
+4. Re-verify before trusting: this file records what was true on
+   2026-08-27. Line numbers drift, and several issue bodies in this repo
+   have been wrong about their own premises. Confirm at the named symbol
+   before building on it.
+
+**Finishing an item:** update its `Status` line to `DONE (<squash sha>)`,
+move it to the bottom section, and update the glance table. Do not delete
+it — the reasoning is worth keeping.
+
+**Standing rules** (from `CLAUDE.md`, repeated because they bite here):
+never commit to `main`; run the verification checklist before every commit;
+any PR touching `ios/ChqCalendar/Features/**`, `App/**`, `Assets.xcassets/**`,
+`ChqCalendarWidgets/**` or `ChqCalendarShared/**` in a user-visible way must
+regenerate App Store screenshots or record a `[skip-screenshots: <reason>]`
+opt-out.
+
+---
+
+## Status at a glance
+
+| # | Item | Issues | Status | Branch / PR |
+|---|---|---|---|---|
+| 0 | Triage record + this queue | — | IN REVIEW | `docs/2026-08-27-issue-triage`, PR #289 |
+| 1 | e2e off-season crash | #287 | NOT STARTED | — |
+| 2 | **iOS 1.1.4** — year-aware navigation | #186, #288, #253 | NOT STARTED | — |
+| 3 | Fresh-clone empty calendar | #286 | NOT STARTED | — |
+| 4 | CI for the Docker dev stack | #215 | NOT STARTED | — |
+| 5 | Dev-env docs + deploy scripts | #216, #217 | NOT STARTED | — |
+| 6 | Date-filtering divergence | #285 | NEEDS A DECISION | — |
+| 7 | My Day ↔ Events round trip | #237 | NOT STARTED | — |
+| 8 | Feed parse cost | #283 | NOT STARTED | — |
+| 9 | Venue name shortcuts | #174 | BLOCKED — content decision | — |
+| 10 | Matcher fuzzy matching | #143 | NOT STARTED | — |
+| 11 | Middle-click autoscroll | #275 | NOT STARTED | — |
+| 12 | Off-season features | #198, #194, #132, #200 | NOT STARTED | — |
+| — | Special Studies classes page | #246 | **OWNER-HANDLED — do not action** | fork `Woodwell:feat/classes-catalog` |
+
+---
+
+## The dated calendar
+
+| Date | What happens | Item |
+|---|---|---|
+| **2026-09-10** | Last event in the 2026 feed | — |
+| **2026-09-11** | `browser-checks` starts aborting on **every branch push** | **1** |
+| **~mid-Sept** | 1.1.4 must be submitted to clear review in time | **2** |
+| **2026-10-01** | Server flips `defaultYear` to 2027; iOS pre-season landing loses both buttons | **2** |
+| **~2027-03-29** | 2027-06-27 enters `.next`'s 90-day window; the iOS pre-season state self-heals | **2** |
+| **June 2027** | Next season's Daily articles begin | **10** |
+
+Nothing else in the queue has a deadline.
+
+---
+
+## 1. #287 — e2e suite aborts off-season
+
+**Status:** NOT STARTED · **Deadline:** 2026-09-11 · **Size:** S · web/e2e only
+
+**Do this first.** Not because it is the largest problem but because every
+branch pushed after Sep 11 gets a red `Build and Test` with a stack trace and
+no summary — including the branches for item 2. Fixing it first is what keeps
+the rest of the queue's CI readable.
+
+**Scope**
+
+- `frontend/e2e/verify-rail.mjs:983` and `:1148` — the two pages that seed
+  `searchTerm: 'williamsburg'` into `chq-calendar-user-state`.
+- `frontend/e2e/regime.mjs:227` — the "one regime per run" throw.
+- `frontend/e2e/verify-full-list.mjs:704` — check `5-webkit the rail
+  highlights today`, which lacks the off-season guard its three siblings have
+  at `:353`, `:587` and check 7.
+
+**Done when**
+
+```bash
+cd frontend && npx vite build && npm run preview &
+E2E_NOW=2026-09-15 node e2e/verify-rail.mjs        # completes, summary, 0 failed
+E2E_NOW=2026-09-15 node e2e/verify-full-list.mjs   # 0 failed
+node e2e/verify-rail.mjs                            # in-season, still 46/46
+```
+
+**Traps**
+
+- **The app is correct; the harness is wrong.** `page.tsx:248`'s
+  `!filters.hasFilters` is deliberate — the comment above it says an answer of
+  "see you next season" is not a response to a reader who asked a question.
+  Do not change `page.tsx`.
+- **Keep the one-regime invariant.** `regime.mjs:227` exists because a run
+  that took both branches would still report success. Make the two seeded
+  pages opt out of the assert, or seed the filter *after* `enterList`.
+- `verify-offseason.mjs` does **not** import `fixedNow.mjs` and ignores
+  `E2E_NOW` entirely — it derives every instant from the live feed.
+  `e2e/README.md:120` reads as if the override is universal. Worth correcting
+  while here.
+- **Never run two Playwright suites at once on one machine.** A `verify-rail`
+  check-12 failure reproduced once under contention and then passed 46/46
+  three times alone.
+
+---
+
+## 2. iOS 1.1.4 — year-aware navigation (#186 + #288 + #253)
+
+**Status:** NOT STARTED · **Submit by ~mid-Sept, live before 2026-10-01** ·
+**Size:** M
+
+1.1.3 (build 6) is **live**, so this needs a new build. These three issues are
+one job: each needs *a navigation that changes the year it navigates in*. Built
+once, all three close; built separately, it gets built twice.
+
+**Why the date matters.** From 2026-10-01 `defaultYear` is 2027, whose five
+published events are ~265 days out — beyond `.next`'s 90-day cap
+(`EventFilter.adaptiveEndDate:203-206`, `maxOffset = 90`). So
+`upcomingDefaultCount == 0`, `now < seasonStart(2027)`, and
+`LandingState.determine` returns `.preSeason`, whose `archiveYear` is `nil`
+(`LandingState.swift:56-61`) and whose preview button is `.postSeason`-only
+(`OffSeasonLandingView.swift:120`). Result: a countdown with **no buttons**,
+until ~2027-03-29. Six months.
+
+**Sub-items, in build order**
+
+- **#288 option 1 first — unbind the landing probe from `.next`.** Ask "does
+  the selected year hold any event at or after `now - 1h`" rather than "does
+  `.next`'s 90-day window hold one". This is the smaller half, it restores the
+  rule-for-rule match `landingState.ts:76-77` promises, and it means most
+  users never reach the pre-season state at all. **If time gets tight, ship
+  this alone and let the rest follow in 1.1.5.**
+- **#186 — `browsePastSeason(year:)`.** Mirror
+  `AppModel.previewNextSeason():1098-1104` (`await select(year:)` then set the
+  filter). Then let `LandingState.archiveYear` return a year for `.preSeason`
+  and un-hide the button in `OffSeasonLandingView.swift:126-131`. The doc
+  comment at `LandingState.swift:50-56` explains precisely why it is hidden
+  today — a label/outcome mismatch a reviewer flagged as Important.
+- **#253 — Siri on an archived year.** `OpenDayIntent` resolves the year from
+  `IntentDataSource.defaultYear()` (`EventIntents.swift:96`) while
+  `AppModel.goToDay` bounds against `selectedYear` (`AppModel.swift:1467-1477`).
+  Note `IntentDataSource.events(now:)` also loads the *default* year's events,
+  so both inputs to `OpenDayTarget.resolve` describe the wrong season. Option 2
+  ("refuse and say so") is **not** cheaper — the intent cannot read the app's
+  live `selectedYear` without the app publishing it to the shared container,
+  which is most of option 1's plumbing.
+
+**Release gates**
+
+- **Screenshots: expected to be a free opt-out.** All ten shots in
+  `ios/Scripts/screenshot-plan.json` are in-season screens (`01-season`
+  through `10-widget`); none covers the off-season or pre-season landing.
+  Regenerate to confirm the manifest does not change, then record
+  `[skip-screenshots: regenerated, no covered shot changed]`.
+- **`whatsNew` must be rewritten.** `docs/app-store/listing-fields.json:8`
+  still describes 1.1.3's chrome consolidation. Promotional Text is the only
+  field changeable without a review cycle.
+- Bump `MARKETING_VERSION` to 1.1.4. Note the app and widget targets carry
+  `CURRENT_PROJECT_VERSION`; the two test bundles sit at 1 and do not ship.
+
+**Traps**
+
+- **No iOS UI test covers the off-season landing at all.** The XCUITest
+  fixture serves `{"years":[2026],"defaultYear":2026}`
+  (`UITestFixtureAPI.swift:83`), so no next-year path is reachable from a UI
+  test. `docs/superpowers/specs/2026-08-24-off-season-landing-269-design.md`
+  §A3 also says the rail-over-landing path "has never been exercised". If the
+  rail is going to be the answer to "pre-season has no buttons", prove it.
+- `LandingStateTests.swift:60` asserts an unreachable combination
+  (`upcomingDefaultCount: 0` for `selectedYear 2027 / defaultYear 2026`; the
+  real app resolves that to `.inSeason` via `EffectiveScope.resolve`). Every
+  2027 test payload is `events-sample.json`, whose six events are all in July
+  **2026** — so the sparse-2027 path is untested in both directions.
+- `AppModel.previewNextSeason():1098` sets `dateScope: .all`, which makes
+  `filter.isDefault` false permanently (`UserStateStore.swift:108-115`). A
+  previewed year that is empty or 404s shows `noMatchesView` — *"your filters
+  match no events"* — instead of the landing. The web port deliberately did
+  not copy this.
+- No `CountdownBanner` renders inside a previewed non-current year
+  (`AppModel.swift:433-441` requires `isCurrentYear`).
+- The `.day` scope exemption is now **one** site — `EffectiveScope.swift`
+  (`09d7ea2`, #233) — not the old trio. Inherit via `EffectiveScope.resolve`.
+- Window hygiene: any year-changing navigation must not leave
+  `windowStartDayKey` / `windowEndDayKey` widened. See #234 and #156 for the
+  shape of that bug class.
+- Scope iOS test runs — the UI leg dominates wall-clock. Do not run the full
+  UI suite while an agent builds.
+
+---
+
+## 3. #286 — a fresh clone renders an empty calendar
+
+**Status:** NOT STARTED · **Size:** S · Can run in parallel with item 2 (web only)
+
+`useEventData.ts:87` reads `/data` in dev, not CloudFront.
+`all-events-2026.json` is gitignored (`.gitignore:63`). The 404 is a bare
+`console.error` (`useEventData.ts:232`), so the reader gets `EmptyState`'s
+"try reloading in a moment" — advice that can never work.
+`backend/src/scripts/syncDataWithLocalFile.ts` is the remedy and
+`backend/README-LOCAL-SYNC.md` documents it, but `grep -rn "README-LOCAL-SYNC"`
+over the repo returns **zero referrers**.
+
+Also refresh the tracked `frontend/public/data/years.json` — it says
+`{"years":[2025,2026],"defaultYear":2026}`, six months stale against
+production's `[2025,2026,2027]`, so no fresh checkout can exercise 2027.
+
+**Done when** a fresh clone plus `docker compose up` shows events, or fails
+with a message naming the sync step.
+
+---
+
+## 4. #215 — CI for the Docker dev stack
+
+**Status:** NOT STARTED · **Size:** M · **Entry criterion: do #286 first**
+
+Do it after #286 so the boot assertion can check *a rendered event*, not just
+a 200 — the two failures that actually shipped were both silent, and a
+build-only job would have caught neither.
+
+Still true: zero `docker` references across the eight workflows. `#248`
+(2026-08-24) changed `docker-compose.yml`, `scripts/setup-local.sh` and
+`backend/Dockerfile.dev` with no CI coverage — the second rot event of this
+shape. Trigger paths must now include LocalStack (`docker-compose.yml:90-103`)
+and `Dockerfile.dev`'s table-init step.
+
+The issue's own open question — per-PR vs nightly — resolves to **per-PR,
+path-filtered**: both rot events came from PRs touching exactly those paths.
+A nightly is a later second job for upstream image drift, not an alternative.
+
+---
+
+## 5. #216 + #217 — dev-env docs and deploy scripts
+
+**Status:** NOT STARTED · **Size:** S · Both fully specced, mechanical
+
+- **#216** — the per-route audit is done and posted as a comment; paste it in
+  as a table. Note the issue's own premise was wrong: dev never touches
+  CloudFront. Drop the orphan `dynamodb_data` volume
+  (`docker-compose.yml:121-122`). Fix `README.md:65`, which tells developers
+  to curl production.
+- **#217** — **delete** `scripts/deploy.sh`, `deploy-frontend.sh`,
+  `deploy-with-validation.sh`; repoint the ten doc referrers; drop the broken
+  root `deploy:frontend` script; **keep and correct**
+  `backend/utils/README.md:147` to root `npm ci`. `deploy.sh:79-86` applies
+  Terraform, which CI deliberately never does — fixing only the `npm install`
+  lines would leave that in place while implying support.
+
+---
+
+## 6. #285 — the date-filtering divergence
+
+**Status:** NEEDS A DECISION (cheap) · implement in **1.1.5**, not 1.1.4
+
+Web deleted date filtering in #274 phase 4; iOS kept scope chips and a week
+grid deliberately (`FilterSheet.swift:138-144`). Both design docs currently
+claim iOS *deleted* that machinery — it relocated it.
+
+Three options in the issue. **Decide now, build later**: if the answer is
+"iOS follows web", it touches `DateScope`, `selectedWeeks`, `EffectiveScope`
+and the persisted payload, and it invalidates the `whatsNew` you are about to
+write for 1.1.4. Whichever way it goes, fix the claim in
+`2026-08-25-web-day-strip-date-navigation-design.md:39` and the iOS
+consolidation design doc.
+
+---
+
+## 7–11. The undated queue
+
+| Order | # | Notes |
+|---|---|---|
+| 7 | **#237** | Layer 1 (round trip) only. Prerequisite satisfied — the anchor day is `EventListView.scrollAnchor:254`, but it is `@State private`, so the work is a lift onto `AppModel`. Two stated blockers already shipped: `DayChipCountStyle` and the `EffectiveScope` collapse. ~10 line refs in the body have drifted; a corrected table is in the issue comments. Screenshot regen **is** required here. |
+| 8 | **#283** | ~660ms cold-load task. The app fetches the **~5MB per-year** file, never the 10MB combined one. Year-level split already shipped; what remains is a sub-year split, trimming fields, chunking the parse, and moving `decodeEventHtmlEntities` to build time — it runs at **three** call sites, including the supposedly-fast warm path (`useEventData.ts:66-69`). **Do not virtualize the list**; measured, the JS version was worse. |
+| 9 | **#174** | **Blocked on a content decision**, not engineering. The divergence is not hypothetical: web already has 11 shortcuts to iOS's 2, including `Hall of Christ: Sanctuary`, one of the issue's own five. So this is reconciling two lists. Add `Sports Club, Lawn Bowling Green` and `Sports Club, Waterfront`, both missed by the issue. Forces a screenshot regen (`02-filters`). |
+| 10 | **#143** | Before June 2027, with the unmatched-article audit. Verified live: the Michael Chan pair scores **0.40**; fuzzing the token *or* correcting the spelling each reaches 0.75 — so **the misspelling alone is the blocker** and the title-fallback half needs separate justification. `MATCHER_VERSION` is **7**; bump to 8. |
+| 11 | **#275** | Retarget the issue: the wheel half is now near-theoretical (`EventList` is deleted; the reassert self-cancels on `wheel`), and the live half is **middle-click autoscroll**, which nothing models. |
+
+---
+
+## 12. Off-season features, in dependency order
+
+**#198** (Home Base — biggest next-season UX win, zero location permission;
+must be excluded from any future preference sync) → **#194** (Apple Watch;
+design done, iOS-first) → **#132** (accounts; large, fresh branch, re-verify
+the 2026-07-03 spec) → **#200** (shared lists; hard-blocked on #132).
+
+---
+
+## Not in the queue
+
+- **#246** — Special Studies classes page. The owner is handling this
+  directly with the contributor. **Do not comment, close, or open a PR
+  against it.** The work lives on the fork
+  `Woodwell/chq-calendar:feat/classes-catalog`.
+
+---
+
+## Completed
+
+*(Move items here as they land, with the squash sha.)*
+
+- **#274** — day strip owns date navigation. Four phases: `d75e1a1` (#276),
+  `0e854fe` (#280), `d3a82fc` (#281), `3ac557b` (#282), plus `1db86b2` (#279).
+  Closed 2026-08-27 after verifying every acceptance criterion.


### PR DESCRIPTION
Two documents from the 2026-08-27 triage of all 16 open issues, re-verified against `main`. Documentation only — no code changes.

- **`docs/plans/2026-08-27-work-queue.md`** — the living plan. Written so a future session can read it, find what is in flight or queued next, and continue. This is the entry point.
- **`docs/plans/2026-08-27-open-issue-triage.md`** — the point-in-time record of what was verified and why.

Supersedes `2026-08-23-open-issue-triage.md`, whose ordering is spent: six of its top seven items shipped between 08-23 and 08-24.

## The order, and what drives it

Two dates, both verified this pass:

| Date | What happens |
|---|---|
| **2026-09-11** | `browser-checks` begins aborting on **every branch push** (#287) |
| **2026-10-01** | `defaultYear` flips to 2027; the iOS pre-season landing loses both buttons for ~6 months (#186/#288/#253) |

1. **#287** — first, because it keeps CI readable for everything after it. The fix belongs in the harness, not the app.
2. **iOS 1.1.4** = #186 + #288 + #253 — one job, one missing capability (*a navigation that changes the year it navigates in*). 1.1.3 build 6 is live, so this needs a new build submitted by ~mid-September. Expected to qualify for a recorded screenshot opt-out: no shot in `screenshot-plan.json` covers the off-season landing.
3. **#286 → #215 → #216/#217** — the dev-environment batch. Web/CI only, so it runs while 1.1.4 is in review.
4. **#285** — decide now, implement in 1.1.5.
5. Then #237, #283, #174, #143, #275, and the large off-season features.

#246 is marked owner-handled and explicitly out of the queue.

## Issue-tracker changes made in this pass

**Closed** #274 (all four phases merged, every acceptance criterion verified). **Filed** #285, #286, #287, #288. **Updated** #283 (also retitled), #275, #253, #237, #217, #216, #215, #186, #174, #143.

## Two season facts the previous pass had wrong

The 2026 feed's last event is **`2026-09-10`**, not "~Aug 30", and **2027 is already published** — 5 events, `2027-06-27` to `2027-08-09`. That second one is what makes #288 reachable and what dates the Oct 1 cliff.

Also: the recorded **2026-09-10 App Store deadline is dead** — verified on both platforms that a post-season launch lands on a usable screen.