### PR TITLE
fix(e2e): the browser suite survives the off-season, and check 12 stops flaking (#287, #290)

### DIFF
--- a/docs/plans/2026-08-27-work-queue.md
+++ b/docs/plans/2026-08-27-work-queue.md
@@ -38,8 +38,8 @@ opt-out.
 
 | # | Item | Issues | Status | Branch / PR |
 |---|---|---|---|---|
-| 0 | Triage record + this queue | — | IN REVIEW | `docs/2026-08-27-issue-triage`, PR #289 |
-| 1 | e2e off-season crash + 200%-zoom flake | #287, #290 | NOT STARTED | — |
+| 0 | Triage record + this queue | — | DONE (`9399318`, `7ee9b72`) | PR #289, #291 |
+| 1 | e2e off-season crash + 200%-zoom flake | #287, #290 | IN REVIEW | `fix/e2e-offseason-and-zoom-flake-287-290` |
 | 2 | **iOS 1.1.4** — year-aware navigation | #186, #288, #253 | NOT STARTED | — |
 | 3 | Fresh-clone empty calendar | #286 | NOT STARTED | — |
 | 4 | CI for the Docker dev stack | #215 | NOT STARTED | — |
@@ -72,7 +72,38 @@ Nothing else in the queue has a deadline.
 
 ## 1. #287 + #290 — the browser suite's two failure modes
 
-**Status:** NOT STARTED · **Deadline:** 2026-09-11 (#287) · **Size:** S–M · web/e2e only
+**Status:** IN REVIEW on `fix/e2e-offseason-and-zoom-flake-287-290` ·
+**Deadline:** 2026-09-11 (#287) · **Size:** S–M · web/e2e only
+
+**What it turned out to be.** Both fixes are in the harness; `page.tsx` and
+every other source file are untouched.
+
+- **#287** — `enterList` takes `seedsOwnFilter`, which suppresses regime
+  *reporting* for a page that seeded a filter into storage. The consistency
+  rule still binds every page that can honestly report, and a
+  `seedsOwnFilter` page running before any regime is established throws.
+  `verify-full-list`'s `5-webkit the rail highlights today` got the
+  off-season skip its three siblings already had.
+- **#290** — **not** the `useDayAnchor` ResizeObserver lead the issue named.
+  The parking loop returns on an instantaneous `|delta| <= 2`, and the
+  ~152,000px jump back up from today's landing lands among ninety
+  `content-visibility: auto` sections that then swap their
+  `contain-intrinsic-size` estimates for real heights: the document grew
+  169,546 → 172,664, ~3,100px above the target, 17ms *after* the loop
+  returned. Chromium's scroll anchoring absorbed +478 and the rest pushed
+  the target down. The loop now confirms against a settled document height.
+  Falsified by making the day header non-sticky — check 12 fails at both
+  widths, so the fix did not make it vacuous.
+- **Also found, previously unreachable** (the run crashed before check 18):
+  the seeds' `lastSaved: Date.now()` was Node's clock while the page's was
+  pinned, so any `E2E_NOW` more than 30 days out silently dropped the seed —
+  six red checks at `E2E_NOW=2026-09-30`. Seeded from `FIXED_NOW` now.
+
+Verified: full `test:browser` chain green in both regimes; `verify-rail`
+green pinned to 2026-09-11, 09-15 and 09-30, and 4 consecutive in-season
+runs at 46/46 against a ~1-in-4 prior failure rate.
+
+<details><summary>The original plan, kept for the reasoning</summary>
 
 Two issues, one sitting. #287 is deterministic and dated; **#290 is already
 failing on `main` today** — `verify-rail`'s check 12 fails roughly 1 in 4, and
@@ -137,6 +168,8 @@ so do not loosen it.
   contention noise of its own. But note that was my first and *wrong*
   explanation for the check-12 failure: it then reproduced in CI on a
   docs-only PR with identical numbers. See #290.
+
+</details>
 
 ---
 

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -104,9 +104,26 @@ reason (today is outside `navBounds`, so `⟳ Now` is correctly absent). It used
 to be joined by check 3, a persisted `this-week` migration; #274 phase 4
 deleted `dateFilter` from the app, so that check and its skip are gone
 together with checks 1, 2 and 4/5 — the date scopes and "show earlier" they
-asserted no longer exist. `verify-full-list` skips checks 5 and 7 off-season,
-for the same reason in both cases: `enterList` has to tap a rail chip to get a
-list at all, so there is no load-time landing left to measure.
+asserted no longer exist. `verify-full-list` skips checks 5, 7 and the WebKit
+`5-webkit the rail highlights today` off-season, for the same reason in all
+three cases: `enterList` has to tap a rail chip to get a list at all, so there
+is no load-time landing left to measure — and once `settleAtTop` has returned
+the reader to the top of the document, the day being read is the first day of
+the year, which is precisely the walk fallback that last check exists to
+reject. It cannot tell the right answer from the wrong one there.
+
+**A page that seeds a filter into `localStorage` before load cannot report the
+regime, and must say so** — `enterList(page, { seedsOwnFilter: true })`.
+Off-season the landing shows only for a reader who has narrowed nothing, so a
+seeded filter suppresses it and a day list renders on a date where an unseeded
+page gets the landing. `verify-rail`'s checks 18 and 20h both seed
+`searchTerm: 'williamsburg'`; before #287 they announced `in-season` in the
+middle of an off-season run and `announce`'s consistency throw took the whole
+suite — and the five suites `&&`-chained after it — down with a stack trace
+and no summary. The consistency rule itself is untouched: it still fires for
+every page that can honestly speak to which regime it found, and a
+`seedsOwnFilter` page that runs before any regime has been established is an
+ordering bug and throws as one.
 
 `verify-filter-reveal`'s check 13 stands down when day sections appear or
 vanish mid-wheel, which makes the reader's movement unattributable — that one
@@ -124,6 +141,13 @@ instant:
 # five days past the season's last event day
 E2E_NOW=2026-09-15 URL=http://localhost:3000/ node e2e/verify-rail.mjs
 ```
+
+It reaches the five suites that go through `fixedNow.mjs` —
+`verify-rail`, `verify-filter-reveal`, `verify-timezone`,
+`verify-header-reveal` and `verify-full-list`. **`verify-offseason.mjs` does
+not import `fixedNow.mjs` and ignores `E2E_NOW` entirely**, so prefixing it is
+a silent no-op; it derives every instant from the live feed instead, which is
+the next paragraph's subject.
 
 `verify-offseason.mjs` runs a five-entry matrix over pinned instants derived
 from the feed — post-season, the September 30 edge, pre-season, mid-season,

--- a/frontend/e2e/regime.mjs
+++ b/frontend/e2e/regime.mjs
@@ -36,8 +36,37 @@ const DAY = '[data-day-key]';
  * Wait for a populated day list, entering the season first if the default
  * screen is the off-season landing. Call instead of
  * `waitForSelector('[data-day-key]')`, after `goto`.
+ *
+ * `seedsOwnFilter` marks a page that wrote a filter into `localStorage`
+ * before load. Such a page cannot report the run's regime, and the fix for
+ * #287 is that it stops trying to. Off-season the landing is shown only when
+ * the reader has narrowed nothing (`page.tsx`: an answer of "see you next
+ * season" is not a response to someone who asked a question), so a seeded
+ * filter suppresses it and a day list renders on exactly the date where an
+ * unseeded page gets the landing. What that page sees is therefore a fact
+ * about its own seed, not about the calendar, and feeding it to `announce`
+ * made `verify-rail` abort mid-run from 2026-09-11 — taking the five suites
+ * chained after it down with no summary.
+ *
+ * It suppresses only the *reporting*. The consistency rule below is what
+ * stops a run from silently taking both branches, and it stays in force for
+ * every page that can honestly speak to which regime it found.
  */
-export async function enterList(page) {
+export async function enterList(page, { seedsOwnFilter = false } = {}) {
+  // A page that cannot report the regime must not be the page that
+  // establishes it: if the opt-out were used first, the run would lose its
+  // one chance to detect the regime from a page that could see it. Both
+  // callers today (`verify-rail` checks 18 and 20h) run late, after a dozen
+  // unseeded pages.
+  if (seedsOwnFilter && regime === null) {
+    throw new Error(
+      'enterList: a seedsOwnFilter page ran before any page established the ' +
+      'regime — it cannot detect one, so the run would have none'
+    );
+  }
+  const report = value => {
+    if (!seedsOwnFilter) announce(value);
+  };
   const first = await Promise.race([
     page.waitForSelector(DAY, { timeout: 30000 }).then(() => 'day'),
     page.waitForSelector(LANDING, { timeout: 30000 }).then(() => 'landing'),
@@ -59,7 +88,7 @@ export async function enterList(page) {
   }
 
   if (first === 'day') {
-    announce('in-season');
+    report('in-season');
     return regime;
   }
 
@@ -98,17 +127,17 @@ export async function enterList(page) {
       );
     }
     if (later === 'day') {
-      announce('in-season');
+      report('in-season');
       return regime;
     }
-    announce('off-season');
+    report('off-season');
     await enterSeasonFromLanding(page);
     await page.waitForSelector(DAY, { timeout: 30000 });
     await settleAtTop(page);
     return regime;
   }
 
-  announce('off-season');
+  report('off-season');
   await enterSeasonFromLanding(page);
   await page.waitForSelector(DAY, { timeout: 30000 });
   await settleAtTop(page);

--- a/frontend/e2e/verify-full-list.mjs
+++ b/frontend/e2e/verify-full-list.mjs
@@ -701,10 +701,25 @@ if (currentRegime() === 'off-season') {
     // `resolveAnchor`, so the highlight and the announced day cannot differ.
     // What this catches is the walk answering from its `keys[0]` fallback —
     // the first day of the YEAR — which is what CI reported twice.
-    check('5-webkit the rail highlights today (webkit)',
-      rail.anchorKey === today,
-      `aria-current is on ${rail.anchorKey ?? '(no chip)'}, today is ${today} ` +
-      `(${rail.anchorCount} chip(s) carry it)${tell}`);
+    //
+    // Off-season it cannot catch that, and it was the one check on this page
+    // that had not noticed (#287): `enterList` reaches the list through a
+    // rail tap and `settleAtTop` then returns the reader to the top of the
+    // document, so the day being read IS the first day of the year. The
+    // correct answer and the fallback coincide, which makes the assertion
+    // unable to tell them apart — and pinned off-season it does not merely go
+    // vacuous, it fails, because today is nowhere near the top of the list.
+    if (currentRegime() === 'off-season') {
+      skip('5-webkit the rail highlights today (webkit)',
+        'today is outside the season off-season, so no chip can carry it — and ' +
+        'the day the reader is on at the top of the document is the same ' +
+        "first-day-of-the-year this check exists to reject as the walk's fallback");
+    } else {
+      check('5-webkit the rail highlights today (webkit)',
+        rail.anchorKey === today,
+        `aria-current is on ${rail.anchorKey ?? '(no chip)'}, today is ${today} ` +
+        `(${rail.anchorCount} chip(s) carry it)${tell}`);
+    }
   }
   await page.close();
   await wk.close();

--- a/frontend/e2e/verify-full-list.mjs
+++ b/frontend/e2e/verify-full-list.mjs
@@ -351,8 +351,8 @@ const selectedYear = page => page.evaluate(() => {
 // parked perfectly on the WRONG day. The two checks are not redundant.
 if (currentRegime() === 'off-season') {
   skip('5 the reader lands on today',
-    'today is outside the season off-season, so there is no "today" section to ' +
-    'land on — `enterList` had to tap a rail chip to get a list at all');
+    'off-season, today falls outside the season, so there is no "today" ' +
+    'section to land on — `enterList` had to tap a rail chip to get a list at all');
 } else {
   const page = await newPage();
   await settle(page);
@@ -585,7 +585,7 @@ if (currentRegime() === 'off-season') {
     new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' }).format(new Date()));
   if (currentRegime() === 'off-season') {
     skip('5-webkit the reader lands on today (webkit)',
-      'today is outside the season off-season, so there is no "today" section to land on');
+      'off-season, today falls outside the season, so there is no "today" section to land on');
   } else {
     check('5-webkit the reader lands on today (webkit)', landed.key === today,
       `landed on ${landed.key}, today is ${today} (of ${landed.days} sections, first ${landed.first})`);
@@ -711,7 +711,7 @@ if (currentRegime() === 'off-season') {
     // vacuous, it fails, because today is nowhere near the top of the list.
     if (currentRegime() === 'off-season') {
       skip('5-webkit the rail highlights today (webkit)',
-        'today is outside the season off-season, so no chip can carry it — and ' +
+        'off-season, today falls outside the season, so no chip can carry it — and ' +
         'the day the reader is on at the top of the document is the same ' +
         "first-day-of-the-year this check exists to reject as the walk's fallback");
     } else {

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -607,6 +607,10 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     // Wait until the document stops growing under us. Returns whether it
     // actually stopped, so a page that never settles is reported as that
     // rather than as a scroll that missed.
+    // Bounded at 4s per call, and only an attempt that has already parked
+    // pays it — so a normal run spends one or two of these (measured: ~300ms
+    // each, the minimum three samples) and a pathological one exhausts the
+    // 25 attempts in well under two minutes and fails with a reason.
     const sleep = ms => new Promise(r => setTimeout(r, ms));
     const heightHolds = async () => {
       let last = -1, same = 0;
@@ -659,11 +663,20 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
       // underneath this loop — so having disarmed it, the loop has to do the
       // hold's job itself. It is the same correction, driven by a settled
       // document height rather than by a ResizeObserver.
+      //
+      // BOTH conditions, and `held` is not decoration. A document that never
+      // stopped growing can still read `<= 2` for the one frame it is
+      // sampled in — which is the same coincidence this whole block exists to
+      // stop trusting, merely made four seconds less likely. Requiring the
+      // height to have actually held is what makes the code enforce what the
+      // paragraph above claims. An unsettled page loops instead, and if it
+      // never settles it exhausts the attempts and is reported as that,
+      // rather than passing on a lucky sample.
       const held = await heightHolds();
       stalled = !held;
       const after = offBy();
       if (after.why) return { ok: false, why: after.why };
-      if (Math.abs(after.delta) <= 2) return { ok: true, key };
+      if (held && Math.abs(after.delta) <= 2) return { ok: true, key };
     }
     // Distinct from the search failure above: a day WAS found, the scroll just
     // never settled on it. Worth telling apart — one is about the fixture, the

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -9,7 +9,7 @@
  * server on :3000.
  */
 import { chromium } from 'playwright';
-import { pinClock } from './fixedNow.mjs';
+import { pinClock, FIXED_NOW } from './fixedNow.mjs';
 import { check, skip, finish } from './results.mjs';
 import { enterList, currentRegime } from './regime.mjs';
 
@@ -18,7 +18,7 @@ const URL = process.env.URL ?? 'http://localhost:3000/';
 const browser = await chromium.launch();
 
 
-async function newPage({ width = 900, height = 900, storage } = {}) {
+async function newPage({ width = 900, height = 900, storage, seedsOwnFilter = false } = {}) {
   // Chautauqua's own timezone, kept for belt-and-braces — it is no longer
   // load-bearing. The paragraph that used to be here claimed the app "treats
   // the browser's clock as event-time" because `startDate`s are
@@ -72,8 +72,9 @@ async function newPage({ width = 900, height = 900, storage } = {}) {
   }
   await page.goto(URL, { waitUntil: 'networkidle' });
   // Off-season the default screen is the landing, not a day list; see
-  // `regime.mjs` for what this does about it.
-  await enterList(page);
+  // `regime.mjs` for what this does about it, and for why a page that seeded
+  // a filter into storage has to opt out of reporting the regime (#287).
+  await enterList(page, { seedsOwnFilter });
   return page;
 }
 
@@ -591,22 +592,87 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     }
 
     const key = target.dataset.dayKey;
-    for (let i = 0; i < 25; i++) {
+
+    // How far the target is from where we want it. Aim to sit MARGIN pixels
+    // past the section's start, so the header has stuck and the section has
+    // not yet begun pushing it back out.
+    const offBy = () => {
       const sec = document.querySelector(`[data-day-key="${key}"]`);
-      if (!sec) return { ok: false, why: `target day ${key} left the DOM while homing in on it` };
+      if (!sec) return { why: `target day ${key} left the DOM while homing in on it` };
       const bottom = railBottom();
-      if (bottom === null) return { ok: false, why: 'the day rail left the page while homing in' };
-      // Aim to sit MARGIN pixels past the section's start, so the header has
-      // stuck and the section has not yet begun pushing it back out.
-      const delta = sec.getBoundingClientRect().top - bottom + MARGIN;
-      if (Math.abs(delta) <= 2) return { ok: true, key };
-      window.scrollBy(0, delta);
-      await frame();
+      if (bottom === null) return { why: 'the day rail left the page while homing in' };
+      return { delta: sec.getBoundingClientRect().top - bottom + MARGIN };
+    };
+
+    // Wait until the document stops growing under us. Returns whether it
+    // actually stopped, so a page that never settles is reported as that
+    // rather than as a scroll that missed.
+    const sleep = ms => new Promise(r => setTimeout(r, ms));
+    const heightHolds = async () => {
+      let last = -1, same = 0;
+      for (let i = 0; i < 40 && same < 3; i++) {
+        await sleep(100);
+        const h = document.documentElement.scrollHeight;
+        if (h === last) same++; else { same = 0; last = h; }
+      }
+      return same >= 3;
+    };
+
+    let stalled = false;
+    for (let i = 0; i < 25; i++) {
+      const at = offBy();
+      if (at.why) return { ok: false, why: at.why };
+      if (Math.abs(at.delta) > 2) {
+        window.scrollBy(0, at.delta);
+        await frame();
+        continue;
+      }
+
+      // Parked — but only for this frame, and that was #290.
+      //
+      // `enterList` lands the reader on today, which with the whole year
+      // mounted (#274 phase 4) is ~158,000px down a ~172,000px document,
+      // while `roomy()` picks the first tall day of the YEAR. So the scroll
+      // above is a ~152,000px jump back up, and it lands among ninety day
+      // sections the browser has never laid out: they carry
+      // `content-visibility: auto`, so each is still reporting its
+      // `contain-intrinsic-size` estimate rather than a measured height.
+      // Coming into view they swap one for the other and the document grows
+      // — measured here, 169,546 to 172,664, ~3,100px of it ABOVE the target.
+      // Chromium's scroll anchoring absorbs some of that (+478px of the
+      // +2,292 in the run below) and the remainder moves the target down.
+      //
+      // Which frame the growth lands in is the whole of the flake. It used to
+      // arrive after this loop returned, inside the caller's 300ms wait, and
+      // check 12 then measured a header 277 to 547px below the rail on a page
+      // that had already confirmed it flush — roughly one run in four:
+      //
+      //     i=0 y=158,026 delta=-152,828 h=169,546
+      //     i=1 y=  5,198 delta=       0 h=169,546   <- old loop returned here
+      //         y=  5,676 delta=     547 h=172,716   <- 17ms later
+      //
+      // The app is not exposed to this: `useDayAnchor`'s hold exists for
+      // exactly this ("a scroll decision invalidated by content changing
+      // height after it was made") and re-asserts the tapped day on every
+      // resize. The harness disarms it on purpose with the `mouse.wheel(0, 1)`
+      // above, because it would otherwise pull the reader back to today
+      // underneath this loop — so having disarmed it, the loop has to do the
+      // hold's job itself. It is the same correction, driven by a settled
+      // document height rather than by a ResizeObserver.
+      const held = await heightHolds();
+      stalled = !held;
+      const after = offBy();
+      if (after.why) return { ok: false, why: after.why };
+      if (Math.abs(after.delta) <= 2) return { ok: true, key };
     }
     // Distinct from the search failure above: a day WAS found, the scroll just
     // never settled on it. Worth telling apart — one is about the fixture, the
     // other about the page moving under the scroll.
-    return { ok: false, why: `scroll did not settle on ${key} within 25 attempts` };
+    return {
+      ok: false,
+      why: `scroll did not settle on ${key} within 25 attempts` +
+        (stalled ? ' — the document never stopped changing height' : ''),
+    };
   });
   await page.waitForTimeout(300);
 
@@ -980,11 +1046,23 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
 // removing them — 1 reachable week, 8 unreachable, unchanged.
 {
   const page = await newPage({
+    // The seed suppresses the off-season landing, so this page's screen says
+    // nothing about the run's regime — see `enterList` (#287).
+    seedsOwnFilter: true,
     storage: ['chq-calendar-user-state', JSON.stringify({
       searchTerm: 'williamsburg',
       selectedTags: [], selectedLocations: [], expandedDescriptions: [],
       recentLocations: [], recentCategories: [], showFavoritesOnly: false,
-      lastSaved: Date.now(),
+      // The PAGE's now, not Node's. `useFilterState` discards a payload
+      // older than `USER_STATE_EXPIRY_MS` (30 days), and `Date.now()` inside
+      // the page is whatever `pinClock` pinned — so a `Date.now()` evaluated
+      // out here reads as 30+ days stale the moment `E2E_NOW` is set that far
+      // ahead, and the seed is dropped in silence. Measured at
+      // `E2E_NOW=2026-09-30` (34 days on): six red checks reporting "9
+      // reachable, 0 unreachable", which is not a finding about the app but
+      // about a seed that never arrived. The state is "saved" at the same
+      // instant the page believes it is.
+      lastSaved: FIXED_NOW.getTime(),
     })],
   });
   const state = await page.evaluate(() => {
@@ -1145,11 +1223,15 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
 {
   const page = await newPage({
     width: 390, height: 844,
+    // As in check 18: a seeded filter beats the landing, so this page cannot
+    // report the regime (#287).
+    seedsOwnFilter: true,
     storage: ['chq-calendar-user-state', JSON.stringify({
       searchTerm: 'williamsburg',
       selectedTags: [], selectedLocations: [], expandedDescriptions: [],
       recentLocations: [], recentCategories: [], showFavoritesOnly: false,
-      lastSaved: Date.now(),
+      // The PAGE's now, not Node's — see check 18's seed.
+      lastSaved: FIXED_NOW.getTime(),
     })],
   });
   await page.click('[data-week-chooser-trigger]');

--- a/frontend/e2e/verify-rail.mjs
+++ b/frontend/e2e/verify-rail.mjs
@@ -607,10 +607,14 @@ for (const [label, width, zoom] of [['320px', 320, 1], ['200% zoom', 900, 2]]) {
     // Wait until the document stops growing under us. Returns whether it
     // actually stopped, so a page that never settles is reported as that
     // rather than as a scroll that missed.
-    // Bounded at 4s per call, and only an attempt that has already parked
-    // pays it — so a normal run spends one or two of these (measured: ~300ms
-    // each, the minimum three samples) and a pathological one exhausts the
-    // 25 attempts in well under two minutes and fails with a reason.
+    // Bounded at 4s per call (40 samples), and only an attempt that has
+    // already parked pays it — so a normal run spends one or two of these at
+    // the ~400ms floor and a pathological one exhausts the 25 attempts in
+    // well under two minutes and fails with a reason.
+    //
+    // The floor is 400ms and four samples, not 300 and three: the first
+    // sample only sets `last` (it compares against the -1 sentinel), so
+    // three *consecutive equal* readings need a baseline before them.
     const sleep = ms => new Promise(r => setTimeout(r, ms));
     const heightHolds = async () => {
       let last = -1, same = 0;


### PR DESCRIPTION
The two ways `browser-checks` fails, both in `verify-rail.mjs`, fixed in one pass. `test:browser` is `&&`-chained with `verify-rail` first, so either one takes the five suites after it down with no summary.

**Both fixes are in the harness. `page.tsx` and every other source file are untouched.**

## #287 — the suite aborted deterministically from 2026-09-11

Checks 18 and 20h seed `searchTerm: 'williamsburg'` into `localStorage` before load. Off-season the landing shows only for a reader who has narrowed nothing (#282's rule, and deliberate — "see you next season" is not an answer to someone who asked a question), so a seeded filter suppresses it and a day list renders on exactly the date where an unseeded page gets the landing. Those pages announced `in-season` mid-run and `announce`'s consistency throw ended the run.

`enterList` now takes `seedsOwnFilter`, which suppresses the **reporting** only. The invariant itself is worth keeping and stays in force for every page that can honestly speak to the regime it found; a `seedsOwnFilter` page running before any regime is established is an ordering bug and throws as one.

`verify-full-list`'s `5-webkit the rail highlights today` was the one check on that page with no off-season guard — its three siblings all have one. Off-season it cannot do its job either way: `settleAtTop` leaves the reader at the top of the document, so the day being read **is** the first day of the year, which is precisely the walk fallback the check exists to reject. It now skips with that reason.

## #290 — check 12 failed ~1 in 4, with byte-identical numbers

Not the `useDayAnchor` ResizeObserver lead the issue named. Instrumented and reproduced rather than guessed at.

`enterList` lands the reader on today, ~158,000px down a ~172,000px document, while `roomy()` picks the first tall day of the **year** — so the parking loop jumps ~152,000px back up into ninety day sections the browser has never laid out. They carry `content-visibility: auto` and swap `contain-intrinsic-size` estimates for real heights as they come into view; the document grew 169,546 → 172,664, ~3,100px of it above the target. Chromium's scroll anchoring absorbed +478 of that and the rest moved the target down. The loop had already returned on an instantaneous `|delta| <= 2`, so the caller's 300ms wait measured a page that moved after it settled:

```
i=0  y=158,026  delta=-152,828  h=169,546
i=1  y=  5,198  delta=       0  h=169,546   <- old loop returned here
     y=  5,676  delta=     547  h=172,716   <- 17ms later
```

The loop now confirms the park against a settled document height before returning. That is the same correction `useDayAnchor`'s hold performs for a real reader — the harness disarms it on purpose with its `mouse.wheel(0, 1)`, because it would otherwise pull the reader back to today underneath the loop, so having disarmed it the loop has to do the hold's job itself.

**Falsified:** made the day header non-sticky, confirmed the marker reached the served bundle, and check 12 failed at both widths (`320px` headerTop 19.5 vs railBottom 140; `200% zoom` headerTop 153 vs railBottom 273). The fix did not make the check vacuous.

## Found while verifying — previously unreachable

`lastSaved: Date.now()` in the two seeds was evaluated in Node while the page's clock is pinned, so any `E2E_NOW` more than `USER_STATE_EXPIRY_MS` (30 days) ahead silently discarded the seed. At `E2E_NOW=2026-09-30` that produced six red checks reporting "9 reachable, 0 unreachable" — a finding about a seed that never arrived, not about the app. Seeded from `FIXED_NOW` now. It was unreachable before because the run crashed at check 18.

`e2e/README.md` corrected too: `E2E_NOW` reaches the five suites that import `fixedNow.mjs`, not all six — `verify-offseason.mjs` ignores it entirely.

## Verification

Full `test:browser` chain, both regimes, against a fresh `npx vite build` + `vite preview` and the real production feed:

| suite | in-season | off-season (`E2E_NOW=2026-09-15`) |
|---|---|---|
| `verify-rail` | 46 passed, 0 failed | 43 passed, 0 failed, 1 skipped |
| `verify-filter-reveal` | 42, 0 | 42, 0 |
| `verify-timezone` | 16, 0 | 16, 0 |
| `verify-offseason` | 14, 0 | 14, 0 |
| `verify-header-reveal` | 19, 0 | 19, 0 |
| `verify-full-list` | 28, 0 | 22, 0, 4 skipped |

`verify-rail` also green pinned to **2026-09-11** (the deadline day) and **2026-09-30** (the last day before the manifest rollover), and 4 consecutive in-season runs at 46/46 against a ~1-in-4 prior failure rate — plus 8/8 on the instrumented isolation of check 12.

Frontend `npm run build` green (109 test files, 1325 tests). Backend `npm run validate` green.

Closes #287
Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FGP4DDz51NAm9XNyDAvqUu